### PR TITLE
feat: auto-import completion, scoring fixes, workspace stability

### DIFF
--- a/contrib/copilot-extension/extension.mjs
+++ b/contrib/copilot-extension/extension.mjs
@@ -16,6 +16,9 @@ const GREP_TOOLS = new Set(["grep", "kotlin_rg", "kotlin_find_subtypes"]);
 // Matches: rg/grep/find with *.kt/*.java, OR fd with -e kt/-e java extension flags
 const GREP_BASH_RE = /\b(rg|grep|fd|find)\b.*(-e\s+(?:kt|java)|\.(kt|java))/;
 
+// glob patterns targeting Kotlin/Java files count as grep-type navigation
+const GLOB_KT_RE = /\.(kt|java|kts)\b/;
+
 // Tools that count as proper LSP usage (reset the streak)
 const LSP_TOOLS = new Set(["lsp"]);
 
@@ -24,14 +27,14 @@ const STREAK_THRESHOLD = 3;  // consecutive grep calls before reinforcing
 let grepStreak = 0;
 
 const LSP_REMINDER = [
-  "⚠️  LSP REMINDER — too many grep calls for Kotlin/Java navigation.",
-  "STOP using grep/rg for symbol lookup. Use LSP tools instead:",
+  "⚠️  LSP REMINDER — too many grep/glob calls for Kotlin/Java navigation.",
+  "STOP using grep/rg/glob for symbol lookup. Use LSP tools instead:",
   "  • lsp workspaceSymbol   — find any class/function/property by name",
   "  • lsp goToDefinition    — jump to where a symbol is defined",
   "  • lsp findReferences    — find all usages of a symbol",
   "  • lsp goToImplementation — find interface implementors (transitive)",
   "  • lsp incomingCalls / outgoingCalls — call graph",
-  "grep/rg is ONLY valid for: free-text/comment search, extension functions,",
+  "grep/rg/glob is ONLY valid for: free-text/comment search, extension functions,",
   "generated code, Java interop, or when LSP returned empty for a known-good symbol.",
   `Full guide: \`${README_PATH}\`.`,
 ].join("\n");
@@ -290,6 +293,13 @@ const session = await joinSession({
       if (toolName === "bash") {
         const cmd = asString(normalizeToolArgs(toolArgs).command);
         if (GREP_BASH_RE.test(cmd)) {
+          grepStreak++;
+        }
+      }
+
+      if (toolName === "glob") {
+        const pattern = asString(normalizeToolArgs(toolArgs).pattern);
+        if (GLOB_KT_RE.test(pattern)) {
           grepStreak++;
         }
       }

--- a/contrib/copilot-extension/extension.mjs
+++ b/contrib/copilot-extension/extension.mjs
@@ -13,8 +13,8 @@ const README_PATH = ".github/extensions/kotlin-lsp/README.md";
 const GREP_TOOLS = new Set(["grep", "kotlin_rg", "kotlin_find_subtypes"]);
 
 // bash commands that are grep-type code navigation
-// Matches: rg/grep/find with *.kt/*.java, OR fd with -e kt/-e java extension flags
-const GREP_BASH_RE = /\b(rg|grep|fd|find)\b.*(-e\s+(?:kt|java)|\.(kt|java))/;
+// Matches: rg/grep/find with *.kt/*.kts/*.java, OR fd with -e kt/-e kts/-e java extension flags
+const GREP_BASH_RE = /\b(rg|grep|fd|find)\b.*(-e\s+(?:kt|kts|java)|\.(kt|kts|java))/;
 
 // glob patterns targeting Kotlin/Java files count as grep-type navigation
 const GLOB_KT_RE = /\.(kt|java|kts)\b/;

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -355,7 +355,8 @@ impl LanguageServer for Backend {
                         None => true,
                         Some(ref r) => {
                             let cur_canon = std::fs::canonicalize(r).unwrap_or_else(|_| r.clone());
-                            !path.starts_with(r) && cand_canon != cur_canon
+                            let path_canon = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+                            !path_canon.starts_with(&cur_canon) && cand_canon != cur_canon
                         },
                     };
                     if should_switch {

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -92,13 +92,16 @@ impl LanguageServer for Backend {
                 .filter(|p| p.is_dir())
         };
 
-        // env var or explicit client rootUri pins the workspace (disables did_open auto-detection).
-        // config file is a passive fallback — never pins.
-        // When the editor provides rootUri it knows the project; no auto-detection needed.
-        let workspace_pinned = env_override.is_some() || client_root.is_some();
+        // Any resolved workspace root — env var, client rootUri, or config file — pins the
+        // workspace and disables did_open auto-detection.  Without pinning, opening a file from
+        // a second project in the same editor session triggers a spurious root switch that aborts
+        // the in-progress workspace index and discards half its results.
+        // Pure auto-detection (no config at all) still works: workspace_pinned stays false until
+        // did_open fires and a root is detected for the first time.
         let resolved_root = env_override
             .or(client_root)
             .or_else(config_fallback);
+        let workspace_pinned = resolved_root.is_some();
 
         if let Some(path) = resolved_root {
             // Set workspace_root immediately so rg/fd calls work even before
@@ -364,9 +367,12 @@ impl LanguageServer for Backend {
 
         if let Some(root) = need_root_switch {
             *self.indexer.workspace_root.write().unwrap() = Some(root.clone());
+            // Pin the workspace after the first auto-detection so that opening a file
+            // from a second project later in the same session doesn't switch again.
+            self.indexer.workspace_pinned.store(true, std::sync::atomic::Ordering::Relaxed);
             self.indexer.root_generation.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
             self.indexer.reset_index_state();
-            log::info!("Auto-detected workspace root: {}", root.display());
+            log::info!("Auto-detected workspace root (now pinned): {}", root.display());
             let idx = Arc::clone(&self.indexer);
             let client = self.client.clone();
             let root2 = root.clone();

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -92,9 +92,10 @@ impl LanguageServer for Backend {
                 .filter(|p| p.is_dir())
         };
 
-        // env var pins the workspace (disables did_open auto-detection).
+        // env var or explicit client rootUri pins the workspace (disables did_open auto-detection).
         // config file is a passive fallback — never pins.
-        let workspace_pinned = env_override.is_some();
+        // When the editor provides rootUri it knows the project; no auto-detection needed.
+        let workspace_pinned = env_override.is_some() || client_root.is_some();
         let resolved_root = env_override
             .or(client_root)
             .or_else(config_fallback);
@@ -346,9 +347,13 @@ impl LanguageServer for Backend {
                 let chosen = found.or_else(|| path.parent().map(|p| p.to_path_buf()));
                 if let Some(candidate_root) = chosen {
                     let current_root = self.indexer.workspace_root.read().unwrap().clone();
+                    let cand_canon = std::fs::canonicalize(&candidate_root).unwrap_or_else(|_| candidate_root.clone());
                     let should_switch = match current_root {
                         None => true,
-                        Some(ref r) => !path.starts_with(r),
+                        Some(ref r) => {
+                            let cur_canon = std::fs::canonicalize(r).unwrap_or_else(|_| r.clone());
+                            !path.starts_with(r) && cand_canon != cur_canon
+                        },
                     };
                     if should_switch {
                         need_root_switch = Some(candidate_root);
@@ -389,6 +394,7 @@ impl LanguageServer for Backend {
                 "Outside-root file — indexing content only: {}",
                 opened_path_opt.as_deref().map(|p| p.display().to_string()).unwrap_or_default()
             );
+            self.indexer.set_live_lines(&uri, &text);
             // Index just this file so hover/go-to-def work, then return.
             let idx = Arc::clone(&self.indexer);
             let sem = idx.parse_sem();
@@ -400,6 +406,10 @@ impl LanguageServer for Backend {
             });
             return;
         }
+
+        // Set live_lines immediately so completion can read the current file content
+        // even before the async index_content task finishes.
+        self.indexer.set_live_lines(&uri, &text);
 
         let idx  = Arc::clone(&self.indexer);
         let sem  = idx.parse_sem();
@@ -683,14 +693,17 @@ impl LanguageServer for Backend {
         let snippets = self.snippet_support.load(Ordering::Relaxed);
 
         let (items, hit_cap) = self.indexer.completions(uri, position, snippets);
-        if items.is_empty() {
+        let still_indexing = self.indexer.indexing_in_progress.load(Ordering::Acquire);
+        if items.is_empty() && !still_indexing {
             return Ok(None);
         }
         // When hit_cap is true the list was truncated — tell the client to
         // re-request completions on every keystroke so the list stays tight
         // as the user types more characters.
+        // Also mark incomplete while the workspace is still being indexed so
+        // the client keeps re-querying instead of caching a partial result.
         Ok(Some(CompletionResponse::List(CompletionList {
-            is_incomplete: hit_cap,
+            is_incomplete: hit_cap || still_indexing,
             items,
         })))
     }

--- a/src/backend.rs
+++ b/src/backend.rs
@@ -386,7 +386,13 @@ impl LanguageServer for Backend {
         let outside_root = pinned && {
             matches!(
                 (opened_path_opt.as_ref(), self.indexer.workspace_root.read().unwrap().clone()),
-                (Some(path), Some(root)) if !path.starts_with(&root)
+                (Some(path), Some(root)) if {
+                    // Use canonical paths to avoid symlink/path-form mismatches
+                    // (consistent with the root-switch guard above).
+                    let canon_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
+                    let canon_root = std::fs::canonicalize(&root).unwrap_or_else(|_| root.clone());
+                    !canon_path.starts_with(&canon_root)
+                }
             )
         };
         if outside_root {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -677,7 +677,8 @@ impl Indexer {
         let _guard = IndexingGuard { indexer: Arc::clone(&self) };
         
         if already {
-            log::info!("index_workspace_impl: an indexing run is already in progress; skipping new start");
+            log::warn!("index_workspace_impl: an indexing run is already in progress, skipping. \
+                       This may cause incomplete indexing — trigger 'kotlin-lsp/reindex' to recover.");
             return WorkspaceIndexResult {
                 files: Vec::new(),
                 stats: IndexStats::default(),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -2594,6 +2594,7 @@ fn warm_discover_files(root: &Path, cache: &IndexCache, matcher: Option<&IgnoreM
         .map(PathBuf::from)
         .filter(|p| p.exists())
         .collect();
+    let on_disk_cached_count = paths.len();
 
     // Phase 2: find files created or modified since the cache was saved.
     // These are the only files `fd` needs to scan for.
@@ -2612,7 +2613,7 @@ fn warm_discover_files(root: &Path, cache: &IndexCache, matcher: Option<&IgnoreM
 
     log::info!(
         "Warm start: {} cached (on-disk) + {} new files (scanned last {}s window)",
-        cached_paths.len(), new_count, elapsed_secs
+        on_disk_cached_count, new_count, elapsed_secs
     );
     paths
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -1938,8 +1938,13 @@ impl Indexer {
         }
         // (compute below, then store in cache at the end)
         let dot_receiver = if before_prefix.ends_with('.') {
-            // Grab the identifier immediately preceding the dot.
-            let recv: String = before_prefix[..before_prefix.len() - 1]
+            // Grab the expression immediately preceding the dot.
+            // For simple identifiers: `foo.` → "foo"
+            // For qualified nested types: `DPSCoordinator.Kind.` → "DPSCoordinator.Kind"
+            // We walk backwards collecting identifier chars; if we then see a dot followed
+            // by another identifier, include that outer segment too (one level only).
+            let before_dot = &before_prefix[..before_prefix.len() - 1];
+            let inner: String = before_dot
                 .chars()
                 .rev()
                 .take_while(|&c| c.is_alphanumeric() || c == '_')
@@ -1947,7 +1952,33 @@ impl Indexer {
                 .chars()
                 .rev()
                 .collect();
-            if recv.is_empty() { None } else { Some(recv) }
+            if inner.is_empty() {
+                None
+            } else {
+                // Check whether there is an `Outer.` prefix immediately before `inner`.
+                let remaining = &before_dot[..before_dot.len() - inner.len()];
+                if remaining.ends_with('.')
+                    && inner.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
+                {
+                    let outer: String = remaining[..remaining.len() - 1]
+                        .chars()
+                        .rev()
+                        .take_while(|&c| c.is_alphanumeric() || c == '_')
+                        .collect::<String>()
+                        .chars()
+                        .rev()
+                        .collect();
+                    if !outer.is_empty()
+                        && outer.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
+                    {
+                        Some(format!("{}.{}", outer, inner))
+                    } else {
+                        Some(inner)
+                    }
+                } else {
+                    Some(inner)
+                }
+            }
         } else {
             None
         };
@@ -5192,6 +5223,28 @@ class Child : Base
         let (items, _) = idx.completions(&vm_uri, Position::new(4, col), true);
         let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
         assert!(labels.contains(&"findAll"), "findAll missing; got: {labels:?}");
+    }
+
+    #[test]
+    fn dot_completion_qualified_nested_type() {
+        // Typing `DPSCoordinator.Kind.` — receiver is "DPSCoordinator.Kind".
+        // Should show enum cases (victory, defeat), NOT members of DPSCoordinator.
+        let coordinator_uri = uri("/DPSCoordinator.swift");
+        let vm_uri = uri("/DPSChangeVictoryViewModel.swift");
+        let idx = Indexer::new();
+        idx.index_content(&coordinator_uri,
+            "class DPSCoordinator {\n    enum Kind {\n        case victory\n        case defeat\n    }\n    func deposit() {}\n    var strategy: String = \"\"\n}");
+        idx.index_content(&vm_uri,
+            "class DPSChangeVictoryViewModel {\n    let coordinator: DPSCoordinator\n    func update() { let k = DPSCoordinator.Kind. }\n}");
+
+        let line = "    func update() { let k = DPSCoordinator.Kind. }";
+        let col = (line.find("DPSCoordinator.Kind.").unwrap() + "DPSCoordinator.Kind.".len()) as u32;
+        let (items, _) = idx.completions(&vm_uri, Position::new(2, col), false);
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+        assert!(labels.contains(&"victory"), "victory case missing; got: {labels:?}");
+        assert!(labels.contains(&"defeat"),  "defeat case missing; got: {labels:?}");
+        assert!(!labels.contains(&"deposit"),  "deposit (DPSCoordinator method) must NOT appear; got: {labels:?}");
+        assert!(!labels.contains(&"strategy"), "strategy (DPSCoordinator prop) must NOT appear; got: {labels:?}");
     }
 
     #[test]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -912,17 +912,30 @@ impl Indexer {
             }
         });
 
+        let gen_skipped   = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let read_failed   = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let url_failed    = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let panic_failed  = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let gen_skipped2  = Arc::clone(&gen_skipped);
+        let read_failed2  = Arc::clone(&read_failed);
+        let url_failed2   = Arc::clone(&url_failed);
+        let panic_failed2 = Arc::clone(&panic_failed);
+
         let results = crate::task_runner::run_concurrent(
             work_items,
             sem,
             move |item, sem| {
                 let idx = Arc::clone(&idx_ref);
+                let gen_skipped   = Arc::clone(&gen_skipped2);
+                let read_failed   = Arc::clone(&read_failed2);
+                let url_failed    = Arc::clone(&url_failed2);
+                let panic_failed  = Arc::clone(&panic_failed2);
                 async move {
                     log::debug!("Parsing: {}", item.path.display());
                     
                     // Check generation before parsing
                     if idx.root_generation.load(std::sync::atomic::Ordering::SeqCst) != item.start_gen {
-                        log::info!("Parse task: generation changed, skipping {}", item.path.display());
+                        gen_skipped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                         return None;
                     }
                     
@@ -930,7 +943,10 @@ impl Indexer {
                     let content = match tokio::fs::read_to_string(&item.path).await {
                         Ok(c) => c,
                         Err(e) => {
-                            log::warn!("Could not read {}: {}", item.path.display(), e);
+                            let n = read_failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                            if n < 5 {
+                                log::warn!("Could not read {}: {}", item.path.display(), e);
+                            }
                             return None;
                         }
                     };
@@ -939,6 +955,7 @@ impl Indexer {
                     let uri = match Url::from_file_path(&item.path) {
                         Ok(u) => u,
                         Err(_) => {
+                            url_failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                             log::warn!("Invalid file path: {}", item.path.display());
                             return None;
                         }
@@ -955,6 +972,7 @@ impl Indexer {
                     }).await {
                         Ok(result) => result,
                         Err(e) => {
+                            panic_failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
                             log::warn!("Parse task panicked for {}: {}", item.path.display(), e);
                             return None;
                         }
@@ -990,7 +1008,12 @@ impl Indexer {
         // Stop the progress reporter (it may still be sleeping on its interval).
         progress_handle.abort();
 
-        log::info!("All {} parse tasks completed", results.len());
+        let gen_skip_n  = gen_skipped.load(std::sync::atomic::Ordering::Relaxed);
+        let read_fail_n = read_failed.load(std::sync::atomic::Ordering::Relaxed);
+        let url_fail_n  = url_failed.load(std::sync::atomic::Ordering::Relaxed);
+        let panic_n     = panic_failed.load(std::sync::atomic::Ordering::Relaxed);
+        log::info!("All {} parse tasks done: gen_skipped={}, read_failed={}, url_failed={}, panics={}",
+            results.len(), gen_skip_n, read_fail_n, url_fail_n, panic_n);
         
         // If generation changed while parse tasks ran, discard results — the new
         // root's indexing run will populate the index correctly.
@@ -2553,20 +2576,25 @@ fn warm_discover_files(root: &Path, cache: &IndexCache, matcher: Option<&IgnoreM
 
     // Phase 1: all previously cached files, filtered through the current ignore matcher
     // so that newly-configured ignorePatterns take effect even on a warm start.
+    // Also skip paths that no longer exist on disk (e.g. files deleted by a branch switch)
+    // to avoid counting them as need_parse and emitting spurious "Could not read" warnings.
     let cached_paths: HashSet<String> = cache.entries.keys()
         .filter(|p| {
             if let Some(m) = matcher {
                 if !m.is_empty() {
                     let path = Path::new(p.as_str());
                     let rel = path.strip_prefix(root).unwrap_or(path);
-                    return !m.matches(rel);
+                    if m.matches(rel) { return false; }
                 }
             }
             true
         })
         .cloned()
         .collect();
-    let mut paths: Vec<PathBuf> = cached_paths.iter().map(PathBuf::from).collect();
+    let mut paths: Vec<PathBuf> = cached_paths.iter()
+        .map(PathBuf::from)
+        .filter(|p| p.exists())
+        .collect();
 
     // Phase 2: find files created or modified since the cache was saved.
     // These are the only files `fd` needs to scan for.
@@ -2584,7 +2612,7 @@ fn warm_discover_files(root: &Path, cache: &IndexCache, matcher: Option<&IgnoreM
     }
 
     log::info!(
-        "Warm start: {} cached + {} new files (scanned last {}s window)",
+        "Warm start: {} cached (on-disk) + {} new files (scanned last {}s window)",
         cached_paths.len(), new_count, elapsed_secs
     );
     paths

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -711,10 +711,9 @@ impl Indexer {
         let total = paths.len();
 
         // On warm start all selected paths are cache hits — pure deserialization with no
-        // parse overhead — so bypass the file-count cap.  The cap was designed to bound
-        // cold-start parse time, not cache-restore time.  An explicit KOTLIN_LSP_MAX_FILES
-        // env var still wins (it overrides the default 2000 with a real limit).
-        let effective_max = if warm_start && max == DEFAULT_MAX_INDEX_FILES {
+        // parse overhead — so bypass the file-count cap entirely.  The cap was designed to
+        // bound cold-start parse time; KOTLIN_LSP_MAX_FILES still limits cold-start parses.
+        let effective_max = if warm_start {
             MAX_FILES_UNLIMITED
         } else {
             max

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1419,4 +1419,17 @@ class LoanReducer {
         assert!(data.syntax_errors.is_empty(),
             "Expected no syntax errors, got: {:?}", data.syntax_errors);
     }
+
+    #[test]
+    fn swift_nested_enum_in_class() {
+        let src = "final class DPSChangeVictoryViewModel: SimpleVictoryViewModel, @unchecked Sendable {\n    let coordinator: DPSCoordinator\n    func update(kind: DPSCoordinator.Kind) {}\n}\n\nclass DPSCoordinator {\n    enum Kind {\n        case victory\n        case defeat\n    }\n}";
+        let data = parse_swift(src);
+        let names: Vec<&str> = data.symbols.iter().map(|s| s.name.as_str()).collect();
+        eprintln!("Symbols: {:?}", names);
+        assert_eq!(sym(&data, "DPSChangeVictoryViewModel").unwrap().kind, SymbolKind::CLASS,
+            "DPSChangeVictoryViewModel should be CLASS");
+        assert!(sym(&data, "Kind").is_some(), "nested Kind enum should be indexed; got: {:?}", names);
+        assert_eq!(sym(&data, "Kind").unwrap().kind, SymbolKind::ENUM, "Kind should be ENUM");
+        assert!(sym(&data, "victory").is_some(), "enum cases should be indexed");
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -708,7 +708,14 @@ pub fn parse_imports_from_lines(lines: &[String]) -> Vec<crate::types::ImportEnt
     for line in lines {
         let trimmed = line.trim_start();
         if !trimmed.starts_with("import ") { continue; }
-        let rest = trimmed["import ".len()..].trim();
+        let rest_raw = trimmed["import ".len()..].trim();
+        if rest_raw.is_empty() { continue; }
+        // Strip inline comments (e.g. `import foo.Bar // generated`)
+        let rest = if let Some(ci) = rest_raw.find("//") {
+            rest_raw[..ci].trim_end()
+        } else {
+            rest_raw
+        };
         if rest.is_empty() { continue; }
         let is_star = rest.ends_with(".*");
         let (path_part, alias) = if let Some(idx) = rest.find(" as ") {
@@ -1448,7 +1455,6 @@ class LoanReducer {
 }
 "#;
         let data = parse_kotlin(src);
-        eprintln!("ERRORS: {:?}", data.syntax_errors);
         assert!(data.syntax_errors.is_empty(),
             "Expected no syntax errors, got: {:?}", data.syntax_errors);
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -717,6 +717,9 @@ pub fn parse_imports_from_lines(lines: &[String]) -> Vec<crate::types::ImportEnt
             rest_raw
         };
         if rest.is_empty() { continue; }
+        // Trim optional trailing `;` (Java-style imports) and skip Java's `static` modifier.
+        let rest = rest.trim_end_matches(';').trim_end();
+        let rest = rest.strip_prefix("static ").map(str::trim_start).unwrap_or(rest);
         let is_star = rest.ends_with(".*");
         let (path_part, alias) = if let Some(idx) = rest.find(" as ") {
             (&rest[..idx], Some(rest[idx + 4..].trim().to_owned()))

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -700,6 +700,39 @@ fn parse_import_header(header: &tree_sitter::Node, bytes: &[u8], data: &mut File
     }
 }
 
+/// Lightweight import scanner for live (unsaved) buffer lines.
+/// Handles: `import pkg.Name`, `import pkg.Name as Alias`, `import pkg.*`
+/// Used by completion to read the current buffer state without a full re-parse.
+pub fn parse_imports_from_lines(lines: &[String]) -> Vec<crate::types::ImportEntry> {
+    let mut imports = Vec::new();
+    for line in lines {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with("import ") { continue; }
+        let rest = trimmed["import ".len()..].trim();
+        if rest.is_empty() { continue; }
+        let is_star = rest.ends_with(".*");
+        let (path_part, alias) = if let Some(idx) = rest.find(" as ") {
+            (&rest[..idx], Some(rest[idx + 4..].trim().to_owned()))
+        } else {
+            (rest, None)
+        };
+        let full_path = if is_star {
+            path_part[..path_part.len() - 2].to_owned() // strip ".*"
+        } else {
+            path_part.to_owned()
+        };
+        let local_name = if is_star {
+            "*".to_owned()
+        } else {
+            alias.unwrap_or_else(|| {
+                full_path.rsplit('.').next().unwrap_or(&full_path).to_owned()
+            })
+        };
+        imports.push(crate::types::ImportEntry { full_path, local_name, is_star });
+    }
+    imports
+}
+
 // ─── Swift import extraction ─────────────────────────────────────────────────
 
 fn extract_swift_imports(root: tree_sitter::Node, bytes: &[u8], data: &mut FileData) {
@@ -1425,11 +1458,10 @@ class LoanReducer {
         let src = "final class DPSChangeVictoryViewModel: SimpleVictoryViewModel, @unchecked Sendable {\n    let coordinator: DPSCoordinator\n    func update(kind: DPSCoordinator.Kind) {}\n}\n\nclass DPSCoordinator {\n    enum Kind {\n        case victory\n        case defeat\n    }\n}";
         let data = parse_swift(src);
         let names: Vec<&str> = data.symbols.iter().map(|s| s.name.as_str()).collect();
-        eprintln!("Symbols: {:?}", names);
         assert_eq!(sym(&data, "DPSChangeVictoryViewModel").unwrap().kind, SymbolKind::CLASS,
-            "DPSChangeVictoryViewModel should be CLASS");
-        assert!(sym(&data, "Kind").is_some(), "nested Kind enum should be indexed; got: {:?}", names);
+            "DPSChangeVictoryViewModel should be CLASS; symbols: {names:?}");
+        assert!(sym(&data, "Kind").is_some(), "nested Kind enum should be indexed; got: {names:?}");
         assert_eq!(sym(&data, "Kind").unwrap().kind, SymbolKind::ENUM, "Kind should be ENUM");
-        assert!(sym(&data, "victory").is_some(), "enum cases should be indexed");
+        assert!(sym(&data, "victory").is_some(), "enum cases should be indexed; got: {names:?}");
     }
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -104,6 +104,12 @@ pub(crate) fn make_import_edit(fqn: &str, lines: &[String]) -> TextEdit {
 
 // ─── match scoring ────────────────────────────────────────────────────────────
 
+/// Returns true if `name` is SCREAMING_SNAKE_CASE (all letters are uppercase).
+/// Used to suppress constants/enum variants when the user types a CamelCase prefix.
+fn is_screaming_snake(name: &str) -> bool {
+    name.chars().any(|c| c.is_alphabetic()) && name.chars().all(|c| c.is_uppercase() || c == '_' || c.is_ascii_digit())
+}
+
 /// Score how well `name` matches `prefix`. Lower = better.
 ///
 /// - `0` — `name` starts with `prefix` (case-insensitive, fastest/best)
@@ -137,6 +143,7 @@ fn camel_acronym_match(name: &str, prefix: &str) -> bool {
     for (i, &c) in chars.iter().enumerate() {
         let is_word_start = i == 0
             || c == '_'
+            || (i > 0 && chars[i - 1] == '_' && c != '_')  // char immediately after underscore
             || (c.is_uppercase() && i > 0 && chars[i - 1].is_lowercase())
             || (c.is_uppercase() && i > 0 && chars[i - 1].is_uppercase()
                 && i + 1 < chars.len() && chars[i + 1].is_lowercase());
@@ -429,6 +436,15 @@ fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippets: bool, an
     let lowercase_mode = first_char.map(|c| c.is_lowercase()).unwrap_or(false);
     // Symmetric to lowercase_mode: user is deliberately typing a CamelCase name.
     let uppercase_mode = first_char.map(|c| c.is_uppercase()).unwrap_or(false);
+    // True when the prefix is clearly CamelCase (uppercase first char + at least one
+    // lowercase letter), meaning the user cannot be typing a SCREAMING_SNAKE constant.
+    let camel_mode = uppercase_mode && prefix.chars().any(|c| c.is_lowercase());
+    // For longer prefixes the user knows what they want: restrict tier-0/1 to
+    // prefix/acronym matches only (no substring).  This prevents noisy substring
+    // hits from filling the cap and crowding out precise tier-2 cross-package matches
+    // (e.g. typing "ChildDash" must surface ChildDashboardViewModel even if the same
+    // package has many classes that contain "child" as a substring).
+    let local_max_score: u8 = if prefix.len() >= 4 { 1 } else { 2 };
     let mut seen = std::collections::HashSet::new();
     let mut items: Vec<CompletionItem> = Vec::new();
 
@@ -452,6 +468,10 @@ fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippets: bool, an
         if uppercase_mode && name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false) {
             return;
         }
+        // CamelCase prefix → hide SCREAMING_SNAKE_CASE names (constants, enum variants).
+        if camel_mode && is_screaming_snake(name) {
+            return;
+        }
         let score = match match_score(name, prefix) {
             Some(s) if s <= max_score => s,
             _ => return,
@@ -469,20 +489,20 @@ fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippets: bool, an
         });
     };
 
-    // 1. Local file symbols — src_tier 0, allow substring fallback (max_score=2).
+    // 1. Local file symbols — src_tier 0, substring fallback only for short prefixes.
     if let Some(f) = idx.files.get(from_uri.as_str()) {
         for sym in &f.symbols {
-            add(&sym.name, symbol_kind_to_completion(sym.kind), 0, 2);
+            add(&sym.name, symbol_kind_to_completion(sym.kind), 0, local_max_score);
         }
         // Constructor params / local vars from declared_names (lowercase only).
         if lowercase_mode {
             for name in &f.declared_names {
-                add(name, CompletionItemKind::VARIABLE, 0, 2);
+                add(name, CompletionItemKind::VARIABLE, 0, local_max_score);
             }
         }
     }
 
-    // 2. Same-package symbols — src_tier 1, allow substring fallback (max_score=2).
+    // 2. Same-package symbols — src_tier 1, substring fallback only for short prefixes.
     let pkg = idx.files.get(from_uri.as_str())
         .and_then(|f| f.package.clone())
         .unwrap_or_default();
@@ -492,7 +512,7 @@ fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippets: bool, an
                 if uri_str == from_uri.as_str() { continue; }
                 if let Some(f) = idx.files.get(uri_str.as_str()) {
                     for sym in &f.symbols {
-                        add(&sym.name, symbol_kind_to_completion(sym.kind), 1, 2);
+                        add(&sym.name, symbol_kind_to_completion(sym.kind), 1, local_max_score);
                     }
                 }
             }
@@ -511,6 +531,7 @@ fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippets: bool, an
             for name in cache.iter() {
                 // Case gate + match quality gate (prefix or acronym only).
                 if name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false) { continue; }
+                if camel_mode && is_screaming_snake(name) { continue; }
                 let score = match match_score(name, prefix) {
                     Some(s) if s <= 1 => s,
                     _ => continue,
@@ -574,6 +595,7 @@ fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippets: bool, an
         if lowercase_mode && label.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
             continue;
         }
+        if camel_mode && is_screaming_snake(&label) { continue; }
         let score = match match_score(&label, prefix) {
             Some(s) if s <= 2 => s,
             _ => continue,
@@ -2884,6 +2906,9 @@ data class State(
         assert_eq!(match_score("ColumnButton", "CB"), Some(1));
         // mSF → myStateFlow
         assert_eq!(match_score("myStateFlow", "mSF"), Some(1));
+        // underscore-prefixed private fields: _ColumnButton, _myStateFlow
+        assert_eq!(match_score("_ColumnButton", "CB"), Some(1));
+        assert_eq!(match_score("_myStateFlow", "mSF"), Some(1));
     }
 
     #[test]
@@ -2968,6 +2993,72 @@ data class State(
         // Lowercase function should not appear.
         assert!(!items.iter().any(|i| i.label == "composable"),
             "function composable must not appear in annotation context");
+    }
+
+    #[test]
+    fn camel_mode_hides_screaming_snake() {
+        let idx = Indexer::new();
+        let cur_uri = uri("/app/Screen.kt");
+        idx.index_content(&cur_uri,
+            "package com.example\nclass ChildDashboardViewModel\nconst val CHILD_DASHBOARD_MAX = 10\nval CHILD_COUNT = 5");
+
+        // Typing CamelCase prefix — SCREAMING_SNAKE constants must not appear.
+        let (items, _) = complete_symbol(&idx, "Child", None, &cur_uri, false);
+        assert!(items.iter().any(|i| i.label == "ChildDashboardViewModel"),
+            "CamelCase class must appear");
+        assert!(!items.iter().any(|i| i.label == "CHILD_DASHBOARD_MAX"),
+            "SCREAMING_SNAKE constant must be hidden in camel_mode");
+        assert!(!items.iter().any(|i| i.label == "CHILD_COUNT"),
+            "SCREAMING_SNAKE val must be hidden in camel_mode");
+
+        // Typing all-uppercase prefix — SCREAMING_SNAKE constants may appear.
+        let (items2, _) = complete_symbol(&idx, "CHILD", None, &cur_uri, false);
+        assert!(items2.iter().any(|i| i.label == "CHILD_DASHBOARD_MAX"),
+            "SCREAMING_SNAKE constant must appear when prefix is uppercase");
+    }
+
+    #[test]
+    fn long_prefix_tier2_not_crowded_out() {
+        // Even when the same-package has many substring-matching symbols,
+        // a cross-package prefix match must survive with a 4+ char prefix.
+        let idx = Indexer::new();
+        let cur_uri  = uri("/app/pkg/Screen.kt");
+        let other_uri = uri("/app/pkg/Other.kt");
+        let cross_uri = uri("/app/other/Cross.kt");
+
+        // 60 same-pkg classes that contain "child" as substring but don't start with it.
+        let same_pkg: String = (0..60)
+            .map(|i| format!("class Something{i}Child"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        idx.index_content(&cur_uri,  "package com.example\n");
+        idx.index_content(&other_uri, &format!("package com.example\n{same_pkg}"));
+        // Cross-package class with prefix match.
+        idx.index_content(&cross_uri, "package com.other\nclass ChildDashboardViewModel");
+
+        // Short prefix (2 chars): substring allowed, cross-pkg fires.
+        let (short, _) = complete_symbol(&idx, "Ch", None, &cur_uri, false);
+        assert!(short.iter().any(|i| i.label == "ChildDashboardViewModel"),
+            "cross-pkg must appear for short prefix");
+
+        // Long prefix (5 chars): substring suppressed for tier-0/1 — cross-pkg prefix match wins.
+        let (long, _) = complete_symbol(&idx, "Child", None, &cur_uri, false);
+        assert!(long.iter().any(|i| i.label == "ChildDashboardViewModel"),
+            "cross-pkg prefix match must survive long prefix even with many same-pkg substring hits");
+        // Same-pkg substring hits (Something*Child) must be absent for long prefix.
+        assert!(!long.iter().any(|i| i.label.ends_with("Child") && i.label.starts_with("Something")),
+            "same-pkg substring matches must be filtered for long prefix");
+    }
+
+    #[test]
+    fn is_screaming_snake_cases() {
+        assert!(is_screaming_snake("MAX_SIZE"));
+        assert!(is_screaming_snake("CHILD_DASHBOARD_MAX"));
+        assert!(is_screaming_snake("A"));
+        assert!(!is_screaming_snake("ChildDashboard"));
+        assert!(!is_screaming_snake("maxSize"));
+        assert!(!is_screaming_snake("_"));      // no letters
+        assert!(!is_screaming_snake("123"));    // no letters
     }
 
     #[test]

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -80,7 +80,7 @@ pub(crate) fn import_insertion_line(lines: &[String]) -> u32 {
 }
 
 /// Build a TextEdit that inserts `import {fqn}\n` at the correct position.
-pub(crate) fn make_import_edit(fqn: &str, lines: &[String]) -> TextEdit {
+pub(crate) fn make_import_edit(fqn: &str, lines: &[String], needs_semicolon: bool) -> TextEdit {
     let line = import_insertion_line(lines);
     // When inserting right after the package line (no existing imports), add a blank line.
     let needs_blank = line > 0
@@ -88,10 +88,11 @@ pub(crate) fn make_import_edit(fqn: &str, lines: &[String]) -> TextEdit {
             .map(|l| l.trim_start().starts_with("package "))
             .unwrap_or(false)
         && lines.get(line as usize).map(|l| !l.trim().is_empty()).unwrap_or(false);
+    let stmt = if needs_semicolon { format!("import {fqn};") } else { format!("import {fqn}") };
     let new_text = if needs_blank {
-        format!("\nimport {fqn}\n")
+        format!("\n{stmt}\n")
     } else {
-        format!("import {fqn}\n")
+        format!("{stmt}\n")
     };
     TextEdit {
         range: Range {
@@ -523,6 +524,7 @@ fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippets: bool, an
     //    prefix/acronym matches only (max_score=1) — no substring flood.
     // Emits one CompletionItem per distinct FQN, with additionalTextEdits for auto-import.
     if !lowercase_mode && prefix.len() >= 2 {
+        let is_java = from_uri.as_str().ends_with(".java");
         // Prefer live_lines (updated on every keystroke) over the indexed snapshot so that
         // import deduplication and insertion position are based on the current buffer state.
         let live = idx.live_lines.get(from_uri.as_str()).map(|ll| ll.clone());
@@ -585,7 +587,7 @@ fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippets: bool, an
                     if !seen.insert(item_key) { continue; }
 
                     let import_edit = if needs_import {
-                        Some(vec![make_import_edit(fqn, &cur_lines)])
+                        Some(vec![make_import_edit(fqn, &cur_lines, is_java)])
                     } else {
                         None
                     };

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -523,9 +523,25 @@ fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippets: bool, an
     //    prefix/acronym matches only (max_score=1) — no substring flood.
     // Emits one CompletionItem per distinct FQN, with additionalTextEdits for auto-import.
     if !lowercase_mode && prefix.len() >= 2 {
+        // Prefer live_lines (updated on every keystroke) over the indexed snapshot so that
+        // import deduplication and insertion position are based on the current buffer state.
+        let live = idx.live_lines.get(from_uri.as_str()).map(|ll| ll.clone());
         let (cur_imports, cur_pkg, cur_lines) = idx.files.get(from_uri.as_str())
-            .map(|f| (f.imports.clone(), f.package.clone().unwrap_or_default(), f.lines.clone()))
-            .unwrap_or_default();
+            .map(|f| {
+                let lines = live.clone().unwrap_or_else(|| f.lines.clone());
+                // Re-scan live lines for imports so we don't use a stale snapshot.
+                let imports = if live.is_some() {
+                    crate::parser::parse_imports_from_lines(&lines)
+                } else {
+                    f.imports.clone()
+                };
+                (imports, f.package.clone().unwrap_or_default(), lines)
+            })
+            .unwrap_or_else(|| {
+                let lines = live.clone().unwrap_or_default();
+                let imports = crate::parser::parse_imports_from_lines(&lines);
+                (imports, String::new(), lines)
+            });
 
         if let Ok(cache) = idx.bare_name_cache.read() {
             for name in cache.iter() {


### PR DESCRIPTION
## Summary

This PR adds **auto-import completion** (cross-package symbols with automatic import insertion), improves **completion relevance scoring**, and fixes a **warm-start race condition** that prevented symbols from appearing until a file was manually visited.

---

## Auto-import completion (tier-2 cross-package)

When you type a CamelCase prefix and there's a matching class/object in another package, the completion item now includes an `additionalTextEdit` that inserts the correct `import` statement automatically.

- `importable_fqns` index on `Indexer` for O(1) FQN lookup per symbol
- `fqns_for_name` / `already_imported` helpers avoid duplicate imports
- `make_import_edit` inserts `import pkg.Symbol` after the last existing import block (or at top of file)
- Tier-2 loop in `complete_bare` emits items with `additionalTextEdits`

## Completion relevance scoring

- **`is_screaming_snake()`** — filters `SCREAMING_SNAKE_CASE` constants/enum variants when the user types a CamelCase prefix (`camel_mode`)
- **`local_max_score`** — for prefixes ≥ 4 chars, tier-0/1 (local + same-package) results are capped at prefix/acronym matches only (score ≤ 1). This prevents noisy substring hits from filling the 150-item cap before precise cross-package hits (e.g. typing `ChildDash` now surfaces `ChildDashboardViewModel`)

## Workspace stability (warm-start race fix)

**Root cause**: When an editor sends `didOpen` for a file during the initial warm-start indexing run, the old code could trigger a root switch → increment `root_generation` → abort the in-progress indexer → spawn a replacement that was immediately rejected (`indexing_in_progress=true`). End result: no full index, symbols only loaded when files were individually visited.

**Fixes**:
- `workspace_pinned` now set when editor provides `rootUri` (not only on `KOTLIN_LSP_WORKSPACE_ROOT` env var). The editor knows the project; `didOpen` auto-detection is bypassed entirely.
- Canonical path comparison in `did_open`: same root via different symlink/path forms no longer triggers a reindex
- `set_live_lines` called synchronously on `didOpen` (before async parse) so completion works on current buffer content immediately
- `isIncomplete=true` while `indexing_in_progress`, so clients keep re-querying instead of caching empty results during warm-start

---

## Testing

- 344 existing tests pass (`cargo test`)
- Manually verified on Android repo: `ChildDashboardViewModel` now appears in completion after warm-start without visiting the file