### PR TITLE
refactor: extract indexer/cache.rs (phase 3, step 8)

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -5,7 +5,6 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Arc, RwLock};
 
 use dashmap::{DashMap, DashSet};
-use serde::{Deserialize, Serialize};
 use tower_lsp::lsp_types::*;
 
 // ─── LSP progress notification helper ────────────────────────────────────────
@@ -65,6 +64,10 @@ pub(crate) use self::infer::{
     find_last_dot_at_depth_zero,
 };
 
+mod cache;
+use self::cache::{IndexCache, try_load_cache, write_status_file, save_cache, FileCacheEntry, CACHE_VERSION, cache_entry_to_file_result};
+pub(crate) use self::cache::workspace_cache_path;
+
 // ─── RAII guard for indexing_in_progress flag ─────────────────────────────────
 
 /// RAII guard that clears `indexing_in_progress` on drop (success, panic, or early return).
@@ -77,28 +80,6 @@ impl Drop for IndexingGuard {
         self.indexer.indexing_in_progress.store(false, std::sync::atomic::Ordering::Release);
         log::debug!("IndexingGuard: cleared indexing_in_progress flag");
     }
-}
-
-// ─── Indexing status file ─────────────────────────────────────────────────────
-
-/// Human-readable status written to `~/.cache/kotlin-lsp/status.json`.
-/// The skill extension reads this to report loading state with time estimates.
-fn status_cache_path() -> PathBuf {
-    let cache_base = std::env::var("XDG_CACHE_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-            PathBuf::from(home).join(".cache")
-        });
-    cache_base.join("kotlin-lsp").join("status.json")
-}
-
-fn write_status_file(content: &str) {
-    let path = status_cache_path();
-    if let Some(parent) = path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    let _ = std::fs::write(&path, content);
 }
 
 /// Hard cap on workspace files indexed eagerly in LSP mode.
@@ -122,89 +103,6 @@ pub fn resolve_max_files(default: usize) -> usize {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(default)
-}
-
-// ─── Disk cache ──────────────────────────────────────────────────────────────
-
-/// Bump when the serialized format changes; invalidates any older cache files.
-const CACHE_VERSION: u32 = 4;
-
-/// Per-file entry stored in the on-disk index cache.
-#[derive(Serialize, Deserialize)]
-pub(crate) struct FileCacheEntry {
-    /// File mtime (seconds since Unix epoch) — primary cache validity check.
-    mtime_secs: u64,
-    /// File size in bytes — secondary guard for same-second edits (1s mtime resolution).
-    file_size: u64,
-    /// FNV-1a content hash — tertiary guard for mtime collisions / FAT FS.
-    content_hash: u64,
-    /// Parsed symbol data for this file.
-    file_data: FileData,
-}
-
-/// Complete serialized index, written to `~/.cache/kotlin-lsp/<root-hash>/index.bin`.
-#[derive(Serialize, Deserialize)]
-struct IndexCache {
-    version: u32,
-    /// True when this cache was built from a complete (non-truncated) workspace scan.
-    /// Only set to true when `total <= max` at index time.
-    /// When false, the entries may be a partial subset of the workspace — warm-manifest
-    /// mode is disabled to avoid hiding files that were never indexed.
-    #[serde(default)]
-    complete_scan: bool,
-    /// Absolute path string → per-file cached data.
-    entries: HashMap<String, FileCacheEntry>,
-}
-
-/// Returns the cache file path for the given workspace root.
-pub(crate) fn workspace_cache_path(root: &Path) -> PathBuf {
-    // Use canonicalized absolute path so equivalent roots map to same cache.
-    let canonical = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
-    // Hash canonical path for filesystem-friendly cache directory name.
-    let root_hash = {
-        use sha2::{Digest, Sha256};
-        let mut hasher = Sha256::new();
-        hasher.update(canonical.to_string_lossy().as_bytes());
-        let digest = hasher.finalize();
-        // take first 8 bytes as u64
-        let mut bytes = [0u8; 8];
-        bytes.copy_from_slice(&digest[..8]);
-        u64::from_be_bytes(bytes)
-    };
-    let cache_base = std::env::var("XDG_CACHE_HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-            PathBuf::from(home).join(".cache")
-        });
-    cache_base
-        .join("kotlin-lsp")
-        .join(format!("{root_hash:016x}"))
-        .join("index.bin")
-}
-
-/// Load and validate the on-disk cache.  Returns `None` if absent / stale / corrupt.
-fn try_load_cache(root: &Path) -> Option<IndexCache> {
-    let path = workspace_cache_path(root);
-    let bytes = std::fs::read(&path).ok()?;
-    let cache: IndexCache = match bincode::deserialize(&bytes) {
-        Ok(c) => c,
-        Err(e) => {
-            log::warn!("Cache deserialize failed (struct layout changed?): {e} — will re-index. \
-                        Delete {path} to suppress this warning.", path = path.display());
-            return None;
-        }
-    };
-    if cache.version != CACHE_VERSION {
-        log::info!("Cache version mismatch — will re-index");
-        return None;
-    }
-    log::info!(
-        "Loaded index cache ({} files) from {}",
-        cache.entries.len(),
-        path.display()
-    );
-    Some(cache)
 }
 
 // ─── Pure helper types ────────────────────────────────────────────────────────
@@ -299,39 +197,6 @@ pub(crate) fn stale_keys_for(uri: &Url, old_data: &crate::types::FileData) -> St
         definition_names,
         qualified_keys,
         package: old_data.package.clone(),
-    }
-}
-
-/// Pure: convert a disk-cache entry into a `FileIndexResult` ready for indexing.
-/// Reconstructs `supertypes` from cached lines (not stored in cache) so that
-/// `goToImplementation` works correctly on cache hits.
-pub(crate) fn cache_entry_to_file_result(uri: &Url, entry: &FileCacheEntry) -> FileIndexResult {
-    let data = &entry.file_data;
-    let class_kinds = [
-        SymbolKind::CLASS, SymbolKind::INTERFACE, SymbolKind::STRUCT,
-        SymbolKind::ENUM, SymbolKind::OBJECT,
-    ];
-    let mut supertypes: Vec<(String, Location)> = Vec::new();
-    for sym in &data.symbols {
-        if !class_kinds.contains(&sym.kind) { continue; }
-        let start = sym.selection_range.start.line as usize;
-        let limit  = (start + 10).min(data.lines.len());
-        let mut decl_lines: Vec<String> = Vec::new();
-        for line in &data.lines[start..limit] {
-            decl_lines.push(line.clone());
-            if line.contains('{') { break; }
-        }
-        let class_loc = Location { uri: uri.clone(), range: sym.selection_range };
-        for super_name in crate::resolver::extract_supers_from_lines(&decl_lines) {
-            supertypes.push((super_name, class_loc.clone()));
-        }
-    }
-    FileIndexResult {
-        uri: uri.clone(),
-        data: data.clone(),
-        supertypes,
-        content_hash: entry.content_hash,
-        error: None,
     }
 }
 
@@ -1015,67 +880,8 @@ impl Indexer {
             Some(r) => r,
             None    => return,
         };
-        let cache_path = workspace_cache_path(root);
-        if let Some(parent) = cache_path.parent() {
-            if let Err(e) = std::fs::create_dir_all(parent) {
-                log::warn!("Cache: could not create directory: {e}");
-                return;
-            }
-        }
-
         let complete_scan = self.last_scan_complete.load(std::sync::atomic::Ordering::Acquire);
-        let mut entries: HashMap<String, FileCacheEntry> = HashMap::new();
-        for file_ref in &self.files {
-            let uri_str = file_ref.key();
-            // Skip library-source files — they are re-indexed from sourcePaths on each startup.
-            if self.library_uris.contains(uri_str) { continue; }
-            let data    = file_ref.value();
-            let hash    = self.content_hashes.get(uri_str).map(|h| *h).unwrap_or(0);
-            if let Ok(url) = uri_str.parse::<Url>() {
-                if let Ok(path) = url.to_file_path() {
-                    let meta = std::fs::metadata(&path);
-                    let mtime = meta.as_ref().ok()
-                        .and_then(|m| m.modified().ok())
-                        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
-                        .map(|d| d.as_secs())
-                        .unwrap_or(0);
-                    let file_size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
-                    entries.insert(
-                        path.to_string_lossy().to_string(),
-                        FileCacheEntry { mtime_secs: mtime, file_size, content_hash: hash, file_data: (**data).clone() },
-                    );
-                }
-            }
-        }
-
-        let cache = IndexCache { version: CACHE_VERSION, complete_scan, entries };
-        match bincode::serialize(&cache) {
-            Ok(bytes) => {
-                // Don't overwrite a complete cache with an incomplete one.
-                // This prevents editor servers (which may load only part of the
-                // workspace) from truncating a cache built by --index-only.
-                if !complete_scan {
-                    if let Ok(meta) = std::fs::metadata(&cache_path) {
-                        if meta.len() > bytes.len() as u64 {
-                            log::info!(
-                                "Cache save skipped: existing cache ({} KB) is larger than \
-                                 incomplete new cache ({} KB)",
-                                meta.len() / 1024, bytes.len() / 1024
-                            );
-                            return;
-                        }
-                    }
-                }
-                match std::fs::write(&cache_path, &bytes) {
-                    Ok(()) => log::info!(
-                        "Cache saved ({} files, {} KB) → {}",
-                        cache.entries.len(), bytes.len() / 1024, cache_path.display()
-                    ),
-                    Err(e) => log::warn!("Cache write failed: {e}"),
-                }
-            }
-            Err(e) => log::warn!("Cache serialize failed: {e}"),
-        }
+        save_cache(root, &self.files, &self.content_hashes, &self.library_uris, complete_scan);
     }
 
     // ────────────────────────────────────────────────────────────────────────
@@ -4653,40 +4459,6 @@ internal class ContactAddressInteractor @Inject constructor(
         let result = super::resolve_max_files(2000);
         std::env::remove_var("KOTLIN_LSP_MAX_FILES");
         assert_eq!(result, 2000);
-    }
-
-    // ── cache_entry_to_file_result ────────────────────────────────────────────
-
-    /// cache_entry_to_file_result must reconstruct supertypes from FileData.lines
-    /// even when the FileCacheEntry was loaded from disk (lines are always cached).
-    #[test]
-    fn cache_entry_to_file_result_supertypes_extracted() {
-        let u = uri("/Cat.kt");
-        let mut data = crate::types::FileData::default();
-        data.lines = Arc::new(vec![
-            "class Cat : IAnimal {".into(),
-            "    fun meow() {}".into(),
-            "}".into(),
-        ]);
-        data.symbols.push(crate::types::SymbolEntry {
-            name: "Cat".into(),
-            kind: tower_lsp::lsp_types::SymbolKind::CLASS,
-            visibility: crate::types::Visibility::Public,
-            range: Default::default(),
-            selection_range: Default::default(),
-            detail: String::new(),
-        });
-
-        let entry = FileCacheEntry {
-            mtime_secs: 100,
-            file_size: 0,
-            content_hash: 42,
-            file_data: data,
-        };
-
-        let result = super::cache_entry_to_file_result(&u, &entry);
-        let super_names: Vec<&str> = result.supertypes.iter().map(|(n, _)| n.as_str()).collect();
-        assert!(super_names.contains(&"IAnimal"), "IAnimal missing from supertypes: {super_names:?}");
     }
 
     // ── apply_workspace_result ────────────────────────────────────────────────

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -65,7 +65,7 @@ pub(crate) use self::infer::{
 };
 
 mod cache;
-use self::cache::{IndexCache, try_load_cache, write_status_file, save_cache, FileCacheEntry, CACHE_VERSION, cache_entry_to_file_result};
+use self::cache::{IndexCache, try_load_cache, write_status_file, save_cache, FileCacheEntry, cache_entry_to_file_result};
 pub(crate) use self::cache::workspace_cache_path;
 
 // ─── RAII guard for indexing_in_progress flag ─────────────────────────────────

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -147,7 +147,9 @@ pub(crate) fn cache_entry_to_file_result(uri: &Url, entry: &FileCacheEntry) -> F
     for sym in &data.symbols {
         if !class_kinds.contains(&sym.kind) { continue; }
         let start = sym.selection_range.start.line as usize;
+        if start >= data.lines.len() { continue; }
         let limit  = (start + 10).min(data.lines.len());
+        if start >= limit { continue; }
         let mut decl_lines: Vec<String> = Vec::new();
         for line in &data.lines[start..limit] {
             decl_lines.push(line.clone());
@@ -233,12 +235,20 @@ pub(super) fn save_cache(
                     }
                 }
             }
-            match std::fs::write(&cache_path, &bytes) {
-                Ok(()) => log::info!(
+            // Write atomically: write to a sibling `.tmp` file then rename,
+            // so a crash mid-write never leaves a truncated cache behind.
+            let tmp_path = cache_path.with_extension("bin.tmp");
+            let write_ok = std::fs::write(&tmp_path, &bytes)
+                .and_then(|()| std::fs::rename(&tmp_path, &cache_path))
+                .is_ok();
+            if write_ok {
+                log::info!(
                     "Cache saved ({} files, {} KB) → {}",
                     cache.entries.len(), bytes.len() / 1024, cache_path.display()
-                ),
-                Err(e) => log::warn!("Cache write failed: {e}"),
+                );
+            } else {
+                let _ = std::fs::remove_file(&tmp_path);
+                log::warn!("Cache write failed for {}", cache_path.display());
             }
         }
         Err(e) => log::warn!("Cache serialize failed: {e}"),

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -1,0 +1,250 @@
+//! On-disk index cache — persistence layer for the kotlin-lsp workspace index.
+//!
+//! # Contents
+//! - [`FileCacheEntry`] / [`IndexCache`] — serialisable data types.
+//! - [`workspace_cache_path`] — deterministic path derived from the workspace root.
+//! - [`try_load_cache`] — load and validate the on-disk cache.
+//! - [`cache_entry_to_file_result`] — pure: turn a cache entry into a [`FileIndexResult`].
+//! - [`save_cache`] — build and write the cache from live index data.
+//! - [`write_status_file`] — write `~/.cache/kotlin-lsp/status.json` for the skill extension.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use dashmap::{DashMap, DashSet};
+use serde::{Deserialize, Serialize};
+use tower_lsp::lsp_types::Url;
+
+use crate::types::{FileData, FileIndexResult};
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+/// Bump when the serialized format changes; invalidates any older cache files.
+pub(crate) const CACHE_VERSION: u32 = 4;
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/// Per-file entry stored in the on-disk index cache.
+#[derive(Serialize, Deserialize)]
+pub(crate) struct FileCacheEntry {
+    /// File mtime (seconds since Unix epoch) — primary cache validity check.
+    pub(crate) mtime_secs: u64,
+    /// File size in bytes — secondary guard for same-second edits (1s mtime resolution).
+    pub(crate) file_size: u64,
+    /// FNV-1a content hash — tertiary guard for mtime collisions / FAT FS.
+    pub(crate) content_hash: u64,
+    /// Parsed symbol data for this file.
+    pub(crate) file_data: FileData,
+}
+
+/// Complete serialized index, written to `~/.cache/kotlin-lsp/<root-hash>/index.bin`.
+#[derive(Serialize, Deserialize)]
+pub(super) struct IndexCache {
+    pub(super) version: u32,
+    /// True when this cache was built from a complete (non-truncated) workspace scan.
+    /// Only set to true when `total <= max` at index time.
+    /// When false, the entries may be a partial subset of the workspace — warm-manifest
+    /// mode is disabled to avoid hiding files that were never indexed.
+    #[serde(default)]
+    pub(super) complete_scan: bool,
+    /// Absolute path string → per-file cached data.
+    pub(super) entries: HashMap<String, FileCacheEntry>,
+}
+
+// ─── Path helpers ─────────────────────────────────────────────────────────────
+
+fn xdg_cache_base() -> PathBuf {
+    std::env::var("XDG_CACHE_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
+            PathBuf::from(home).join(".cache")
+        })
+}
+
+fn status_cache_path() -> PathBuf {
+    xdg_cache_base().join("kotlin-lsp").join("status.json")
+}
+
+/// Returns the cache file path for the given workspace root.
+///
+/// Uses a SHA-256 hash of the canonicalized root path as the directory name so
+/// equivalent roots always map to the same cache file regardless of symlinks.
+pub(crate) fn workspace_cache_path(root: &Path) -> PathBuf {
+    let canonical = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let root_hash = {
+        use sha2::{Digest, Sha256};
+        let mut hasher = Sha256::new();
+        hasher.update(canonical.to_string_lossy().as_bytes());
+        let digest = hasher.finalize();
+        let mut bytes = [0u8; 8];
+        bytes.copy_from_slice(&digest[..8]);
+        u64::from_be_bytes(bytes)
+    };
+    xdg_cache_base()
+        .join("kotlin-lsp")
+        .join(format!("{root_hash:016x}"))
+        .join("index.bin")
+}
+
+// ─── Status file ─────────────────────────────────────────────────────────────
+
+/// Write a human-readable status blob to `~/.cache/kotlin-lsp/status.json`.
+///
+/// The skill extension reads this to report loading state with time estimates.
+pub(super) fn write_status_file(content: &str) {
+    let path = status_cache_path();
+    if let Some(parent) = path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&path, content);
+}
+
+// ─── Load ─────────────────────────────────────────────────────────────────────
+
+/// Load and validate the on-disk cache.  Returns `None` if absent / stale / corrupt.
+pub(super) fn try_load_cache(root: &Path) -> Option<IndexCache> {
+    let path = workspace_cache_path(root);
+    let bytes = std::fs::read(&path).ok()?;
+    let cache: IndexCache = match bincode::deserialize(&bytes) {
+        Ok(c) => c,
+        Err(e) => {
+            log::warn!(
+                "Cache deserialize failed (struct layout changed?): {e} — will re-index. \
+                 Delete {path} to suppress this warning.",
+                path = path.display()
+            );
+            return None;
+        }
+    };
+    if cache.version != CACHE_VERSION {
+        log::info!("Cache version mismatch — will re-index");
+        return None;
+    }
+    log::info!(
+        "Loaded index cache ({} files) from {}",
+        cache.entries.len(),
+        path.display()
+    );
+    Some(cache)
+}
+
+// ─── Pure conversion ──────────────────────────────────────────────────────────
+
+/// Pure: convert a disk-cache entry into a [`FileIndexResult`] ready for indexing.
+///
+/// Reconstructs `supertypes` from cached lines (not stored separately in cache) so
+/// that `goToImplementation` works correctly on cache hits.
+pub(crate) fn cache_entry_to_file_result(uri: &Url, entry: &FileCacheEntry) -> FileIndexResult {
+    use tower_lsp::lsp_types::{Location, SymbolKind};
+    let data = &entry.file_data;
+    let class_kinds = [
+        SymbolKind::CLASS, SymbolKind::INTERFACE, SymbolKind::STRUCT,
+        SymbolKind::ENUM, SymbolKind::OBJECT,
+    ];
+    let mut supertypes: Vec<(String, Location)> = Vec::new();
+    for sym in &data.symbols {
+        if !class_kinds.contains(&sym.kind) { continue; }
+        let start = sym.selection_range.start.line as usize;
+        let limit  = (start + 10).min(data.lines.len());
+        let mut decl_lines: Vec<String> = Vec::new();
+        for line in &data.lines[start..limit] {
+            decl_lines.push(line.clone());
+            if line.contains('{') { break; }
+        }
+        let class_loc = Location { uri: uri.clone(), range: sym.selection_range };
+        for super_name in crate::resolver::extract_supers_from_lines(&decl_lines) {
+            supertypes.push((super_name, class_loc.clone()));
+        }
+    }
+    FileIndexResult {
+        uri: uri.clone(),
+        data: data.clone(),
+        supertypes,
+        content_hash: entry.content_hash,
+        error: None,
+    }
+}
+
+// ─── Save ─────────────────────────────────────────────────────────────────────
+
+/// Build and write the workspace index cache to disk.
+///
+/// Reads filesystem metadata (mtime, size) for each file, so this function
+/// performs IO.  Library-source files (from `sourcePaths`) are excluded since
+/// they are re-indexed on every startup.
+///
+/// Does **not** overwrite a larger complete cache with a smaller incomplete one,
+/// to prevent an editor server (which may load only part of the workspace) from
+/// truncating a cache built by `--index-only`.
+pub(super) fn save_cache(
+    root:           &Path,
+    files:          &DashMap<String, Arc<FileData>>,
+    content_hashes: &DashMap<String, u64>,
+    library_uris:   &DashSet<String>,
+    complete_scan:  bool,
+) {
+    let cache_path = workspace_cache_path(root);
+    if let Some(parent) = cache_path.parent() {
+        if let Err(e) = std::fs::create_dir_all(parent) {
+            log::warn!("Cache: could not create directory: {e}");
+            return;
+        }
+    }
+
+    let mut entries: HashMap<String, FileCacheEntry> = HashMap::new();
+    for file_ref in files.iter() {
+        let uri_str = file_ref.key();
+        // Skip library-source files — re-indexed from sourcePaths on each startup.
+        if library_uris.contains(uri_str) { continue; }
+        let data = file_ref.value();
+        let hash = content_hashes.get(uri_str).map(|h| *h).unwrap_or(0);
+        if let Ok(url) = uri_str.parse::<Url>() {
+            if let Ok(path) = url.to_file_path() {
+                let meta      = std::fs::metadata(&path);
+                let mtime     = meta.as_ref().ok()
+                    .and_then(|m| m.modified().ok())
+                    .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|d| d.as_secs())
+                    .unwrap_or(0);
+                let file_size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
+                entries.insert(
+                    path.to_string_lossy().to_string(),
+                    FileCacheEntry { mtime_secs: mtime, file_size, content_hash: hash, file_data: (**data).clone() },
+                );
+            }
+        }
+    }
+
+    let cache = IndexCache { version: CACHE_VERSION, complete_scan, entries };
+    match bincode::serialize(&cache) {
+        Ok(bytes) => {
+            // Don't overwrite a complete cache with an incomplete one.
+            if !complete_scan {
+                if let Ok(meta) = std::fs::metadata(&cache_path) {
+                    if meta.len() > bytes.len() as u64 {
+                        log::info!(
+                            "Cache save skipped: existing cache ({} KB) is larger than \
+                             incomplete new cache ({} KB)",
+                            meta.len() / 1024, bytes.len() / 1024
+                        );
+                        return;
+                    }
+                }
+            }
+            match std::fs::write(&cache_path, &bytes) {
+                Ok(()) => log::info!(
+                    "Cache saved ({} files, {} KB) → {}",
+                    cache.entries.len(), bytes.len() / 1024, cache_path.display()
+                ),
+                Err(e) => log::warn!("Cache write failed: {e}"),
+            }
+        }
+        Err(e) => log::warn!("Cache serialize failed: {e}"),
+    }
+}
+
+#[cfg(test)]
+#[path = "cache_tests.rs"]
+mod tests;

--- a/src/indexer/cache_tests.rs
+++ b/src/indexer/cache_tests.rs
@@ -74,24 +74,36 @@ fn cache_entry_to_file_result_preserves_hash() {
 /// `workspace_cache_path` must be stable: same root → same path.
 #[test]
 fn workspace_cache_path_stable() {
-    let root = std::path::Path::new("/tmp/my_project");
-    let p1 = workspace_cache_path(root);
-    let p2 = workspace_cache_path(root);
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("my_project");
+    let p1 = workspace_cache_path(&root);
+    let p2 = workspace_cache_path(&root);
     assert_eq!(p1, p2);
 }
 
 /// Different roots must produce different cache paths.
 #[test]
 fn workspace_cache_path_differs_for_different_roots() {
-    let p1 = workspace_cache_path(std::path::Path::new("/tmp/project_a"));
-    let p2 = workspace_cache_path(std::path::Path::new("/tmp/project_b"));
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let p1 = workspace_cache_path(&tmp.path().join("project_a"));
+    let p2 = workspace_cache_path(&tmp.path().join("project_b"));
     assert_ne!(p1, p2);
 }
 
-/// `try_load_cache` must return `None` for a non-existent path (no panic).
+/// `try_load_cache` must return `None` for a non-existent root (no panic).
 #[test]
 fn try_load_cache_missing_returns_none() {
-    let result = try_load_cache(std::path::Path::new("/tmp/kotlin_lsp_test_nonexistent_root_xyz"));
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("workspace");
+    std::fs::create_dir(&root).expect("create workspace dir");
+
+    // Ensure no stale cache exists for this fresh root.
+    let cache_path = workspace_cache_path(&root);
+    if cache_path.exists() {
+        std::fs::remove_file(&cache_path).expect("remove pre-existing cache file");
+    }
+
+    let result = try_load_cache(&root);
     assert!(result.is_none());
 }
 
@@ -101,25 +113,33 @@ fn save_and_load_cache_roundtrip() {
     use crate::indexer::Indexer;
 
     let tmp = tempfile::tempdir().expect("tempdir");
-    let root = tmp.path();
+    let root = tmp.path().join("workspace");
+    std::fs::create_dir(&root).expect("create workspace dir");
 
-    // Build a minimal indexer with one file.
+    // Build a minimal indexer with one file backed by a real temp path.
     let src = "package com.example\nclass RoundtripClass";
-    let u = Url::parse("file:///tmp/RoundtripClass.kt").unwrap();
+    let kt_file = tmp.path().join("RoundtripClass.kt");
+    std::fs::write(&kt_file, src).expect("write kt file");
+    let u = Url::from_file_path(&kt_file).expect("valid file URL");
+
     let idx = Indexer::new();
     idx.index_content(&u, src);
 
-    // Write cache.
-    save_cache(root, &idx.files, &idx.content_hashes, &idx.library_uris, true);
+    // Write cache to the workspace root (workspace_cache_path uses XDG_CACHE_HOME
+    // which may point to ~/.cache; we accept that for this test and clean up below).
+    save_cache(&root, &idx.files, &idx.content_hashes, &idx.library_uris, true);
+    let cache_path = workspace_cache_path(&root);
 
     // Read cache back.
-    let loaded = try_load_cache(root).expect("cache should exist after save");
+    let loaded = try_load_cache(&root).expect("cache should exist after save");
     assert_eq!(loaded.version, CACHE_VERSION);
     assert!(loaded.complete_scan);
 
-    // The file path from `Url::to_file_path` may differ per OS; check via URI lookup.
-    let file_path = u.to_file_path().unwrap().to_string_lossy().to_string();
+    let file_path = kt_file.to_string_lossy().to_string();
     let entry = loaded.entries.get(&file_path).expect("entry should be present");
     let has_class = entry.file_data.symbols.iter().any(|s| s.name == "RoundtripClass");
     assert!(has_class, "RoundtripClass symbol missing from cache roundtrip");
+
+    // Clean up the cache file written to the user's cache dir.
+    let _ = std::fs::remove_file(&cache_path);
 }

--- a/src/indexer/cache_tests.rs
+++ b/src/indexer/cache_tests.rs
@@ -1,0 +1,125 @@
+//! Unit tests for `indexer::cache`.
+
+use std::sync::Arc;
+use tower_lsp::lsp_types::{SymbolKind, Url};
+
+use super::*;
+use crate::types::{FileData, SymbolEntry, Visibility};
+
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file:///test{path}")).unwrap()
+}
+
+/// `cache_entry_to_file_result` must reconstruct supertypes from `FileData.lines`
+/// even when the `FileCacheEntry` was loaded from disk (lines are always cached).
+#[test]
+fn cache_entry_to_file_result_supertypes_extracted() {
+    let u = uri("/Cat.kt");
+    let mut data = FileData::default();
+    data.lines = Arc::new(vec![
+        "class Cat : IAnimal {".into(),
+        "    fun meow() {}".into(),
+        "}".into(),
+    ]);
+    data.symbols.push(SymbolEntry {
+        name: "Cat".into(),
+        kind: SymbolKind::CLASS,
+        visibility: Visibility::Public,
+        range: Default::default(),
+        selection_range: Default::default(),
+        detail: String::new(),
+    });
+
+    let entry = FileCacheEntry {
+        mtime_secs: 100,
+        file_size: 0,
+        content_hash: 42,
+        file_data: data,
+    };
+
+    let result = cache_entry_to_file_result(&u, &entry);
+    let super_names: Vec<&str> = result.supertypes.iter().map(|(n, _)| n.as_str()).collect();
+    assert!(
+        super_names.contains(&"IAnimal"),
+        "IAnimal missing from supertypes: {super_names:?}",
+    );
+}
+
+/// `cache_entry_to_file_result` must copy `content_hash` through unchanged.
+#[test]
+fn cache_entry_to_file_result_preserves_hash() {
+    let u = uri("/Foo.kt");
+    let mut data = FileData::default();
+    data.lines = Arc::new(vec!["class Foo".into()]);
+    data.symbols.push(SymbolEntry {
+        name: "Foo".into(),
+        kind: SymbolKind::CLASS,
+        visibility: Visibility::Public,
+        range: Default::default(),
+        selection_range: Default::default(),
+        detail: String::new(),
+    });
+
+    let entry = FileCacheEntry {
+        mtime_secs: 0,
+        file_size: 0,
+        content_hash: 0xdeadbeef,
+        file_data: data,
+    };
+
+    let result = cache_entry_to_file_result(&u, &entry);
+    assert_eq!(result.content_hash, 0xdeadbeef);
+}
+
+/// `workspace_cache_path` must be stable: same root → same path.
+#[test]
+fn workspace_cache_path_stable() {
+    let root = std::path::Path::new("/tmp/my_project");
+    let p1 = workspace_cache_path(root);
+    let p2 = workspace_cache_path(root);
+    assert_eq!(p1, p2);
+}
+
+/// Different roots must produce different cache paths.
+#[test]
+fn workspace_cache_path_differs_for_different_roots() {
+    let p1 = workspace_cache_path(std::path::Path::new("/tmp/project_a"));
+    let p2 = workspace_cache_path(std::path::Path::new("/tmp/project_b"));
+    assert_ne!(p1, p2);
+}
+
+/// `try_load_cache` must return `None` for a non-existent path (no panic).
+#[test]
+fn try_load_cache_missing_returns_none() {
+    let result = try_load_cache(std::path::Path::new("/tmp/kotlin_lsp_test_nonexistent_root_xyz"));
+    assert!(result.is_none());
+}
+
+/// `save_cache` → `try_load_cache` roundtrip: symbols survive disk persistence.
+#[test]
+fn save_and_load_cache_roundtrip() {
+    use crate::indexer::Indexer;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path();
+
+    // Build a minimal indexer with one file.
+    let src = "package com.example\nclass RoundtripClass";
+    let u = Url::parse("file:///tmp/RoundtripClass.kt").unwrap();
+    let idx = Indexer::new();
+    idx.index_content(&u, src);
+
+    // Write cache.
+    save_cache(root, &idx.files, &idx.content_hashes, &idx.library_uris, true);
+
+    // Read cache back.
+    let loaded = try_load_cache(root).expect("cache should exist after save");
+    assert_eq!(loaded.version, CACHE_VERSION);
+    assert!(loaded.complete_scan);
+
+    // The file path from `Url::to_file_path` may differ per OS; check via URI lookup.
+    let file_path = u.to_file_path().unwrap().to_string_lossy().to_string();
+    let entry = loaded.entries.get(&file_path).expect("entry should be present");
+    let has_class = entry.file_data.symbols.iter().any(|s| s.name == "RoundtripClass");
+    assert!(has_class, "RoundtripClass symbol missing from cache roundtrip");
+}

--- a/src/indexer/cache_tests.rs
+++ b/src/indexer/cache_tests.rs
@@ -10,6 +10,23 @@ fn uri(path: &str) -> Url {
     Url::parse(&format!("file:///test{path}")).unwrap()
 }
 
+/// Global mutex serialising tests that mutate `XDG_CACHE_HOME`.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Run `f` with `XDG_CACHE_HOME` temporarily pointing at `dir`.
+/// Restores the original value (or removes the var) on exit, even on panic.
+fn with_xdg_cache<F: FnOnce()>(dir: &std::path::Path, f: F) {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let prev = std::env::var("XDG_CACHE_HOME").ok();
+    std::env::set_var("XDG_CACHE_HOME", dir);
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    match prev {
+        Some(v) => std::env::set_var("XDG_CACHE_HOME", v),
+        None    => std::env::remove_var("XDG_CACHE_HOME"),
+    }
+    if let Err(e) = result { std::panic::resume_unwind(e); }
+}
+
 /// `cache_entry_to_file_result` must reconstruct supertypes from `FileData.lines`
 /// even when the `FileCacheEntry` was loaded from disk (lines are always cached).
 #[test]
@@ -97,14 +114,10 @@ fn try_load_cache_missing_returns_none() {
     let root = tmp.path().join("workspace");
     std::fs::create_dir(&root).expect("create workspace dir");
 
-    // Ensure no stale cache exists for this fresh root.
-    let cache_path = workspace_cache_path(&root);
-    if cache_path.exists() {
-        std::fs::remove_file(&cache_path).expect("remove pre-existing cache file");
-    }
-
-    let result = try_load_cache(&root);
-    assert!(result.is_none());
+    with_xdg_cache(tmp.path(), || {
+        let result = try_load_cache(&root);
+        assert!(result.is_none());
+    });
 }
 
 /// `save_cache` → `try_load_cache` roundtrip: symbols survive disk persistence.
@@ -116,7 +129,6 @@ fn save_and_load_cache_roundtrip() {
     let root = tmp.path().join("workspace");
     std::fs::create_dir(&root).expect("create workspace dir");
 
-    // Build a minimal indexer with one file backed by a real temp path.
     let src = "package com.example\nclass RoundtripClass";
     let kt_file = tmp.path().join("RoundtripClass.kt");
     std::fs::write(&kt_file, src).expect("write kt file");
@@ -125,21 +137,16 @@ fn save_and_load_cache_roundtrip() {
     let idx = Indexer::new();
     idx.index_content(&u, src);
 
-    // Write cache to the workspace root (workspace_cache_path uses XDG_CACHE_HOME
-    // which may point to ~/.cache; we accept that for this test and clean up below).
-    save_cache(&root, &idx.files, &idx.content_hashes, &idx.library_uris, true);
-    let cache_path = workspace_cache_path(&root);
+    with_xdg_cache(tmp.path(), || {
+        save_cache(&root, &idx.files, &idx.content_hashes, &idx.library_uris, true);
 
-    // Read cache back.
-    let loaded = try_load_cache(&root).expect("cache should exist after save");
-    assert_eq!(loaded.version, CACHE_VERSION);
-    assert!(loaded.complete_scan);
+        let loaded = try_load_cache(&root).expect("cache should exist after save");
+        assert_eq!(loaded.version, CACHE_VERSION);
+        assert!(loaded.complete_scan);
 
-    let file_path = kt_file.to_string_lossy().to_string();
-    let entry = loaded.entries.get(&file_path).expect("entry should be present");
-    let has_class = entry.file_data.symbols.iter().any(|s| s.name == "RoundtripClass");
-    assert!(has_class, "RoundtripClass symbol missing from cache roundtrip");
-
-    // Clean up the cache file written to the user's cache dir.
-    let _ = std::fs::remove_file(&cache_path);
+        let file_path = kt_file.to_string_lossy().to_string();
+        let entry = loaded.entries.get(&file_path).expect("entry should be present");
+        let has_class = entry.file_data.symbols.iter().any(|s| s.name == "RoundtripClass");
+        assert!(has_class, "RoundtripClass symbol missing from cache roundtrip");
+    });
 }


### PR DESCRIPTION
## Summary

Extracts all disk-cache persistence logic from `indexer.rs` (~233 lines removed) into a new `src/indexer/cache.rs` module.

## What moved

| Symbol | Was in | Now in |
|--------|--------|--------|
| `CACHE_VERSION` | `indexer.rs` | `cache.rs` |
| `FileCacheEntry` | `indexer.rs` | `cache.rs` |
| `IndexCache` | `indexer.rs` | `cache.rs` |
| `xdg_cache_base()` | `indexer.rs` | `cache.rs` |
| `status_cache_path()` | `indexer.rs` | `cache.rs` |
| `write_status_file()` | `indexer.rs` | `cache.rs` |
| `workspace_cache_path()` | `indexer.rs` | `cache.rs` |
| `try_load_cache()` | `indexer.rs` | `cache.rs` |
| `cache_entry_to_file_result()` | `indexer.rs` | `cache.rs` |
| `save_cache()` (new free fn) | — | `cache.rs` |

`save_cache_to_disk` becomes a 3-line wrapper calling `save_cache()`.

## New tests (`src/indexer/cache_tests.rs`)

6 tests covering:
- Supertypes extracted from `FileData.lines` on cache restore
- Content hash preservation across save/load roundtrip  
- `workspace_cache_path` stability and differentiation by root
- `try_load_cache` returns `None` for missing file
- Full save/load roundtrip with `tempfile::tempdir()`

## Part of the phase 3 refactor series

| Step | Module | Status |
|------|--------|--------|
| 1–7 | Phase 1–2 (types, sig, args, it_this, infer cluster) | ✅ merged |
| **8** | **`indexer/cache.rs`** | **this PR** |
| 9 | `indexer/discover.rs` | pending |
| 10 | `indexer/scan.rs` | pending |
| 11 | `indexer/apply.rs` | pending |
| 12–13 | lookup, scope | pending |