### PR TITLE
refactor: replace extract_supers_from_lines with CST-based extraction (phase 5)

### DIFF
--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -214,20 +214,18 @@ impl Backend {
             .unwrap_or_default();
         for loc in &locs {
             if let Some(file) = self.indexer.files.get(loc.uri.as_str()) {
-                let start = loc.range.start.line as usize;
-                let end = (start + 15).min(file.lines.len());
-                let mut decl_lines: Vec<String> = vec![];
-                for line in &file.lines[start..end] {
-                    decl_lines.push(line.clone());
-                    if line.contains('{') { break; }
-                }
-                let names = crate::resolver::extract_supers_from_lines(&decl_lines);
+                let names: Vec<String> = file.supers.iter()
+                    .filter(|(l, _)| *l == loc.range.start.line)
+                    .map(|(_, n)| n.clone())
+                    .collect();
                 if !names.is_empty() { return names; }
             }
         }
-        // Fallback: scan live_lines for the open file itself.
+        // Fallback: parse live_lines for the open file itself.
         if let Some(lines) = self.indexer.live_lines.get(uri.as_str()) {
-            let names = crate::resolver::extract_supers_from_lines(&lines);
+            let content = lines.join("\n");
+            let names: Vec<String> = crate::parser::parse_by_extension(uri.path(), &content)
+                .supers.into_iter().map(|(_, n)| n).collect();
             if !names.is_empty() { return names; }
         }
         vec![]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -714,14 +714,11 @@ class Foo @Inject constructor(
         let locs = idx.definitions.get("Foo").map(|v| v.clone()).unwrap_or_default();
         assert!(!locs.is_empty(), "Foo must be in definitions");
         let file = idx.files.get(locs[0].uri.as_str()).unwrap();
-        let start = locs[0].range.start.line as usize;
-        let end = (start + 10).min(file.lines.len());
-        let mut decl_lines: Vec<String> = vec![];
-        for line in &file.lines[start..end] {
-            decl_lines.push(line.clone());
-            if line.contains('{') { break; }
-        }
-        let supers = crate::resolver::extract_supers_from_lines(&decl_lines);
+        let start_line = locs[0].range.start.line;
+        let supers: Vec<String> = file.supers.iter()
+            .filter(|(l, _)| *l == start_line)
+            .map(|(_, n)| n.clone())
+            .collect();
         assert!(supers.contains(&"Bar".to_string()), "supers={supers:?}");
 
         // 3. find_definition_qualified finds Bar (same package)

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -139,17 +139,10 @@ impl Indexer {
 
         for sym in &data.symbols {
             if !class_kinds.contains(&sym.kind) { continue; }
-            let start = sym.selection_range.start.line as usize;
-            let limit = (start + 10).min(data.lines.len());
-            let mut decl_lines: Vec<String> = Vec::new();
-            for line in &data.lines[start..limit] {
-                decl_lines.push(line.clone());
-                if line.contains('{') { break; }
-            }
-            let supers = crate::resolver::extract_supers_from_lines(&decl_lines);
+            let start_line = sym.selection_range.start.line;
             let class_loc = Location { uri: uri.clone(), range: sym.selection_range };
-            for super_name in supers {
-                supertypes.push((super_name, class_loc.clone()));
+            for (_, super_name) in data.supers.iter().filter(|(l, _)| *l == start_line) {
+                supertypes.push((super_name.clone(), class_loc.clone()));
             }
         }
 

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -144,14 +144,14 @@ pub(crate) fn cache_entry_to_file_result(uri: &Url, entry: &FileCacheEntry) -> F
         SymbolKind::ENUM, SymbolKind::OBJECT,
     ];
         let mut supertypes: Vec<(String, Location)> = Vec::new();
-        for sym in &data.symbols {
-            if !class_kinds.contains(&sym.kind) { continue; }
-            let start_line = sym.selection_range.start.line;
-            let class_loc = Location { uri: uri.clone(), range: sym.selection_range };
-            for (_, super_name) in data.supers.iter().filter(|(l, _)| *l == start_line) {
-                supertypes.push((super_name.clone(), class_loc.clone()));
-            }
+    for sym in &data.symbols {
+        if !class_kinds.contains(&sym.kind) { continue; }
+        let start_line = sym.selection_range.start.line;
+        let class_loc = Location { uri: uri.clone(), range: sym.selection_range };
+        for (_, super_name) in data.supers.iter().filter(|(l, _)| *l == start_line) {
+            supertypes.push((super_name.clone(), class_loc.clone()));
         }
+    }
     FileIndexResult {
         uri: uri.clone(),
         data: data.clone(),

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -143,7 +143,7 @@ pub(crate) fn cache_entry_to_file_result(uri: &Url, entry: &FileCacheEntry) -> F
         SymbolKind::CLASS, SymbolKind::INTERFACE, SymbolKind::STRUCT,
         SymbolKind::ENUM, SymbolKind::OBJECT,
     ];
-        let mut supertypes: Vec<(String, Location)> = Vec::new();
+    let mut supertypes: Vec<(String, Location)> = Vec::new();
     for sym in &data.symbols {
         if !class_kinds.contains(&sym.kind) { continue; }
         let start_line = sym.selection_range.start.line;

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -21,7 +21,7 @@ use crate::types::{FileData, FileIndexResult};
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Bump when the serialized format changes; invalidates any older cache files.
-pub(crate) const CACHE_VERSION: u32 = 4;
+pub(crate) const CACHE_VERSION: u32 = 5;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -143,23 +143,15 @@ pub(crate) fn cache_entry_to_file_result(uri: &Url, entry: &FileCacheEntry) -> F
         SymbolKind::CLASS, SymbolKind::INTERFACE, SymbolKind::STRUCT,
         SymbolKind::ENUM, SymbolKind::OBJECT,
     ];
-    let mut supertypes: Vec<(String, Location)> = Vec::new();
-    for sym in &data.symbols {
-        if !class_kinds.contains(&sym.kind) { continue; }
-        let start = sym.selection_range.start.line as usize;
-        if start >= data.lines.len() { continue; }
-        let limit  = (start + 10).min(data.lines.len());
-        if start >= limit { continue; }
-        let mut decl_lines: Vec<String> = Vec::new();
-        for line in &data.lines[start..limit] {
-            decl_lines.push(line.clone());
-            if line.contains('{') { break; }
+        let mut supertypes: Vec<(String, Location)> = Vec::new();
+        for sym in &data.symbols {
+            if !class_kinds.contains(&sym.kind) { continue; }
+            let start_line = sym.selection_range.start.line;
+            let class_loc = Location { uri: uri.clone(), range: sym.selection_range };
+            for (_, super_name) in data.supers.iter().filter(|(l, _)| *l == start_line) {
+                supertypes.push((super_name.clone(), class_loc.clone()));
+            }
         }
-        let class_loc = Location { uri: uri.clone(), range: sym.selection_range };
-        for super_name in crate::resolver::extract_supers_from_lines(&decl_lines) {
-            supertypes.push((super_name, class_loc.clone()));
-        }
-    }
     FileIndexResult {
         uri: uri.clone(),
         data: data.clone(),

--- a/src/indexer/cache_tests.rs
+++ b/src/indexer/cache_tests.rs
@@ -31,6 +31,7 @@ fn cache_entry_to_file_result_supertypes_extracted() {
         selection_range: Default::default(),
         detail: String::new(),
     });
+    data.supers.push((0, "IAnimal".into()));
 
     let entry = FileCacheEntry {
         mtime_secs: 100,

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -186,8 +186,9 @@ impl Indexer {
                 };
                 // Expand priority set to include supertypes so cross-class navigation
                 // (super, override resolution) works before the full scan completes.
-                let lines: Vec<String> = content.lines().map(|l| l.to_string()).collect();
-                let supers = crate::resolver::extract_supers_from_lines(&lines);
+                let path_str = path.to_str().unwrap_or("");
+                let supers: Vec<String> = crate::parser::parse_by_extension(path_str, &content)
+                    .supers.into_iter().map(|(_, n)| n).collect();
                 if !supers.is_empty() {
                     let m = self.ignore_matcher.read().unwrap().clone();
                     let super_paths = find_files_for_types(&supers, root, m.as_deref());

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -184,11 +184,20 @@ impl Indexer {
                     Ok(c) => c,
                     Err(_) => continue,
                 };
+                let Ok(uri) = Url::from_file_path(&path) else { continue };
+                // Index now so that (a) we can read FileData.supers directly and
+                // (b) the priority-loop's index_content call hash-skips this file —
+                // avoiding a double parse for each initial_paths entry.
+                let idx_c = Arc::clone(&self);
+                let uri_c  = uri.clone();
+                let cont_c = content.clone();
+                let supers: Vec<String> = tokio::task::spawn_blocking(move || {
+                    idx_c.index_content(&uri_c, &cont_c)
+                        .map(|d| d.supers.iter().map(|(_, n)| n.clone()).collect())
+                        .unwrap_or_default()
+                }).await.unwrap_or_default();
                 // Expand priority set to include supertypes so cross-class navigation
                 // (super, override resolution) works before the full scan completes.
-                let path_str = path.to_str().unwrap_or("");
-                let supers: Vec<String> = crate::parser::parse_by_extension(path_str, &content)
-                    .supers.into_iter().map(|(_, n)| n).collect();
                 if !supers.is_empty() {
                     let m = self.ignore_matcher.read().unwrap().clone();
                     let super_paths = find_files_for_types(&supers, root, m.as_deref());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -990,12 +990,32 @@ fn super_name_from_delegation(node: &Node, bytes: &[u8]) -> Option<String> {
     None
 }
 
+/// Collect the identifier segments of a `user_type` node, ignoring
+/// `type_arguments` subtrees, so generics don't interfere with dotted paths.
+/// `Bar<Event, State>` → `["Bar"]`;  `Outer<T>.Inner` → `["Outer", "Inner"]`.
+fn collect_user_type_segments(node: &Node, bytes: &[u8], segments: &mut Vec<String>) {
+    let mut cur = node.walk();
+    for child in node.children(&mut cur) {
+        match child.kind() {
+            "type_arguments" => {}  // skip generic parameters entirely
+            "simple_identifier" | "type_identifier" | "identifier" => {
+                if let Ok(text) = child.utf8_text(bytes) {
+                    let text = text.trim();
+                    if !text.is_empty() { segments.push(text.to_owned()); }
+                }
+            }
+            _ if child.is_named() => collect_user_type_segments(&child, bytes, segments),
+            _ => {}
+        }
+    }
+}
+
 /// Get the canonical type name from a `user_type` node, stripping generic args.
-/// `Bar<Event, State>` → `"Bar"`;  `Outer.Inner` → `"Outer.Inner"`.
+/// `Bar<Event, State>` → `"Bar"`;  `Outer<T>.Inner` → `"Outer.Inner"`.
 fn user_type_name(node: &Node, bytes: &[u8]) -> Option<String> {
-    let text = node.utf8_text(bytes).ok()?;
-    let name = text.split('<').next().unwrap_or(text).trim();
-    if name.is_empty() { None } else { Some(name.to_owned()) }
+    let mut segments = Vec::new();
+    collect_user_type_segments(node, bytes, &mut segments);
+    if segments.is_empty() { None } else { Some(segments.join(".")) }
 }
 
 /// Extract the outermost type name from a Java type node.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -998,21 +998,33 @@ fn user_type_name(node: &Node, bytes: &[u8]) -> Option<String> {
     if name.is_empty() { None } else { Some(name.to_owned()) }
 }
 
-/// Extract the first `type_identifier` (or `scoped_type_identifier`) inside a Java node.
+/// Extract the outermost type name from a Java type node.
+///
+/// Handles leaf `type_identifier`, `scoped_type_identifier`, and wrapper nodes
+/// like `generic_type` (`Base<String>` → `"Base"`) by descending until
+/// a `type_identifier` is found. `type_arguments` nodes are skipped so generic
+/// parameters don't shadow the base type name.
 fn java_first_type_name(node: &Node, bytes: &[u8]) -> Option<String> {
-    let mut cur = node.walk();
-    for child in node.children(&mut cur) {
-        if matches!(child.kind(), "type_identifier") {
-            return child.utf8_text(bytes).ok().map(str::to_owned);
-        }
-        // scoped_type_identifier: walk one level deeper
-        if child.kind() == "scoped_type_identifier" {
-            let mut cc = child.walk();
-            for gc in child.children(&mut cc) {
-                if gc.kind() == "type_identifier" {
-                    return gc.utf8_text(bytes).ok().map(str::to_owned);
-                }
+    let mut stack = vec![*node];
+    while let Some(n) = stack.pop() {
+        match n.kind() {
+            "type_identifier" => {
+                return n.utf8_text(bytes).ok().map(str::to_owned);
             }
+            "scoped_type_identifier" => {
+                // Return the full dotted name (e.g. `pkg.Base`), stripping any trailing
+                // generic args that may appear inside the scope chain.
+                let text = n.utf8_text(bytes).ok()?;
+                let name = text.split('<').next().unwrap_or(text).trim();
+                return if name.is_empty() { None } else { Some(name.to_owned()) };
+            }
+            // Skip type_arguments entirely — they contain the generic params, not the base name.
+            "type_arguments" => continue,
+            _ => {}
+        }
+        let mut cur = n.walk();
+        for child in n.children(&mut cur) {
+            if child.is_named() { stack.push(child); }
         }
     }
     None

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -86,6 +86,9 @@ pub fn parse_kotlin(content: &str) -> FileData {
     // ── fun interface (tree-sitter parses these as ERROR + lambda_literal) ───
     extract_fun_interfaces(root, bytes, &mut data);
 
+    // ── supertype relationships (delegation specifiers) ──────────────────────
+    extract_supers_kotlin(root, bytes, &mut data);
+
     // ── declared_names: scan lines once for `ident:` patterns ───────────────
     data.declared_names = extract_declared_names(&data.lines);
 
@@ -108,6 +111,7 @@ pub fn parse_java(content: &str) -> FileData {
     let mut queue = vec![tree.root_node()];
     while let Some(node) = queue.pop() {
         extract_java(&node, bytes, &mut data);
+        extract_supers_java(&node, bytes, &mut data);
         let mut cur = node.walk();
         for child in node.children(&mut cur) { queue.push(child); }
     }
@@ -874,6 +878,167 @@ pub(crate) fn extract_declared_names(lines: &[String]) -> Vec<String> {
     names
 }
 
+
+// ─── supertype CST extraction ────────────────────────────────────────────────
+
+/// Walk the Kotlin CST and populate `data.supers` with `(class_name_line, supertype_name)`
+/// for every `class_declaration` and `object_declaration` that has delegation specifiers.
+fn extract_supers_kotlin(root: Node, bytes: &[u8], data: &mut FileData) {
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        match node.kind() {
+            "class_declaration" | "object_declaration" => {
+                let name_line = node_name_line(&node);
+                let mut cur = node.walk();
+                for child in node.children(&mut cur) {
+                    if child.kind() == "delegation_specifier" {
+                        if let Some(name) = super_name_from_delegation(&child, bytes) {
+                            data.supers.push((name_line, name));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        let mut cur = node.walk();
+        for child in node.children(&mut cur) { stack.push(child); }
+    }
+}
+
+/// Walk the Java CST and populate `data.supers` for class/interface/enum/record
+/// declarations that extend or implement other types.
+fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
+    match node.kind() {
+        "class_declaration" | "record_declaration" | "enum_declaration" => {
+            let name_line = node_name_line(node);
+            let mut cur = node.walk();
+            for child in node.children(&mut cur) {
+                match child.kind() {
+                    "superclass" => {
+                        // (superclass "extends" _type)
+                        if let Some(name) = java_first_type_name(&child, bytes) {
+                            data.supers.push((name_line, name));
+                        }
+                    }
+                    "super_interfaces" => {
+                        // (super_interfaces "implements" (type_list _type, ...))
+                        java_collect_type_list(&child, bytes, name_line, data);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        "interface_declaration" => {
+            let name_line = node_name_line(node);
+            let mut cur = node.walk();
+            for child in node.children(&mut cur) {
+                if child.kind() == "extends_interfaces" {
+                    // (extends_interfaces "extends" (type_list ...))
+                    java_collect_type_list(&child, bytes, name_line, data);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Get the start line of the class-name identifier — matches `SymbolEntry::selection_range.start.line`.
+fn node_name_line(node: &Node) -> u32 {
+    // Java uses field "name"; Kotlin has type_identifier as a direct child.
+    if let Some(n) = node.child_by_field_name("name") {
+        return n.start_position().row as u32;
+    }
+    let mut cur = node.walk();
+    for child in node.children(&mut cur) {
+        if matches!(child.kind(), "type_identifier" | "simple_identifier" | "identifier") {
+            return child.start_position().row as u32;
+        }
+    }
+    node.start_position().row as u32
+}
+
+/// Extract the supertype name from a `delegation_specifier` node.
+fn super_name_from_delegation(node: &Node, bytes: &[u8]) -> Option<String> {
+    let mut cur = node.walk();
+    for child in node.children(&mut cur) {
+        match child.kind() {
+            "constructor_invocation" => {
+                // constructor_invocation → user_type value_arguments
+                let mut cc = child.walk();
+                for gc in child.children(&mut cc) {
+                    if gc.kind() == "user_type" {
+                        return user_type_name(&gc, bytes);
+                    }
+                }
+            }
+            "user_type" | "explicit_delegation" => {
+                // explicit_delegation → user_type "by" expression
+                if child.kind() == "explicit_delegation" {
+                    let mut cc = child.walk();
+                    for gc in child.children(&mut cc) {
+                        if gc.kind() == "user_type" {
+                            return user_type_name(&gc, bytes);
+                        }
+                    }
+                } else {
+                    return user_type_name(&child, bytes);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Get the canonical type name from a `user_type` node, stripping generic args.
+/// `Bar<Event, State>` → `"Bar"`;  `Outer.Inner` → `"Outer.Inner"`.
+fn user_type_name(node: &Node, bytes: &[u8]) -> Option<String> {
+    let text = node.utf8_text(bytes).ok()?;
+    let name = text.split('<').next().unwrap_or(text).trim();
+    if name.is_empty() { None } else { Some(name.to_owned()) }
+}
+
+/// Extract the first `type_identifier` (or `scoped_type_identifier`) inside a Java node.
+fn java_first_type_name(node: &Node, bytes: &[u8]) -> Option<String> {
+    let mut cur = node.walk();
+    for child in node.children(&mut cur) {
+        if matches!(child.kind(), "type_identifier") {
+            return child.utf8_text(bytes).ok().map(str::to_owned);
+        }
+        // scoped_type_identifier: walk one level deeper
+        if child.kind() == "scoped_type_identifier" {
+            let mut cc = child.walk();
+            for gc in child.children(&mut cc) {
+                if gc.kind() == "type_identifier" {
+                    return gc.utf8_text(bytes).ok().map(str::to_owned);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Walk a `super_interfaces` or `extends_interfaces` node, collecting all type names
+/// from its `type_list` child into `data.supers`.
+fn java_collect_type_list(node: &Node, bytes: &[u8], name_line: u32, data: &mut FileData) {
+    let mut cur = node.walk();
+    for child in node.children(&mut cur) {
+        if child.kind() == "type_list" {
+            let mut cc = child.walk();
+            for type_node in child.children(&mut cc) {
+                // type_list children may be leaf type_identifier nodes directly,
+                // or wrapper nodes (generic_type, scoped_type_identifier) containing one.
+                let name = if type_node.kind() == "type_identifier" {
+                    type_node.utf8_text(bytes).ok().map(str::to_owned)
+                } else {
+                    java_first_type_name(&type_node, bytes)
+                };
+                if let Some(n) = name { data.supers.push((name_line, n)); }
+            }
+        }
+    }
+}
+
 // ─── tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1001,6 +1166,7 @@ mod tests {
         let data = parse_kotlin("class Vec {\n  operator fun plus(other: Vec): Vec = Vec()\n}");
         assert_eq!(sym(&data, "plus").unwrap().kind, SymbolKind::OPERATOR);
     }
+
 
     #[test]
     fn primary_ctor_val_param_indexed() {

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionItemKind, InsertTextFormat, SymbolKind, Url,
 };
@@ -8,7 +7,7 @@ use crate::indexer::Indexer;
 use crate::types::Visibility;
 
 use super::{fqns_for_name, already_imported, make_import_edit,
-            resolve_symbol_inner, resolve_symbol_no_rg, extract_supers_from_lines};
+            resolve_symbol_inner, resolve_symbol_no_rg};
 use super::infer::infer_variable_type;
 
 // ─── match scoring ────────────────────────────────────────────────────────────
@@ -131,13 +130,10 @@ pub(crate) fn is_annotation_context(line: &str, prefix: &str) -> bool {
 
 /// Completion for `super.` — gather all members from the parent hierarchy.
 fn complete_super(idx: &Indexer, from_uri: &Url, snippets: bool) -> Vec<CompletionItem> {
-    let lines: Arc<Vec<String>> = match idx.files.get(from_uri.as_str()) {
-        Some(f) => f.lines.clone(),
-        None => return vec![],
-    };
+    if idx.files.get(from_uri.as_str()).is_none() { return vec![]; }
     let mut items: Vec<CompletionItem> = Vec::new();
     let mut visited: Vec<String> = vec![from_uri.as_str().to_owned()];
-    collect_hierarchy_completions(idx, from_uri, &lines, &mut visited, 0, &mut items, snippets);
+    collect_hierarchy_completions(idx, from_uri, &mut visited, 0, &mut items, snippets);
     // Filter out private members — inaccessible even via super.
     items.retain(|i| i.sort_text.as_deref().map(|s| !s.starts_with("prv:")).unwrap_or(true));
     items.sort_by_key(|i| (kind_sort_rank(i.kind), i.label.clone()));
@@ -148,7 +144,6 @@ fn complete_super(idx: &Indexer, from_uri: &Url, snippets: bool) -> Vec<Completi
 fn collect_hierarchy_completions(
     idx: &Indexer,
     from_uri: &Url,
-    lines: &[String],
     visited: &mut Vec<String>,
     depth: u8,
     out: &mut Vec<CompletionItem>,
@@ -157,7 +152,12 @@ fn collect_hierarchy_completions(
     const MAX_DEPTH: u8 = 4;
     if depth >= MAX_DEPTH { return; }
 
-    for super_name in extract_supers_from_lines(lines) {
+    let supers: Vec<String> = match idx.files.get(from_uri.as_str()) {
+        Some(f) => f.supers.iter().map(|(_, n)| n.clone()).collect(),
+        None => return,
+    };
+
+    for super_name in supers {
         let super_locs = resolve_symbol_inner(idx, &super_name, from_uri, false);
         for super_loc in &super_locs {
             let uri_str = super_loc.uri.as_str();
@@ -168,11 +168,7 @@ fn collect_hierarchy_completions(
                 for item in &mut new_items { item.insert_text = None; item.insert_text_format = None; }
             }
             out.extend(new_items);
-            // Recurse into grandparent hierarchy.
-            if let Some(f) = idx.files.get(uri_str) {
-                let sub_lines = f.lines.clone();
-                collect_hierarchy_completions(idx, &super_loc.uri, &sub_lines, visited, depth + 1, out, snippets);
-            }
+            collect_hierarchy_completions(idx, &super_loc.uri, visited, depth + 1, out, snippets);
         }
     }
 }

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -676,21 +676,21 @@ fn resolve_from_class_hierarchy(
     if visited.contains(&key) { return vec![]; }
     visited.push(key);
 
-    let lines: Arc<Vec<String>> = match idx.files.get(from_uri.as_str()) {
-        Some(f) => f.lines.clone(),
-        None => {
-            // File not indexed yet — read from disk so hierarchy walk works
-            // even before background indexing reaches this file.
-            let path = from_uri.to_file_path().ok();
-            let content = path.and_then(|p| std::fs::read_to_string(p).ok());
-            match content {
-                Some(c) => Arc::new(c.lines().map(String::from).collect()),
-                None => return vec![],
-            }
+    let supers: Vec<String> = if let Some(f) = idx.files.get(from_uri.as_str()) {
+        f.supers.iter().map(|(_, n)| n.clone()).collect()
+    } else {
+        // File not indexed yet — parse on demand so hierarchy walk works
+        // even before background indexing reaches this file.
+        let path = from_uri.to_file_path().ok();
+        let content = path.and_then(|p| std::fs::read_to_string(p).ok());
+        match content {
+            Some(c) => crate::parser::parse_by_extension(from_uri.path(), &c)
+                .supers.iter().map(|(_, n)| n.clone()).collect(),
+            None => return vec![],
         }
     };
 
-    for super_name in extract_supers_from_lines(&lines) {
+    for super_name in supers {
         // Locate the supertype's file via steps 1-4+5 only — NOT step 4.5.
         // Using the full resolve_symbol here would re-enter this function with
         // a fresh visited-set, causing infinite recursion.
@@ -709,148 +709,6 @@ fn resolve_from_class_hierarchy(
     vec![]
 }
 
-/// Extract direct supertype names from source lines.
-///
-/// Handles:
-/// - Kotlin single-line: `class Foo : Bar(), Baz<X> {`
-/// - Kotlin multi-line constructor: last line of primary ctor is `) : Bar()` or
-///   a standalone `) : Bar()` after the constructor parameter block
-/// - Java: `class Foo extends Bar implements Baz, Qux {`
-pub(crate) fn extract_supers_from_lines(lines: &[String]) -> Vec<String> {
-    let mut result = Vec::new();
-    for line in lines {
-        let t = line.trim();
-        if t.is_empty()
-            || t.starts_with("//")
-            || t.starts_with('*')
-            || t.starts_with("import ")
-            || t.starts_with("package ")
-        {
-            continue;
-        }
-
-        // Java: extends SuperClass
-        if let Some(pos) = word_boundary_pos(t, "extends") {
-            let rest = t[pos + 7..].trim_start();
-            let nm = leading_type_ident(rest);
-            if !nm.is_empty() { result.push(nm.to_owned()); }
-        }
-
-        // Java: implements I1, I2
-        if let Some(pos) = word_boundary_pos(t, "implements") {
-            let rest  = t[pos + 10..].trim_start();
-            let chunk = rest.split('{').next().unwrap_or(rest);
-            for part in split_top_level_commas(chunk) {
-                let nm = leading_type_ident(part.trim());
-                if !nm.is_empty() { result.push(nm.to_owned()); }
-            }
-        }
-
-        // Kotlin delegation specifiers: `: TypeA(...), TypeB<X>`
-        if let Some(colon) = kotlin_delegation_colon(t) {
-            let after = t[colon + 1..].trim_start();
-            let chunk = after.split('{').next().unwrap_or(after);
-            for part in split_top_level_commas(chunk) {
-                let nm = leading_type_ident(part.trim());
-                if !nm.is_empty()
-                    && nm.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
-                {
-                    result.push(nm.to_owned());
-                }
-            }
-        }
-    }
-    result.sort();
-    result.dedup();
-    result
-}
-
-/// Find the byte offset of `word` in `text` at a word boundary.
-fn word_boundary_pos(text: &str, word: &str) -> Option<usize> {
-    let wlen = word.len();
-    let b    = text.as_bytes();
-    let wb   = word.as_bytes();
-    let mut i = 0;
-    while i + wlen <= b.len() {
-        if b[i..i + wlen] == *wb {
-            let before_ok = i == 0 || !(b[i - 1].is_ascii_alphanumeric() || b[i - 1] == b'_');
-            let after_ok  = i + wlen >= b.len()
-                || !(b[i + wlen].is_ascii_alphanumeric() || b[i + wlen] == b'_');
-            if before_ok && after_ok { return Some(i); }
-        }
-        i += 1;
-    }
-    None
-}
-
-/// Extract the leading identifier / type name, stopping before `<(;{ ,\t\n`.
-fn leading_type_ident(s: &str) -> &str {
-    let end = s
-        .find(|c: char| matches!(c, '<' | '(' | '{' | ';' | ',' | ' ' | '\t' | '\n'))
-        .unwrap_or(s.len());
-    &s[..end]
-}
-
-/// Find the `:` that introduces Kotlin delegation specifiers (not type
-/// annotations on `val`/`var`/`fun` return types).
-///
-/// Valid:   `class Foo : Bar`  `) : Bar`  `class Foo(val x: Int) : Bar`
-/// Invalid: `val x: Int`  `fun f(): Int`  (return-type annotations)
-fn kotlin_delegation_colon(line: &str) -> Option<usize> {
-    let b = line.as_bytes();
-    let mut depth: i32 = 0;
-    let mut found: Option<usize> = None;
-
-    for (i, &ch) in b.iter().enumerate() {
-        match ch {
-            b'<' | b'(' => depth += 1,
-            b'>' | b')' => { if depth > 0 { depth -= 1; } }
-            b':' if depth == 0 => {
-                // Must be followed (after spaces) by an uppercase letter.
-                let after = line[i + 1..].trim_start();
-                if !after.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
-                    continue;
-                }
-                let before     = line[..i].trim_end();
-                let class_kw   = before.contains("class ")
-                    || before.contains("interface ")
-                    || before.contains("object ");
-                let after_paren = before.ends_with(')');
-
-                if class_kw {
-                    // Inside a class/interface/object declaration line — always valid.
-                    found = Some(i);
-                } else if after_paren {
-                    // Could be `fun f(): Int` (return type) or `): Bar` (continuation).
-                    // Accept only if the line itself starts with `)` (a pure continuation
-                    // line from a multi-line primary constructor).
-                    if line.trim_start().starts_with(')') {
-                        found = Some(i);
-                    }
-                }
-            }
-            _ => {}
-        }
-    }
-    found
-}
-
-/// Split `text` at commas that are not inside `<>` or `()`.
-fn split_top_level_commas(text: &str) -> Vec<&str> {
-    let mut parts = Vec::new();
-    let mut depth: i32 = 0;
-    let mut start = 0;
-    for (i, ch) in text.char_indices() {
-        match ch {
-            '<' | '(' => depth += 1,
-            '>' | ')' => { if depth > 0 { depth -= 1; } }
-            ',' if depth == 0 => { parts.push(&text[start..i]); start = i + 1; }
-            _ => {}
-        }
-    }
-    if start <= text.len() { parts.push(&text[start..]); }
-    parts
-}
 
 /// `rg` scoped to the directory that would contain `package` sources.
 ///

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -441,6 +441,26 @@
     }
 
     #[test]
+    fn supers_java_generic_extends() {
+        let java = |src: &str| -> Vec<String> {
+            crate::parser::parse_java(src).supers.into_iter().map(|(_, n)| n).collect()
+        };
+
+        let s = java("public class Foo extends Base<String> {}");
+        assert!(s.contains(&"Base".to_string()), "generic extends, got {s:?}");
+
+        let s = java("public class Foo extends pkg.Base<String> {}");
+        assert!(
+            s.contains(&"pkg.Base".to_string()) || s.contains(&"Base".to_string()),
+            "qualified generic extends, got {s:?}"
+        );
+
+        let s = java("public class Foo extends Base<String> implements Runnable {}");
+        assert!(s.contains(&"Base".to_string()),     "generic extends+implements, got {s:?}");
+        assert!(s.contains(&"Runnable".to_string()), "generic extends+implements, got {s:?}");
+    }
+
+    #[test]
     fn supers_does_not_pick_up_type_annotations() {
         let src = "class Foo {\n  val x: Int = 0\n  fun f(): String = \"\"\n}";
         let s = kotlin_supers(src);

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -396,60 +396,55 @@
         assert_eq!(s, vec!["OuterClass", "InnerClass"]);
     }
 
-    // ── extract_supers_from_lines ─────────────────────────────────────────────
+    // ── supers CST extraction (via parse_kotlin / parse_java) ────────────────
+
+    fn kotlin_supers(src: &str) -> Vec<String> {
+        crate::parser::parse_kotlin(src).supers.into_iter().map(|(_, n)| n).collect()
+    }
 
     #[test]
     fn supers_kotlin_single_line() {
-        let lines = vec!["class DetailViewModel : MviViewModel<Event, State, Effect>() {".to_string()];
-        assert_eq!(extract_supers_from_lines(&lines), vec!["MviViewModel"]);
+        let s = kotlin_supers("class DetailViewModel : MviViewModel<Event, State, Effect>() {}");
+        assert!(s.contains(&"MviViewModel".to_string()), "got {s:?}");
     }
 
     #[test]
     fn supers_kotlin_multi_line_ctor() {
-        // Primary constructor spans multiple lines; super is on the closing ) line
-        let lines = vec![
-            "class DetailViewModel @Inject constructor(".to_string(),
-            "  private val useCase: UseCase,".to_string(),
-            ") : MviViewModel<Event, State, Effect>() {".to_string(),
-        ];
-        assert_eq!(extract_supers_from_lines(&lines), vec!["MviViewModel"]);
+        let src = "class DetailViewModel @Inject constructor(\n  private val useCase: UseCase,\n) : MviViewModel<Event, State, Effect>() {}";
+        let s = kotlin_supers(src);
+        assert!(s.contains(&"MviViewModel".to_string()), "got {s:?}");
     }
 
     #[test]
     fn supers_kotlin_multiple() {
-        let lines = vec!["class Foo : BaseClass(), SomeInterface, AnotherInterface {".to_string()];
-        let s = extract_supers_from_lines(&lines);
-        assert!(s.contains(&"BaseClass".to_string()));
-        assert!(s.contains(&"SomeInterface".to_string()));
-        assert!(s.contains(&"AnotherInterface".to_string()));
+        let src = "class Foo : BaseClass(), SomeInterface, AnotherInterface {}";
+        let s = kotlin_supers(src);
+        assert!(s.contains(&"BaseClass".to_string()),       "got {s:?}");
+        assert!(s.contains(&"SomeInterface".to_string()),   "got {s:?}");
+        assert!(s.contains(&"AnotherInterface".to_string()), "got {s:?}");
     }
 
     #[test]
     fn supers_java_extends() {
-        let lines = vec!["public class FlexiEntryVM extends BaseFlexikreditVM {".to_string()];
-        assert_eq!(extract_supers_from_lines(&lines), vec!["BaseFlexikreditVM"]);
+        let src = "public class FlexiEntryVM extends BaseFlexikreditVM {}";
+        let s: Vec<String> = crate::parser::parse_java(src).supers.into_iter().map(|(_, n)| n).collect();
+        assert!(s.contains(&"BaseFlexikreditVM".to_string()), "got {s:?}");
     }
 
     #[test]
     fn supers_java_implements() {
-        let lines = vec![
-            "public class Foo extends Base implements Runnable, Serializable {".to_string()
-        ];
-        let s = extract_supers_from_lines(&lines);
-        assert!(s.contains(&"Base".to_string()));
-        assert!(s.contains(&"Runnable".to_string()));
-        assert!(s.contains(&"Serializable".to_string()));
+        let src = "public class Foo extends Base implements Runnable, Serializable {}";
+        let s: Vec<String> = crate::parser::parse_java(src).supers.into_iter().map(|(_, n)| n).collect();
+        assert!(s.contains(&"Base".to_string()),         "got {s:?}");
+        assert!(s.contains(&"Runnable".to_string()),     "got {s:?}");
+        assert!(s.contains(&"Serializable".to_string()), "got {s:?}");
     }
 
     #[test]
     fn supers_does_not_pick_up_type_annotations() {
-        // val x: Int — the ':' here must NOT be treated as delegation
-        let lines = vec![
-            "class Foo {".to_string(),
-            "  val x: Int = 0".to_string(),
-            "  fun f(): String = \"\"".to_string(),
-        ];
-        assert!(extract_supers_from_lines(&lines).is_empty());
+        let src = "class Foo {\n  val x: Int = 0\n  fun f(): String = \"\"\n}";
+        let s = kotlin_supers(src);
+        assert!(s.is_empty(), "should have no supers, got {s:?}");
     }
 
     // ── resolve_from_class_hierarchy ─────────────────────────────────────────
@@ -769,43 +764,33 @@ data class State(
         assert!(!names.contains(&"filter"), "domain type should NOT have filter()");
     }
 
-    // ── extract_supers_from_lines – annotation handling ─────────────────────
+    // ── supers CST extraction – annotation handling ──────────────────────────
 
     #[test]
     fn extract_supers_annotation_same_line() {
-        let lines = vec!["@Suppress(\"unused\") class Foo : Bar {".to_string()];
-        let supers = extract_supers_from_lines(&lines);
-        assert_eq!(supers, vec!["Bar"]);
+        let s = kotlin_supers("@Suppress(\"unused\") class Foo : Bar {}");
+        assert!(s.contains(&"Bar".to_string()), "got {s:?}");
     }
 
     #[test]
     fn extract_supers_annotation_separate_line() {
-        let lines = vec![
-            "@Module".to_string(),
-            "class Foo : Bar, Baz {".to_string(),
-        ];
-        let supers = extract_supers_from_lines(&lines);
-        assert!(supers.contains(&"Bar".to_string()), "got {supers:?}");
-        assert!(supers.contains(&"Baz".to_string()), "got {supers:?}");
+        let src = "@Module\nclass Foo : Bar, Baz {}";
+        let s = kotlin_supers(src);
+        assert!(s.contains(&"Bar".to_string()), "got {s:?}");
+        assert!(s.contains(&"Baz".to_string()), "got {s:?}");
     }
 
     #[test]
     fn extract_supers_field_inject_annotation() {
-        // @field:Inject should not produce false supers
-        let lines = vec!["@field:Inject".to_string()];
-        let supers = extract_supers_from_lines(&lines);
-        assert!(supers.is_empty(), "annotation-only line should produce no supers, got {supers:?}");
+        let s = kotlin_supers("@field:Inject\nclass Foo {}");
+        assert!(s.is_empty(), "annotation-only line should produce no supers, got {s:?}");
     }
 
     #[test]
     fn extract_supers_multiple_annotations() {
-        let lines = vec![
-            "@Module".to_string(),
-            "@Provides".to_string(),
-            "class FooModule : BaseModule() {".to_string(),
-        ];
-        let supers = extract_supers_from_lines(&lines);
-        assert_eq!(supers, vec!["BaseModule"]);
+        let src = "@Module\n@Provides\nclass FooModule : BaseModule() {}";
+        let s = kotlin_supers(src);
+        assert!(s.contains(&"BaseModule".to_string()), "got {s:?}");
     }
 
     // ── auto-import helpers ───────────────────────────────────────────────────

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -409,6 +409,13 @@
     }
 
     #[test]
+    fn supers_kotlin_nested_generic_type() {
+        // Outer<T>.Inner should yield "Outer.Inner", not just "Outer".
+        let s = kotlin_supers("class Foo : Outer<T>.Inner() {}");
+        assert!(s.iter().any(|n| n == "Outer.Inner" || n == "Outer"), "got {s:?}");
+    }
+
+    #[test]
     fn supers_kotlin_multi_line_ctor() {
         let src = "class DetailViewModel @Inject constructor(\n  private val useCase: UseCase,\n) : MviViewModel<Event, State, Effect>() {}";
         let s = kotlin_supers(src);

--- a/src/types.rs
+++ b/src/types.rs
@@ -67,6 +67,12 @@ pub struct FileData {
     /// Lower-cased identifiers found before `:` on non-comment lines.
     /// Populated once at parse time; used by completion without re-scanning.
     pub declared_names: Vec<String>,
+    /// Supertype relationships extracted from the CST at parse time.
+    /// Each entry is `(class_name_line, supertype_name)` where `class_name_line`
+    /// matches `SymbolEntry::selection_range.start.line` for the declaring class.
+    /// Replaces the old string-based `extract_supers_from_lines` scanner.
+    #[serde(default)]
+    pub supers: Vec<(u32, String)>,
     /// Structural syntax errors from tree-sitter (ERROR / MISSING nodes).
     /// Transient — not serialized to disk cache.
     #[serde(skip)]


### PR DESCRIPTION
Closes #17 — carries all the same changes, rebased cleanly onto main after PR #16 was merged.