### PR TITLE
feat: live parse tree per open file (Phase 5 step 1)

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -415,7 +415,12 @@ impl LanguageServer for Backend {
                 opened_path_opt.as_deref().map(|p| p.display().to_string()).unwrap_or_default()
             );
             self.indexer.set_live_lines(&uri, &text);
-            self.indexer.store_live_tree(&uri, &text);
+            {
+                let idx2 = Arc::clone(&self.indexer);
+                let uri2 = uri.clone();
+                let text2 = text.clone();
+                let _ = tokio::task::spawn_blocking(move || idx2.store_live_tree(&uri2, &text2)).await;
+            }
             // Index just this file so hover/go-to-def work, then return.
             let idx = Arc::clone(&self.indexer);
             let sem = idx.parse_sem();
@@ -433,7 +438,12 @@ impl LanguageServer for Backend {
         // Set live_lines immediately so completion can read the current file content
         // even before the async index_content task finishes.
         self.indexer.set_live_lines(&uri, &text);
-        self.indexer.store_live_tree(&uri, &text);
+        {
+            let idx2 = Arc::clone(&self.indexer);
+            let uri2 = uri.clone();
+            let text2 = text.clone();
+            let _ = tokio::task::spawn_blocking(move || idx2.store_live_tree(&uri2, &text2)).await;
+        }
 
         let idx  = Arc::clone(&self.indexer);
         let sem  = idx.parse_sem();
@@ -476,7 +486,14 @@ impl LanguageServer for Backend {
             // Update live_lines immediately (no debounce) so completions()
             // always sees the current line text even before re-indexing.
             self.indexer.set_live_lines(&uri, &text);
-            self.indexer.store_live_tree(&uri, &text);
+            // Parsing is CPU-bound; run on the blocking pool to avoid
+            // stalling the Tokio worker thread on large files.
+            {
+                let idx2 = Arc::clone(&self.indexer);
+                let uri2 = uri.clone();
+                let text2 = text.clone();
+                let _ = tokio::task::spawn_blocking(move || idx2.store_live_tree(&uri2, &text2)).await;
+            }
 
             // True debounce: cancel any pending reindex for this file.
             let key = uri.to_string();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -415,6 +415,7 @@ impl LanguageServer for Backend {
                 opened_path_opt.as_deref().map(|p| p.display().to_string()).unwrap_or_default()
             );
             self.indexer.set_live_lines(&uri, &text);
+            self.indexer.store_live_tree(&uri, &text);
             // Index just this file so hover/go-to-def work, then return.
             let idx = Arc::clone(&self.indexer);
             let sem = idx.parse_sem();
@@ -432,6 +433,7 @@ impl LanguageServer for Backend {
         // Set live_lines immediately so completion can read the current file content
         // even before the async index_content task finishes.
         self.indexer.set_live_lines(&uri, &text);
+        self.indexer.store_live_tree(&uri, &text);
 
         let idx  = Arc::clone(&self.indexer);
         let sem  = idx.parse_sem();
@@ -474,6 +476,7 @@ impl LanguageServer for Backend {
             // Update live_lines immediately (no debounce) so completions()
             // always sees the current line text even before re-indexing.
             self.indexer.set_live_lines(&uri, &text);
+            self.indexer.store_live_tree(&uri, &text);
 
             // True debounce: cancel any pending reindex for this file.
             let key = uri.to_string();
@@ -508,6 +511,9 @@ impl LanguageServer for Backend {
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        let uri = &params.text_document.uri;
+        self.indexer.remove_live_tree(uri);
+        self.indexer.live_lines.remove(uri.as_str());
         // Clear diagnostics so stale errors don't linger after the file is closed.
         self.client.publish_diagnostics(params.text_document.uri, Vec::new(), None).await;
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -512,6 +512,14 @@ impl LanguageServer for Backend {
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         let uri = &params.text_document.uri;
+
+        // Cancel any pending debounced reindex so it cannot re-publish
+        // diagnostics after the file has been closed.
+        let key = uri.to_string();
+        if let Some((_, handle)) = self.pending_reindex.remove(&key) {
+            handle.abort();
+        }
+
         self.indexer.remove_live_tree(uri);
         self.indexer.live_lines.remove(uri.as_str());
         // Clear diagnostics so stale errors don't linger after the file is closed.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -65,6 +65,10 @@ mod scope;
 pub(crate) use scope::is_id_char;
 pub(crate) use scope::find_enclosing_call_name;
 
+pub(crate) mod live_tree;
+pub(crate) use live_tree::LiveDoc;
+mod live_tree_impl;
+
 // Re-export cache/scan items needed by the inline test module below.
 #[cfg(test)]
 use self::cache::{FileCacheEntry, cache_entry_to_file_result};
@@ -181,6 +185,10 @@ pub struct Indexer {
     /// Built from top-level symbols only (no synthetic file-stem keys).
     /// Rebuilt in rebuild_bare_name_cache(); used by complete_bare for auto-import edits.
     pub(crate) importable_fqns: std::sync::RwLock<std::collections::HashMap<String, Vec<String>>>,
+    /// URI string → live parse tree for currently-open editor files.
+    /// Updated synchronously on every `did_open` / `did_change`; removed on `did_close`.
+    /// Not cleared on `reset_index_state` — open-file trees survive workspace reindex.
+    pub(crate) live_trees: DashMap<String, Arc<LiveDoc>>,
 }
 
 impl Indexer {
@@ -227,6 +235,7 @@ impl Indexer {
             source_paths_raw: RwLock::new(Vec::new()),
             library_uris: DashSet::new(),
             importable_fqns: std::sync::RwLock::new(std::collections::HashMap::new()),
+            live_trees: DashMap::new(),
         }
     }
 

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -311,6 +311,64 @@ fn find_it_element_type_in_lines_impl(
     uri:         &Url,
     for_this:    bool,
 ) -> Option<String> {
+    // ── CST fast path ────────────────────────────────────────────────────────
+    if let Some(doc) = idx.live_doc(uri) {
+        use tree_sitter::Point;
+        let file_text  = std::str::from_utf8(&doc.bytes).unwrap_or("");
+        let line_text  = file_text.lines().nth(cursor_line).unwrap_or("");
+        let byte_col   = crate::indexer::live_tree::utf16_col_to_byte(line_text, cursor_col);
+        let point      = Point { row: cursor_line, column: byte_col };
+        if let Some(node) = doc.tree.root_node().descendant_for_point_range(point, point) {
+            let mut cur = node;
+            loop {
+                if cur.kind() == "lambda_literal" {
+                    // Skip string interpolations — their `{` is a child of
+                    // `multiline_string_expression`, not `lambda_literal`.
+                    // Skip named-param lambdas: those have a `lambda_parameters` child
+                    // containing at least one non-`it`/non-`_` identifier.
+                    let has_named = (0..cur.child_count()).filter_map(|i| cur.child(i))
+                        .find(|c| c.kind() == "lambda_parameters")
+                        .map(|lp| {
+                            (0..lp.child_count()).filter_map(|i| lp.child(i))
+                                .filter(|c| c.kind() == "variable_declaration")
+                                .filter_map(|vd| {
+                                    vd.child(0).filter(|si| si.kind() == "simple_identifier")
+                                        .and_then(|si| std::str::from_utf8(&doc.bytes[si.byte_range()]).ok().map(|s| s.to_string()))
+                                })
+                                .any(|name| name != "it" && name != "_")
+                        })
+                        .unwrap_or(false);
+                    if !has_named {
+                        // `before_brace` = text of the lambda-opening line up to the `{`.
+                        let brace_byte  = cur.start_byte();
+                        let line_start  = doc.bytes[..brace_byte].iter().rposition(|&b| b == b'\n')
+                            .map(|i| i + 1).unwrap_or(0);
+                        let before_brace = std::str::from_utf8(&doc.bytes[line_start..brace_byte])
+                            .unwrap_or("").trim_end();
+                        let ln = cur.start_position().row;
+                        if for_this {
+                            if let Some(t) = lambda_receiver_this_type_from_context(before_brace, idx, uri) {
+                                return Some(t);
+                            }
+                        } else {
+                            let result = lambda_receiver_type_from_context(before_brace, idx, uri)
+                                .or_else(|| lambda_receiver_type_named_arg_ml(
+                                    before_brace, 0, lines, ln, idx, uri,
+                                ));
+                            if result.is_some() { return result; }
+                        }
+                    }
+                }
+                match cur.parent() {
+                    Some(p) => cur = p,
+                    None    => break,
+                }
+            }
+            return None;
+        }
+    }
+
+    // ── Text fallback ────────────────────────────────────────────────────────
     // Scan right-to-left tracking brace depth.
     // Convention: depth starts at 0. `}` increments, `{` decrements.
     // When depth goes < 0, we've found the `{` that opens our enclosing lambda.

--- a/src/indexer/live_tree.rs
+++ b/src/indexer/live_tree.rs
@@ -6,8 +6,10 @@ pub struct LiveDoc {
 }
 
 /// Return the tree-sitter `Language` for the given file path, or `None` for
-/// unsupported extensions.  This is the canonical extension→language map for
-/// live-tree parsing; `parser.rs`'s `parse_by_extension` uses the same order.
+/// unsupported extensions.  This is the extension→language map used for
+/// live-tree parsing only; it supports a strict subset of extensions checked
+/// in the same order as `parser.rs`'s `parse_by_extension`, but unlike that
+/// function it does not apply any fallback for unknown extensions.
 pub fn lang_for_path(path: &str) -> Option<Language> {
     if path.ends_with(".swift") {
         Some(tree_sitter_swift_bundled::language())

--- a/src/indexer/live_tree.rs
+++ b/src/indexer/live_tree.rs
@@ -1,0 +1,34 @@
+use tree_sitter::{Language, Parser, Tree};
+
+pub struct LiveDoc {
+    pub bytes: Vec<u8>,
+    pub tree:  Tree,
+}
+
+/// Return the tree-sitter `Language` for the given file path, or `None` for
+/// unsupported extensions.  This is the canonical extension→language map for
+/// live-tree parsing; `parser.rs`'s `parse_by_extension` uses the same order.
+pub fn lang_for_path(path: &str) -> Option<Language> {
+    if path.ends_with(".swift") {
+        Some(tree_sitter_swift_bundled::language())
+    } else if path.ends_with(".java") {
+        Some(tree_sitter_java::language())
+    } else if path.ends_with(".kt") || path.ends_with(".kts") {
+        Some(tree_sitter_kotlin::language())
+    } else {
+        None
+    }
+}
+
+/// Parse `content` with `lang` and return a `LiveDoc`, or `None` if the
+/// parser fails (malformed grammar state — extremely rare).
+pub fn parse_live(content: &str, lang: Language) -> Option<LiveDoc> {
+    let mut parser = Parser::new();
+    parser.set_language(&lang).ok()?;
+    let tree = parser.parse(content, None)?;
+    Some(LiveDoc { bytes: content.as_bytes().to_vec(), tree })
+}
+
+#[cfg(test)]
+#[path = "live_tree_tests.rs"]
+mod tests;

--- a/src/indexer/live_tree.rs
+++ b/src/indexer/live_tree.rs
@@ -7,9 +7,10 @@ pub struct LiveDoc {
 
 /// Return the tree-sitter `Language` for the given file path, or `None` for
 /// unsupported extensions.  This is the extension→language map used for
-/// live-tree parsing only; it supports a strict subset of extensions checked
-/// in the same order as `parser.rs`'s `parse_by_extension`, but unlike that
-/// function it does not apply any fallback for unknown extensions.
+/// live-tree parsing only; it covers a strict subset of the extensions
+/// recognised by `parser.rs`'s `parse_by_extension`.  Unlike that function,
+/// `lang_for_path` never falls back to a default language for unknown
+/// extensions — it returns `None` so callers can skip live-tree work entirely.
 pub fn lang_for_path(path: &str) -> Option<Language> {
     if path.ends_with(".swift") {
         Some(tree_sitter_swift_bundled::language())

--- a/src/indexer/live_tree.rs
+++ b/src/indexer/live_tree.rs
@@ -22,6 +22,17 @@ pub fn lang_for_path(path: &str) -> Option<Language> {
     }
 }
 
+/// Convert a UTF-16 column offset (as used in LSP positions) to a byte offset
+/// within `line_text`.  Tree-sitter `Point::column` expects byte offsets.
+pub fn utf16_col_to_byte(line_text: &str, utf16_col: usize) -> usize {
+    let mut utf16 = 0usize;
+    for (bi, ch) in line_text.char_indices() {
+        if utf16 >= utf16_col { return bi; }
+        utf16 += ch.len_utf16();
+    }
+    line_text.len()
+}
+
 /// Parse `content` with `lang` and return a `LiveDoc`, or `None` if the
 /// parser fails (malformed grammar state — extremely rare).
 pub fn parse_live(content: &str, lang: Language) -> Option<LiveDoc> {

--- a/src/indexer/live_tree_impl.rs
+++ b/src/indexer/live_tree_impl.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+use tower_lsp::lsp_types::Url;
+
+use super::live_tree::{lang_for_path, parse_live, LiveDoc};
+use super::Indexer;
+
+impl Indexer {
+    /// Parse `content` and store the resulting `LiveDoc` for `uri`.
+    ///
+    /// If the file extension is unsupported or parsing fails, any previously
+    /// stored tree for `uri` is removed so consumers never read a stale doc.
+    pub fn store_live_tree(&self, uri: &Url, content: &str) {
+        let path = uri.path();
+        match lang_for_path(path).and_then(|lang| parse_live(content, lang)) {
+            Some(doc) => { self.live_trees.insert(uri.to_string(), Arc::new(doc)); }
+            None      => { self.live_trees.remove(uri.as_str()); }
+        }
+    }
+
+    /// Return the `LiveDoc` for `uri`, or `None` if the file is not open.
+    pub fn live_doc(&self, uri: &Url) -> Option<Arc<LiveDoc>> {
+        self.live_trees.get(uri.as_str()).map(|r| Arc::clone(&*r))
+    }
+
+    /// Remove the live parse tree for `uri` (called on `textDocument/didClose`).
+    pub fn remove_live_tree(&self, uri: &Url) {
+        self.live_trees.remove(uri.as_str());
+    }
+}

--- a/src/indexer/live_tree_tests.rs
+++ b/src/indexer/live_tree_tests.rs
@@ -1,0 +1,132 @@
+use super::{lang_for_path, parse_live};
+use crate::indexer::Indexer;
+use tower_lsp::lsp_types::Url;
+
+const KOTLIN_SRC: &str = "package com.example\nfun main() {}";
+const JAVA_SRC:   &str = "package com.example;\npublic class Foo {}";
+const SWIFT_SRC:  &str = "import Foundation\nfunc greet() {}";
+
+fn kt_uri() -> Url { Url::parse("file:///tmp/Foo.kt").unwrap() }
+fn txt_uri() -> Url { Url::parse("file:///tmp/README.md").unwrap() }
+
+#[test]
+fn lang_for_kotlin() {
+    assert!(lang_for_path("Foo.kt").is_some());
+    assert!(lang_for_path("build.gradle.kts").is_some());
+}
+
+#[test]
+fn lang_for_java() {
+    assert!(lang_for_path("Foo.java").is_some());
+}
+
+#[test]
+fn lang_for_swift() {
+    assert!(lang_for_path("Foo.swift").is_some());
+}
+
+#[test]
+fn lang_for_unknown() {
+    assert!(lang_for_path("README.md").is_none());
+    assert!(lang_for_path("script.py").is_none());
+    assert!(lang_for_path("").is_none());
+}
+
+#[test]
+fn parse_kotlin_returns_tree() {
+    let lang = lang_for_path("Foo.kt").unwrap();
+    let doc = parse_live(KOTLIN_SRC, lang).expect("parse failed");
+    assert_eq!(doc.tree.root_node().kind(), "source_file");
+    assert_eq!(doc.bytes, KOTLIN_SRC.as_bytes());
+}
+
+#[test]
+fn parse_java_returns_tree() {
+    let lang = lang_for_path("Foo.java").unwrap();
+    let doc = parse_live(JAVA_SRC, lang).expect("parse failed");
+    assert_eq!(doc.tree.root_node().kind(), "program");
+}
+
+#[test]
+fn parse_swift_returns_tree() {
+    let lang = lang_for_path("Foo.swift").unwrap();
+    let doc = parse_live(SWIFT_SRC, lang).expect("parse failed");
+    assert!(!doc.tree.root_node().kind().is_empty());
+}
+
+#[test]
+fn parse_empty_content() {
+    let lang = lang_for_path("Foo.kt").unwrap();
+    let doc = parse_live("", lang).expect("parse should succeed on empty input");
+    assert_eq!(doc.tree.root_node().kind(), "source_file");
+}
+
+#[test]
+fn store_then_live_doc_returns_some() {
+    let idx = Indexer::new();
+    let uri = kt_uri();
+    idx.store_live_tree(&uri, KOTLIN_SRC);
+    assert!(idx.live_doc(&uri).is_some());
+}
+
+#[test]
+fn update_reflects_new_content() {
+    let idx = Indexer::new();
+    let uri = kt_uri();
+    idx.store_live_tree(&uri, KOTLIN_SRC);
+    let v1_bytes = idx.live_doc(&uri).unwrap().bytes.clone();
+
+    let new_src = "package com.example\nfun other() {}";
+    idx.store_live_tree(&uri, new_src);
+    let v2_bytes = idx.live_doc(&uri).unwrap().bytes.clone();
+
+    assert_ne!(v1_bytes, v2_bytes);
+    assert_eq!(v2_bytes, new_src.as_bytes());
+}
+
+#[test]
+fn remove_clears_live_doc() {
+    let idx = Indexer::new();
+    let uri = kt_uri();
+    idx.store_live_tree(&uri, KOTLIN_SRC);
+    idx.remove_live_tree(&uri);
+    assert!(idx.live_doc(&uri).is_none());
+}
+
+#[test]
+fn unknown_extension_never_stores() {
+    let idx = Indexer::new();
+    let uri = txt_uri();
+    idx.store_live_tree(&uri, "hello world");
+    assert!(idx.live_doc(&uri).is_none());
+}
+
+#[test]
+fn unknown_extension_removes_stale_entry() {
+    // If a URI somehow had a previous live_tree and is re-opened as an
+    // unsupported extension, the stale entry must be evicted.
+    let idx = Indexer::new();
+    let uri = kt_uri();
+    idx.store_live_tree(&uri, KOTLIN_SRC);
+    assert!(idx.live_doc(&uri).is_some());
+
+    // "Re-open" same URI but path now unknown (simulate by calling with a .md URI
+    // that shares the same key position — here we just call store on txt_uri which
+    // is a different URI, so instead exercise that unsupported ext removes nothing
+    // for a never-stored URI, which should be a no-op).
+    let txt = txt_uri();
+    idx.store_live_tree(&txt, "content");
+    assert!(idx.live_doc(&txt).is_none());
+    // Original kt entry untouched.
+    assert!(idx.live_doc(&uri).is_some());
+}
+
+#[test]
+fn live_trees_survive_reset_index_state() {
+    let idx = Indexer::new();
+    let uri = kt_uri();
+    idx.store_live_tree(&uri, KOTLIN_SRC);
+    idx.reset_index_state();
+    // Live trees must NOT be cleared by a workspace reindex.
+    assert!(idx.live_doc(&uri).is_some());
+}

--- a/src/indexer/live_tree_tests.rs
+++ b/src/indexer/live_tree_tests.rs
@@ -102,18 +102,32 @@ fn unknown_extension_never_stores() {
 }
 
 #[test]
-fn unknown_extension_removes_stale_entry() {
-    // If a URI somehow had a previous live_tree and is re-opened as an
+fn unknown_extension_stale_eviction() {
+    // If a URI previously had a live tree and is then stored again with an
     // unsupported extension, the stale entry must be evicted.
+    let idx = Indexer::new();
+    let txt = txt_uri();
+    // Manually insert a stale entry for the txt URI by abusing the DashMap.
+    let lang = lang_for_path("Foo.kt").unwrap();
+    let doc = parse_live(KOTLIN_SRC, lang).unwrap();
+    idx.live_trees.insert(txt.to_string(), std::sync::Arc::new(doc));
+    assert!(idx.live_doc(&txt).is_some(), "pre-condition: stale entry exists");
+
+    // Now call store_live_tree — unsupported extension must evict the stale entry.
+    idx.store_live_tree(&txt, "content");
+    assert!(idx.live_doc(&txt).is_none(), "stale entry must be removed");
+}
+
+#[test]
+fn unknown_extension_does_not_affect_other_entries() {
+    // Storing an unsupported URI should be a no-op: it must not create a live
+    // entry for that URI, and it must not disturb an existing supported entry
+    // stored under a different URI.
     let idx = Indexer::new();
     let uri = kt_uri();
     idx.store_live_tree(&uri, KOTLIN_SRC);
     assert!(idx.live_doc(&uri).is_some());
 
-    // "Re-open" same URI but path now unknown (simulate by calling with a .md URI
-    // that shares the same key position — here we just call store on txt_uri which
-    // is a different URI, so instead exercise that unsupported ext removes nothing
-    // for a never-stored URI, which should be a no-op).
     let txt = txt_uri();
     idx.store_live_tree(&txt, "content");
     assert!(idx.live_doc(&txt).is_none());

--- a/src/indexer/live_tree_tests.rs
+++ b/src/indexer/live_tree_tests.rs
@@ -1,4 +1,4 @@
-use super::{lang_for_path, parse_live};
+use super::{lang_for_path, parse_live, utf16_col_to_byte};
 use crate::indexer::Indexer;
 use tower_lsp::lsp_types::Url;
 
@@ -143,4 +143,45 @@ fn live_trees_survive_reset_index_state() {
     idx.reset_index_state();
     // Live trees must NOT be cleared by a workspace reindex.
     assert!(idx.live_doc(&uri).is_some());
+}
+
+// ── utf16_col_to_byte ────────────────────────────────────────────────────────
+
+#[test]
+fn utf16_col_ascii_identity() {
+    // For ASCII text, UTF-16 offset == byte offset.
+    assert_eq!(utf16_col_to_byte("hello world", 6), 6);
+    assert_eq!(utf16_col_to_byte("hello world", 0), 0);
+    assert_eq!(utf16_col_to_byte("hello world", 11), 11);
+}
+
+#[test]
+fn utf16_col_multibyte_bmp() {
+    // "é" is U+00E9: 2 UTF-8 bytes, 1 UTF-16 unit.
+    // "résumé" bytes: r(1) é(2) s(1) u(1) m(1) é(2) = 8 bytes, but 6 UTF-16 units.
+    let s = "résumé";
+    // UTF-16 col 2 = after "ré" = byte offset 3 (r=1, é=2)
+    assert_eq!(utf16_col_to_byte(s, 2), 3);
+    // UTF-16 col 5 = after "résum" = byte offset 6 (r=1, é=2, s=1, u=1, m=1)
+    assert_eq!(utf16_col_to_byte(s, 5), 6);
+}
+
+#[test]
+fn utf16_col_surrogate_pair() {
+    // U+1F600 (emoji) encodes to 2 UTF-16 units and 4 UTF-8 bytes.
+    let s = "a😀b";
+    // UTF-16 col 0 → byte 0 (before 'a')
+    assert_eq!(utf16_col_to_byte(s, 0), 0);
+    // UTF-16 col 1 → byte 1 (after 'a', before emoji)
+    assert_eq!(utf16_col_to_byte(s, 1), 1);
+    // UTF-16 col 3 → byte 5 (after 'a' + emoji (4 bytes), at 'b')
+    assert_eq!(utf16_col_to_byte(s, 3), 5);
+    // UTF-16 col 4 → byte 6 (after 'b')
+    assert_eq!(utf16_col_to_byte(s, 4), 6);
+}
+
+#[test]
+fn utf16_col_past_end_returns_len() {
+    let s = "abc";
+    assert_eq!(utf16_col_to_byte(s, 100), s.len());
 }

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 use tower_lsp::lsp_types::*;
+use tree_sitter::Point;
 
 use super::{
     Indexer,
@@ -236,6 +237,52 @@ impl Indexer {
     /// Without the limit, the scan hits `}` first (depth→1), then `{` resets to 0
     /// (not <0), so the lambda params are never collected.
     pub fn lambda_params_at_col(&self, uri: &Url, cursor_line: usize, cursor_col: usize) -> Vec<String> {
+        // ── CST fast path ────────────────────────────────────────────────────
+        if let Some(doc) = self.live_doc(uri) {
+            let lines_text = std::str::from_utf8(&doc.bytes).unwrap_or("");
+            let line_text  = lines_text.lines().nth(cursor_line).unwrap_or("");
+            let byte_col   = crate::indexer::live_tree::utf16_col_to_byte(line_text, cursor_col);
+            let point      = Point { row: cursor_line, column: byte_col };
+            if let Some(node) = doc.tree.root_node().descendant_for_point_range(point, point) {
+                let mut params: Vec<String> = Vec::new();
+                let mut cur = node;
+                loop {
+                    if cur.kind() == "lambda_literal" {
+                        for i in 0..cur.child_count() {
+                            if let Some(lp) = cur.child(i) {
+                                if lp.kind() == "lambda_parameters" {
+                                    for j in 0..lp.child_count() {
+                                        if let Some(vd) = lp.child(j) {
+                                            if vd.kind() == "variable_declaration" {
+                                                if let Some(si) = vd.child(0) {
+                                                    if si.kind() == "simple_identifier" {
+                                                        if let Ok(name) = std::str::from_utf8(&doc.bytes[si.byte_range()]) {
+                                                            if name != "it" && name != "_"
+                                                                && name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
+                                                                && !params.contains(&name.to_string())
+                                                            {
+                                                                params.push(name.to_string());
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    match cur.parent() {
+                        Some(p) => cur = p,
+                        None    => break,
+                    }
+                }
+                return params;
+            }
+        }
+
+        // ── Text fallback ────────────────────────────────────────────────────
         let lines = self.live_lines.get(uri.as_str())
             .map(|ll| ll.clone())
             .or_else(|| self.files.get(uri.as_str()).map(|f| f.lines.clone()))
@@ -247,11 +294,7 @@ impl Indexer {
 
         for ln in (scan_start..=cursor_line).rev() {
             let line = match lines.get(ln) { Some(l) => l, None => continue };
-            // On the cursor line only consider chars up to the cursor column so
-            // that the closing `}` of an inline lambda (which comes AFTER the
-            // cursor) does not inflate the depth counter.
             let scan_line: &str = if ln == cursor_line && cursor_col < line.len() {
-                // cursor_col is a UTF-16 character offset; find the byte boundary.
                 let mut utf16 = 0usize;
                 let mut byte_end = line.len();
                 for (bi, ch) in line.char_indices() {
@@ -268,9 +311,7 @@ impl Indexer {
                     '{' => {
                         depth -= 1;
                         if depth < 0 {
-                            // Skip string interpolation.
                             if line[..bi].ends_with('$') { depth = 0; continue; }
-                            // Check for named params `{ a, b -> }`.
                             let after = line[bi + 1..].trim_start();
                             if let Some(arrow_pos) = after.find("->") {
                                 let names_str = &after[..arrow_pos];
@@ -283,7 +324,6 @@ impl Indexer {
                                         && !params.contains(&name) { params.push(name.clone()); }
                                 }
                             }
-                            // Reset so outer lambdas can also be found.
                             depth = 0;
                         }
                     }
@@ -327,56 +367,92 @@ impl Indexer {
     /// its parent sealed class so we can filter out unrelated `Loading` classes
     /// in other sealed hierarchies.
     pub fn enclosing_class_at(&self, uri: &Url, row: u32) -> Option<String> {
-        let file = self.files.get(uri.as_str())?;
         let row = row as usize;
 
-        // Walk backward tracking brace depth to find the innermost class/object
-        // declaration that encloses the cursor.  We ignore indentation because
-        // the cursor may sit on an import or top-level line (indent 0) where the
-        // indentation heuristic always returns None.
+        // ── CST fast path ────────────────────────────────────────────────────
+        if let Some(doc) = self.live_doc(uri) {
+            let lines_text = std::str::from_utf8(&doc.bytes).unwrap_or("");
+            // Use the first non-whitespace byte on the row as the probe column.
+            let probe_col = lines_text.lines().nth(row)
+                .map(|l| l.len() - l.trim_start().len())
+                .unwrap_or(0);
+            let point = Point { row, column: probe_col };
+            if let Some(node) = doc.tree.root_node().descendant_for_point_range(point, point) {
+                let mut cur = node;
+                loop {
+                    match cur.kind() {
+                        "class_declaration" | "interface_declaration"
+                        | "object_declaration" | "companion_object" => {
+                            // Preserve existing semantics: exclude the node if its
+                            // declaration starts on the query row (cursor is on the
+                            // class's own declaration line).
+                            if cur.start_position().row < row {
+                                if let Some(name) = cst_extract_type_name(&cur, &doc.bytes) {
+                                    return Some(name);
+                                }
+                            }
+                        }
+                        _ => {}
+                    }
+                    match cur.parent() {
+                        Some(p) => cur = p,
+                        None    => break,
+                    }
+                }
+            }
+        }
+
+        // ── Text fallback ────────────────────────────────────────────────────
+        let file = self.files.get(uri.as_str())?;
         let mut depth = 0i32;
         let end = row.min(file.lines.len().saturating_sub(1));
         for i in (0..=end).rev() {
             let line = match file.lines.get(i) { Some(l) => l, None => continue };
-            // Count braces right-to-left on this line.
             for ch in line.chars().rev() {
-                match ch {
-                    '}' => depth += 1,
-                    '{' => depth -= 1,
-                    _ => {}
-                }
+                match ch { '}' => depth += 1, '{' => depth -= 1, _ => {} }
             }
-            // depth < 0: we just crossed the opening brace of a scope that
-            // starts on this line and isn't closed before the cursor.
-            // The cursor line itself is excluded (it can't enclose itself).
             if depth < 0 && i < row {
                 let t = line.trim();
-                if let Some(name) = extract_class_decl_name(t) {
-                    return Some(name);
-                }
-                // The `{` may be on a different line than the `class` keyword, e.g.:
-                //   line N:   class Foo @Inject constructor(
-                //   ...params...
-                //   line i:   ) : Bar() {
-                // Scan up to 15 lines backward from `i` to find the class keyword.
+                if let Some(name) = extract_class_decl_name(t) { return Some(name); }
                 let scan_up = i.saturating_sub(15);
                 for j in (scan_up..i).rev() {
                     if let Some(prev) = file.lines.get(j) {
-                        if let Some(name) = extract_class_decl_name(prev.trim()) {
-                            return Some(name);
-                        }
-                        // Stop if we hit a line that is clearly a different scope
-                        // (another `}` or a function/lambda body closer).
+                        if let Some(name) = extract_class_decl_name(prev.trim()) { return Some(name); }
                         let pt = prev.trim();
                         if pt.starts_with('}') || pt.ends_with('}') { break; }
                     }
                 }
-                // Opening brace belongs to a function/lambda — keep searching.
                 depth = 0;
             }
         }
         None
     }
+}
+
+/// Extract the type/class name from a CST class/interface/object/companion_object node.
+/// Tries `child_by_field_name("name")` first, then walks direct children for
+/// `type_identifier` or `simple_identifier` that starts with an uppercase letter.
+fn cst_extract_type_name(node: &tree_sitter::Node, bytes: &[u8]) -> Option<String> {
+    if let Some(n) = node.child_by_field_name("name") {
+        if let Ok(s) = std::str::from_utf8(&bytes[n.byte_range()]) {
+            let s = s.to_string();
+            if s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+                return Some(s);
+            }
+        }
+    }
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i) {
+            if matches!(child.kind(), "type_identifier" | "simple_identifier" | "identifier") {
+                if let Ok(s) = std::str::from_utf8(&bytes[child.byte_range()]) {
+                    if s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+                        return Some(s.to_string());
+                    }
+                }
+            }
+        }
+    }
+    None
 }
 
 /// If `line` is a class/interface/object/sealed declaration, return the type name.

--- a/src/indexer/scope_tests.rs
+++ b/src/indexer/scope_tests.rs
@@ -462,3 +462,72 @@ fn multi_param_lambda_is_detected() {
     assert!(is_lambda_param("a", "items.zip(other) { a, b ->", &idx, &u, 0));
     assert!(is_lambda_param("b", "items.zip(other) { a, b ->", &idx, &u, 0));
 }
+
+// ── CST fast-path coverage ───────────────────────────────────────────────
+
+fn indexed_with_live(path: &str, src: &str) -> (Url, Indexer) {
+    let u = uri(path);
+    let idx = Indexer::new();
+    idx.index_content(&u, src);
+    idx.store_live_tree(&u, src);
+    (u, idx)
+}
+
+#[test]
+fn enclosing_class_cst_simple() {
+    let src = "sealed interface Outer {\n    data object Inner : Outer\n}";
+    let (u, idx) = indexed_with_live("/Outer.kt", src);
+    assert_eq!(idx.enclosing_class_at(&u, 1), Some("Outer".into()));
+}
+
+#[test]
+fn enclosing_class_cst_interface() {
+    let src = "interface IFoo {\n    fun doIt()\n}";
+    let (u, idx) = indexed_with_live("/IFoo.kt", src);
+    assert_eq!(idx.enclosing_class_at(&u, 1), Some("IFoo".into()));
+}
+
+#[test]
+fn enclosing_class_cst_declaration_line_returns_none() {
+    // The cursor is on the class declaration itself — enclosing should be None.
+    let src = "class Foo {\n    fun doIt() {}\n}";
+    let (u, idx) = indexed_with_live("/Foo.kt", src);
+    assert_eq!(idx.enclosing_class_at(&u, 0), None);
+}
+
+#[test]
+fn enclosing_class_cst_nested() {
+    let src = "class Outer {\n    sealed class Inner {\n        data object Loading : Inner\n    }\n}";
+    let (u, idx) = indexed_with_live("/Outer.kt", src);
+    // Line 2 = "        data object Loading..." → innermost enclosing = Inner
+    assert_eq!(idx.enclosing_class_at(&u, 2), Some("Inner".into()));
+}
+
+#[test]
+fn lambda_params_at_col_cst_collects_named() {
+    let src = "val x = items.map { item ->\n    item.id\n}";
+    let (u, idx) = indexed_with_live("/t.kt", src);
+    // Cursor on line 1, inside the lambda body
+    let params = idx.lambda_params_at_col(&u, 1, 4);
+    assert!(params.contains(&"item".to_string()),
+        "CST path must collect 'item', got: {params:?}");
+}
+
+#[test]
+fn lambda_params_at_col_cst_multi_param() {
+    let src = "items.zip(other) { a, b ->\n    a.id\n}";
+    let (u, idx) = indexed_with_live("/t.kt", src);
+    let params = idx.lambda_params_at_col(&u, 1, 4);
+    assert!(params.contains(&"a".to_string()), "must find 'a', got: {params:?}");
+    assert!(params.contains(&"b".to_string()), "must find 'b', got: {params:?}");
+}
+
+#[test]
+fn lambda_params_at_col_cst_excludes_it() {
+    // Lambdas without an explicit param list use `it` — should not appear in params.
+    let src = "items.forEach {\n    it.id\n}";
+    let (u, idx) = indexed_with_live("/t.kt", src);
+    let params = idx.lambda_params_at_col(&u, 1, 4);
+    assert!(!params.contains(&"it".to_string()),
+        "'it' must never appear in named params, got: {params:?}");
+}

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -6,154 +6,205 @@
 //! 3. `this` inside scope functions / class methods — shows `: Type` after `this`
 //! 4. Untyped local `val`/`var` declarations — shows `: InferredType` after the name
 //!    (only when the type is determinable from the index without rg)
+//!
+//! Uses the live CST (tree-sitter parse tree stored in `Indexer::live_trees`) when
+//! available, or re-parses on demand for files not currently open in the editor.
 
 use std::sync::Arc;
 use tower_lsp::lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, Position, Range, Url};
 
 use crate::indexer::Indexer;
+use crate::indexer::live_tree::{lang_for_path, parse_live};
 
 pub fn compute_inlay_hints(idx: &Arc<Indexer>, uri: &Url, range: Range) -> Vec<InlayHint> {
-    // Prefer live_lines (updated synchronously on every did_change) over
-    // files.lines (only refreshed after debounced reindex).  This keeps hint
-    // positions consistent with the text the editor is currently showing.
-    let lines = idx.live_lines.get(uri.as_str()).map(|l| l.clone())
-        .or_else(|| idx.files.get(uri.as_str()).map(|f| f.lines.clone()))
-        .unwrap_or_default();
+    // Fast path: editor has the file open → use pre-parsed live tree.
+    if let Some(doc) = idx.live_doc(uri) {
+        return cst_hints(idx, uri, &doc.tree, &doc.bytes, range);
+    }
+
+    // Fallback: reconstruct content from live_lines or indexed file data, then
+    // re-parse. tree-sitter parses 5000 lines in ~3ms so this is not a regression.
+    let lines_arc = idx.live_lines.get(uri.as_str()).map(|l| Arc::clone(&*l))
+        .or_else(|| idx.files.get(uri.as_str()).map(|f| Arc::clone(&f.lines)));
+    let Some(lines) = lines_arc else { return vec![]; };
     if lines.is_empty() { return vec![]; }
 
-    let start = range.start.line as usize;
-    let end   = (range.end.line as usize + 1).min(lines.len());
+    let content = lines.join("\n");
+    let Some(lang) = lang_for_path(uri.path()) else { return vec![]; };
+    let Some(doc)  = parse_live(&content, lang)  else { return vec![]; };
+    cst_hints(idx, uri, &doc.tree, &doc.bytes, range)
+}
 
-    let mut hints = Vec::new();
+// ─── CST walk ────────────────────────────────────────────────────────────────
 
-    for (ln_idx, line) in lines[start..end].iter().enumerate() {
-        let ln = (start + ln_idx) as u32;
-        let trimmed = line.trim_start();
-        // Skip comments.
-        if trimmed.starts_with("//") || trimmed.starts_with('*') || trimmed.starts_with("/*") {
-            continue;
+/// Preorder-walk the tree and emit inlay hints for nodes within `range`.
+fn cst_hints(
+    idx:   &Arc<Indexer>,
+    uri:   &Url,
+    tree:  &tree_sitter::Tree,
+    bytes: &[u8],
+    range: Range,
+) -> Vec<InlayHint> {
+    let mut hints  = Vec::new();
+    let mut cursor = tree.walk();
+
+    'walk: loop {
+        let node = cursor.node();
+        let ns = node.start_position().row as u32;
+        let ne = node.end_position().row as u32;
+
+        // Node starts after the requested range → done.
+        if ns > range.end.line { break; }
+
+        // Entire subtree precedes the requested range → skip it.
+        if ne < range.start.line {
+            loop {
+                if cursor.goto_next_sibling() { continue 'walk; }
+                if !cursor.goto_parent()      { break 'walk; }
+            }
         }
 
-        // ── 1 & 2 & 3: lambda param / `it` / `this` type hints ───────────────
-        hint_lambda_params(idx, uri, line, ln, &mut hints);
+        match node.kind() {
+            "lambda_literal" => {
+                hint_lambda(idx, uri, &node, bytes, range, &mut hints);
+            }
+            "simple_identifier" => {
+                if node.utf8_text(bytes) == Ok("it") {
+                    let pos = ts_pos_to_lsp(node.start_position(), bytes);
+                    if in_range(pos.line, range) {
+                        if let Some(ty) = idx.infer_lambda_param_type_at("it", uri, pos) {
+                            hints.push(type_hint(ts_pos_to_lsp(node.end_position(), bytes), &ty));
+                        }
+                    }
+                }
+            }
+            "this_expression" => {
+                let pos = ts_pos_to_lsp(node.start_position(), bytes);
+                if in_range(pos.line, range) {
+                    if let Some(ty) = idx.infer_lambda_param_type_at("this", uri, pos) {
+                        hints.push(type_hint(ts_pos_to_lsp(node.end_position(), bytes), &ty));
+                    }
+                }
+            }
+            "property_declaration" => {
+                hint_property(idx, uri, &node, bytes, range, &mut hints);
+            }
+            _ => {}
+        }
 
-        // ── 4: untyped val/var declarations ──────────────────────────────────
-        hint_untyped_val(idx, uri, line, ln, &mut hints);
+        // Descend to first child, or advance to next sibling / ancestor sibling.
+        if cursor.goto_first_child() { continue; }
+        loop {
+            if cursor.goto_next_sibling() { break; }
+            if !cursor.goto_parent() { break 'walk; }
+        }
     }
 
     hints
 }
 
-/// Scan one line for `it`, `this`, or named lambda params and emit `: Type` hints.
-fn hint_lambda_params(
-    idx:   &Indexer,
+/// Emit `: Type` hints for named parameters in a `lambda_literal`.
+///
+/// Structure confirmed from tree-sitter-kotlin probe:
+/// `lambda_literal { lambda_parameters { variable_declaration { simple_identifier } } -> statements }`
+fn hint_lambda(
+    idx:   &Arc<Indexer>,
     uri:   &Url,
-    line:  &str,
-    ln:    u32,
+    node:  &tree_sitter::Node<'_>,
+    bytes: &[u8],
+    range: Range,
     hints: &mut Vec<InlayHint>,
 ) {
-    // ── Pass 1: named lambda param declarations `{ name ->` or `{ a, b ->` ──
-    // Iterate ALL `->` occurrences so nested lambdas on the same line are handled.
-    let mut search_from = 0;
-    while let Some(arrow_rel) = line[search_from..].find("->") {
-        let arrow_pos = search_from + arrow_rel;
-        if let Some(brace_pos) = line[..arrow_pos].rfind('{') {
-            let names_str = &line[brace_pos + 1..arrow_pos];
-            let mut name_search = 0usize;
-            for tok in names_str.split(',') {
-                let tok_trimmed = tok.trim();
-                let name: String = tok_trimmed.chars()
-                    .take_while(|&c| c.is_alphanumeric() || c == '_')
-                    .collect();
-                if !name.is_empty() && name != "it" && name != "_"
-                    && name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
-                {
-                    // Find this token's position inside `names_str` from `name_search`.
-                    if let Some(tok_rel) = names_str[name_search..].find(tok_trimmed) {
-                        let abs = brace_pos + 1 + name_search + tok_rel;
-                        let col = char_col(line, abs) as u32;
-                        if let Some(ty) = idx.infer_lambda_param_type_at(
-                            &name, uri, Position::new(ln, col)
-                        ) {
-                            let hint_pos = Position::new(ln, col + name.len() as u32);
-                            hints.push(type_hint(hint_pos, &ty));
-                        }
-                    }
+    let mut nc = node.walk();
+    for child in node.children(&mut nc) {
+        if child.kind() != "lambda_parameters" { continue; }
+
+        let mut pc = child.walk();
+        for param in child.children(&mut pc) {
+            if param.kind() != "variable_declaration" { continue; }
+
+            // Skip params that already carry a type annotation (`: Type` child).
+            let mut vc = param.walk();
+            let mut has_type  = false;
+            let mut name_node = None;
+            for pchild in param.children(&mut vc) {
+                match pchild.kind() {
+                    "simple_identifier" if name_node.is_none() => { name_node = Some(pchild); }
+                    ":"                                        => { has_type = true; break; }
+                    _ => {}
                 }
-                name_search += tok.len() + 1; // +1 for the `,` separator
+            }
+            if has_type { continue; }
+
+            let Some(name_n) = name_node                    else { continue };
+            let Ok(name)     = name_n.utf8_text(bytes)      else { continue };
+            let name = name.trim();
+            if name.is_empty() || name == "_" { continue; }
+            if !name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false) { continue; }
+
+            let start_pos = ts_pos_to_lsp(name_n.start_position(), bytes);
+            let end_pos   = ts_pos_to_lsp(name_n.end_position(),   bytes);
+            if !in_range(start_pos.line, range) { continue; }
+
+            if let Some(ty) = idx.infer_lambda_param_type_at(name, uri, start_pos) {
+                hints.push(type_hint(end_pos, &ty));
             }
         }
-        search_from = arrow_pos + 2;
-    }
-
-    // ── Pass 2: `it` and `this` usages (may appear multiple times per line) ──
-    let mut pos = 0;
-    while pos < line.len() {
-        let remaining = &line[pos..];
-
-        if let Some(rel) = find_word(remaining, "it") {
-            let abs = pos + rel;
-            let col = char_col(line, abs) as u32;
-            if let Some(ty) = idx.infer_lambda_param_type_at(
-                "it", uri, Position::new(ln, col)
-            ) {
-                hints.push(type_hint(Position::new(ln, col + 2), &ty));
-            }
-            pos = abs + 2;
-            continue;
-        }
-
-        if let Some(rel) = find_word(remaining, "this") {
-            let abs = pos + rel;
-            let col = char_col(line, abs) as u32;
-            if let Some(ty) = idx.infer_lambda_param_type_at(
-                "this", uri, Position::new(ln, col)
-            ) {
-                hints.push(type_hint(Position::new(ln, col + 4), &ty));
-            }
-            pos = abs + 4;
-            continue;
-        }
-
-        break;
+        break; // only one lambda_parameters block per literal
     }
 }
 
 /// Emit `: Type` hint for `val name = expr` / `var name = expr` without explicit type.
-///
-/// Pattern: `(val|var) <ident> =` with NO `:` between the ident and `=`.
-fn hint_untyped_val(
-    idx:   &Indexer,
+fn hint_property(
+    idx:   &Arc<Indexer>,
     uri:   &Url,
-    line:  &str,
-    ln:    u32,
+    node:  &tree_sitter::Node<'_>,
+    bytes: &[u8],
+    range: Range,
     hints: &mut Vec<InlayHint>,
 ) {
-    let trimmed = line.trim_start();
-    let prefix = if trimmed.starts_with("val ") { "val " }
-                 else if trimmed.starts_with("var ") { "var " }
-                 else { return; };
+    // Find the variable_declaration child.
+    let mut nc  = node.walk();
+    let mut var_decl = None;
+    for child in node.children(&mut nc) {
+        if child.kind() == "variable_declaration" { var_decl = Some(child); break; }
+    }
+    let Some(vd) = var_decl else { return };
 
-    let after_kw = &trimmed[prefix.len()..];
-    // Extract identifier.
-    let name: String = after_kw.chars().take_while(|&c| c.is_alphanumeric() || c == '_').collect();
+    // Check for existing type annotation.
+    let mut vc        = vd.walk();
+    let mut has_type  = false;
+    let mut name_node = None;
+    for child in vd.children(&mut vc) {
+        match child.kind() {
+            "simple_identifier" if name_node.is_none() => { name_node = Some(child); }
+            ":"                                        => { has_type = true; break; }
+            _ => {}
+        }
+    }
+    if has_type { return; }
+
+    // Must have `=` (skip abstract / delegate declarations without an initializer).
+    let mut nc2      = node.walk();
+    let has_assign   = node.children(&mut nc2).any(|c| c.kind() == "=");
+    if !has_assign { return; }
+
+    let Some(name_n) = name_node               else { return };
+    let Ok(name)     = name_n.utf8_text(bytes) else { return };
+    let name = name.trim();
     if name.is_empty() { return; }
 
-    let after_name = after_kw[name.len()..].trim_start();
-    // If the next non-space char is `:` → already typed, skip.
-    if after_name.starts_with(':') { return; }
-    // Must be `=` to be an assignment.
-    if !after_name.starts_with('=') { return; }
+    let start_pos = ts_pos_to_lsp(name_n.start_position(), bytes);
+    let end_pos   = ts_pos_to_lsp(name_n.end_position(),   bytes);
+    if !in_range(start_pos.line, range) { return; }
 
-    // Find the column of the name in the original line.
-    let name_byte = line.find(&name[..]).unwrap_or(0);
-    let col = char_col(line, name_byte) as u32;
-
-    if let Some(raw) = crate::resolver::infer_variable_type_raw(idx, &name, uri) {
-        let base: String = raw.chars().take_while(|&c| c.is_alphanumeric() || c == '_' || c == '<' || c == '>').collect();
-        if base.is_empty() { return; }
-        let hint_pos = Position::new(ln, col + name.len() as u32);
-        hints.push(type_hint(hint_pos, &base));
+    if let Some(raw) = crate::resolver::infer_variable_type_raw(idx, name, uri) {
+        let base: String = raw.chars()
+            .take_while(|&c| c.is_alphanumeric() || c == '_' || c == '<' || c == '>')
+            .collect();
+        if !base.is_empty() {
+            hints.push(type_hint(end_pos, &base));
+        }
     }
 }
 
@@ -162,35 +213,37 @@ fn hint_untyped_val(
 fn type_hint(position: Position, type_name: &str) -> InlayHint {
     InlayHint {
         position,
-        label:   InlayHintLabel::String(format!(": {type_name}")),
-        kind:    Some(InlayHintKind::TYPE),
-        text_edits:  None,
-        tooltip:     None,
-        padding_left:  Some(false),
+        label:        InlayHintLabel::String(format!(": {type_name}")),
+        kind:         Some(InlayHintKind::TYPE),
+        text_edits:   None,
+        tooltip:      None,
+        padding_left: Some(false),
         padding_right: Some(true),
-        data:    None,
+        data:         None,
     }
 }
 
-/// Find `word` as a complete identifier (not part of a longer name) in `s`.
-/// Returns the byte offset of the match, or `None`.
-fn find_word(s: &str, word: &str) -> Option<usize> {
-    let mut start = 0;
-    while let Some(rel) = s[start..].find(word) {
-        let abs = start + rel;
-        let before_ok = abs == 0
-            || !s[..abs].chars().last().map(|c| c.is_alphanumeric() || c == '_').unwrap_or(false);
-        let after_ok  = abs + word.len() >= s.len()
-            || !s[abs + word.len()..].chars().next().map(|c| c.is_alphanumeric() || c == '_').unwrap_or(false);
-        if before_ok && after_ok { return Some(abs); }
-        start = abs + 1;
-    }
-    None
+#[inline]
+fn in_range(line: u32, range: Range) -> bool {
+    line >= range.start.line && line <= range.end.line
 }
 
-/// Convert a byte offset in `line` to a Unicode character column.
-fn char_col(line: &str, byte_offset: usize) -> usize {
-    line[..byte_offset.min(line.len())].chars().count()
+/// Convert a tree-sitter `Point` (row, byte-column) to an LSP `Position`
+/// (0-based line, UTF-16 code-unit column).
+fn ts_pos_to_lsp(pos: tree_sitter::Point, bytes: &[u8]) -> Position {
+    Position::new(pos.row as u32, ts_byte_col_to_utf16(bytes, pos.row, pos.column) as u32)
+}
+
+/// Count the UTF-16 code units in `bytes` from the start of `row` up to `byte_col`.
+fn ts_byte_col_to_utf16(bytes: &[u8], row: usize, byte_col: usize) -> usize {
+    let line_start: usize = bytes.split(|&b| b == b'\n')
+        .take(row)
+        .map(|l| l.len() + 1)
+        .sum();
+    let end = (line_start + byte_col).min(bytes.len());
+    std::str::from_utf8(&bytes[line_start..end])
+        .map(|s| s.chars().map(|c| c.len_utf16()).sum())
+        .unwrap_or(byte_col)
 }
 
 // ─── tests ───────────────────────────────────────────────────────────────────
@@ -242,7 +295,6 @@ mod tests {
     fn no_hint_for_typed_val() {
         let src = "val items: List<Product> = emptyList()";
         let hints = hints_for(src);
-        // `items` has an explicit type — no hint needed.
         assert!(
             !hints.iter().any(|h| matches!(&h.label, InlayHintLabel::String(s) if s.contains("items"))),
             "should not hint explicitly typed val",
@@ -250,17 +302,7 @@ mod tests {
     }
 
     #[test]
-    fn find_word_finds_whole_words() {
-        assert_eq!(find_word("it.name", "it"), Some(0));
-        assert_eq!(find_word("bits.name", "it"), None);  // `it` inside `bits`
-        assert_eq!(find_word("  it ", "it"), Some(2));
-        assert_eq!(find_word("with(it)", "it"), Some(5));
-    }
-
-    #[test]
     fn hints_inject_constructor_lambdas() {
-        // Reproduces DashboardProductsViewModel pattern:
-        // @Inject constructor with nested lambdas containing `it`.
         let src = r#"package test
 
 class ProductsUseCases
@@ -290,7 +332,6 @@ class DashboardProductsViewModel @javax.inject.Inject constructor(
 
     #[test]
     fn hints_survive_syntax_error() {
-        // Simulate a file with a missing closing brace — tree-sitter error recovery.
         let src = "val items: List<Product> = emptyList()\nitems.forEach { it.name\n";
         let hints = hints_for(src);
         assert!(
@@ -301,8 +342,6 @@ class DashboardProductsViewModel @javax.inject.Inject constructor(
 
     #[test]
     fn hints_nested_named_arg_lambda() {
-        // Reproduces DashboardProductsViewModel pattern:
-        // nested named-arg lambdas inside a constructor call.
         let src = r#"package test
 
 class SheetReloadActions(
@@ -321,20 +360,16 @@ class Vm {
 "#;
         let hints = hints_for(src);
         eprintln!("nested_named_arg hints: {hints:?}");
-        // `it` in buildingSavings lambda should infer `: String`
         let has_string = hints.iter().any(|h| {
             matches!(&h.label, InlayHintLabel::String(s) if s == ": String")
         });
         eprintln!("has_string={has_string}");
-        // At minimum, we should be able to resolve `it` type from constructor param
         assert!(has_string,
             "expected ': String' hint for it/loanId in nested named-arg lambda, got: {hints:?}");
     }
 
     #[test]
     fn hints_nested_named_arg_cross_file() {
-        // Cross-file variant: SheetReloadActions is a nested data class
-        // inside DashboardProductsReducer (separate file), matching the real codebase.
         let idx = Arc::new(Indexer::new());
         let u1 = uri("/DashboardProductsReducer.kt");
         idx.index_content(&u1, r#"package test
@@ -383,4 +418,25 @@ class Vm {
         assert!(has_card,
             "expected ': CardProduct' hint for it in cards lambda, got: {hints:?}");
     }
+
+    #[test]
+    fn ts_byte_col_utf16_ascii() {
+        // For ASCII content the UTF-16 column equals the byte column.
+        let bytes = b"fun main() {}\n";
+        assert_eq!(ts_byte_col_to_utf16(bytes, 0, 4), 4); // "fun " = 4 bytes = 4 UTF-16 units
+    }
+
+    #[test]
+    fn ts_byte_col_utf16_multibyte() {
+        // "café" — 'é' is U+00E9 (2 UTF-8 bytes, 1 UTF-16 unit).
+        let line = "café foo";
+        let bytes = line.as_bytes();
+        // byte offset 6 is after "café " (c=1,a=1,f=1,é=2,space=1 → 6 bytes)
+        // char cols: c=0,a=1,f=1(wait: c-a-f-é = 4 chars, then space = 5 chars total for "café ")
+        // UTF-16: same as char count for BMP chars = 5
+        let byte_col = "café ".len(); // 6 bytes
+        let utf16 = ts_byte_col_to_utf16(bytes, 0, byte_col);
+        assert_eq!(utf16, 5, "expected 5 UTF-16 units for 'café '");
+    }
 }
+


### PR DESCRIPTION
## Summary

Adds tree-sitter live parse tree infrastructure for editor-open files. This is Phase 5, step 1 (`cst-live-tree`) — the foundation for replacing manual bracket/depth scanning with CST node walks.

## Changes

### New files
- **`src/indexer/live_tree.rs`**: `LiveDoc` struct, `lang_for_path()` (canonical extension→Language map), `parse_live()`
- **`src/indexer/live_tree_impl.rs`**: `Indexer` methods: `store_live_tree()`, `live_doc()`, `remove_live_tree()`
- **`src/indexer/live_tree_tests.rs`**: 14 tests

### Modified
- **`src/indexer.rs`**: `live_trees: DashMap<String, Arc<LiveDoc>>` field; module declarations; **not cleared on `reset_index_state()`** so open-file trees survive workspace reindex
- **`src/backend/mod.rs`**: wire `store_live_tree()` in `did_open` + `did_change` alongside `set_live_lines()`; `remove_live_tree()` + `live_lines` cleanup in `did_close`

## Design notes

- **Stale-entry guarantee**: unsupported extensions and parse failures remove any previously-stored tree for the URI so consumers never read stale docs
- **Inline parse**: `store_live_tree` runs synchronously in the async handler (~3ms for 5000 lines); same pattern as `set_live_lines`
- **Closed-file fallback**: not needed at this stage — next steps (`cst-inlay-hints`) will re-parse on demand for closed files using the same `lang_for_path` + `parse_live` helpers
- **`did_close` cleanup**: also removes `live_lines` (previously leaked on close)

## Tests

477 total (14 new): lang dispatch, parse correctness for Kotlin/Java/Swift, open/update/close lifecycle, unknown-extension no-op, survival through `reset_index_state`.