### PR TITLE
refactor(6.3): add CST fast path to signature_help

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -134,6 +134,78 @@ The skill extension provides:
 - `kotlin_lsp_set_workspace` — write config file and restart LSP for a new project
 - `kotlin_lsp_info` — capabilities and known limitations
 
+## Rust coding guidelines
+
+These rules are distilled from the actionbook/rust-skills layer framework and leonardomso/rust-skills,
+cherry-picked for relevance to kotlin-lsp's architecture.
+
+### Design tracing (actionbook layer model)
+
+Before making a design decision, trace through three layers top-down:
+
+1. **WHY (Domain)** — What constraint does this solve? (e.g. "infer functions are pure reads over a snapshot")
+2. **WHAT (Design)** — What pattern fits? (e.g. `InferDeps` trait, `CursorPos` newtype)
+3. **HOW (Mechanics)** — Which Rust feature? (e.g. generic bound, struct, method)
+
+Never jump straight to HOW. A misdiagnosed WHY produces technically correct but wrong abstractions.
+
+### Newtypes for semantic safety
+
+Adjacent `usize` params like `(cursor_line, cursor_col)` are a transposition bug waiting to happen.
+Wrap them in a named struct with documented units:
+
+```rust
+/// Cursor position in a document. `col` is UTF-16 code units (LSP protocol).
+pub struct CursorPos { pub line: usize, pub col: usize }
+```
+
+Apply when: two same-type params appear together in ≥2 function signatures with swappable semantics.
+
+### Rule of Three before abstracting
+
+Don't introduce a generic bound until you have ≥2 distinct concrete implementations that actually
+differ. For the `InferDeps` trait pattern: the rule is met — `Indexer` (production) and `TestDeps`
+(test stub) are genuinely different. If only one concrete type exists, keep the function concrete.
+
+### Prefer generics over `Box<dyn Trait>`
+
+Use `impl Trait` or `<T: Trait>` for infer functions (static dispatch, zero cost, no heap).
+Reserve `Box<dyn Trait>` only for heterogeneous runtime collections or plugin-style registries.
+
+```rust
+// Good: infer function with generic bound
+fn infer_it_type<D: InferDeps>(deps: &D, pos: CursorPos) -> Option<String> { ... }
+
+// Avoid: dyn Trait adds vtable overhead and heap allocation for no benefit here
+fn infer_it_type(deps: &dyn InferDeps, pos: CursorPos) -> Option<String> { ... }
+```
+
+### Traits for testability
+
+Extract snapshot access behind a trait so infer functions can be tested without a full `Indexer`:
+
+```rust
+pub trait InferDeps {
+    fn lines(&self, uri: &str) -> Option<Arc<Vec<String>>>;
+    fn live_doc(&self, uri: &str) -> Option<Arc<LiveDoc>>;
+    fn symbol_detail(&self, name: &str, container: &str) -> Option<String>;
+}
+```
+
+Unit tests implement `TestDeps` as a simple struct — no DashMap, no disk, fast.
+
+### Purity in infer functions
+
+Functions that read doc/index data and return inference results are pure: `(inputs) -> output`.
+Do not let them mutate index state. Mutation (on-demand indexing, cache fills) belongs on `Indexer`,
+not inside the infer call graph.
+
+### Dedup before abstracting
+
+Before introducing a new utility function, check if it already exists:
+- `utf16_col_to_byte` — in `src/indexer/live_tree.rs`; don't inline the loop
+- `lines_for(uri)` — in `src/indexer/scope.rs` (moving to `indexer.rs`); don't duplicate the pattern
+
 ## Known limitations
 
 - **No type resolution** — tree-sitter gives structure, not type-checked references

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use crate::indexer::find_fun_signature_with_receiver;
+use crate::resolver::{ReceiverKind, infer_receiver_type};
 use super::Backend;
 use super::helpers::resolve_references_scope;
 use super::actions::is_non_call_keyword;
@@ -59,14 +60,12 @@ impl Backend {
         // so hover shows the member from the correct class (mirrors goto_definition fix).
         if let Some(qual) = qualifier.as_deref() {
             if qual == "this" || qual == "it" {
-                if let Some(type_name) = self.indexer.infer_lambda_param_type_at(qual, uri, position) {
-                    // Try full qualified name first (e.g. `Outer.Inner`), then short segment.
-                    let locs = self.indexer.find_definition_qualified(&word, Some(&type_name), uri);
-                    let locs = if locs.is_empty() {
-                        let short = type_name.rsplit('.').next().unwrap_or(&type_name);
-                        if short != type_name {
-                            self.indexer.find_definition_qualified(&word, Some(short), uri)
-                        } else { locs }
+                let kind = ReceiverKind::Contextual { name: qual, position };
+                if let Some(rt) = infer_receiver_type(&self.indexer, kind, uri) {
+                    // Try full qualified type first (e.g. `Outer.Inner`), then leaf segment.
+                    let locs = self.indexer.find_definition_qualified(&word, Some(&rt.qualified), uri);
+                    let locs = if locs.is_empty() && rt.leaf != rt.qualified {
+                        self.indexer.find_definition_qualified(&word, Some(&rt.leaf), uri)
                     } else { locs };
                     if let Some(loc) = locs.first() {
                         if let Some(md) = self.indexer.hover_info_at_location(loc, &word) {
@@ -392,115 +391,16 @@ impl Backend {
         let col = crate::indexer::live_tree::utf16_col_to_byte(line_text, pos.character as usize);
         let before = &line_text[..col];
 
-        // ── CST fast path ────────────────────────────────────────────────────
-        // Walk from the cursor node up to the nearest call_expression ancestor,
-        // then extract fn name, qualifier, and active param from the tree.
-        // O(depth) vs the O(lines × chars) text scan below.
-        if let Some((cst_name, cst_qualifier, cst_active_param)) =
-            cst_signature_help_data(pos, &self.indexer, uri)
-        {
-            let params_text = find_fun_signature_with_receiver(
-                &self.indexer, uri, &cst_name, cst_qualifier.as_deref(),
-            );
-            if !params_text.is_empty() {
-                return Ok(build_signature_help(&cst_name, &params_text, cst_active_param));
-            }
-        }
-
-        // ── Text path ────────────────────────────────────────────────────────
-        let mut depth: i32 = 0;
-        let mut active_param: u32 = 0;
-        let mut call_name: Option<String> = None;
-        let mut call_qualifier: Option<String> = None; // receiver before the dot
-        let chars: Vec<char> = before.chars().collect();
-        let mut i = chars.len();
-        while i > 0 {
-            i -= 1;
-            match chars[i] {
-                ')' | ']' => { depth += 1; }
-                '{' | '}' => {
-                    // Brace means we've exited the current lambda/block scope —
-                    // stop scanning to avoid finding an outer function's paren.
-                    break;
-                }
-                '(' => {
-                    if depth == 0 {
-                        let mut j = i;
-                        while j > 0 && (chars[j - 1].is_alphanumeric() || chars[j - 1] == '_') {
-                            j -= 1;
-                        }
-                        let candidate: String = chars[j..i].iter().collect();
-                        if !candidate.is_empty() && !is_non_call_keyword(&candidate) {
-                            call_name = Some(candidate);
-                            // Capture qualifier: the identifier before a `.` if present.
-                            if j > 0 && chars[j - 1] == '.' {
-                                let mut k = j - 1;
-                                while k > 0 && (chars[k - 1].is_alphanumeric() || chars[k - 1] == '_') {
-                                    k -= 1;
-                                }
-                                let q: String = chars[k..j - 1].iter().collect();
-                                if !q.is_empty() {
-                                    call_qualifier = Some(q);
-                                }
-                            }
-                        }
-                        break;
-                    }
-                    depth -= 1;
-                }
-                ',' if depth == 0 => { active_param += 1; }
-                _ => {}
-            }
-        }
-
-        // If not found on this line, try multiline scan (up to 10 lines up).
-        // Only cross into a previous line if the current line doesn't contain a
-        // closing brace (which would mean we're inside a block body, not an arg list).
-        let in_block_body = before.contains('{') || before.contains('}')
-            || lines[line_idx].trim_start().starts_with('}');
-        if call_name.is_none() && line_idx > 0 && !in_block_body {
-            let scan_start = line_idx.saturating_sub(10);
-            'outer: for scan_line in (scan_start..line_idx).rev() {
-                let l = &lines[scan_line];
-                // Stop if we cross a closing brace — that means we entered a block body.
-                if l.contains('{') || l.contains('}') {
-                    break;
-                }
-                // Find the last `(` on this line.
-                for (p, _) in l.char_indices().filter(|&(_, c)| c == '(').collect::<Vec<_>>().into_iter().rev() {
-                    let before_paren = &l[..p];
-                    let name: String = before_paren.chars()
-                        .rev()
-                        .take_while(|&c| c.is_alphanumeric() || c == '_')
-                        .collect::<String>()
-                        .chars().rev().collect();
-                    if !name.is_empty() && !is_non_call_keyword(&name) {
-                        // Make sure this `(` is unmatched (not closed on the same line).
-                        let after_paren = &l[p..];
-                        let net: i32 = after_paren.chars().map(|c| match c {
-                            '(' => 1, ')' => -1, _ => 0,
-                        }).sum();
-                        if net > 0 {
-                            call_name = Some(name);
-                            if scan_line + 1 < line_idx {
-                                for mid_line in &lines[(scan_line + 1)..line_idx] {
-                                    active_param += mid_line.chars().filter(|&c| c == ',').count() as u32;
-                                }
-                            }
-                            active_param += before.chars().filter(|&c| c == ',').count() as u32;
-                            break 'outer;
-                        }
-                    }
-                }
-            }
-        }
-
-        let name = match call_name {
-            Some(n) if !n.is_empty() => n,
-            _ => return Ok(None),
+        // Extract (fn_name, qualifier, active_param) — CST first, text fallback.
+        let Some((name, qualifier, active_param)) =
+            extract_call_info(pos, &self.indexer, uri, lines, before, line_idx)
+        else {
+            return Ok(None);
         };
 
-        let params_text = find_fun_signature_with_receiver(&self.indexer, uri, &name, call_qualifier.as_deref());
+        let params_text = find_fun_signature_with_receiver(
+            &self.indexer, uri, &name, qualifier.as_deref(),
+        );
         if params_text.is_empty() {
             return Ok(None);
         }
@@ -601,15 +501,35 @@ fn build_signature_help(fn_name: &str, params_text: &str, active_param: u32) -> 
     })
 }
 
-/// CST fast path for signature help.
+/// Extract `(fn_name, qualifier, active_param)` for the call under the cursor.
 ///
-/// Walks from the cursor node upward to find the nearest `call_expression`
-/// ancestor, then extracts `(fn_name, qualifier, active_param)`.  Returns
-/// `None` when:
-/// - no live tree is available (text path runs instead)
-/// - the cursor is inside a lambda literal rather than an argument list
-/// - the callee is not a simple or navigation expression
-fn cst_signature_help_data(
+/// Tries the CST (live tree) first — O(depth), accurate qualifier extraction.
+/// Falls back to a text scan when no live tree is available, when the cursor
+/// is inside a lambda literal, or when the callee shape is not recognised.
+fn extract_call_info(
+    pos:      Position,
+    indexer:  &crate::indexer::Indexer,
+    uri:      &Url,
+    lines:    &[String],
+    before:   &str,
+    line_idx: usize,
+) -> Option<(String, Option<String>, u32)> {
+    // ── CST path ─────────────────────────────────────────────────────────────
+    if let Some(result) = cst_call_info(pos, indexer, uri) {
+        return Some(result);
+    }
+
+    // ── Text path ────────────────────────────────────────────────────────────
+    text_call_info(lines, before, line_idx)
+}
+
+/// CST path: walk from cursor up to `call_expression`, extract name/qualifier/param.
+///
+/// Returns `None` when:
+/// - no live tree available
+/// - cursor is inside a `lambda_literal`
+/// - callee shape not recognised (`simple_identifier` / `navigation_expression`)
+fn cst_call_info(
     pos:     Position,
     indexer: &crate::indexer::Indexer,
     uri:     &Url,
@@ -648,16 +568,39 @@ fn cst_signature_help_data(
             (name, None)
         }
         "navigation_expression" => {
+            // Tree structure: navigation_expression
+            //   simple_identifier "receiver"        ← direct child (the qualifier)
+            //   navigation_suffix                   ← direct child
+            //     "."
+            //     simple_identifier "methodName"    ← fn name lives here
+            //
+            // We must look inside navigation_suffix for the function name, NOT
+            // use direct-children-only iteration which misses the nested identifier.
+            let mut fn_name_opt: Option<String> = None;
+            let mut qualifier_opt: Option<String> = None;
             let mut walker = callee.walk();
-            let idents: Vec<_> = callee.children(&mut walker)
-                .filter(|c| c.kind() == "simple_identifier" || c.kind() == "type_identifier")
-                .collect();
-            let fn_node = idents.last()?;
-            let fn_name = std::str::from_utf8(&bytes[fn_node.byte_range()]).ok()?.to_string();
-            let qualifier = idents.len().checked_sub(2).and_then(|qi| {
-                std::str::from_utf8(&bytes[idents[qi].byte_range()]).ok().map(|s| s.to_string())
-            });
-            (fn_name, qualifier)
+            for child in callee.children(&mut walker) {
+                match child.kind() {
+                    "simple_identifier" | "type_identifier" => {
+                        // First direct identifier = the receiver/qualifier.
+                        qualifier_opt = std::str::from_utf8(&bytes[child.byte_range()])
+                            .ok().map(|s| s.to_string());
+                    }
+                    "navigation_suffix" => {
+                        // The function name is the simple_identifier inside the suffix.
+                        let mut sw = child.walk();
+                        for sc in child.children(&mut sw) {
+                            if sc.kind() == "simple_identifier" || sc.kind() == "type_identifier" {
+                                fn_name_opt = std::str::from_utf8(&bytes[sc.byte_range()])
+                                    .ok().map(|s| s.to_string());
+                                break;
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            (fn_name_opt?, qualifier_opt)
         }
         _ => return None,
     };
@@ -698,4 +641,97 @@ fn cst_find_value_arguments(call_expr: tree_sitter::Node<'_>) -> Option<tree_sit
         }
     }
     None
+}
+
+/// Text-scan fallback: extract `(fn_name, qualifier, active_param)` by walking
+/// backwards through `before` (and up to 10 previous lines for multiline calls).
+fn text_call_info(
+    lines:    &[String],
+    before:   &str,
+    line_idx: usize,
+) -> Option<(String, Option<String>, u32)> {
+    let mut depth: i32 = 0;
+    let mut active_param: u32 = 0;
+    let mut call_name: Option<String> = None;
+    let mut call_qualifier: Option<String> = None;
+
+    let chars: Vec<char> = before.chars().collect();
+    let mut i = chars.len();
+    while i > 0 {
+        i -= 1;
+        match chars[i] {
+            ')' | ']' => { depth += 1; }
+            '{' | '}' => { break; }
+            '(' => {
+                if depth == 0 {
+                    let mut j = i;
+                    while j > 0 && (chars[j - 1].is_alphanumeric() || chars[j - 1] == '_') {
+                        j -= 1;
+                    }
+                    let candidate: String = chars[j..i].iter().collect();
+                    if !candidate.is_empty() && !is_non_call_keyword(&candidate) {
+                        call_name = Some(candidate);
+                        if j > 0 && chars[j - 1] == '.' {
+                            let mut k = j - 1;
+                            while k > 0 && (chars[k - 1].is_alphanumeric() || chars[k - 1] == '_') {
+                                k -= 1;
+                            }
+                            let q: String = chars[k..j - 1].iter().collect();
+                            if !q.is_empty() { call_qualifier = Some(q); }
+                        }
+                    }
+                    break;
+                }
+                depth -= 1;
+            }
+            ',' if depth == 0 => { active_param += 1; }
+            _ => {}
+        }
+    }
+
+    // Multiline: scan up to 10 lines back when the call opens on a previous line.
+    let in_block_body = before.contains('{') || before.contains('}')
+        || lines[line_idx].trim_start().starts_with('}');
+    if call_name.is_none() && line_idx > 0 && !in_block_body {
+        let scan_start = line_idx.saturating_sub(10);
+        'outer: for scan_line in (scan_start..line_idx).rev() {
+            let l = &lines[scan_line];
+            if l.contains('{') || l.contains('}') { break; }
+            for (p, _) in l.char_indices().filter(|&(_, c)| c == '(')
+                .collect::<Vec<_>>().into_iter().rev()
+            {
+                let before_paren = &l[..p];
+                let name: String = before_paren.chars().rev()
+                    .take_while(|&c| c.is_alphanumeric() || c == '_')
+                    .collect::<String>().chars().rev().collect();
+                if !name.is_empty() && !is_non_call_keyword(&name) {
+                    let net: i32 = l[p..].chars()
+                        .map(|c| match c { '(' => 1, ')' => -1, _ => 0 }).sum();
+                    if net > 0 {
+                        // Qualifier before the dot on the same line.
+                        let before_name = &before_paren[..before_paren.len() - name.len()];
+                        let qualifier = if before_name.ends_with('.') {
+                            let q: String = before_name[..before_name.len() - 1]
+                                .chars().rev()
+                                .take_while(|&c| c.is_alphanumeric() || c == '_')
+                                .collect::<String>().chars().rev().collect();
+                            if q.is_empty() { None } else { Some(q) }
+                        } else { None };
+                        call_name = Some(name);
+                        call_qualifier = qualifier;
+                        if scan_line + 1 < line_idx {
+                            for mid in &lines[(scan_line + 1)..line_idx] {
+                                active_param += mid.chars().filter(|&c| c == ',').count() as u32;
+                            }
+                        }
+                        active_param += before.chars().filter(|&c| c == ',').count() as u32;
+                        break 'outer;
+                    }
+                }
+            }
+        }
+    }
+
+    let name = call_name.filter(|n| !n.is_empty())?;
+    Some((name, call_qualifier, active_param))
 }

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -392,7 +392,22 @@ impl Backend {
         let col = crate::indexer::live_tree::utf16_col_to_byte(line_text, pos.character as usize);
         let before = &line_text[..col];
 
-        // Count commas at the current paren depth to find active param.
+        // ── CST fast path ────────────────────────────────────────────────────
+        // Walk from the cursor node up to the nearest call_expression ancestor,
+        // then extract fn name, qualifier, and active param from the tree.
+        // O(depth) vs the O(lines × chars) text scan below.
+        if let Some((cst_name, cst_qualifier, cst_active_param)) =
+            cst_signature_help_data(pos, &self.indexer, uri)
+        {
+            let params_text = find_fun_signature_with_receiver(
+                &self.indexer, uri, &cst_name, cst_qualifier.as_deref(),
+            );
+            if !params_text.is_empty() {
+                return Ok(build_signature_help(&cst_name, &params_text, cst_active_param));
+            }
+        }
+
+        // ── Text path ────────────────────────────────────────────────────────
         let mut depth: i32 = 0;
         let mut active_param: u32 = 0;
         let mut call_name: Option<String> = None;
@@ -490,29 +505,7 @@ impl Backend {
             return Ok(None);
         }
 
-        let raw = params_text.trim_matches(|c| c == '(' || c == ')');
-        let param_parts: Vec<&str> = raw.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
-
-        let parameters: Vec<ParameterInformation> = param_parts.iter().map(|p| {
-            ParameterInformation {
-                label: ParameterLabel::Simple(p.to_string()),
-                documentation: None,
-            }
-        }).collect();
-
-        let label = format!("{}({})", name, param_parts.join(", "));
-        let active_param = active_param.min(parameters.len().saturating_sub(1) as u32);
-
-        Ok(Some(SignatureHelp {
-            signatures: vec![SignatureInformation {
-                label,
-                documentation: None,
-                parameters: Some(parameters),
-                active_parameter: Some(active_param),
-            }],
-            active_signature: Some(0),
-            active_parameter: Some(active_param),
-        }))
+        Ok(build_signature_help(&name, &params_text, active_param))
     }
 
     pub(super) async fn folding_range_impl(
@@ -580,4 +573,129 @@ impl Backend {
 
         Ok(if ranges.is_empty() { None } else { Some(ranges) })
     }
+}
+
+// ─── Private helpers for signature_help_impl ─────────────────────────────────
+
+/// Build a `SignatureHelp` response from pre-computed parts.
+fn build_signature_help(fn_name: &str, params_text: &str, active_param: u32) -> Option<SignatureHelp> {
+    let raw = params_text.trim_matches(|c| c == '(' || c == ')');
+    let param_parts: Vec<&str> = raw.split(',').map(|s| s.trim()).filter(|s| !s.is_empty()).collect();
+    let parameters: Vec<ParameterInformation> = param_parts.iter().map(|p| {
+        ParameterInformation {
+            label: ParameterLabel::Simple(p.to_string()),
+            documentation: None,
+        }
+    }).collect();
+    let label = format!("{}({})", fn_name, param_parts.join(", "));
+    let active_param = active_param.min(parameters.len().saturating_sub(1) as u32);
+    Some(SignatureHelp {
+        signatures: vec![SignatureInformation {
+            label,
+            documentation: None,
+            parameters: Some(parameters),
+            active_parameter: Some(active_param),
+        }],
+        active_signature: Some(0),
+        active_parameter: Some(active_param),
+    })
+}
+
+/// CST fast path for signature help.
+///
+/// Walks from the cursor node upward to find the nearest `call_expression`
+/// ancestor, then extracts `(fn_name, qualifier, active_param)`.  Returns
+/// `None` when:
+/// - no live tree is available (text path runs instead)
+/// - the cursor is inside a lambda literal rather than an argument list
+/// - the callee is not a simple or navigation expression
+fn cst_signature_help_data(
+    pos:     Position,
+    indexer: &crate::indexer::Indexer,
+    uri:     &Url,
+) -> Option<(String, Option<String>, u32)> {
+    use tree_sitter::Point;
+    use crate::indexer::live_tree::utf16_col_to_byte;
+
+    let doc = indexer.live_doc(uri)?;
+    let bytes = &doc.bytes;
+    let full_text = std::str::from_utf8(bytes).ok()?;
+
+    let line_idx = pos.line as usize;
+    let line_text = full_text.lines().nth(line_idx)?;
+    let byte_col = utf16_col_to_byte(line_text, pos.character as usize);
+    let point = Point { row: line_idx, column: byte_col };
+    let start_node = doc.tree.root_node().descendant_for_point_range(point, point)?;
+
+    // Walk up: find call_expression; bail out if we cross into a lambda literal.
+    let mut cur = start_node;
+    let call_expr = loop {
+        match cur.kind() {
+            "call_expression" => break Some(cur),
+            "lambda_literal" => break None,
+            _ => match cur.parent() {
+                Some(p) => cur = p,
+                None => break None,
+            }
+        }
+    }?;
+
+    // Extract function name and optional qualifier from the callee.
+    let callee = call_expr.child(0)?;
+    let (fn_name, qualifier) = match callee.kind() {
+        "simple_identifier" | "type_identifier" => {
+            let name = std::str::from_utf8(&bytes[callee.byte_range()]).ok()?.to_string();
+            (name, None)
+        }
+        "navigation_expression" => {
+            let mut walker = callee.walk();
+            let idents: Vec<_> = callee.children(&mut walker)
+                .filter(|c| c.kind() == "simple_identifier" || c.kind() == "type_identifier")
+                .collect();
+            let fn_node = idents.last()?;
+            let fn_name = std::str::from_utf8(&bytes[fn_node.byte_range()]).ok()?.to_string();
+            let qualifier = idents.len().checked_sub(2).and_then(|qi| {
+                std::str::from_utf8(&bytes[idents[qi].byte_range()]).ok().map(|s| s.to_string())
+            });
+            (fn_name, qualifier)
+        }
+        _ => return None,
+    };
+
+    // Find the value_arguments node (may be inside call_suffix).
+    let value_arguments = cst_find_value_arguments(call_expr)?;
+
+    // Count active param: how many value_argument children end before the cursor.
+    let cursor_byte = full_text.lines()
+        .take(line_idx)
+        .map(|l| l.len() + 1) // +1 for the newline
+        .sum::<usize>() + byte_col;
+    let active_param = {
+        let mut count = 0u32;
+        let mut walker = value_arguments.walk();
+        for child in value_arguments.children(&mut walker) {
+            if child.kind() == "value_argument" {
+                if child.end_byte() <= cursor_byte { count += 1; } else { break; }
+            }
+        }
+        count
+    };
+
+    Some((fn_name, qualifier, active_param))
+}
+
+/// Find the `value_arguments` node within a `call_expression`, searching
+/// through the optional `call_suffix` intermediate node.
+fn cst_find_value_arguments(call_expr: tree_sitter::Node<'_>) -> Option<tree_sitter::Node<'_>> {
+    let mut walker = call_expr.walk();
+    for child in call_expr.children(&mut walker) {
+        if child.kind() == "value_arguments" { return Some(child); }
+        if child.kind() == "call_suffix" {
+            let mut w2 = child.walk();
+            for gc in child.children(&mut w2) {
+                if gc.kind() == "value_arguments" { return Some(gc); }
+            }
+        }
+    }
+    None
 }

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -1,6 +1,7 @@
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use super::Backend;
+use crate::resolver::{ReceiverKind, infer_receiver_type};
 
 fn locs_to_response(locs: Vec<Location>) -> GotoDefinitionResponse {
     match locs.len() {
@@ -77,21 +78,14 @@ impl Backend {
 
         // `this.field` / `it.field` — resolve the implicit receiver/lambda type and
         // use it as the real qualifier so definition lookup finds the correct file.
-        // `resolve_qualified("this", …)` only searches the current file + hierarchy,
-        // which misses members declared on a lambda receiver type (e.g. `Address`
-        // inside `cardAddress?.run { this.descriptiveNumber }`).
-        // `it` is never in declared_names, so `infer_variable_type` always returns
-        // None; we must go through `infer_lambda_param_type_at` here too.
         if let Some(qual) = qualifier.as_deref() {
             if qual == "this" || qual == "it" {
-                if let Some(type_name) = self.indexer.infer_lambda_param_type_at(qual, uri, position) {
-                    // Try full qualified name first (e.g. `Outer.Inner`), then short segment.
-                    let locs = self.indexer.find_definition_qualified(&word, Some(&type_name), uri);
-                    let locs = if locs.is_empty() {
-                        let short = type_name.rsplit('.').next().unwrap_or(&type_name);
-                        if short != type_name {
-                            self.indexer.find_definition_qualified(&word, Some(short), uri)
-                        } else { locs }
+                let kind = ReceiverKind::Contextual { name: qual, position };
+                if let Some(rt) = infer_receiver_type(&self.indexer, kind, uri) {
+                    // Try full qualified type first (e.g. `Outer.Inner`), then leaf segment.
+                    let locs = self.indexer.find_definition_qualified(&word, Some(&rt.qualified), uri);
+                    let locs = if locs.is_empty() && rt.leaf != rt.qualified {
+                        self.indexer.find_definition_qualified(&word, Some(&rt.leaf), uri)
                     } else { locs };
                     if !locs.is_empty() {
                         return Ok(Some(locs_to_response(locs)));

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -9,6 +9,7 @@
 use tower_lsp::lsp_types::{SymbolKind, Url};
 
 use crate::indexer::Indexer;
+use crate::resolver::{ReceiverKind, infer_receiver_type};
 
 // ─── Multiline signature collector ───────────────────────────────────────────
 
@@ -272,33 +273,35 @@ pub(crate) fn find_fun_signature_with_receiver(
     receiver: Option<&str>,
 ) -> String {
     if let Some(recv) = receiver {
-        // Infer the receiver's type and resolve to its file.
-        if let Some(type_name) = crate::resolver::infer_variable_type_raw(idx, recv, uri) {
-            let outer = type_name.split('.').next().unwrap_or(&type_name);
-            let locs = crate::resolver::resolve_symbol(idx, outer, None, uri);
-            for loc in &locs {
-                if let Some(data) = idx.files.get(loc.uri.as_str()) {
-                    if let Some(sig) = collect_fun_params_text(name, loc.uri.as_str(), idx) {
+        let Some(rt) = infer_receiver_type(idx, ReceiverKind::Variable(recv), uri) else {
+            // Receiver present but type could not be resolved — avoid a global
+            // name-only scan that may return a completely unrelated function.
+            return String::new();
+        };
+        let locs = crate::resolver::resolve_symbol(idx, &rt.outer, None, uri);
+        for loc in &locs {
+            if let Some(data) = idx.files.get(loc.uri.as_str()) {
+                if let Some(sig) = collect_fun_params_text(name, loc.uri.as_str(), idx) {
+                    return sig;
+                }
+                // Also search by line range within the type's body.
+                let type_end = data.symbols.iter()
+                    .find(|s| s.name == rt.outer)
+                    .map(|s| s.range.end.line)
+                    .unwrap_or(u32::MAX);
+                for sym in data.symbols.iter()
+                    .filter(|s| s.name == name && s.range.start.line <= type_end)
+                {
+                    if let Some(sig) = collect_params_from_line(
+                        &data.lines,
+                        sym.range.start.line as usize,
+                    ) {
                         return sig;
-                    }
-                    // Also search by line range within the type's body.
-                    let type_end = data.symbols.iter()
-                        .find(|s| s.name == outer)
-                        .map(|s| s.range.end.line)
-                        .unwrap_or(u32::MAX);
-                    for sym in data.symbols.iter()
-                        .filter(|s| s.name == name && s.range.start.line <= type_end)
-                    {
-                        if let Some(sig) = collect_params_from_line(
-                            &data.lines,
-                            sym.range.start.line as usize,
-                        ) {
-                            return sig;
-                        }
                     }
                 }
             }
         }
+        return String::new();
     }
     find_fun_signature_full(name, idx, uri).unwrap_or_default()
 }

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -15,6 +15,7 @@ use tower_lsp::lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, Position, R
 
 use crate::indexer::Indexer;
 use crate::indexer::live_tree::{lang_for_path, parse_live};
+use crate::resolver::{ReceiverKind, infer_receiver_type};
 
 pub fn compute_inlay_hints(idx: &Arc<Indexer>, uri: &Url, range: Range) -> Vec<InlayHint> {
     // Fast path: editor has the file open → use pre-parsed live tree.
@@ -83,8 +84,9 @@ fn cst_hints(
                 if node.utf8_text(bytes) == Ok("it") {
                     let pos = ts_pos_to_lsp(node.start_position(), &starts, bytes);
                     if in_range(pos.line, range) {
-                        if let Some(ty) = idx.infer_lambda_param_type_at("it", uri, pos) {
-                            hints.push(type_hint(ts_pos_to_lsp(node.end_position(), &starts, bytes), &ty));
+                        let kind = ReceiverKind::Contextual { name: "it", position: pos };
+                        if let Some(rt) = infer_receiver_type(idx, kind, uri) {
+                            hints.push(type_hint(ts_pos_to_lsp(node.end_position(), &starts, bytes), &rt.raw));
                         }
                     }
                 }
@@ -92,8 +94,9 @@ fn cst_hints(
             "this_expression" => {
                 let pos = ts_pos_to_lsp(node.start_position(), &starts, bytes);
                 if in_range(pos.line, range) {
-                    if let Some(ty) = idx.infer_lambda_param_type_at("this", uri, pos) {
-                        hints.push(type_hint(ts_pos_to_lsp(node.end_position(), &starts, bytes), &ty));
+                    let kind = ReceiverKind::Contextual { name: "this", position: pos };
+                    if let Some(rt) = infer_receiver_type(idx, kind, uri) {
+                        hints.push(type_hint(ts_pos_to_lsp(node.end_position(), &starts, bytes), &rt.raw));
                     }
                 }
             }
@@ -158,8 +161,8 @@ fn hint_lambda(
             let end_pos   = ts_pos_to_lsp(name_n.end_position(),   starts, bytes);
             if !in_range(start_pos.line, range) { continue; }
 
-            if let Some(ty) = idx.infer_lambda_param_type_at(name, uri, start_pos) {
-                hints.push(type_hint(end_pos, &ty));
+            if let Some(rt) = infer_receiver_type(idx, ReceiverKind::Contextual { name, position: start_pos }, uri) {
+                hints.push(type_hint(end_pos, &rt.raw));
             }
         }
         break; // only one lambda_parameters block per literal
@@ -222,8 +225,8 @@ fn hint_property(
     }
 
     // Fallback: text-based inference (handles `val x: Type` pattern aliases etc.)
-    if let Some(raw) = crate::resolver::infer_variable_type_raw(idx, name, uri) {
-        let base: String = raw.chars()
+    if let Some(rt) = infer_receiver_type(idx, ReceiverKind::Variable(name), uri) {
+        let base: String = rt.raw.chars()
             .take_while(|&c| c.is_alphanumeric() || c == '_' || c == '<' || c == '>')
             .collect();
         if !base.is_empty() {

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -8,7 +8,7 @@ use crate::types::Visibility;
 
 use super::{fqns_for_name, already_imported, make_import_edit,
             resolve_symbol_inner, resolve_symbol_no_rg};
-use super::infer::infer_variable_type;
+use super::infer::{infer_variable_type, ReceiverKind, ReceiverType, infer_receiver_type};
 
 // ─── match scoring ────────────────────────────────────────────────────────────
 
@@ -181,33 +181,28 @@ pub(crate) fn complete_dot(idx: &Indexer, receiver: &str, from_uri: &Url, snippe
         return complete_super(idx, from_uri, snippets);
     }
 
-    // Infer type from variable annotation.
-    let type_name = match infer_variable_type(idx, receiver, from_uri) {
-        Some(t) => t,
+    // Infer and normalise the receiver's type.
+    let rt = match infer_receiver_type(idx, ReceiverKind::Variable(receiver), from_uri) {
+        Some(r) => r,
         None => {
             // Could be an uppercase class/object — look it up directly.
             if receiver.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
-                receiver.to_string()
+                ReceiverType::from_raw(receiver.to_string())
             } else {
                 return vec![];
             }
         }
     };
 
-    // Resolve type to its source file, handling dotted types like `Outer.Inner`.
-    let Some(file_uri) = resolve_type_to_file(idx, &type_name, from_uri) else {
-        return vec![];
+    // Resolve the outer type to its source file (no rg — per-keystroke path).
+    let file_uri = match resolve_symbol_no_rg(idx, &rt.outer, from_uri).first() {
+        Some(loc) => loc.uri.to_string(),
+        None      => return vec![],
     };
 
-    // When the type is `Outer.Inner`, show only the inner type's members.
-    // For a plain type like `ProductKey`, also scope to just that type's body —
-    // avoids leaking top-level functions from the same file.
-    let mut items = if let Some(dot) = type_name.find('.') {
-        let inner_name = &type_name[dot + 1..];
-        symbols_from_nested_type(idx, &file_uri, inner_name)
-    } else {
-        symbols_from_nested_type(idx, &file_uri, &type_name)
-    };
+    // For dotted types (e.g. `Outer.Inner`), show only the inner type's members.
+    // `rt.leaf` is the last segment, so it works for both plain and dotted types.
+    let mut items = symbols_from_nested_type(idx, &file_uri, &rt.leaf);
 
     // Filter out private members — they are inaccessible from outside the class.
     items.retain(|i| i.sort_text.as_deref().map(|s| !s.starts_with("prv:")).unwrap_or(true));
@@ -226,17 +221,8 @@ pub(crate) fn complete_dot(idx: &Indexer, receiver: &str, from_uri: &Url, snippe
     // Append stdlib extensions filtered to the receiver type. Only add Kotlin stdlib
     // when the current file is a Kotlin file; add Swift-specific snippets for Swift.
     let from_path = from_uri.path();
-    items.extend(crate::stdlib_tail::dot_completions_for_lang(from_path, &type_name, snippets));
+    items.extend(crate::stdlib_tail::dot_completions_for_lang(from_path, &rt.qualified, snippets));
     items
-}
-
-/// Resolve a (possibly dotted) type name to the URI of its containing file.
-/// `"DashboardProductsReducer.Factory"` → file where `DashboardProductsReducer` lives.
-fn resolve_type_to_file(idx: &Indexer, type_name: &str, from_uri: &Url) -> Option<String> {
-    // For dotted types, resolve the outer class only.
-    let outer = type_name.split('.').next().unwrap_or(type_name);
-    let locs = resolve_symbol_no_rg(idx, outer, from_uri);
-    Some(locs.first()?.uri.to_string())
 }
 
 /// Return completions for symbols declared INSIDE `type_name` within the given file.

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -2,6 +2,71 @@ use tower_lsp::lsp_types::{Position, Range, Url};
 
 use crate::indexer::Indexer;
 
+// ─── Receiver type resolution ─────────────────────────────────────────────────
+
+/// How the receiver expression should be resolved.
+///
+/// - `Variable`: a named val/var (e.g. `interactor`, `viewModel`).
+///   Resolved via line-scan type annotation (`val name: Type`).
+/// - `Contextual`: `it`, `this`, or a named lambda parameter.
+///   Requires cursor `position` for scope analysis; falls back to
+///   `infer_variable_type_raw` only if scope analysis returns nothing.
+pub enum ReceiverKind<'a> {
+    Variable(&'a str),
+    Contextual { name: &'a str, position: Position },
+}
+
+/// A fully-normalised receiver type with multiple access forms.
+///
+/// All forms are derived from a single raw string (e.g. `"Outer.Inner<Param>"`):
+/// - `raw`       — original with generics: `"Outer.Inner<Param>"`
+/// - `qualified` — no generics, dots preserved: `"Outer.Inner"`
+/// - `outer`     — first dot-segment: `"Outer"`  (used for file lookup)
+/// - `leaf`      — last dot-segment: `"Inner"`   (used for fallback member lookup)
+pub struct ReceiverType {
+    pub raw:       String,
+    pub qualified: String,
+    pub outer:     String,
+    pub leaf:      String,
+}
+
+impl ReceiverType {
+    pub fn from_raw(raw: String) -> Self {
+        // Strip generics: take chars until first `<`.
+        let qualified: String = raw.chars().take_while(|&c| c != '<').collect();
+        let outer = qualified.split('.').next().unwrap_or(&qualified).to_string();
+        let leaf  = qualified.rsplit('.').next().unwrap_or(&qualified).to_string();
+        ReceiverType { raw, qualified, outer, leaf }
+    }
+}
+
+/// Infer the type of a receiver expression and normalise it into a
+/// [`ReceiverType`].
+///
+/// Returns `None` when type inference fails (no annotation, unindexed file,
+/// or lambda scope not resolvable).  Call sites then decide whether to skip
+/// or fall back; this function never performs a global rg scan.
+pub fn infer_receiver_type(
+    idx:  &Indexer,
+    kind: ReceiverKind<'_>,
+    uri:  &Url,
+) -> Option<ReceiverType> {
+    let raw = match kind {
+        ReceiverKind::Variable(name) => infer_variable_type_raw(idx, name, uri)?,
+        ReceiverKind::Contextual { name, position } => {
+            // Lambda / implicit-receiver path.
+            if let Some(ty) = idx.infer_lambda_param_type_at(name, uri, position) {
+                ty
+            } else {
+                // Contextual fallback: ordinary annotated var that happens to
+                // appear in a lambda context (e.g. captured val with explicit type).
+                infer_variable_type_raw(idx, name, uri)?
+            }
+        }
+    };
+    Some(ReceiverType::from_raw(raw))
+}
+
 /// Scan the current file's lines for a type annotation on `var_name` and return
 /// the declared type name if found.  Delegates to [`infer_type_in_lines`].
 pub(crate) fn infer_variable_type(idx: &Indexer, var_name: &str, uri: &Url) -> Option<String> {

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -36,7 +36,7 @@ pub(crate) mod find;
 
 pub use complete::{complete_symbol, complete_symbol_with_context, symbols_from_uri_as_completions_pub};
 pub(crate) use complete::is_annotation_context;
-pub use infer::{infer_variable_type_raw, extract_collection_element_type};
+pub use infer::{infer_variable_type_raw, extract_collection_element_type, ReceiverKind, ReceiverType, infer_receiver_type};
 
 // Re-exports used only in tests.
 #[cfg(test)]

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -1176,3 +1176,50 @@ data class State(
         assert!(!is_annotation_context("Composable", "Composable")); // no @
         // "x@Comp" — technically matches, real code won't have identifiers directly before @
     }
+
+    // ── ReceiverType::from_raw ────────────────────────────────────────────────
+
+    #[test]
+    fn receiver_type_simple() {
+        let rt = infer::ReceiverType::from_raw("MyClass".to_string());
+        assert_eq!(rt.raw,       "MyClass");
+        assert_eq!(rt.qualified, "MyClass");
+        assert_eq!(rt.outer,     "MyClass");
+        assert_eq!(rt.leaf,      "MyClass");
+    }
+
+    #[test]
+    fn receiver_type_with_generics() {
+        let rt = infer::ReceiverType::from_raw("Flow<UiState>".to_string());
+        assert_eq!(rt.raw,       "Flow<UiState>");
+        assert_eq!(rt.qualified, "Flow");
+        assert_eq!(rt.outer,     "Flow");
+        assert_eq!(rt.leaf,      "Flow");
+    }
+
+    #[test]
+    fn receiver_type_dotted_nested() {
+        let rt = infer::ReceiverType::from_raw("Outer.Inner".to_string());
+        assert_eq!(rt.raw,       "Outer.Inner");
+        assert_eq!(rt.qualified, "Outer.Inner");
+        assert_eq!(rt.outer,     "Outer");
+        assert_eq!(rt.leaf,      "Inner");
+    }
+
+    #[test]
+    fn receiver_type_dotted_with_generics() {
+        let rt = infer::ReceiverType::from_raw("Outer.Inner<Param>".to_string());
+        assert_eq!(rt.raw,       "Outer.Inner<Param>");
+        assert_eq!(rt.qualified, "Outer.Inner");
+        assert_eq!(rt.outer,     "Outer");
+        assert_eq!(rt.leaf,      "Inner");
+    }
+
+    #[test]
+    fn receiver_type_generic_with_params() {
+        let rt = infer::ReceiverType::from_raw("OneYearOlderInteractor<Params>".to_string());
+        assert_eq!(rt.qualified, "OneYearOlderInteractor");
+        assert_eq!(rt.outer,     "OneYearOlderInteractor");
+        assert_eq!(rt.leaf,      "OneYearOlderInteractor");
+    }
+


### PR DESCRIPTION
## Summary

Walk from cursor node up to the nearest `call_expression` via the live tree-sitter tree to get function name, qualifier, and active param index — replacing the backward O(n) char/line scan.

## Changes

- **`cst_signature_help_data()`**: walk up from cursor to `call_expression` (bail on `lambda_literal`), extract callee name + optional qualifier, count `value_argument` siblings before cursor for active param.
- **`cst_find_value_arguments()`**: finds `value_arguments` node inside `call_expression`, including when nested in `call_suffix`.
- **`build_signature_help()`**: extracted helper shared by both CST and text paths.
- **Text fallback** retained when no live tree is available.

## Part of

Phase 6 CST fast paths: #23 (6.1 is_lambda_param) → #24 (6.2 find_as_call_arg_type) → this PR (6.3 signature_help)