### PR TITLE
refactor: Phase 8 — CursorContext + second-it CST fallback

### DIFF
--- a/src/backend/cursor.rs
+++ b/src/backend/cursor.rs
@@ -1,0 +1,80 @@
+//! Per-request cursor context.
+//!
+//! `CursorContext::build` centralises the data-gathering that every LSP
+//! feature handler (hover, goto-def, completion) used to repeat independently:
+//! - extracting the word + optional dot-qualifier under the cursor
+//! - resolving the contextual receiver type for `it` / `this` / named lambda params
+//! - pre-resolving the lambda-param declaration location (for goto-def)
+//! - fetching the live parse tree once
+//!
+//! Features that do NOT need an identifier under the cursor (sig-help, bare
+//! completion) build their own context — this struct is not for them.
+
+use std::sync::Arc;
+use tower_lsp::lsp_types::{Location, Position, Url};
+
+use crate::indexer::{Indexer, live_tree::LiveDoc};
+use crate::resolver::{ReceiverKind, ReceiverType, infer_receiver_type};
+
+/// Cursor context for identifier-based LSP features (hover, goto-def, completion).
+///
+/// Built once per request; individual fields are `None` when not applicable.
+pub struct CursorContext {
+    /// The identifier token under the cursor.
+    pub word:      String,
+    /// The dot-qualifier to the left of the cursor (e.g. `"it"`, `"viewModel"`).
+    /// `None` when cursor is on a bare name with no qualifying expression.
+    pub qualifier: Option<String>,
+    /// Resolved contextual receiver — **only** set when `word` or `qualifier` is
+    /// `it`, `this`, or a named lambda parameter.  Plain variable or type
+    /// qualifiers are left for callers to resolve via `find_definition_qualified`.
+    pub contextual: Option<ReceiverType>,
+    /// When `contextual` is `None` and the word appears to be a named lambda
+    /// parameter in scope, this holds the jump-target declaration location so
+    /// goto-def can navigate to `{ name -> }` without a type.
+    pub lambda_decl: Option<Location>,
+    /// Live parse tree for the open file, if the editor has it open.
+    pub live_doc: Option<Arc<LiveDoc>>,
+}
+
+impl CursorContext {
+    /// Build a cursor context for the given URI + LSP position.
+    ///
+    /// Returns `None` only when there is no identifier under the cursor
+    /// (e.g. cursor is in whitespace or on a non-identifier token).
+    pub fn build(idx: &Indexer, uri: &Url, position: Position) -> Option<Self> {
+        let (word, qualifier) = idx.word_and_qualifier_at(uri, position)?;
+
+        let live_doc = idx.live_doc(uri);
+
+        // Determine whether this is a contextual name (it / this / lambda param).
+        let is_contextual = qualifier.as_deref().map_or(false, |q| q == "it" || q == "this")
+            || (qualifier.is_none()
+                && (word == "it" || word == "this"
+                    || word.chars().next().map_or(false, |c| c.is_lowercase())));
+
+        let contextual = if is_contextual {
+            let name: &str = qualifier.as_deref().unwrap_or(&word);
+            infer_receiver_type(idx, ReceiverKind::Contextual { name, position }, uri)
+        } else {
+            None
+        };
+
+        // For goto-def: if inference failed but the word is a named lambda param
+        // in scope, pre-resolve the declaration location.
+        let lambda_decl = if contextual.is_none() && is_contextual && qualifier.is_none() {
+            let line = position.line as usize;
+            let col  = position.character as usize;
+            let params = idx.lambda_params_at_col(uri, line, col);
+            if params.contains(&word) {
+                idx.find_lambda_param_decl(uri, &word, line)
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+
+        Some(CursorContext { word, qualifier, contextual, lambda_decl, live_doc })
+    }
+}

--- a/src/backend/cursor.rs
+++ b/src/backend/cursor.rs
@@ -47,11 +47,27 @@ impl CursorContext {
 
         let live_doc = idx.live_doc(uri);
 
-        // Determine whether this is a contextual name (it / this / lambda param).
-        let is_contextual = qualifier.as_deref().map_or(false, |q| q == "it" || q == "this")
-            || (qualifier.is_none()
-                && (word == "it" || word == "this"
-                    || word.chars().next().map_or(false, |c| c.is_lowercase())));
+        let line = position.line as usize;
+        let col  = position.character as usize;
+
+        // `it`/`this` are always contextual (lambda receiver inference).
+        let is_it_or_this = qualifier.as_deref().map_or(false, |q| q == "it" || q == "this")
+            || (qualifier.is_none() && (word == "it" || word == "this"));
+
+        // For other lowercase bare identifiers, confirm they are in scope as lambda
+        // params before running contextual inference.  Without this check, regular
+        // annotated variables like `val user: User` would be resolved to their type
+        // class on hover, which is incorrect.
+        let in_scope_lambda_params: Vec<String> = if !is_it_or_this
+            && qualifier.is_none()
+            && word.chars().next().map_or(false, |c| c.is_lowercase())
+        {
+            idx.lambda_params_at_col(uri, line, col)
+        } else {
+            vec![]
+        };
+
+        let is_contextual = is_it_or_this || in_scope_lambda_params.contains(&word);
 
         let contextual = if is_contextual {
             let name: &str = qualifier.as_deref().unwrap_or(&word);
@@ -63,9 +79,13 @@ impl CursorContext {
         // For goto-def: if inference failed but the word is a named lambda param
         // in scope, pre-resolve the declaration location.
         let lambda_decl = if contextual.is_none() && is_contextual && qualifier.is_none() {
-            let line = position.line as usize;
-            let col  = position.character as usize;
-            let params = idx.lambda_params_at_col(uri, line, col);
+            // For `it`/`this`, lambda_params_at_col wasn't called yet — call it now.
+            // For named params the cache already has the result.
+            let params = if in_scope_lambda_params.is_empty() {
+                idx.lambda_params_at_col(uri, line, col)
+            } else {
+                in_scope_lambda_params
+            };
             if params.contains(&word) {
                 idx.find_lambda_param_decl(uri, &word, line)
             } else {

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -2,8 +2,8 @@ use std::sync::Arc;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use crate::indexer::find_fun_signature_with_receiver;
-use crate::resolver::{ReceiverKind, infer_receiver_type};
 use super::Backend;
+use super::cursor::CursorContext;
 use super::helpers::resolve_references_scope;
 use super::actions::is_non_call_keyword;
 
@@ -13,23 +13,21 @@ impl Backend {
         let uri      = &pp.text_document.uri;
         let position = pp.position;
 
-        let Some((word, qualifier)) = self.indexer.word_and_qualifier_at(uri, position) else {
+        let Some(ctx) = CursorContext::build(&self.indexer, uri, position) else {
             return Ok(None);
         };
 
         // For `it` or a named lambda param, generate hover showing the inferred type.
-        if qualifier.is_none() && (word == "it" || word.chars().next().map(|c| c.is_lowercase()).unwrap_or(true)) {
-            if let Some(type_name) = self.indexer.infer_lambda_param_type_at(&word, uri, position) {
+        if ctx.qualifier.is_none() {
+            if let Some(ref rt) = ctx.contextual {
+                let type_name = &rt.raw;
                 let lang = if uri.path().ends_with(".kt") { "kotlin" }
                            else if uri.path().ends_with(".swift") { "swift" }
                            else { "java" };
-                // Show the inferred binding
                 let kw = if uri.path().ends_with(".swift") { "let" } else { "val" };
-                let sig_md = format!("```{lang}\n{kw} {word}: {type_name}\n```");
-                // For symbol lookup use the last segment of a qualified name
-                // (symbols are indexed by short name, e.g. `CardProduct` not
-                // `CreditCardDashboardInteractor.CardProduct`).
-                let lookup_name = type_name.rsplit('.').next().unwrap_or(&type_name);
+                let sig_md = format!("```{lang}\n{kw} {}: {type_name}\n```", ctx.word);
+                // For symbol lookup use the last segment of a qualified name.
+                let lookup_name = type_name.rsplit('.').next().unwrap_or(type_name.as_str());
                 let type_hover = self.indexer.hover_info(lookup_name);
                 let full = if let Some(th) = type_hover {
                     format!("{sig_md}\n\n---\n\n{th}")
@@ -44,11 +42,9 @@ impl Backend {
                     range: None,
                 }));
             }
-            // If the word is a lambda parameter (type resolution failed), don't
-            // fall through to rg-based definition lookup — it would find unrelated
-            // symbols with the same name and show confusing hover text.
-            let lambda_params = self.indexer.lambda_params_at_col(uri, position.line as usize, position.character as usize);
-            if lambda_params.contains(&word) {
+            // Lambda parameter with failed type inference — don't fall through to rg
+            // lookup (would show confusing hover for unrelated symbols).
+            if ctx.lambda_decl.is_some() {
                 return Ok(None);
             }
         }
@@ -56,38 +52,34 @@ impl Backend {
         // Use the same resolution chain as go-to-definition so hover always
         // points at the same symbol (import-aware, not just first index match).
 
-        // `this.field` / `it.field` — resolve to the actual receiver/lambda type
-        // so hover shows the member from the correct class (mirrors goto_definition fix).
-        if let Some(qual) = qualifier.as_deref() {
-            if qual == "this" || qual == "it" {
-                let kind = ReceiverKind::Contextual { name: qual, position };
-                if let Some(rt) = infer_receiver_type(&self.indexer, kind, uri) {
-                    // Try full qualified type first (e.g. `Outer.Inner`), then leaf segment.
-                    let locs = self.indexer.find_definition_qualified(&word, Some(&rt.qualified), uri);
-                    let locs = if locs.is_empty() && rt.leaf != rt.qualified {
-                        self.indexer.find_definition_qualified(&word, Some(&rt.leaf), uri)
-                    } else { locs };
-                    if let Some(loc) = locs.first() {
-                        if let Some(md) = self.indexer.hover_info_at_location(loc, &word) {
-                            return Ok(Some(Hover {
-                                contents: HoverContents::Markup(MarkupContent {
-                                    kind:  MarkupKind::Markdown,
-                                    value: md,
-                                }),
-                                range: None,
-                            }));
-                        }
+        // `this.field` / `it.field` — use the already-resolved contextual receiver
+        // so hover shows the member from the correct class.
+        if ctx.qualifier.is_some() {
+            if let Some(ref rt) = ctx.contextual {
+                let locs = self.indexer.find_definition_qualified(&ctx.word, Some(&rt.qualified), uri);
+                let locs = if locs.is_empty() && rt.leaf != rt.qualified {
+                    self.indexer.find_definition_qualified(&ctx.word, Some(&rt.leaf), uri)
+                } else { locs };
+                if let Some(loc) = locs.first() {
+                    if let Some(md) = self.indexer.hover_info_at_location(loc, &ctx.word) {
+                        return Ok(Some(Hover {
+                            contents: HoverContents::Markup(MarkupContent {
+                                kind:  MarkupKind::Markdown,
+                                value: md,
+                            }),
+                            range: None,
+                        }));
                     }
                 }
             }
         }
 
-        let locs = self.indexer.find_definition_qualified(&word, qualifier.as_deref(), uri);
+        let locs = self.indexer.find_definition_qualified(&ctx.word, ctx.qualifier.as_deref(), uri);
         let hover_md = if let Some(loc) = locs.first() {
-            self.indexer.hover_info_at_location(loc, &word)
+            self.indexer.hover_info_at_location(loc, &ctx.word)
         } else {
             // Index lookup — works for already-indexed symbols + stdlib.
-            let from_index = self.indexer.hover_info(&word);
+            let from_index = self.indexer.hover_info(&ctx.word);
             if from_index.is_some() {
                 from_index
             } else {
@@ -98,8 +90,8 @@ impl Backend {
                     let m = self.indexer.ignore_matcher.read().unwrap().clone();
                     (crate::rg::effective_rg_root(wr.as_deref(), file_path.as_deref()), m)
                 };
-                let rg_locs = crate::rg::rg_find_definition(&word, rg_root.as_deref(), matcher.as_deref());
-                rg_locs.first().and_then(|loc| self.indexer.hover_info_at_location(loc, &word))
+                let rg_locs = crate::rg::rg_find_definition(&ctx.word, rg_root.as_deref(), matcher.as_deref());
+                rg_locs.first().and_then(|loc| self.indexer.hover_info_at_location(loc, &ctx.word))
             }
         };
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -15,6 +15,7 @@ pub mod handlers;
 pub mod rename;
 pub mod actions;
 pub mod helpers;
+pub mod cursor;
 
 pub struct Backend {
     pub(super) client:  Client,

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -60,8 +60,8 @@ impl Backend {
                 }
             }
             // Lambda parameter with failed type inference — jump to `{ name -> }`.
-            if let Some(loc) = ctx.lambda_decl {
-                return Ok(Some(GotoDefinitionResponse::Scalar(loc)));
+            if let Some(loc) = ctx.lambda_decl.as_ref() {
+                return Ok(Some(GotoDefinitionResponse::Scalar(loc.clone())));
             }
         }
 

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -1,7 +1,7 @@
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use super::Backend;
-use crate::resolver::{ReceiverKind, infer_receiver_type};
+use super::cursor::CursorContext;
 
 fn locs_to_response(locs: Vec<Location>) -> GotoDefinitionResponse {
     match locs.len() {
@@ -19,12 +19,12 @@ impl Backend {
         let uri      = &pp.text_document.uri;
         let position = pp.position;
 
-        let Some((word, qualifier)) = self.indexer.word_and_qualifier_at(uri, position) else {
+        let Some(ctx) = CursorContext::build(&self.indexer, uri, position) else {
             return Ok(None);
         };
 
         // Special case: `this` keyword — navigate to the enclosing class definition.
-        if qualifier.is_none() && word == "this" {
+        if ctx.qualifier.is_none() && ctx.word == "this" {
             if let Some(class_name) = self.indexer.enclosing_class_at(uri, position.line) {
                 let locs = self.indexer.find_definition_qualified(&class_name, None, uri);
                 if !locs.is_empty() {
@@ -35,7 +35,7 @@ impl Backend {
         }
 
         // Special case: `super` keyword — navigate to the enclosing class's first supertype.
-        if qualifier.is_none() && word == "super" {
+        if ctx.qualifier.is_none() && ctx.word == "super" {
             if let Some(result) = self.goto_super_class(uri, position.line).await {
                 return Ok(Some(result));
             }
@@ -43,58 +43,43 @@ impl Backend {
         }
 
         // Special case: `super.method(...)` — resolve `method` in the parent class.
-        if qualifier.as_deref() == Some("super") {
-            if let Some(result) = self.goto_super_method(uri, position.line, &word).await {
+        if ctx.qualifier.as_deref() == Some("super") {
+            if let Some(result) = self.goto_super_method(uri, position.line, &ctx.word).await {
                 return Ok(Some(result));
             }
             return Ok(None);
         }
 
-        // Special case: `it` or a named lambda parameter — resolve to the
-        // inferred element/receiver type class instead of trying a text search.
-        if qualifier.is_none() && (word == "it" || word.chars().next().map(|c| c.is_lowercase()).unwrap_or(true)) {
-            if let Some(type_name) = self.indexer.infer_lambda_param_type_at(&word, uri, position) {
-                // For qualified names (e.g. `Outer.Inner`) try the full name first,
-                // then fall back to the last segment which is what the index stores.
-                let lookup = type_name.rsplit('.').next().unwrap_or(&type_name);
+        // `it` / named lambda parameter — resolve to the element/receiver type class.
+        if ctx.qualifier.is_none() {
+            if let Some(ref rt) = ctx.contextual {
+                let lookup = rt.leaf.as_str();
                 let locs = self.indexer.find_definition_qualified(lookup, None, uri);
                 if !locs.is_empty() {
-                    return Ok(match locs.len() {
-                        1 => Some(GotoDefinitionResponse::Scalar(locs.into_iter().next().unwrap())),
-                        _ => Some(GotoDefinitionResponse::Array(locs)),
-                    });
+                    return Ok(Some(locs_to_response(locs)));
                 }
             }
-            // If the word is a lambda parameter (type resolution failed), jump to
-            // the `{ name ->` declaration line in the current file.
-            let lambda_params = self.indexer.lambda_params_at_col(uri, position.line as usize, position.character as usize);
-            if lambda_params.contains(&word) {
-                if let Some(loc) = self.indexer.find_lambda_param_decl(uri, &word, position.line as usize) {
-                    return Ok(Some(GotoDefinitionResponse::Scalar(loc)));
-                }
-                return Ok(None);
+            // Lambda parameter with failed type inference — jump to `{ name -> }`.
+            if let Some(loc) = ctx.lambda_decl {
+                return Ok(Some(GotoDefinitionResponse::Scalar(loc)));
             }
         }
 
-        // `this.field` / `it.field` — resolve the implicit receiver/lambda type and
-        // use it as the real qualifier so definition lookup finds the correct file.
-        if let Some(qual) = qualifier.as_deref() {
-            if qual == "this" || qual == "it" {
-                let kind = ReceiverKind::Contextual { name: qual, position };
-                if let Some(rt) = infer_receiver_type(&self.indexer, kind, uri) {
-                    // Try full qualified type first (e.g. `Outer.Inner`), then leaf segment.
-                    let locs = self.indexer.find_definition_qualified(&word, Some(&rt.qualified), uri);
-                    let locs = if locs.is_empty() && rt.leaf != rt.qualified {
-                        self.indexer.find_definition_qualified(&word, Some(&rt.leaf), uri)
-                    } else { locs };
-                    if !locs.is_empty() {
-                        return Ok(Some(locs_to_response(locs)));
-                    }
+        // `this.field` / `it.field` — use the already-resolved contextual receiver
+        // so lookup finds the member in the correct class.
+        if ctx.qualifier.is_some() {
+            if let Some(ref rt) = ctx.contextual {
+                let locs = self.indexer.find_definition_qualified(&ctx.word, Some(&rt.qualified), uri);
+                let locs = if locs.is_empty() && rt.leaf != rt.qualified {
+                    self.indexer.find_definition_qualified(&ctx.word, Some(&rt.leaf), uri)
+                } else { locs };
+                if !locs.is_empty() {
+                    return Ok(Some(locs_to_response(locs)));
                 }
             }
         }
 
-        let locs = self.indexer.find_definition_qualified(&word, qualifier.as_deref(), uri);
+        let locs = self.indexer.find_definition_qualified(&ctx.word, ctx.qualifier.as_deref(), uri);
         if !locs.is_empty() {
             return Ok(match locs.len() {
                 1 => Some(GotoDefinitionResponse::Scalar(locs.into_iter().next().unwrap())),
@@ -111,7 +96,7 @@ impl Backend {
             let m = self.indexer.ignore_matcher.read().unwrap().clone();
             (crate::rg::effective_rg_root(wr.as_deref(), file_path.as_deref()), m)
         };
-        let name_clone = word.clone();
+        let name_clone = ctx.word.clone();
         let rg_locs = tokio::task::spawn_blocking(move || {
             crate::rg::rg_find_definition(&name_clone, root_opt.as_deref(), matcher.as_deref())
         }).await.unwrap_or_default();

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -360,7 +360,7 @@ fn cst_call_arg_type(pos: CursorPos, idx: &Indexer, uri: &Url) -> Option<String>
 
 /// Extract the function name from a `call_expression` node.
 /// Handles simple calls `foo(...)` and navigation chains `foo.bar(...)`.
-fn cst_call_fn_name(call_expr: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<String> {
+pub(crate) fn cst_call_fn_name(call_expr: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<String> {
     let callee = call_expr.child(0)?;
     let name_node = match callee.kind() {
         "simple_identifier" | "type_identifier" => callee,
@@ -377,7 +377,7 @@ fn cst_call_fn_name(call_expr: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<St
 
 /// If `value_argument` has a named-arg label (`simple_identifier "="` prefix),
 /// return the label text; otherwise `None`.
-fn cst_named_arg_label(value_arg: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<String> {
+pub(crate) fn cst_named_arg_label(value_arg: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<String> {
     let count = value_arg.child_count();
     for i in 0..count.saturating_sub(1) {
         let (c, next) = (value_arg.child(i)?, value_arg.child(i + 1)?);
@@ -389,7 +389,7 @@ fn cst_named_arg_label(value_arg: tree_sitter::Node<'_>, bytes: &[u8]) -> Option
 }
 
 /// Count how many `value_argument` siblings precede `value_arg` in its parent.
-fn cst_value_arg_position(value_arg: tree_sitter::Node<'_>) -> usize {
+pub(crate) fn cst_value_arg_position(value_arg: tree_sitter::Node<'_>) -> usize {
     let parent = match value_arg.parent() { Some(p) => p, None => return 0 };
     let target_id = value_arg.id();
     let mut pos = 0usize;

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -33,6 +33,9 @@ use super::{
     has_named_params_not_it,
     extract_first_arg,
     lambda_param_position_on_line,
+    cst_call_fn_name,
+    cst_named_arg_label,
+    cst_value_arg_position,
 };
 
 // ── from indexer.rs (parent of infer; descendants can access private items) ──
@@ -342,7 +345,12 @@ fn find_it_element_type_in_lines_impl(
                             let result = lambda_receiver_type_from_context(before_brace, idx, uri)
                                 .or_else(|| lambda_receiver_type_named_arg_ml(
                                     before_brace, 0, lines, ln, idx, uri,
-                                ));
+                                ))
+                                // CST structural fallback: walk up the call tree to find
+                                // the enclosing function call and the lambda's argument
+                                // position. Handles multi-line cases where the call site
+                                // is on a different line than the lambda `{`.
+                                .or_else(|| cst_lambda_param_type_via_call(&doc, &cur, idx, uri));
                             if result.is_some() { return result; }
                         }
                     }
@@ -603,6 +611,58 @@ fn lambda_receiver_type_named_arg_ml(
 
     let param_type = find_named_param_type_in_sig(&sig, named_arg)?;
     lambda_type_nth_input(&param_type, lambda_param_pos)
+}
+
+/// CST structural fallback for `it` type: given a `lambda_literal` node, walk
+/// up the call tree to find the enclosing function call and the lambda's
+/// positional or named argument index, then return the first input type of
+/// that parameter.
+///
+/// This handles multi-line cases where the function call is on a different line
+/// than the lambda opening `{`, so the text-based `before_brace` approach cannot
+/// reach the function name.
+fn cst_lambda_param_type_via_call(
+    doc:    &crate::indexer::live_tree::LiveDoc,
+    lambda: &tree_sitter::Node<'_>,
+    idx:    &Indexer,
+    uri:    &Url,
+) -> Option<String> {
+    let bytes = &doc.bytes;
+    let mut cur = *lambda;
+    loop {
+        let parent = cur.parent()?;
+        match parent.kind() {
+            "value_argument" => {
+                // Lambda is a parenthesised argument.
+                let mut node = parent;
+                let call_expr = loop {
+                    let p = node.parent()?;
+                    if p.kind() == "call_expression" { break p; }
+                    node = p;
+                };
+                let fn_name = cst_call_fn_name(call_expr, bytes)?;
+                let sig = find_fun_signature_full(&fn_name, idx, uri)?;
+                let param_type = if let Some(label) = cst_named_arg_label(parent, bytes) {
+                    find_named_param_type_in_sig(&sig, &label)
+                } else {
+                    nth_fun_param_type_str(&sig, cst_value_arg_position(parent))
+                }?;
+                return lambda_type_first_input(&param_type);
+            }
+            "call_suffix" => {
+                // Trailing lambda: `fn(...) { it }` or `fn { it }`.
+                let call_expr = parent.parent()?;
+                if call_expr.kind() != "call_expression" { cur = parent; continue; }
+                let fn_name = cst_call_fn_name(call_expr, bytes)?;
+                let sig = find_fun_signature_full(&fn_name, idx, uri)?;
+                let last_type = last_fun_param_type_str(&sig)?;
+                return lambda_type_first_input(&last_type);
+            }
+            // Stop at an enclosing lambda — its iteration in the outer loop will handle it.
+            "lambda_literal" => return None,
+            _ => { cur = parent; }
+        }
+    }
 }
 
 /// For an INLINE lambda argument `fn(a, b, { param -> ... })`:

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -20,6 +20,18 @@ fn indexed(path: &str, src: &str) -> (Url, Indexer) {
     (u, idx)
 }
 
+/// Index `sig_src` for signature lookup, plus store a live tree for `code_src`
+/// at the same URI (for CST fast-path tests).
+fn indexed_with_live(path: &str, sig_src: &str, code_src: &str) -> (Url, Indexer, Vec<String>) {
+    let u = uri(path);
+    let idx = Indexer::new();
+    idx.index_content(&u, sig_src);
+    idx.store_live_tree(&u, code_src);
+    idx.set_live_lines(&u, code_src);
+    let lines: Vec<String> = code_src.lines().map(String::from).collect();
+    (u, idx, lines)
+}
+
 // ── find_it_element_type ─────────────────────────────────────────────────────
 
 #[test]
@@ -56,6 +68,59 @@ fn it_element_type_scope_fn_let() {
         find_it_element_type("user.let { it.", &idx, &u).as_deref(),
         Some("User")
     );
+}
+
+// ── two lambdas same line ─────────────────────────────────────────────────────
+
+#[test]
+fn it_type_second_of_two_lambdas_same_line() {
+    // { setState { it } }, { setEffect { it } }
+    // First `it` (inside setState lambda): should resolve to State
+    // Second `it` (inside setEffect lambda): should resolve to Effect
+    let src = "fun setState(block: (State) -> Unit) {}\nfun setEffect(block: (Effect) -> Unit) {}";
+    let (u, idx) = indexed("/t.kt", src);
+    let before1 = "{ setState { ";
+    let before2 = "{ setState { it } }, { setEffect { ";
+    assert_eq!(find_it_element_type(before1, &idx, &u).as_deref(), Some("State"),
+        "first it (inside setState) should resolve to State");
+    assert_eq!(find_it_element_type(before2, &idx, &u).as_deref(), Some("Effect"),
+        "second it (inside setEffect) should resolve to Effect");
+}
+
+// ── two lambdas, multi-line, outer function not indexed ─────────────────────
+
+/// Bug regression: when both lambdas are on separate lines inside an `observe()`
+/// call and the inner function (`setEffect`) is NOT indexed, the second `it`
+/// must still resolve via the CST structural walk-up to `observe`'s 2nd param.
+#[test]
+fn it_type_second_lambda_multiline_unindexed_inner() {
+    // observe is indexed; setState/setEffect are NOT (only `observe` matters here).
+    let sig_src = "fun observe(onState: (State) -> Unit, onEffect: (Effect) -> Unit) {}";
+    // The code snippet has observe on line 0, lambdas on lines 1 and 2.
+    let code_src = "observe(\n    { setState { it } },\n    { setEffect { it } }\n)";
+    // Line 2: "    { setEffect { it } }"
+    //          0123456789012345678901234
+    // second `it` is at col 18 on line 2
+    let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
+    let pos = crate::types::CursorPos { line: 2, utf16_col: 18 };
+    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    assert_eq!(result.as_deref(), Some("Effect"),
+        "second it inside unindexed setEffect should resolve via observe's 2nd param");
+}
+
+/// Same scenario but for the FIRST lambda — must resolve to observe's 1st param.
+#[test]
+fn it_type_first_lambda_multiline_unindexed_inner() {
+    let sig_src = "fun observe(onState: (State) -> Unit, onEffect: (Effect) -> Unit) {}";
+    let code_src = "observe(\n    { setState { it } },\n    { setEffect { it } }\n)";
+    // Line 1: "    { setState { it } },"
+    //          012345678901234567890123
+    // first `it` is at col 17 on line 1
+    let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
+    let pos = crate::types::CursorPos { line: 1, utf16_col: 17 };
+    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    assert_eq!(result.as_deref(), Some("State"),
+        "first it inside unindexed setState should resolve via observe's 1st param");
 }
 
 // ── find_this_element_type_in_lines ─────────────────────────────────────────
@@ -270,4 +335,20 @@ fn it_type_let_still_infers_receiver() {
         Some("User"),
         "let: it should still resolve to User"
     );
+}
+
+/// When setState IS indexed and the live tree is available, the simple
+/// trailing-lambda case (Case B) must still resolve via the EXISTING path
+/// — `cst_lambda_param_type_via_call` must NOT be called or, if it is,
+/// must not interfere.
+#[test]
+fn it_type_indexed_inner_fn_cst_still_works() {
+    let sig_src = "fun setState(block: (State) -> Unit) {}";
+    let code_src = "setState { it }";
+    let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
+    // "setState { " = 11 chars → `it` at col 11
+    let pos = crate::types::CursorPos { line: 0, utf16_col: 11 };
+    let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
+    assert_eq!(result.as_deref(), Some("State"),
+        "simple trailing-lambda with live tree must still resolve via Case B");
 }

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -35,6 +35,9 @@ pub(crate) use args::{
     find_named_param_type_in_sig,
     lambda_param_position_on_line,
     has_named_params_not_it,
+    cst_call_fn_name,
+    cst_named_arg_label,
+    cst_value_arg_position,
 };
 
 pub(crate) use it_this::{


### PR DESCRIPTION
## Changes

### Fix: second `it` lambda param type inference (commit 1)

Adds `cst_lambda_param_type_via_call` which walks up the CST from a `lambda_literal` node through `value_argument → call_expression` to resolve the lambda's positional arg type structurally. Fixes multi-line cases where the outer lambda's `{` is on a different line than the call:

```kotlin
observe(
    { setState { it } },   // it: State  ✓
    { setEffect { it } }   // it: Effect ✓ (was missing)
)
```

### Refactor: CursorContext centralises hover/goto-def data gathering (commit 2)

New `src/backend/cursor.rs` with `CursorContext::build()` computed once per request:
- `word` + `qualifier` (was duplicated in nav.rs and handlers.rs)
- `contextual: Option<ReceiverType>` — only for `it`/`this`/named lambda params
- `lambda_decl: Option<Location>` — jump target when type fails but name is a lambda param
- `live_doc` — live parse tree

Wired into `hover_impl` and `goto_definition_impl`, removing ~80 lines of duplicated resolver calls.