### PR TITLE
refactor(9): InferDeps trait — seam between Indexer and pure leaf helpers

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -191,6 +191,15 @@ pub struct Indexer {
     pub(crate) live_trees: DashMap<String, Arc<LiveDoc>>,
 }
 
+impl crate::indexer::infer::InferDeps for Indexer {
+    fn find_fun_params_text(&self, fn_name: &str, uri: &Url) -> Option<String> {
+        find_fun_signature_full(fn_name, self, uri)
+    }
+    fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String> {
+        crate::resolver::infer_variable_type_raw(self, var_name, uri)
+    }
+}
+
 impl Indexer {
     pub fn parse_sem(&self) -> Arc<tokio::sync::Semaphore> {
         Arc::clone(&self.parse_sem)

--- a/src/indexer/infer/deps.rs
+++ b/src/indexer/infer/deps.rs
@@ -1,0 +1,87 @@
+//! `InferDeps` — a narrow seam that isolates pure lambda/type inference helpers
+//! from the full `Indexer` so they can be unit-tested with lightweight stubs.
+//!
+//! ## What goes in the trait
+//!
+//! Only the two operations that the pure leaf helpers in `it_this.rs` need:
+//! - looking up a function's parameter signature
+//! - inferring a variable's declared type
+//!
+//! The trait intentionally excludes `mem_lines_for` and `live_doc`: those are
+//! needed by the higher-level orchestrators (`find_it_element_type_in_lines_impl`
+//! etc.) which already take `&Indexer`.  Move them into the trait only if those
+//! orchestrators are later pushed behind the seam.
+//!
+//! ## `fun_params_text` is not cheap
+//!
+//! The `Indexer` implementation of `find_fun_params_text` delegates to
+//! `find_fun_signature_full`, which may perform on-demand rg indexing.
+//! Callers should not assume this is a pure in-memory lookup.
+
+use tower_lsp::lsp_types::Url;
+
+/// Minimum dependency surface for pure lambda/type inference leaf functions.
+///
+/// Two concrete impls exist (Rule of Three satisfied):
+/// - `Indexer` — production, full resolution with rg fallback
+/// - `TestDeps` — test stub, drives leaf-helper unit tests from plain `HashMap`s
+pub trait InferDeps {
+    /// Return the raw parameter signature text for a function, e.g.
+    /// `"(key: K, flow: Flow<T>, map: (T) -> Model)"`.
+    ///
+    /// May perform on-demand rg/disk I/O in the `Indexer` implementation.
+    /// Returns `None` when the function is not found.
+    fn find_fun_params_text(&self, fn_name: &str, uri: &Url) -> Option<String>;
+
+    /// Infer the declared type of a local variable from its annotation in the
+    /// file at `uri`, e.g. `"val interactor: OneYearOlderInteractor"` → `"OneYearOlderInteractor"`.
+    ///
+    /// Returns `None` when the variable has no detectable declaration.
+    fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String>;
+}
+
+// ─── Test stub ───────────────────────────────────────────────────────────────
+
+/// Lightweight stub for unit-testing pure inference leaf functions.
+///
+/// Keyed by `(uri_str, name)` to mirror production `uri`-aware resolution and
+/// prevent tests from hiding ambiguity bugs that would surface in real projects.
+#[cfg(test)]
+pub(crate) struct TestDeps {
+    /// `(uri_str, fn_name)` → raw params text
+    pub fun_sigs:  std::collections::HashMap<(String, String), String>,
+    /// `(uri_str, var_name)` → type name
+    pub var_types: std::collections::HashMap<(String, String), String>,
+}
+
+#[cfg(test)]
+impl TestDeps {
+    pub fn new() -> Self {
+        TestDeps {
+            fun_sigs:  std::collections::HashMap::new(),
+            var_types: std::collections::HashMap::new(),
+        }
+    }
+
+    /// Register `fn_name` → `params_text` for `uri`.
+    pub fn with_fun(mut self, uri: &str, fn_name: &str, params: &str) -> Self {
+        self.fun_sigs.insert((uri.to_string(), fn_name.to_string()), params.to_string());
+        self
+    }
+
+    /// Register `var_name` → `type_name` for `uri`.
+    pub fn with_var(mut self, uri: &str, var_name: &str, ty: &str) -> Self {
+        self.var_types.insert((uri.to_string(), var_name.to_string()), ty.to_string());
+        self
+    }
+}
+
+#[cfg(test)]
+impl InferDeps for TestDeps {
+    fn find_fun_params_text(&self, fn_name: &str, uri: &Url) -> Option<String> {
+        self.fun_sigs.get(&(uri.to_string(), fn_name.to_string())).cloned()
+    }
+    fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String> {
+        self.var_types.get(&(uri.to_string(), var_name.to_string())).cloned()
+    }
+}

--- a/src/indexer/infer/deps.rs
+++ b/src/indexer/infer/deps.rs
@@ -22,12 +22,12 @@ use tower_lsp::lsp_types::Url;
 
 /// Minimum dependency surface for pure lambda/type inference leaf functions.
 ///
-/// Two concrete impls exist (Rule of Three satisfied):
+/// Two concrete implementations:
 /// - `Indexer` — production, full resolution with rg fallback
 /// - `TestDeps` — test stub, drives leaf-helper unit tests from plain `HashMap`s
 pub trait InferDeps {
-    /// Return the raw parameter signature text for a function, e.g.
-    /// `"(key: K, flow: Flow<T>, map: (T) -> Model)"`.
+    /// Return the raw parameter text inside a function's outer `()`, e.g.
+    /// `"key: K, flow: Flow<T>, map: (T) -> Model"` (no surrounding parens).
     ///
     /// May perform on-demand rg/disk I/O in the `Indexer` implementation.
     /// Returns `None` when the function is not found.

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -36,6 +36,8 @@ use super::{
     cst_call_fn_name,
     cst_named_arg_label,
     cst_value_arg_position,
+    // deps.rs
+    InferDeps,
 };
 
 // ── from indexer.rs (parent of infer; descendants can access private items) ──
@@ -208,7 +210,7 @@ pub(crate) fn is_lambda_param(
 ///   D) multi-line named-arg `name = {\n  it }` — resolved by callers via `_ml` variant
 pub(crate) fn lambda_receiver_type_from_context(
     before_brace: &str,
-    idx:          &Indexer,
+    deps:         &impl InferDeps,
     uri:          &Url,
 ) -> Option<String> {
     let trimmed = before_brace.trim_end();
@@ -234,7 +236,7 @@ pub(crate) fn lambda_receiver_type_from_context(
             .collect();
 
         if !receiver_var.is_empty() {
-            if let Some(raw) = crate::resolver::infer_variable_type_raw(idx, &receiver_var, uri) {
+            if let Some(raw) = deps.find_var_type(&receiver_var, uri) {
                 if let Some(elem) = crate::resolver::extract_collection_element_type(&raw) {
                     return Some(elem);
                 }
@@ -243,7 +245,7 @@ pub(crate) fn lambda_receiver_type_from_context(
                 // `block: suspend (T) -> Unit`).  Fall back to receiver type when the method
                 // is not found (e.g. stdlib `run`, `apply`, `let` → receiver type is correct).
                 if !method.is_empty() {
-                    if let Some(ty) = fun_trailing_lambda_it_type(&method, idx, uri) {
+                    if let Some(ty) = fun_trailing_lambda_it_type(&method, deps, uri) {
                         return Some(ty);
                     }
                 }
@@ -272,7 +274,7 @@ pub(crate) fn lambda_receiver_type_from_context(
         // first argument as the receiver and infer its type directly.
         if trailing_fn == "with" {
             if let Some(recv_name) = extract_first_arg(trimmed) {
-                if let Some(raw) = crate::resolver::infer_variable_type_raw(idx, recv_name, uri) {
+                if let Some(raw) = deps.find_var_type(recv_name, uri) {
                     let base: String = raw.chars().take_while(|&c| is_id_char(c)).collect();
                     if !base.is_empty() { return Some(base); }
                 }
@@ -283,7 +285,7 @@ pub(crate) fn lambda_receiver_type_from_context(
                 }
             }
         }
-        if let Some(ty) = fun_trailing_lambda_it_type(&trailing_fn, idx, uri) {
+        if let Some(ty) = fun_trailing_lambda_it_type(&trailing_fn, deps, uri) {
             return Some(ty);
         }
     }
@@ -291,7 +293,7 @@ pub(crate) fn lambda_receiver_type_from_context(
     // ── Case C: inline lambda arg — `fn(arg, { param -> ... }, ...)` ─────────
     // `before_brace` ends inside an unclosed `(`, so scan backward to find
     // the function name and the positional index of this lambda argument.
-    inline_lambda_param_type(trimmed, idx, uri)
+    inline_lambda_param_type(trimmed, deps, uri)
 }
 
 // ─── private helpers ─────────────────────────────────────────────────────────
@@ -476,7 +478,7 @@ pub(crate) fn lambda_brace_pos_for_param(line: &str, param_name: &str) -> Option
 ///  - Everything else: return `None` (don't hint `this` from the lambda).
 fn lambda_receiver_this_type_from_context(
     before_brace: &str,
-    idx:          &Indexer,
+    deps:         &impl InferDeps,
     uri:          &Url,
 ) -> Option<String> {
     let trimmed = before_brace.trim_end();
@@ -498,13 +500,13 @@ fn lambda_receiver_this_type_from_context(
 
         if !receiver_var.is_empty() && !method.is_empty() {
             // Prefer the method's own receiver-lambda type (only for indexed fns).
-            if let Some(ty) = fun_trailing_lambda_this_type(&method, idx, uri) {
+            if let Some(ty) = fun_trailing_lambda_this_type(&method, deps, uri) {
                 return Some(ty);
             }
             // Only functions listed in `RECEIVER_THIS_FNS` (`run`, `apply`) are treated as
             // receiver-`this` lambdas; `also`/`let` are intentionally excluded.
             if RECEIVER_THIS_FNS.contains(&method.as_str()) {
-                if let Some(raw) = crate::resolver::infer_variable_type_raw(idx, &receiver_var, uri) {
+                if let Some(raw) = deps.find_var_type(&receiver_var, uri) {
                     let base: String = raw.chars().take_while(|&c| is_id_char(c)).collect();
                     if !base.is_empty() { return Some(base); }
                 }
@@ -524,7 +526,7 @@ fn lambda_receiver_this_type_from_context(
         .collect();
     if trailing_fn == "with" {
         if let Some(recv_name) = extract_first_arg(trimmed) {
-            if let Some(raw) = crate::resolver::infer_variable_type_raw(idx, recv_name, uri) {
+            if let Some(raw) = deps.find_var_type(recv_name, uri) {
                 let base: String = raw.chars().take_while(|&c| is_id_char(c)).collect();
                 if !base.is_empty() { return Some(base); }
             }
@@ -624,7 +626,7 @@ fn lambda_receiver_type_named_arg_ml(
 fn cst_lambda_param_type_via_call(
     doc:    &crate::indexer::live_tree::LiveDoc,
     lambda: &tree_sitter::Node<'_>,
-    idx:    &Indexer,
+    deps:   &impl InferDeps,
     uri:    &Url,
 ) -> Option<String> {
     let bytes = &doc.bytes;
@@ -641,7 +643,7 @@ fn cst_lambda_param_type_via_call(
                     node = p;
                 };
                 let fn_name = cst_call_fn_name(call_expr, bytes)?;
-                let sig = find_fun_signature_full(&fn_name, idx, uri)?;
+                let sig = deps.find_fun_params_text(&fn_name, uri)?;
                 let param_type = if let Some(label) = cst_named_arg_label(parent, bytes) {
                     find_named_param_type_in_sig(&sig, &label)
                 } else {
@@ -654,7 +656,7 @@ fn cst_lambda_param_type_via_call(
                 let call_expr = parent.parent()?;
                 if call_expr.kind() != "call_expression" { cur = parent; continue; }
                 let fn_name = cst_call_fn_name(call_expr, bytes)?;
-                let sig = find_fun_signature_full(&fn_name, idx, uri)?;
+                let sig = deps.find_fun_params_text(&fn_name, uri)?;
                 let last_type = last_fun_param_type_str(&sig)?;
                 return lambda_type_first_input(&last_type);
             }
@@ -668,7 +670,7 @@ fn cst_lambda_param_type_via_call(
 /// For an INLINE lambda argument `fn(a, b, { param -> ... })`:
 /// find the enclosing function name and the 0-based position of this lambda,
 /// then look up that function parameter's type.
-fn inline_lambda_param_type(before_brace: &str, idx: &Indexer, uri: &Url) -> Option<String> {
+fn inline_lambda_param_type(before_brace: &str, deps: &impl InferDeps, uri: &Url) -> Option<String> {
     // Scan right-to-left to find the nearest unclosed `(`.
     // Convention: `)` increments depth, `(` decrements.  depth < 0 → found it.
     let mut depth: i32 = 0;
@@ -698,7 +700,7 @@ fn inline_lambda_param_type(before_brace: &str, idx: &Indexer, uri: &Url) -> Opt
 
     if fn_name.is_empty() { return None; }
 
-    let sig = find_fun_signature_full(&fn_name, idx, uri)?;
+    let sig = deps.find_fun_params_text(&fn_name, uri)?;
     let param_type = nth_fun_param_type_str(&sig, comma_count)?;
     lambda_type_first_input(&param_type)
 }
@@ -708,16 +710,16 @@ fn inline_lambda_param_type(before_brace: &str, idx: &Indexer, uri: &Url) -> Opt
 ///
 /// Example: `fun loadProduct(key: K, flow: Flow<T>, map: (ResultState<T>) -> Model)`
 /// returns `Some("ResultState")` so that `it` in `loadProduct(...) { it }` resolves.
-fn fun_trailing_lambda_it_type(fn_name: &str, idx: &Indexer, uri: &Url) -> Option<String> {
-    let sig = find_fun_signature_full(fn_name, idx, uri)?;
+fn fun_trailing_lambda_it_type(fn_name: &str, deps: &impl InferDeps, uri: &Url) -> Option<String> {
+    let sig = deps.find_fun_params_text(fn_name, uri)?;
     let last_type = last_fun_param_type_str(&sig)?;
     lambda_type_first_input(&last_type)
 }
 
 /// Like `fun_trailing_lambda_it_type` but for `this`: only returns a type when
 /// the trailing lambda parameter is a **receiver lambda** `T.() -> R`.
-fn fun_trailing_lambda_this_type(fn_name: &str, idx: &Indexer, uri: &Url) -> Option<String> {
-    let sig = find_fun_signature_full(fn_name, idx, uri)?;
+fn fun_trailing_lambda_this_type(fn_name: &str, deps: &impl InferDeps, uri: &Url) -> Option<String> {
+    let sig = deps.find_fun_params_text(fn_name, uri)?;
     let last_type = last_fun_param_type_str(&sig)?;
     lambda_type_receiver(&last_type)
 }

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -352,3 +352,66 @@ fn it_type_indexed_inner_fn_cst_still_works() {
     assert_eq!(result.as_deref(), Some("State"),
         "simple trailing-lambda with live tree must still resolve via Case B");
 }
+
+// ── TestDeps-based leaf-helper tests ─────────────────────────────────────────
+//
+// These tests drive the pure leaf helpers (Cases B & C of
+// `lambda_receiver_type_from_context`) using `TestDeps` instead of a full
+// `Indexer`, proving the seam works and the helpers are truly I/O-free.
+
+fn test_uri() -> Url { uri("/deps_test.kt") }
+
+#[test]
+fn test_deps_case_b_trailing_lambda_it_type() {
+    // `loadData { it }` — trailing lambda, function registered in TestDeps.
+    let u = test_uri();
+    let deps = super::super::TestDeps::new()
+        .with_fun(u.as_str(), "loadData", "block: (Product) -> Unit");
+    let result = lambda_receiver_type_from_context("loadData", &deps, &u);
+    assert_eq!(result.as_deref(), Some("Product"),
+        "Case B: trailing lambda param type from TestDeps");
+}
+
+#[test]
+fn test_deps_case_b_with_args() {
+    // `loadData(key) { it }` — same, after `strip_trailing_call_args` strips `(key)`.
+    let u = test_uri();
+    let deps = super::super::TestDeps::new()
+        .with_fun(u.as_str(), "loadData", "key: String, block: (Product) -> Unit");
+    let result = lambda_receiver_type_from_context("loadData(key)", &deps, &u);
+    assert_eq!(result.as_deref(), Some("Product"),
+        "Case B with args stripped: last param lambda type");
+}
+
+#[test]
+fn test_deps_case_a_receiver_dot_method() {
+    // `items.map { it }` — receiver is `items: List<Item>`.
+    let u = test_uri();
+    let deps = super::super::TestDeps::new()
+        .with_var(u.as_str(), "items", "List<Item>");
+    let result = lambda_receiver_type_from_context("items.map", &deps, &u);
+    assert_eq!(result.as_deref(), Some("Item"),
+        "Case A: extract element type from List<Item>");
+}
+
+#[test]
+fn test_deps_case_a_var_type_no_collection() {
+    // `repo.run { it }` — receiver type returned directly when no collection elem.
+    let u = test_uri();
+    let deps = super::super::TestDeps::new()
+        .with_var(u.as_str(), "repo", "Repository")
+        .with_fun(u.as_str(), "run", "block: (Repository) -> Unit");
+    // `run` is found so the method's lambda-param type wins.
+    let result = lambda_receiver_type_from_context("repo.run", &deps, &u);
+    assert_eq!(result.as_deref(), Some("Repository"),
+        "Case A: non-collection receiver, method lambda param type");
+}
+
+#[test]
+fn test_deps_unknown_fn_returns_none() {
+    // Function not registered → None.
+    let u = test_uri();
+    let deps = super::super::TestDeps::new();
+    let result = lambda_receiver_type_from_context("unknownFn", &deps, &u);
+    assert_eq!(result, None, "unknown function should return None");
+}

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -1,15 +1,21 @@
 //! Type-inference helpers for the Kotlin indexer.
 //!
 //! Each submodule handles one class of inference:
+//! - `deps`     — `InferDeps` trait + `TestDeps` stub for unit-testing leaf helpers
 //! - `lambda`   — decomposing lambda/function types (`(T) -> R`, receiver lambdas, etc.)
 //! - `sig`      — function signature extraction (pure string/slice functions)
 //! - `args`     — call argument parsing (pure)
 //! - `it_this`  — resolving `it`/`this` element types inside Kotlin lambda bodies
 
+pub mod deps;
 pub mod lambda;
 pub mod sig;
 pub mod args;
 pub mod it_this;
+
+pub(crate) use deps::InferDeps;
+#[cfg(test)]
+pub(crate) use deps::TestDeps;
 
 pub(crate) use lambda::{
     RECEIVER_THIS_FNS,


### PR DESCRIPTION
Introduces InferDeps trait as a narrow seam. See commit message for details.