### PR TITLE
refactor(10): never-nesting — extract pure helpers, shared kernels, flat loops

### DIFF
--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -183,38 +183,17 @@ impl Backend {
                     l.uri == *uri && l.range.start.line == line_idx as u32
                 });
                 if dup_line { continue; }
-                let mut search = line.as_str();
-                let mut byte_off = 0usize;
-                while let Some(pos) = search.find(name.as_str()) {
-                    let abs = byte_off + pos;
-                    let before_ok = abs == 0 || {
-                        let ch = line[..abs].chars().next_back().unwrap_or(' ');
-                        !ch.is_alphanumeric() && ch != '_'
-                    };
-                    let after_ok = {
-                        let end = abs + name.len();
-                        end >= line.len() || {
-                            let ch = line[end..].chars().next().unwrap_or(' ');
-                            !ch.is_alphanumeric() && ch != '_'
-                        }
-                    };
-                    if before_ok && after_ok {
-                        // Compute UTF-16 column (LSP units) for the match start.
-                        let col: u32 = line[..abs].chars().map(|c| c.len_utf16() as u32).sum();
-                        let col_end: u32 = col + name.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
-                        let range = Range::new(
-                            Position::new(line_idx as u32, col),
-                            Position::new(line_idx as u32, col_end),
-                        );
-                        let already = locs.iter().any(|l: &Location| {
-                            l.uri == *uri && l.range.start == range.start
-                        });
-                        if !already {
-                            locs.push(Location { uri: uri.clone(), range });
-                        }
+                for abs in word_byte_offsets(line, name.as_str()) {
+                    // Compute UTF-16 column (LSP units) for the match start.
+                    let col: u32 = line[..abs].chars().map(|c| c.len_utf16() as u32).sum();
+                    let col_end: u32 = col + name.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
+                    let range = Range::new(
+                        Position::new(line_idx as u32, col),
+                        Position::new(line_idx as u32, col_end),
+                    );
+                    if !locs.iter().any(|l: &Location| l.uri == *uri && l.range.start == range.start) {
+                        locs.push(Location { uri: uri.clone(), range });
                     }
-                    byte_off += pos + name.len().max(1);
-                    search = &line[byte_off.min(line.len())..];
                 }
             }
         }
@@ -726,4 +705,62 @@ fn text_call_info(
 
     let name = call_name.filter(|n| !n.is_empty())?;
     Some((name, call_qualifier, active_param))
+}
+
+/// Iterator over the byte offsets in `line` where `word` occurs as a whole
+/// word (not as a substring of a longer identifier).
+fn word_byte_offsets<'a>(line: &'a str, word: &'a str) -> impl Iterator<Item = usize> + 'a {
+    let word_len = word.len();
+    let is_id = |c: char| c.is_alphanumeric() || c == '_';
+    let mut search_from = 0;
+    std::iter::from_fn(move || {
+        while let Some(rel) = line[search_from..].find(word) {
+            let pos = search_from + rel;
+            search_from = pos + word_len;
+            let before_ok = pos == 0 || !is_id(line[..pos].chars().next_back()?);
+            let after_ok = pos + word_len >= line.len()
+                || !is_id(line[pos + word_len..].chars().next()?);
+            if before_ok && after_ok { return Some(pos); }
+        }
+        None
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::word_byte_offsets;
+
+    #[test]
+    fn finds_single_word() {
+        let offsets: Vec<_> = word_byte_offsets("hello world", "world").collect();
+        assert_eq!(offsets, vec![6]);
+    }
+
+    #[test]
+    fn skips_partial_match() {
+        // "name" should not match inside "rename"
+        let offsets: Vec<_> = word_byte_offsets("rename name", "name").collect();
+        assert_eq!(offsets, vec![7]);
+    }
+
+    #[test]
+    fn multiple_occurrences() {
+        let offsets: Vec<_> = word_byte_offsets("a b a c a", "a").collect();
+        assert_eq!(offsets, vec![0, 4, 8]);
+    }
+
+    #[test]
+    fn unicode_line() {
+        // "ñ" is 2 bytes in UTF-8; "name" after it still at correct byte offset
+        let line = "ñ name ñ";
+        let offsets: Vec<_> = word_byte_offsets(line, "name").collect();
+        assert_eq!(offsets.len(), 1);
+        assert_eq!(&line[offsets[0]..offsets[0] + 4], "name");
+    }
+
+    #[test]
+    fn no_match() {
+        let offsets: Vec<_> = word_byte_offsets("foo bar", "baz").collect();
+        assert!(offsets.is_empty());
+    }
 }

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -208,25 +208,6 @@ pub(crate) fn find_named_param_type_in_sig(sig: &str, param_name: &str) -> Optio
 
 // ─── Lambda parameter helpers ─────────────────────────────────────────────────
 
-/// 0-based index of `param_name` in a multi-param lambda opening `{ a, b, c ->`.
-/// Returns 0 for single-param lambdas.
-pub(crate) fn lambda_param_position_on_line(line: &str, param_name: &str) -> usize {
-    let mut search_from = 0;
-    while let Some(rel) = line[search_from..].find("->") {
-        let arrow_pos = search_from + rel;
-        if let Some(brace_pos) = line[..arrow_pos].rfind('{') {
-            let names_str = &line[brace_pos + 1..arrow_pos];
-            for (i, tok) in names_str.split(',').enumerate() {
-                let tok = tok.trim();
-                let n: String = tok.chars().take_while(|&c| c.is_alphanumeric() || c == '_').collect();
-                if n == param_name { return i; }
-            }
-        }
-        search_from = arrow_pos + 2;
-    }
-    0
-}
-
 /// Returns `true` if `after_open_brace` looks like the opening of an explicitly
 /// named parameter lambda — single-param `{ name ->` or multi-param `{ a, b ->`.
 ///

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -32,7 +32,6 @@ use super::{
     find_named_param_type_in_sig,
     has_named_params_not_it,
     extract_first_arg,
-    lambda_param_position_on_line,
     cst_call_fn_name,
     cst_named_arg_label,
     cst_value_arg_position,
@@ -109,10 +108,8 @@ pub(crate) fn find_named_lambda_param_type_in_lines(
     // Include cursor_line itself (different from completion path which is exclusive).
     for ln in (scan_start..=cursor_line).rev() {
         let line = match lines.get(ln) { Some(l) => l, None => continue };
-        if !line_has_lambda_param(line, param_name) { continue; }
-        let brace_pos = lambda_brace_pos_for_param(line, param_name).unwrap_or(0);
+        let Some((brace_pos, pos)) = find_lambda_brace_for_param(line, param_name) else { continue; };
         let before_brace = &line[..brace_pos];
-        let pos = lambda_param_position_on_line(line, param_name);
         let result = lambda_receiver_type_from_context(before_brace, idx, uri)
             .or_else(|| lambda_receiver_type_named_arg_ml(before_brace, pos, lines, ln, idx, uri));
         if result.is_some() { return result; }
@@ -140,16 +137,13 @@ pub(crate) fn find_named_lambda_param_type(
 
     // 1. Check same line first — covers `items.forEach { item -> item.`
     //    Also handles multi-param: `items.map { a, b -> a.`
-    if line_has_lambda_param(before_cursor, param_name) {
-        if let Some(brace_pos) = lambda_brace_pos_for_param(before_cursor, param_name) {
-            let before_brace = &before_cursor[..brace_pos];
-            let pos = lambda_param_position_on_line(before_cursor, param_name);
-            let result = lambda_receiver_type_from_context(before_brace, idx, uri)
-                .or_else(|| lines.as_deref().and_then(|ls|
-                    lambda_receiver_type_named_arg_ml(before_brace, pos, ls, cursor_line, idx, uri)
-                ));
-            if result.is_some() { return result; }
-        }
+    if let Some((brace_pos, pos)) = find_lambda_brace_for_param(before_cursor, param_name) {
+        let before_brace = &before_cursor[..brace_pos];
+        let result = lambda_receiver_type_from_context(before_brace, idx, uri)
+            .or_else(|| lines.as_deref().and_then(|ls|
+                lambda_receiver_type_named_arg_ml(before_brace, pos, ls, cursor_line, idx, uri)
+            ));
+        if result.is_some() { return result; }
     }
 
     // 2. Scan backward through previous lines.
@@ -157,14 +151,11 @@ pub(crate) fn find_named_lambda_param_type(
     let scan_start = cursor_line.saturating_sub(20);
     for ln in (scan_start..cursor_line).rev() {
         let line = match lines.get(ln) { Some(l) => l, None => continue };
-        if !line_has_lambda_param(line, param_name) { continue; }
-        if let Some(brace_pos) = lambda_brace_pos_for_param(line, param_name) {
-            let before_brace = &line[..brace_pos];
-            let pos = lambda_param_position_on_line(line, param_name);
-            let result = lambda_receiver_type_from_context(before_brace, idx, uri)
-                .or_else(|| lambda_receiver_type_named_arg_ml(before_brace, pos, &lines, ln, idx, uri));
-            if result.is_some() { return result; }
-        }
+        let Some((brace_pos, pos)) = find_lambda_brace_for_param(line, param_name) else { continue; };
+        let before_brace = &line[..brace_pos];
+        let result = lambda_receiver_type_from_context(before_brace, idx, uri)
+            .or_else(|| lambda_receiver_type_named_arg_ml(before_brace, pos, &lines, ln, idx, uri));
+        if result.is_some() { return result; }
     }
     None
 }
@@ -298,6 +289,75 @@ pub(crate) fn lambda_receiver_type_from_context(
 
 // ─── private helpers ─────────────────────────────────────────────────────────
 
+/// Returns `true` if `lambda_node` (a `lambda_literal` CST node) has a
+/// `lambda_parameters` child that contains at least one named parameter that
+/// is neither `it` nor `_`.
+pub(super) fn has_lambda_named_params(lambda_node: tree_sitter::Node<'_>, bytes: &[u8]) -> bool {
+    let Some(lp) = (0..lambda_node.child_count())
+        .filter_map(|i| lambda_node.child(i))
+        .find(|c| c.kind() == "lambda_parameters")
+    else { return false; };
+
+    (0..lp.child_count())
+        .filter_map(|i| lp.child(i))
+        .filter(|c| c.kind() == "variable_declaration")
+        .any(|vd| {
+            let Some(si) = vd.child(0).filter(|n| n.kind() == "simple_identifier") else { return false; };
+            let Ok(name) = std::str::from_utf8(&bytes[si.byte_range()]) else { return false; };
+            name != "it" && name != "_"
+        })
+}
+
+/// Walk ancestors from `start_node` looking for a `lambda_literal` without
+/// named params, then infer the `it`/`this` type for that lambda.
+///
+/// This is the extracted body of the CST fast-path in
+/// `find_it_element_type_in_lines_impl`.
+fn cst_it_or_this_type(
+    start_node: tree_sitter::Node<'_>,
+    doc:        &crate::indexer::live_tree::LiveDoc,
+    lines:      &[String],
+    for_this:   bool,
+    idx:        &Indexer,
+    uri:        &Url,
+) -> Option<String> {
+    let mut cur = start_node;
+    loop {
+        if cur.kind() == "lambda_literal" && !has_lambda_named_params(cur, &doc.bytes) {
+            // Extract text of the lambda-opening line up to the `{`.
+            let brace_byte = cur.start_byte();
+            let line_start = doc.bytes[..brace_byte]
+                .iter()
+                .rposition(|&b| b == b'\n')
+                .map(|i| i + 1)
+                .unwrap_or(0);
+            let before_brace = std::str::from_utf8(&doc.bytes[line_start..brace_byte])
+                .unwrap_or("")
+                .trim_end();
+            let ln = cur.start_position().row;
+
+            if for_this {
+                if let Some(t) = lambda_receiver_this_type_from_context(before_brace, idx, uri) {
+                    return Some(t);
+                }
+            } else {
+                // CST structural fallback: walk up the call tree to find
+                // the enclosing function call and the lambda's argument
+                // position. Handles multi-line cases where the call site
+                // is on a different line than the lambda `{`.
+                let result = lambda_receiver_type_from_context(before_brace, idx, uri)
+                    .or_else(|| lambda_receiver_type_named_arg_ml(
+                        before_brace, 0, lines, ln, idx, uri,
+                    ))
+                    .or_else(|| cst_lambda_param_type_via_call(doc, &cur, idx, uri));
+                if result.is_some() { return result; }
+            }
+        }
+        let Some(p) = cur.parent() else { return None; };
+        cur = p;
+    }
+}
+
 fn find_it_element_type_in_lines_impl(
     lines:    &[String],
     pos:      CursorPos,
@@ -308,62 +368,13 @@ fn find_it_element_type_in_lines_impl(
     // ── CST fast path ────────────────────────────────────────────────────────
     if let Some(doc) = idx.live_doc(uri) {
         use tree_sitter::Point;
-        let line_text  = lines.get(pos.line).map(|s| s.as_str()).unwrap_or("");
-        let byte_col   = crate::indexer::live_tree::utf16_col_to_byte(line_text, pos.utf16_col);
-        let point      = Point { row: pos.line, column: byte_col };
+        let line_text = lines.get(pos.line).map(|s| s.as_str()).unwrap_or("");
+        let byte_col  = crate::indexer::live_tree::utf16_col_to_byte(line_text, pos.utf16_col);
+        let point     = Point { row: pos.line, column: byte_col };
         if let Some(node) = doc.tree.root_node().descendant_for_point_range(point, point) {
-            let mut cur = node;
-            loop {
-                if cur.kind() == "lambda_literal" {
-                    // Skip string interpolations — their `{` is a child of
-                    // `multiline_string_expression`, not `lambda_literal`.
-                    // Skip named-param lambdas: those have a `lambda_parameters` child
-                    // containing at least one non-`it`/non-`_` identifier.
-                    let has_named = (0..cur.child_count()).filter_map(|i| cur.child(i))
-                        .find(|c| c.kind() == "lambda_parameters")
-                        .map(|lp| {
-                            (0..lp.child_count()).filter_map(|i| lp.child(i))
-                                .filter(|c| c.kind() == "variable_declaration")
-                                .filter_map(|vd| {
-                                    vd.child(0).filter(|si| si.kind() == "simple_identifier")
-                                        .and_then(|si| std::str::from_utf8(&doc.bytes[si.byte_range()]).ok().map(|s| s.to_string()))
-                                })
-                                .any(|name| name != "it" && name != "_")
-                        })
-                        .unwrap_or(false);
-                    if !has_named {
-                        // `before_brace` = text of the lambda-opening line up to the `{`.
-                        let brace_byte  = cur.start_byte();
-                        let line_start  = doc.bytes[..brace_byte].iter().rposition(|&b| b == b'\n')
-                            .map(|i| i + 1).unwrap_or(0);
-                        let before_brace = std::str::from_utf8(&doc.bytes[line_start..brace_byte])
-                            .unwrap_or("").trim_end();
-                        let ln = cur.start_position().row;
-                        if for_this {
-                            if let Some(t) = lambda_receiver_this_type_from_context(before_brace, idx, uri) {
-                                return Some(t);
-                            }
-                        } else {
-                            let result = lambda_receiver_type_from_context(before_brace, idx, uri)
-                                .or_else(|| lambda_receiver_type_named_arg_ml(
-                                    before_brace, 0, lines, ln, idx, uri,
-                                ))
-                                // CST structural fallback: walk up the call tree to find
-                                // the enclosing function call and the lambda's argument
-                                // position. Handles multi-line cases where the call site
-                                // is on a different line than the lambda `{`.
-                                .or_else(|| cst_lambda_param_type_via_call(&doc, &cur, idx, uri));
-                            if result.is_some() { return result; }
-                        }
-                    }
-                }
-                match cur.parent() {
-                    Some(p) => cur = p,
-                    None    => break,
-                }
-            }
-            return None;
+            return cst_it_or_this_type(node, &doc, lines, for_this, idx, uri);
         }
+        // Node not found for this position — fall through to text scan.
     }
 
     // ── Text fallback ────────────────────────────────────────────────────────
@@ -422,45 +433,69 @@ fn find_it_element_type_in_lines_impl(
     None
 }
 
+/// Iterator over `(brace_pos, names_str)` for each `->` in `line` that has a
+/// preceding `{`. `names_str` is the text between `{` and `->` (not trimmed).
+/// This is the shared scanning kernel used by all lambda-param helpers.
+fn lambda_brace_arrows(line: &str) -> impl Iterator<Item = (usize, &str)> {
+    let mut search_from = 0usize;
+    std::iter::from_fn(move || {
+        loop {
+            let rel = line[search_from..].find("->")?;
+            let arrow_pos = search_from + rel;
+            search_from = arrow_pos + 2;
+            if let Some(brace_pos) = line[..arrow_pos].rfind('{') {
+                let names_str = &line[brace_pos + 1..arrow_pos];
+                return Some((brace_pos, names_str));
+            }
+        }
+    })
+}
+
+fn names_has_param(names_str: &str, param_name: &str) -> bool {
+    names_str.split(',').any(|tok| {
+        let n: String = tok.trim().chars().take_while(|&c| c.is_alphanumeric() || c == '_').collect();
+        n == param_name
+    })
+}
+
+fn param_index_in(names_str: &str, param_name: &str) -> Option<usize> {
+    names_str.split(',').enumerate().find_map(|(i, tok)| {
+        let n: String = tok.trim().chars().take_while(|&c| c.is_alphanumeric() || c == '_').collect();
+        if n == param_name { Some(i) } else { None }
+    })
+}
+
 /// Returns true if `line` contains a lambda declaration that names `param_name`
 /// as one of its parameters (handles single and multi-param patterns):
 ///   `{ param -> ... }`, `{ a, param, b -> ... }`
 pub(crate) fn line_has_lambda_param(line: &str, param_name: &str) -> bool {
-    // There may be multiple `->` on one line (e.g. inline + trailing lambda).
-    // Iterate every `->` and check whether param_name is in the names before it.
-    let mut search_from = 0;
-    while let Some(rel) = line[search_from..].find("->") {
-        let arrow_pos = search_from + rel;
-        if let Some(brace_pos) = line[..arrow_pos].rfind('{') {
-            let names_str = &line[brace_pos + 1..arrow_pos];
-            for tok in names_str.split(',') {
-                let tok = tok.trim();
-                let n: String = tok.chars().take_while(|&c| c.is_alphanumeric() || c == '_').collect();
-                if n == param_name { return true; }
-            }
-        }
-        search_from = arrow_pos + 2;
-    }
-    false
+    lambda_brace_arrows(line).any(|(_, names)| names_has_param(names, param_name))
 }
 
 /// Find the `{` byte position in `line` for the lambda that declares `param_name`.
 /// Scans all `->` occurrences (a line may have multiple lambdas).
 pub(crate) fn lambda_brace_pos_for_param(line: &str, param_name: &str) -> Option<usize> {
-    let mut search_from = 0;
-    while let Some(rel) = line[search_from..].find("->") {
-        let arrow_pos = search_from + rel;
-        if let Some(brace_pos) = line[..arrow_pos].rfind('{') {
-            let names_str = &line[brace_pos + 1..arrow_pos];
-            for tok in names_str.split(',') {
-                let tok = tok.trim();
-                let n: String = tok.chars().take_while(|&c| c.is_alphanumeric() || c == '_').collect();
-                if n == param_name { return Some(brace_pos); }
-            }
-        }
-        search_from = arrow_pos + 2;
-    }
-    None
+    lambda_brace_arrows(line)
+        .find(|(_, names)| names_has_param(names, param_name))
+        .map(|(pos, _)| pos)
+}
+
+/// Returns `(brace_pos, param_index)` for the lambda on `line` that declares
+/// `param_name`, combining `lambda_brace_pos_for_param` + `lambda_param_position_on_line`
+/// into a single scan.
+pub(crate) fn find_lambda_brace_for_param(line: &str, param_name: &str) -> Option<(usize, usize)> {
+    lambda_brace_arrows(line)
+        .find_map(|(brace_pos, names)| {
+            param_index_in(names, param_name).map(|idx| (brace_pos, idx))
+        })
+}
+
+/// 0-based index of `param_name` in a multi-param lambda opening `{ a, b, c ->`.
+/// Returns 0 for single-param lambdas.
+pub(crate) fn lambda_param_position_on_line(line: &str, param_name: &str) -> usize {
+    lambda_brace_arrows(line)
+        .find_map(|(_, names)| param_index_in(names, param_name))
+        .unwrap_or(0)
 }
 
 ///

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -213,6 +213,49 @@ fn lambda_brace_pos_none_for_unknown_param() {
     assert_eq!(lambda_brace_pos_for_param(line, "unknown"), None);
 }
 
+// ── find_lambda_brace_for_param ──────────────────────────────────────────────
+
+#[test]
+fn find_lambda_brace_returns_brace_pos_and_index() {
+    let line = "items.forEach { item -> item.name }";
+    assert_eq!(find_lambda_brace_for_param(line, "item"), Some((14, 0)));
+}
+
+#[test]
+fn find_lambda_brace_multi_param() {
+    let line = "fn { a, b -> a + b }";
+    assert_eq!(find_lambda_brace_for_param(line, "b"), Some((3, 1)));
+}
+
+#[test]
+fn find_lambda_brace_unknown_param() {
+    let line = "fn { x -> x }";
+    assert_eq!(find_lambda_brace_for_param(line, "y"), None);
+}
+
+#[test]
+fn find_lambda_brace_extra_spaces() {
+    let line = "{   name   -> name.foo }";
+    assert_eq!(find_lambda_brace_for_param(line, "name"), Some((0, 0)));
+}
+
+// ── lambda_param_position_on_line ─────────────────────────────────────────────
+
+#[test]
+fn lambda_param_position_single() {
+    assert_eq!(lambda_param_position_on_line("{ a -> }", "a"), 0);
+}
+
+#[test]
+fn lambda_param_position_second() {
+    assert_eq!(lambda_param_position_on_line("{ a, b -> }", "b"), 1);
+}
+
+#[test]
+fn lambda_param_position_missing() {
+    assert_eq!(lambda_param_position_on_line("{ a -> }", "x"), 0);
+}
+
 // ── has_named_params_not_it ──────────────────────────────────────────────────
 
 #[test]
@@ -351,6 +394,68 @@ fn it_type_indexed_inner_fn_cst_still_works() {
     let result = find_it_element_type_in_lines(&lines, pos, &idx, &u);
     assert_eq!(result.as_deref(), Some("State"),
         "simple trailing-lambda with live tree must still resolve via Case B");
+}
+
+// ── has_lambda_named_params ──────────────────────────────────────────────────
+
+fn parse_kotlin(src: &str) -> tree_sitter::Tree {
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&tree_sitter_kotlin::language()).unwrap();
+    parser.parse(src, None).unwrap()
+}
+
+fn find_node_kind<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
+    if node.kind() == kind { return Some(node); }
+    for i in 0..node.child_count() {
+        if let Some(n) = node.child(i).and_then(|c| find_node_kind(c, kind)) {
+            return Some(n);
+        }
+    }
+    None
+}
+
+#[test]
+fn has_lambda_named_params_false_for_no_params() {
+    // lambda_literal with no lambda_parameters child → false
+    let src = "val x = items.map { it.name }";
+    let bytes = src.as_bytes();
+    let tree = parse_kotlin(src);
+    let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+    assert!(!super::has_lambda_named_params(lambda, bytes),
+        "no lambda_parameters child should yield false");
+}
+
+#[test]
+fn has_lambda_named_params_false_for_it() {
+    // lambda_parameters containing only `it` → false
+    let src = "val x = items.map { it -> it.name }";
+    let bytes = src.as_bytes();
+    let tree = parse_kotlin(src);
+    let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+    assert!(!super::has_lambda_named_params(lambda, bytes),
+        "param named `it` should yield false");
+}
+
+#[test]
+fn has_lambda_named_params_true_for_named() {
+    // lambda_parameters containing `item` → true
+    let src = "val x = items.map { item -> item.name }";
+    let bytes = src.as_bytes();
+    let tree = parse_kotlin(src);
+    let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+    assert!(super::has_lambda_named_params(lambda, bytes),
+        "param named `item` should yield true");
+}
+
+#[test]
+fn has_lambda_named_params_false_for_underscore() {
+    // lambda_parameters containing only `_` → false
+    let src = "val x = items.map { _ -> 42 }";
+    let bytes = src.as_bytes();
+    let tree = parse_kotlin(src);
+    let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+    assert!(!super::has_lambda_named_params(lambda, bytes),
+        "param named `_` should yield false");
 }
 
 // ── TestDeps-based leaf-helper tests ─────────────────────────────────────────

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -39,7 +39,6 @@ pub(crate) use args::{
     extract_first_arg,
     extract_named_arg_name,
     find_named_param_type_in_sig,
-    lambda_param_position_on_line,
     has_named_params_not_it,
     cst_call_fn_name,
     cst_named_arg_label,
@@ -56,5 +55,7 @@ pub(crate) use it_this::{
     lambda_receiver_type_from_context,
     line_has_lambda_param,
     lambda_brace_pos_for_param,
+    find_lambda_brace_for_param,
+    lambda_param_position_on_line,
     find_last_dot_at_depth_zero,
 };

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -171,6 +171,33 @@ pub(crate) fn collect_params_from_line(lines: &[String], start_line: usize) -> O
 
 // ─── Parameter type accessors ─────────────────────────────────────────────────
 
+/// Split `text` at top-level commas (depth 0), skipping commas inside `()`, `<>`, `[]`.
+/// The `->` Kotlin function-type arrow is handled: `>` preceded by `-` is NOT a closing
+/// generic delimiter.
+///
+/// Returns the raw slices between commas; does NOT trim or filter empty parts.
+pub(crate) fn split_params_at_depth_zero(text: &str) -> Vec<&str> {
+    let mut parts: Vec<&str> = Vec::new();
+    let mut depth: i32 = 0;
+    let mut start = 0;
+    let mut prev = '\0';
+    for (i, ch) in text.char_indices() {
+        match ch {
+            '(' | '<' | '[' => depth += 1,
+            ')' | ']' => depth -= 1,
+            '>' if prev != '-' && depth > 0 => depth -= 1,
+            ',' if depth == 0 => {
+                parts.push(&text[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+        prev = ch;
+    }
+    parts.push(&text[start..]);
+    parts
+}
+
 /// Split the flattened parameter list by `,` at depth-0 (respecting `()`, `<>`).
 /// Returns the type string of the parameter at position `n` (0-based).
 /// Falls back to the last parameter if `n` is out of range.
@@ -179,25 +206,7 @@ pub(crate) fn collect_params_from_line(lines: &[String], start_line: usize) -> O
 /// `>` which would falsely decrement `<>` depth.  We skip the `>` of any `->` by
 /// tracking the previous character.
 pub(crate) fn nth_fun_param_type_str(params_text: &str, n: usize) -> Option<String> {
-    let mut parts: Vec<&str> = Vec::new();
-    let mut depth: i32 = 0;
-    let mut start = 0;
-    let mut prev = '\0';
-    for (i, ch) in params_text.char_indices() {
-        match ch {
-            '(' | '<' | '[' => depth += 1,
-            ')' | ']' => depth -= 1,
-            // Skip `>` of `->` and guard against going negative on bare `>` operators.
-            '>' if prev != '-' && depth > 0 => depth -= 1,
-            ',' if depth == 0 => {
-                parts.push(&params_text[start..i]);
-                start = i + 1;
-            }
-            _ => {}
-        }
-        prev = ch;
-    }
-    parts.push(&params_text[start..]);
+    let mut parts = split_params_at_depth_zero(params_text);
     // Drop trailing-comma empty parts (Kotlin allows `fun f(a: A, b: B,) {}`).
     parts.retain(|p| !p.trim().is_empty());
     if parts.is_empty() { return None; }
@@ -211,23 +220,10 @@ pub(crate) fn nth_fun_param_type_str(params_text: &str, n: usize) -> Option<Stri
 
 /// Return the type string of the last parameter in `params_text`.
 pub(crate) fn last_fun_param_type_str(params_text: &str) -> Option<String> {
-    // Count top-level parameters (same `->` skip logic as nth_fun_param_type_str).
-    let count = {
-        let mut n = 1usize;
-        let mut depth: i32 = 0;
-        let mut prev = '\0';
-        for ch in params_text.chars() {
-            match ch {
-                '(' | '<' | '[' => depth += 1,
-                ')' | ']' => depth -= 1,
-                '>' if prev != '-' && depth > 0 => depth -= 1,
-                ',' if depth == 0 => n += 1,
-                _ => {}
-            }
-            prev = ch;
-        }
-        n
-    };
+    let count = split_params_at_depth_zero(params_text)
+        .iter()
+        .filter(|p| !p.trim().is_empty())
+        .count();
     nth_fun_param_type_str(params_text, count.saturating_sub(1))
 }
 

--- a/src/indexer/infer/sig_tests.rs
+++ b/src/indexer/infer/sig_tests.rs
@@ -161,6 +161,45 @@ fn last_param_type_empty_returns_none() {
     assert_eq!(last_fun_param_type_str(""), None);
 }
 
+// ─── split_params_at_depth_zero ──────────────────────────────────────────────
+
+use super::split_params_at_depth_zero;
+
+#[test]
+fn split_simple() {
+    assert_eq!(split_params_at_depth_zero("a: A, b: B"), vec!["a: A", " b: B"]);
+}
+
+#[test]
+fn split_nested_generics() {
+    // comma inside <> must not split
+    assert_eq!(split_params_at_depth_zero("a: Map<K, V>, b: B"), vec!["a: Map<K, V>", " b: B"]);
+}
+
+#[test]
+fn split_function_type_arrow() {
+    // `->` must not cause `>` to consume generic depth
+    assert_eq!(split_params_at_depth_zero("block: (T) -> Unit, n: Int"),
+               vec!["block: (T) -> Unit", " n: Int"]);
+}
+
+#[test]
+fn split_empty() {
+    assert_eq!(split_params_at_depth_zero(""), vec![""]);
+}
+
+#[test]
+fn split_single() {
+    assert_eq!(split_params_at_depth_zero("a: A"), vec!["a: A"]);
+}
+
+#[test]
+fn split_trailing_comma() {
+    let parts = split_params_at_depth_zero("a: A, b: B,");
+    assert_eq!(parts.len(), 3);
+    assert_eq!(parts[2], "");
+}
+
 // ─── strip_trailing_call_args ─────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Phase 10 — Never-Nesting Refactoring

Zero behaviour change. 531 tests pass (+22 new).

### Changes

| Technique | Location | Before → After |
|-----------|----------|----------------|
| Extract fn + `let-else` | `it_this.rs` | `has_lambda_named_params` — 5-level nested closure chain → named pure fn |
| Extract fn | `it_this.rs` | `cst_it_or_this_type` — CST ancestor-walk body extracted from `find_it_element_type_in_lines_impl` |
| Shared kernel + iterator | `it_this.rs` | `lambda_brace_arrows` — 3 identical loop bodies → 1 shared iterator; `find_lambda_brace_for_param` replaces 3-pass pattern with single scan |
| Move fn | `args.rs → it_this.rs` | `lambda_param_position_on_line` lives next to the kernel it uses |
| Extract shared utility | `sig.rs` | `split_params_at_depth_zero` — depth-tracking comma split extracted from `nth_fun_param_type_str` / `last_fun_param_type_str` |
| Extract iterator + flatten | `handlers.rs` | `word_byte_offsets` — 4-level nested while/for/if/if → flat `for abs in word_byte_offsets(...)` |

### New tests
- 4 × `has_lambda_named_params` (CST node cases)
- 7 × `find_lambda_brace_for_param` / `lambda_param_position_on_line`
- 6 × `split_params_at_depth_zero`
- 5 × `word_byte_offsets` (incl. Unicode boundary)

### Phase 11 targets identified (next PR)
- `last_ident_in(s)` — eliminate 7× `.chars().rev().take_while().collect().chars().rev().collect()`
- `find_ancestor(node, pred, bail)` — replace 4+ `loop { match cur.parent() }` blocks  
- `collect_lambda_param_names` — fix 8-level nesting in `scope.rs:lambda_params_at_col`
- `resolve_with_receiver_fallback` on Backend — deduplicate verbatim 4-line block in nav.rs + handlers.rs