### PR TITLE
refactor(phase11): shared abstractions

### DIFF
--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -56,10 +56,7 @@ impl Backend {
         // so hover shows the member from the correct class.
         if ctx.qualifier.is_some() {
             if let Some(ref rt) = ctx.contextual {
-                let locs = self.indexer.find_definition_qualified(&ctx.word, Some(&rt.qualified), uri);
-                let locs = if locs.is_empty() && rt.leaf != rt.qualified {
-                    self.indexer.find_definition_qualified(&ctx.word, Some(&rt.leaf), uri)
-                } else { locs };
+                let locs = self.resolve_with_receiver_fallback(&ctx.word, rt, uri);
                 if let Some(loc) = locs.first() {
                     if let Some(md) = self.indexer.hover_info_at_location(loc, &ctx.word) {
                         return Ok(Some(Hover {
@@ -672,23 +669,18 @@ fn text_call_info(
                 .collect::<Vec<_>>().into_iter().rev()
             {
                 let before_paren = &l[..p];
-                let name: String = before_paren.chars().rev()
-                    .take_while(|&c| c.is_alphanumeric() || c == '_')
-                    .collect::<String>().chars().rev().collect();
-                if !name.is_empty() && !is_non_call_keyword(&name) {
+                let name = crate::indexer::last_ident_in(before_paren);
+                if !name.is_empty() && !is_non_call_keyword(name) {
                     let net: i32 = l[p..].chars()
                         .map(|c| match c { '(' => 1, ')' => -1, _ => 0 }).sum();
                     if net > 0 {
                         // Qualifier before the dot on the same line.
                         let before_name = &before_paren[..before_paren.len() - name.len()];
                         let qualifier = if before_name.ends_with('.') {
-                            let q: String = before_name[..before_name.len() - 1]
-                                .chars().rev()
-                                .take_while(|&c| c.is_alphanumeric() || c == '_')
-                                .collect::<String>().chars().rev().collect();
-                            if q.is_empty() { None } else { Some(q) }
+                            let q = crate::indexer::last_ident_in(&before_name[..before_name.len() - 1]);
+                            if q.is_empty() { None } else { Some(q.to_owned()) }
                         } else { None };
-                        call_name = Some(name);
+                        call_name = Some(name.to_owned());
                         call_qualifier = qualifier;
                         if scan_line + 1 < line_idx {
                             for mid in &lines[(scan_line + 1)..line_idx] {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -38,6 +38,22 @@ impl Backend {
             snippet_support: Arc::new(AtomicBool::new(false)),
         }
     }
+
+    /// Try `find_definition_qualified` with `rt.qualified`, falling back to `rt.leaf`
+    /// when the first lookup is empty and the two names differ.
+    pub(super) fn resolve_with_receiver_fallback(
+        &self,
+        word: &str,
+        rt: &crate::resolver::ReceiverType,
+        uri: &Url,
+    ) -> Vec<Location> {
+        let locs = self.indexer.find_definition_qualified(word, Some(&rt.qualified), uri);
+        if locs.is_empty() && rt.leaf != rt.qualified {
+            self.indexer.find_definition_qualified(word, Some(&rt.leaf), uri)
+        } else {
+            locs
+        }
+    }
 }
 
 #[async_trait]

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -69,10 +69,7 @@ impl Backend {
         // so lookup finds the member in the correct class.
         if ctx.qualifier.is_some() {
             if let Some(ref rt) = ctx.contextual {
-                let locs = self.indexer.find_definition_qualified(&ctx.word, Some(&rt.qualified), uri);
-                let locs = if locs.is_empty() && rt.leaf != rt.qualified {
-                    self.indexer.find_definition_qualified(&ctx.word, Some(&rt.leaf), uri)
-                } else { locs };
+                let locs = self.resolve_with_receiver_fallback(&ctx.word, rt, uri);
                 if !locs.is_empty() {
                     return Ok(Some(locs_to_response(locs)));
                 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -34,6 +34,7 @@ pub(crate) use self::infer::{
     find_named_param_type_in_sig,
     lambda_param_position_on_line,
     has_named_params_not_it,
+    cst_call_fn_name,
     // it_this.rs
     find_it_element_type,
     find_it_element_type_in_lines,
@@ -63,6 +64,7 @@ mod lookup;
 
 mod scope;
 pub(crate) use scope::is_id_char;
+pub(crate) use scope::last_ident_in;
 pub(crate) use scope::find_enclosing_call_name;
 
 pub(crate) mod live_tree;
@@ -2065,6 +2067,29 @@ class Foo @Inject constructor(
             !indexer.definitions.contains_key("VendorClass"),
             "VendorClass (under third-party/) must be excluded"
         );
+    }
+
+    // ── last_ident_in ────────────────────────────────────────────────────────
+
+    #[test]
+    fn last_ident_in_simple() {
+        assert_eq!(crate::indexer::last_ident_in("foo.barBaz"), "barBaz");
+    }
+    #[test]
+    fn last_ident_in_whole_string() {
+        assert_eq!(crate::indexer::last_ident_in("identifier"), "identifier");
+    }
+    #[test]
+    fn last_ident_in_empty() {
+        assert_eq!(crate::indexer::last_ident_in(""), "");
+    }
+    #[test]
+    fn last_ident_in_no_ident() {
+        assert_eq!(crate::indexer::last_ident_in("foo.bar("), "");
+    }
+    #[test]
+    fn last_ident_in_with_spaces() {
+        assert_eq!(crate::indexer::last_ident_in("  someIdent"), "someIdent");
     }
 }
 

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -6,7 +6,7 @@
 use tower_lsp::lsp_types::Url;
 
 use crate::indexer::{Indexer, is_id_char, find_enclosing_call_name};
-use crate::indexer::infer::sig::{find_fun_signature_full, nth_fun_param_type_str};
+use crate::indexer::infer::sig::{find_fun_signature_full, nth_fun_param_type_str, split_params_at_depth_zero};
 use crate::types::CursorPos;
 
 // ─── Type-directed call-argument inference ────────────────────────────────────
@@ -173,23 +173,7 @@ pub(crate) fn extract_named_arg_name(before_brace: &str) -> Option<&str> {
 /// Handles `val`/`var` prefixes, strips them. Returns the full type string
 /// (may be a functional type like `(String, Boolean) -> Unit`).
 pub(crate) fn find_named_param_type_in_sig(sig: &str, param_name: &str) -> Option<String> {
-    // Split by comma at depth 0, tracking `()`, `[]`, and `<>`.
-    // The `>` in `->` must NOT decrement `<>` depth — skip it when prev char is `-`.
-    let mut parts: Vec<&str> = Vec::new();
-    let mut depth: i32 = 0;
-    let mut start = 0;
-    let mut prev = '\0';
-    for (i, ch) in sig.char_indices() {
-        match ch {
-            '(' | '[' | '<' => depth += 1,
-            ')' | ']' => depth -= 1,
-            '>' if prev != '-' && depth > 0 => depth -= 1,
-            ',' if depth == 0 => { parts.push(&sig[start..i]); start = i + 1; }
-            _ => {}
-        }
-        prev = ch;
-    }
-    if start < sig.len() { parts.push(&sig[start..]); }
+    let parts = split_params_at_depth_zero(sig);
 
     let colon_pat = format!("{param_name}:");
     for part in parts {

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -43,6 +43,7 @@ use super::{
 use super::super::{
     Indexer,
     is_id_char,
+    last_ident_in,
     find_enclosing_call_name,
 };
 
@@ -215,19 +216,14 @@ pub(crate) fn lambda_receiver_type_from_context(
     // (e.g., `fn(Enum.VALUE, {` must not match the dot inside `Enum.VALUE`).
     if let Some(dot_pos) = find_last_dot_at_depth_zero(callee) {
         let receiver_expr = callee[..dot_pos].trim_end();
-        let receiver_var: String = receiver_expr
-            .chars().rev()
-            .take_while(|&c| is_id_char(c))
-            .collect::<String>()
-            .chars().rev()
-            .collect();
+        let receiver_var = last_ident_in(receiver_expr);
         // Extract method name (everything after the dot up to the first non-id char).
         let method: String = callee[dot_pos + 1..].trim_start()
             .chars().take_while(|&c| is_id_char(c))
             .collect();
 
         if !receiver_var.is_empty() {
-            if let Some(raw) = deps.find_var_type(&receiver_var, uri) {
+            if let Some(raw) = deps.find_var_type(receiver_var, uri) {
                 if let Some(elem) = crate::resolver::extract_collection_element_type(&raw) {
                     return Some(elem);
                 }
@@ -246,7 +242,7 @@ pub(crate) fn lambda_receiver_type_from_context(
                 }
             }
             if receiver_var.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
-                return Some(receiver_var);
+                return Some(receiver_var.to_owned());
             }
         }
     }
@@ -255,11 +251,7 @@ pub(crate) fn lambda_receiver_type_from_context(
     // Extract the trailing identifier from callee — handles cases where callee
     // is prefixed by outer-lambda context like `{ setState` (the `{` belongs
     // to an enclosing lambda, not this call).
-    let trailing_fn: String = callee.chars().rev()
-        .take_while(|&c| is_id_char(c))
-        .collect::<String>()
-        .chars().rev()
-        .collect();
+    let trailing_fn = last_ident_in(callee);
     if !trailing_fn.is_empty() {
         // Known stdlib scope function `with(receiver) { this }` — extract the
         // first argument as the receiver and infer its type directly.
@@ -276,7 +268,7 @@ pub(crate) fn lambda_receiver_type_from_context(
                 }
             }
         }
-        if let Some(ty) = fun_trailing_lambda_it_type(&trailing_fn, deps, uri) {
+        if let Some(ty) = fun_trailing_lambda_it_type(trailing_fn, deps, uri) {
             return Some(ty);
         }
     }
@@ -523,12 +515,7 @@ fn lambda_receiver_this_type_from_context(
     // ── Case A: `receiver.method` ────────────────────────────────────────────
     if let Some(dot_pos) = find_last_dot_at_depth_zero(callee) {
         let receiver_expr = callee[..dot_pos].trim_end();
-        let receiver_var: String = receiver_expr
-            .chars().rev()
-            .take_while(|&c| is_id_char(c))
-            .collect::<String>()
-            .chars().rev()
-            .collect();
+        let receiver_var = last_ident_in(receiver_expr);
         let method: String = callee[dot_pos + 1..].trim_start()
             .chars().take_while(|&c| is_id_char(c))
             .collect();
@@ -541,12 +528,12 @@ fn lambda_receiver_this_type_from_context(
             // Only functions listed in `RECEIVER_THIS_FNS` (`run`, `apply`) are treated as
             // receiver-`this` lambdas; `also`/`let` are intentionally excluded.
             if RECEIVER_THIS_FNS.contains(&method.as_str()) {
-                if let Some(raw) = deps.find_var_type(&receiver_var, uri) {
+                if let Some(raw) = deps.find_var_type(receiver_var, uri) {
                     let base: String = raw.chars().take_while(|&c| is_id_char(c)).collect();
                     if !base.is_empty() { return Some(base); }
                 }
                 if receiver_var.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
-                    return Some(receiver_var);
+                    return Some(receiver_var.to_owned());
                 }
             }
         }
@@ -554,11 +541,7 @@ fn lambda_receiver_this_type_from_context(
     }
 
     // ── Case B: `with(receiver) { this }` ───────────────────────────────────
-    let trailing_fn: String = callee.chars().rev()
-        .take_while(|&c| is_id_char(c))
-        .collect::<String>()
-        .chars().rev()
-        .collect();
+    let trailing_fn = last_ident_in(callee);
     if trailing_fn == "with" {
         if let Some(recv_name) = extract_first_arg(trimmed) {
             if let Some(raw) = deps.find_var_type(recv_name, uri) {
@@ -725,17 +708,11 @@ fn inline_lambda_param_type(before_brace: &str, deps: &impl InferDeps, uri: &Url
     }
 
     let open_pos = open_paren_byte?;
-    let fn_name: String = before_brace[..open_pos]
-        .trim_end()
-        .chars().rev()
-        .take_while(|&c| is_id_char(c))
-        .collect::<String>()
-        .chars().rev()
-        .collect();
+    let fn_name = last_ident_in(before_brace[..open_pos].trim_end());
 
     if fn_name.is_empty() { return None; }
 
-    let sig = deps.find_fun_params_text(&fn_name, uri)?;
+    let sig = deps.find_fun_params_text(fn_name, uri)?;
     let param_type = nth_fun_param_type_str(&sig, comma_count)?;
     lambda_type_first_input(&param_type)
 }

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -246,35 +246,11 @@ impl Indexer {
                 let mut cur = node;
                 loop {
                     if cur.kind() == "lambda_literal" {
-                        for i in 0..cur.child_count() {
-                            if let Some(lp) = cur.child(i) {
-                                if lp.kind() == "lambda_parameters" {
-                                    for j in 0..lp.child_count() {
-                                        if let Some(vd) = lp.child(j) {
-                                            if vd.kind() == "variable_declaration" {
-                                                if let Some(si) = vd.child(0) {
-                                                    if si.kind() == "simple_identifier" {
-                                                        if let Ok(name) = std::str::from_utf8(&doc.bytes[si.byte_range()]) {
-                                                            if name != "it" && name != "_"
-                                                                && name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
-                                                                && !params.contains(&name.to_string())
-                                                            {
-                                                                params.push(name.to_string());
-                                                            }
-                                                        }
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                        let new_names = collect_lambda_param_names(cur, &doc.bytes, &params);
+                        params.extend(new_names);
                     }
-                    match cur.parent() {
-                        Some(p) => cur = p,
-                        None    => break,
-                    }
+                    let Some(p) = cur.parent() else { break; };
+                    cur = p;
                 }
                 return params;
             }
@@ -427,6 +403,34 @@ impl Indexer {
     }
 }
 
+/// Collect named lambda parameter identifiers from a `lambda_literal` CST node.
+/// Skips `it`, `_`, uppercase-first (type refs), and deduplicates.
+/// Returns an empty `Vec` if the lambda has no `lambda_parameters` child.
+fn collect_lambda_param_names(
+    lambda_node: tree_sitter::Node<'_>,
+    bytes:       &[u8],
+    existing:    &[String],
+) -> Vec<String> {
+    let Some(lp) = (0..lambda_node.child_count())
+        .filter_map(|i| lambda_node.child(i))
+        .find(|c| c.kind() == "lambda_parameters")
+    else { return Vec::new(); };
+
+    (0..lp.child_count())
+        .filter_map(|i| lp.child(i))
+        .filter(|c| c.kind() == "variable_declaration")
+        .filter_map(|vd| {
+            let si = vd.child(0).filter(|n| n.kind() == "simple_identifier")?;
+            std::str::from_utf8(&bytes[si.byte_range()]).ok().map(|s| s.to_string())
+        })
+        .filter(|name| {
+            name != "it" && name != "_"
+            && name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
+            && !existing.contains(name)
+        })
+        .collect()
+}
+
 /// Extract the type/class name from a CST class/interface/object/companion_object node.
 /// Tries `child_by_field_name("name")` first, then walks direct children for
 /// `type_identifier` or `simple_identifier` that starts with an uppercase letter.
@@ -490,6 +494,18 @@ pub(super) fn extract_class_decl_name(line: &str) -> Option<String> {
 
 pub(crate) fn is_id_char(c: char) -> bool {
     c.is_alphanumeric() || c == '_'
+}
+
+/// Return the trailing contiguous identifier slice in `s` — the longest
+/// suffix whose characters all satisfy `is_id_char`.  Returns `""` if none.
+///
+/// Example: `last_ident_in("foo.barBaz")` → `"barBaz"`
+pub(crate) fn last_ident_in(s: &str) -> &str {
+    let ident_bytes: usize = s.chars().rev()
+        .take_while(|&c| is_id_char(c))
+        .map(|c| c.len_utf8())
+        .sum();
+    &s[s.len() - ident_bytes..]
 }
 
 /// Scan backward from `(line_no, col)` — where `col` is the START of the cursor

--- a/src/indexer/scope_tests.rs
+++ b/src/indexer/scope_tests.rs
@@ -531,3 +531,53 @@ fn lambda_params_at_col_cst_excludes_it() {
     assert!(!params.contains(&"it".to_string()),
         "'it' must never appear in named params, got: {params:?}");
 }
+
+// ── collect_lambda_param_names ───────────────────────────────────────────────
+
+fn parse_kotlin_scope(src: &str) -> tree_sitter::Tree {
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&tree_sitter_kotlin::language()).unwrap();
+    parser.parse(src, None).unwrap()
+}
+
+fn find_node_scope<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
+    if node.kind() == kind { return Some(node); }
+    for i in 0..node.child_count() {
+        if let Some(n) = node.child(i).and_then(|c| find_node_scope(c, kind)) {
+            return Some(n);
+        }
+    }
+    None
+}
+
+#[test]
+fn collect_lambda_param_names_named() {
+    let src = "val x = items.map { item -> item.foo }";
+    let bytes = src.as_bytes();
+    let tree = parse_kotlin_scope(src);
+    let lambda = find_node_scope(tree.root_node(), "lambda_literal").unwrap();
+    let names = super::collect_lambda_param_names(lambda, bytes, &[]);
+    assert_eq!(names, vec!["item".to_string()],
+        "should collect 'item', got: {names:?}");
+}
+
+#[test]
+fn collect_lambda_param_names_skips_it() {
+    let src = "val x = items.map { it -> it.foo }";
+    let bytes = src.as_bytes();
+    let tree = parse_kotlin_scope(src);
+    let lambda = find_node_scope(tree.root_node(), "lambda_literal").unwrap();
+    let names = super::collect_lambda_param_names(lambda, bytes, &[]);
+    assert!(names.is_empty(), "should skip 'it', got: {names:?}");
+}
+
+#[test]
+fn collect_lambda_param_names_multi() {
+    let src = "val x = items.zip(other) { a, b -> a.id }";
+    let bytes = src.as_bytes();
+    let tree = parse_kotlin_scope(src);
+    let lambda = find_node_scope(tree.root_node(), "lambda_literal").unwrap();
+    let names = super::collect_lambda_param_names(lambda, bytes, &[]);
+    assert!(names.contains(&"a".to_string()), "should contain 'a', got: {names:?}");
+    assert!(names.contains(&"b".to_string()), "should contain 'b', got: {names:?}");
+}

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -243,22 +243,9 @@ fn hint_property(
 fn infer_type_from_init(init: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<String> {
     // call_expression: callee(...) or callee<T>(...)
     if init.kind() == "call_expression" {
-        let callee = init.child(0)?;
-        // Callee may be a navigation chain: `Pkg.Type(...)` — use last segment.
-        let name_node = match callee.kind() {
-            "simple_identifier" | "type_identifier" => callee,
-            "navigation_expression" => {
-                // last child that is an identifier
-                let mut nc = callee.walk();
-                callee.children(&mut nc)
-                    .filter(|c| c.kind() == "simple_identifier" || c.kind() == "type_identifier")
-                    .last()?
-            }
-            _ => return None,
-        };
-        let name = name_node.utf8_text(bytes).ok()?.trim();
+        let name = crate::indexer::cst_call_fn_name(init, bytes)?;
         if name.starts_with(|c: char| c.is_uppercase()) {
-            return Some(name.to_string());
+            return Some(name);
         }
     }
     None


### PR DESCRIPTION
## Phase 11 — Shared abstractions

Zero behaviour change throughout. 539 tests pass (+8 new).

### Changes

| Utility | Files | Sites | Effect |
|---|---|---|---|
| `last_ident_in(s) -> &str` | indexer.rs, it_this.rs, handlers.rs | 7 | Removes double-reverse-collect allocation pattern |
| `collect_lambda_param_names` | scope.rs | 1 | Flattens 8-level nested CST if-let → flat iterator chain |
| `resolve_with_receiver_fallback` | mod.rs, handlers.rs, nav.rs | 2 | Deduplicates verbatim qualified+leaf fallback block |
| `split_params_at_depth_zero` reuse | args.rs | 1 | Replaces inline 12-line depth-counting loop |
| `cst_call_fn_name` reuse | inlay_hints.rs | 1 | Replaces inline CST call-name reimplementation |

### Techniques

- **Shared slice utility** — `last_ident_in` returns `&str` (no alloc) instead of double-reversing through an owned `String`
- **Iterator chain over CST children** — `collect_lambda_param_names` uses `.filter_map` + `let-else` instead of 8 nested `if let`
- **Extract method** — `resolve_with_receiver_fallback` eliminates verbatim code duplication across two backend files
- **DRY** — two callers now delegate to existing tested helpers instead of maintaining their own copies