### PR TITLE
refactor(phase12): type-dependent traits — NodeExt, LinesExt, IndexerExt

### DIFF
--- a/src/backend/cursor.rs
+++ b/src/backend/cursor.rs
@@ -51,7 +51,7 @@ impl CursorContext {
         let col  = position.character as usize;
 
         // `it`/`this` are always contextual (lambda receiver inference).
-        let is_it_or_this = qualifier.as_deref().map_or(false, |q| q == "it" || q == "this")
+        let is_it_or_this = qualifier.as_deref().is_some_and(|q| q == "it" || q == "this")
             || (qualifier.is_none() && (word == "it" || word == "this"));
 
         // For other lowercase bare identifiers, confirm they are in scope as lambda
@@ -60,7 +60,7 @@ impl CursorContext {
         // class on hover, which is incorrect.
         let in_scope_lambda_params: Vec<String> = if !is_it_or_this
             && qualifier.is_none()
-            && word.chars().next().map_or(false, |c| c.is_lowercase())
+            && word.chars().next().is_some_and(|c| c.is_lowercase())
         {
             idx.lambda_params_at_col(uri, line, col)
         } else {

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -662,7 +662,7 @@ fn text_call_info(
                         // Qualifier before the dot on the same line.
                         let before_name = &before_paren[..before_paren.len() - name.len()];
                         let qualifier = if before_name.ends_with('.') {
-                            let q = crate::indexer::last_ident_in(&before_name[..before_name.len() - 1]);
+                            let q = crate::indexer::last_ident_in(before_name.strip_suffix('.').unwrap_or(before_name));
                             if q.is_empty() { None } else { Some(q.to_owned()) }
                         } else { None };
                         call_name = Some(name.to_owned());

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use crate::indexer::find_fun_signature_with_receiver;
+use crate::indexer::NodeExt;
 use super::Backend;
 use super::cursor::CursorContext;
 use super::helpers::resolve_references_scope;
@@ -574,7 +575,7 @@ fn cst_call_info(
     };
 
     // Find the value_arguments node (may be inside call_suffix).
-    let value_arguments = cst_find_value_arguments(call_expr)?;
+    let value_arguments = call_expr.find_value_arguments()?;
 
     // Count active param: how many value_argument children end before the cursor.
     let cursor_byte = full_text.lines()
@@ -593,22 +594,6 @@ fn cst_call_info(
     };
 
     Some((fn_name, qualifier, active_param))
-}
-
-/// Find the `value_arguments` node within a `call_expression`, searching
-/// through the optional `call_suffix` intermediate node.
-fn cst_find_value_arguments(call_expr: tree_sitter::Node<'_>) -> Option<tree_sitter::Node<'_>> {
-    let mut walker = call_expr.walk();
-    for child in call_expr.children(&mut walker) {
-        if child.kind() == "value_arguments" { return Some(child); }
-        if child.kind() == "call_suffix" {
-            let mut w2 = child.walk();
-            for gc in child.children(&mut w2) {
-                if gc.kind() == "value_arguments" { return Some(gc); }
-            }
-        }
-    }
-    None
 }
 
 /// Text-scan fallback: extract `(fn_name, qualifier, active_param)` by walking

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -34,7 +34,6 @@ pub(crate) use self::infer::{
     find_named_param_type_in_sig,
     lambda_param_position_on_line,
     has_named_params_not_it,
-    cst_call_fn_name,
     // it_this.rs
     find_it_element_type,
     find_it_element_type_in_lines,
@@ -61,6 +60,9 @@ mod apply;
 pub(crate) use self::apply::{file_contributions, stale_keys_for, build_bare_names};
 
 mod lookup;
+
+mod node_ext;
+pub(crate) use node_ext::NodeExt;
 
 mod scope;
 pub(crate) use scope::is_id_char;
@@ -293,12 +295,11 @@ impl Indexer {
         self.files.get(uri).map(|f| f.lines.clone())
     }
 
-    ///
-    /// Uses `live_lines` (updated synchronously on every keystroke) for the
-    /// current file's line text, falling back to indexed lines or disk.
-    pub fn completions(&self, uri: &Url, position: Position, snippets: bool) -> (Vec<CompletionItem>, bool) {
-        // Ensure the file is indexed — on first open, did_open's spawn_blocking
-        // may not have finished by the time the first completion request arrives.
+    // ─── completion helpers (methods on Indexer) ─────────────────────────────
+
+    /// Ensures the file at `uri` is indexed, loading from disk if needed.
+    /// Called on the completion hot-path before the debounced re-index finishes.
+    fn ensure_indexed(&self, uri: &Url) {
         if !self.files.contains_key(uri.as_str()) {
             if let Ok(path) = uri.to_file_path() {
                 if let Ok(content) = std::fs::read_to_string(&path) {
@@ -306,43 +307,88 @@ impl Indexer {
                 }
             }
         }
+    }
 
-        // Use live_lines (no debounce delay) for the current line so dot-detection
-        // is always accurate even when the user types faster than the 120ms debounce.
-        let line_owned: String;
-        let line: &str = if let Some(ll) = self.live_lines.get(uri.as_str()) {
-            if let Some(l) = ll.get(position.line as usize) {
-                line_owned = l.clone();
-                &line_owned
-            } else { return (vec![], false); }
-        } else if let Some(data) = self.files.get(uri.as_str()) {
-            if let Some(l) = data.lines.get(position.line as usize) {
-                line_owned = l.clone();
-                &line_owned
-            } else { return (vec![], false); }
-        } else { return (vec![], false); };
-
-        // Slice line up to cursor (UTF-16 aware).
-        let target = position.character as usize;
-        let mut utf16 = 0usize;
-        let mut byte_end = line.len();
-        for (bi, ch) in line.char_indices() {
-            if utf16 >= target { byte_end = bi; break; }
-            utf16 += ch.len_utf16();
+    /// Returns the text of line `line_idx` for `uri`, preferring live lines.
+    fn line_for_position(&self, uri: &Url, line_idx: u32) -> Option<String> {
+        let idx = line_idx as usize;
+        if let Some(ll) = self.live_lines.get(uri.as_str()) {
+            return ll.get(idx).cloned();
         }
-        let before = &line[..byte_end];
+        self.files.get(uri.as_str())?.lines.get(idx).cloned()
+    }
 
-        // Extract the identifier fragment the user is currently typing.
-        let prefix: String = before.chars()
-            .rev()
-            .take_while(|&c| c.is_alphanumeric() || c == '_')
-            .collect::<String>()
-            .chars()
-            .rev()
-            .collect();
+    /// Resolves the element type for an `it`/`this`/named-param dot-receiver.
+    fn resolve_lambda_recv_type(
+        &self,
+        recv: &str,
+        before: &str,
+        cursor_line: usize,
+        cursor_col: usize,
+        uri: &Url,
+    ) -> Option<String> {
+        if recv == "it" || recv == "this" {
+            // Try single-line first (fast path: `obj.run { this. }` on same line).
+            let t = find_it_element_type(before, self, uri);
+            if t.is_some() && recv == "it" {
+                return t;
+            }
+            // Multi-line fallback: lambda opened on a previous line.
+            let lines = self.mem_lines_for(uri.as_str());
+            let pos = CursorPos { line: cursor_line, utf16_col: cursor_col };
+            let ml = lines.and_then(|ls| {
+                if recv == "this" {
+                    find_this_element_type_in_lines(&ls, pos, self, uri)
+                } else {
+                    find_it_element_type_in_lines(&ls, pos, self, uri)
+                }
+            });
+            if ml.is_some() {
+                return ml;
+            }
+            if recv == "this" {
+                return self.enclosing_class_at(uri, cursor_line as u32);
+            }
+            None
+        } else {
+            find_named_lambda_param_type(before, recv, self, uri, cursor_line)
+        }
+    }
 
-        // Check if the char before the prefix is a dot.
-        let before_prefix = &before[..before.len() - prefix.len()];
+    /// Appends lambda-parameter completions for bare-word (non-dot) completion.
+    fn add_lambda_param_completions(
+        &self,
+        items: &mut Vec<CompletionItem>,
+        uri: &Url,
+        line_idx: usize,
+        prefix: &str,
+    ) {
+        let prefix_lower = prefix.to_lowercase();
+        for param in self.lambda_params_at(uri, line_idx) {
+            if param.to_lowercase().starts_with(&prefix_lower) {
+                if !items.iter().any(|i| i.label == param) {
+                    items.push(CompletionItem {
+                        label:     param.clone(),
+                        kind:      Some(CompletionItemKind::VARIABLE),
+                        sort_text: Some(format!("005:{param}")),
+                        ..Default::default()
+                    });
+                }
+            }
+        }
+    }
+
+    ///
+    /// Uses `live_lines` (updated synchronously on every keystroke) for the
+    /// current file's line text, falling back to indexed lines or disk.
+    pub fn completions(&self, uri: &Url, position: Position, snippets: bool) -> (Vec<CompletionItem>, bool) {
+        self.ensure_indexed(uri);
+
+        let Some(line) = self.line_for_position(uri, position.line) else {
+            return (vec![], false);
+        };
+        let before = before_cursor(&line, position.character);
+        let (prefix, before_prefix) = split_prefix(&before);
 
         // ── completion result cache ──────────────────────────────────────────
         // Dot-completion: all members of a type are returned regardless of what
@@ -364,95 +410,25 @@ impl Indexer {
                 }
             }
         }
-        // (compute below, then store in cache at the end)
-        let dot_receiver = if let Some(before_dot) = before_prefix.strip_suffix('.') {
-            // Grab the expression immediately preceding the dot.
-            // For simple identifiers: `foo.` → "foo"
-            // For qualified nested types: `DPSCoordinator.Kind.` → "DPSCoordinator.Kind"
-            // We walk backwards collecting identifier chars; if we then see a dot followed
-            // by another identifier, include that outer segment too (one level only).
-            let inner: String = before_dot
-                .chars()
-                .rev()
-                .take_while(|&c| c.is_alphanumeric() || c == '_')
-                .collect::<String>()
-                .chars()
-                .rev()
-                .collect();
-            if inner.is_empty() {
-                None
-            } else {
-                // Check whether there is an `Outer.` prefix immediately before `inner`.
-                let remaining = &before_dot[..before_dot.len() - inner.len()];
-                if remaining.ends_with('.')
-                    && inner.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
-                {
-                    let outer: String = remaining[..remaining.len() - 1]
-                        .chars()
-                        .rev()
-                        .take_while(|&c| c.is_alphanumeric() || c == '_')
-                        .collect::<String>()
-                        .chars()
-                        .rev()
-                        .collect();
-                    if !outer.is_empty()
-                        && outer.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
-                    {
-                        Some(format!("{}.{}", outer, inner))
-                    } else {
-                        Some(inner)
-                    }
-                } else {
-                    Some(inner)
-                }
-            }
-        } else {
-            None
-        };
+
+        let dot_recv = dot_receiver(&before_prefix);
 
         // `this.` / `it.` / named-param dot-completion.
         // `this` can mean: (a) scope-function receiver, (b) enclosing class.
         // `it` means: implicit lambda param.
         // Named lambda params are detected via `is_lambda_param`.
-        if let Some(ref recv) = dot_receiver {
+        if let Some(ref recv) = dot_recv {
             if recv == "it" || recv == "this"
-                || is_lambda_param(recv, before, self, uri, position.line as usize)
+                || is_lambda_param(recv, &before, self, uri, position.line as usize)
             {
                 let cursor_line = position.line as usize;
                 let cursor_col  = before.chars().count();
-                let elem_type = if recv == "it" || recv == "this" {
-                    // Try single-line first (fast path: `obj.run { this. }` on same line).
-                    let t = find_it_element_type(before, self, uri);
-                    if t.is_some() && recv == "it" {
-                        t
-                    } else {
-                        // Multi-line fallback: lambda opened on a previous line.
-                        let lines = self.mem_lines_for(uri.as_str());
-                        let pos = CursorPos { line: cursor_line, utf16_col: cursor_col };
-                        let ml = lines.and_then(|ls| {
-                            if recv == "this" {
-                                find_this_element_type_in_lines(&ls, pos, self, uri)
-                            } else {
-                                find_it_element_type_in_lines(&ls, pos, self, uri)
-                            }
-                        });
-                        if ml.is_some() {
-                            ml
-                        } else if recv == "this" {
-                            self.enclosing_class_at(uri, position.line)
-                        } else {
-                            None
-                        }
-                    }
-                } else {
-                    find_named_lambda_param_type(before, recv, self, uri, position.line as usize)
-                };
+                let elem_type = self.resolve_lambda_recv_type(recv, &before, cursor_line, cursor_col, uri);
                 if let Some(elem_type) = elem_type {
                     let (items, _) = crate::resolver::complete_symbol(self, &prefix, Some(&elem_type), uri, snippets);
                     if items.is_empty() {
                         // Type name known (e.g. generic param `T`, `StateType`) but not
                         // indexed — show a single hint item so the user sees the inferred type.
-                        use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
                         return (vec![CompletionItem {
                             label: format!("{recv}: {elem_type}"),
                             kind: Some(CompletionItemKind::TYPE_PARAMETER),
@@ -468,31 +444,15 @@ impl Indexer {
             }
         }
 
-        let (mut items, hit_cap) = {
-            // Detect @AnnotationName context — suppress functions/variables.
-            let annotation_only = dot_receiver.is_none()
-                && crate::resolver::is_annotation_context(before, &prefix);
-            crate::resolver::complete_symbol_with_context(
-                self, &prefix, dot_receiver.as_deref(), uri, snippets, annotation_only,
-            )
-        };
+        let annotation_only = dot_recv.is_none()
+            && crate::resolver::is_annotation_context(&before, &prefix);
+        let (mut items, hit_cap) = crate::resolver::complete_symbol_with_context(
+            self, &prefix, dot_recv.as_deref(), uri, snippets, annotation_only,
+        );
 
         // Add scope-aware lambda parameter names (bare-word completion only).
-        if dot_receiver.is_none() {
-            let prefix_lower = prefix.to_lowercase();
-            for param in self.lambda_params_at(uri, position.line as usize) {
-                if param.to_lowercase().starts_with(&prefix_lower) {
-                    use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind};
-                    if !items.iter().any(|i| i.label == param) {
-                        items.push(CompletionItem {
-                            label:     param.clone(),
-                            kind:      Some(CompletionItemKind::VARIABLE),
-                            sort_text: Some(format!("005:{param}")),
-                            ..Default::default()
-                        });
-                    }
-                }
-            }
+        if dot_recv.is_none() {
+            self.add_lambda_param_completions(&mut items, uri, position.line as usize, &prefix);
         }
 
         // Store in last_completion cache.
@@ -502,6 +462,50 @@ impl Indexer {
 
         (items, hit_cap)
     }
+}
+
+// ─── completion helpers (free functions) ─────────────────────────────────────
+
+/// Returns a copy of `line` up to the UTF-16 column `utf16_col`.
+fn before_cursor(line: &str, utf16_col: u32) -> String {
+    let target = utf16_col as usize;
+    let mut utf16 = 0usize;
+    let mut byte_end = line.len();
+    for (bi, ch) in line.char_indices() {
+        if utf16 >= target { byte_end = bi; break; }
+        utf16 += ch.len_utf16();
+    }
+    line[..byte_end].to_owned()
+}
+
+/// Splits `before` into the trailing identifier fragment (`prefix`) and
+/// everything that precedes it (`before_prefix`).
+fn split_prefix(before: &str) -> (String, String) {
+    let prefix = last_ident_in(before).to_owned();
+    let before_prefix = before[..before.len() - prefix.len()].to_owned();
+    (prefix, before_prefix)
+}
+
+/// Returns the expression immediately before a trailing dot in `before_prefix`,
+/// or `None` if `before_prefix` does not end with a dot.
+///
+/// Handles one level of qualification: `Outer.Inner.` → `"Outer.Inner"`.
+fn dot_receiver(before_prefix: &str) -> Option<String> {
+    let before_dot = before_prefix.strip_suffix('.')?;
+    let inner = last_ident_in(before_dot);
+    if inner.is_empty() { return None; }
+    let remaining = &before_dot[..before_dot.len() - inner.len()];
+    if remaining.ends_with('.')
+        && inner.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
+    {
+        let outer = last_ident_in(&remaining[..remaining.len() - 1]);
+        if !outer.is_empty()
+            && outer.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
+        {
+            return Some(format!("{outer}.{inner}"));
+        }
+    }
+    Some(inner.to_owned())
 }
 
 // ─── rg cross-file fallback ──────────────────────────────────────────────────
@@ -2090,6 +2094,33 @@ class Foo @Inject constructor(
     #[test]
     fn last_ident_in_with_spaces() {
         assert_eq!(crate::indexer::last_ident_in("  someIdent"), "someIdent");
+    }
+
+    // ── completion helpers ───────────────────────────────────────────────────
+
+    #[test]
+    fn split_prefix_after_dot() {
+        let (prefix, before_prefix) = split_prefix("foo.bar");
+        assert_eq!(prefix, "bar");
+        assert_eq!(before_prefix, "foo.");
+    }
+    #[test]
+    fn split_prefix_bare() {
+        let (prefix, before_prefix) = split_prefix("someIdent");
+        assert_eq!(prefix, "someIdent");
+        assert_eq!(before_prefix, "");
+    }
+    #[test]
+    fn dot_receiver_simple() {
+        assert_eq!(dot_receiver("foo."), Some("foo".to_string()));
+    }
+    #[test]
+    fn dot_receiver_qualified() {
+        assert_eq!(dot_receiver("Outer.Inner."), Some("Outer.Inner".to_string()));
+    }
+    #[test]
+    fn dot_receiver_none() {
+        assert_eq!(dot_receiver("foo"), None);
     }
 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -458,7 +458,7 @@ impl Indexer {
 
         // Store in last_completion cache.
         if let Ok(mut guard) = self.last_completion.lock() {
-            *guard = Some((cache_key, prefix.clone(), items.clone()));
+            *guard = Some((cache_key, prefix.to_owned(), items.clone()));
         }
 
         (items, hit_cap)
@@ -468,7 +468,7 @@ impl Indexer {
 // ─── completion helpers (free functions) ─────────────────────────────────────
 
 /// Returns a copy of `line` up to the UTF-16 column `utf16_col`.
-fn before_cursor(line: &str, utf16_col: u32) -> String {
+fn before_cursor(line: &str, utf16_col: u32) -> &str {
     let target = utf16_col as usize;
     let mut utf16 = 0usize;
     let mut byte_end = line.len();
@@ -476,14 +476,14 @@ fn before_cursor(line: &str, utf16_col: u32) -> String {
         if utf16 >= target { byte_end = bi; break; }
         utf16 += ch.len_utf16();
     }
-    line[..byte_end].to_owned()
+    &line[..byte_end]
 }
 
 /// Splits `before` into the trailing identifier fragment (`prefix`) and
 /// everything that precedes it (`before_prefix`).
-fn split_prefix(before: &str) -> (String, String) {
-    let prefix = last_ident_in(before).to_owned();
-    let before_prefix = before[..before.len() - prefix.len()].to_owned();
+fn split_prefix(before: &str) -> (&str, &str) {
+    let prefix = last_ident_in(before);
+    let before_prefix = &before[..before.len() - prefix.len()];
     (prefix, before_prefix)
 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -366,15 +366,15 @@ impl Indexer {
     ) {
         let prefix_lower = prefix.to_lowercase();
         for param in self.lambda_params_at(uri, line_idx) {
-            if param.to_lowercase().starts_with(&prefix_lower) {
-                if !items.iter().any(|i| i.label == param) {
-                    items.push(CompletionItem {
-                        label:     param.clone(),
-                        kind:      Some(CompletionItemKind::VARIABLE),
-                        sort_text: Some(format!("005:{param}")),
-                        ..Default::default()
-                    });
-                }
+            if param.to_lowercase().starts_with(prefix_lower.as_str())
+                && !items.iter().any(|i| i.label == param)
+            {
+                items.push(CompletionItem {
+                    label:     param.clone(),
+                    kind:      Some(CompletionItemKind::VARIABLE),
+                    sort_text: Some(format!("005:{param}")),
+                    ..Default::default()
+                });
             }
         }
     }
@@ -389,7 +389,7 @@ impl Indexer {
             return (vec![], false);
         };
         let before = before_cursor(&line, position.character);
-        let (prefix, before_prefix) = split_prefix(&before);
+        let (prefix, before_prefix) = split_prefix(before);
 
         // ── completion result cache ──────────────────────────────────────────
         // Dot-completion: all members of a type are returned regardless of what
@@ -412,7 +412,7 @@ impl Indexer {
             }
         }
 
-        let dot_recv = dot_receiver(&before_prefix);
+        let dot_recv = dot_receiver(before_prefix);
 
         // `this.` / `it.` / named-param dot-completion.
         // `this` can mean: (a) scope-function receiver, (b) enclosing class.
@@ -420,13 +420,13 @@ impl Indexer {
         // Named lambda params are detected via `is_lambda_param`.
         if let Some(ref recv) = dot_recv {
             if recv == "it" || recv == "this"
-                || is_lambda_param(recv, &before, self, uri, position.line as usize)
+                || is_lambda_param(recv, before, self, uri, position.line as usize)
             {
                 let cursor_line = position.line as usize;
                 let cursor_col  = before.chars().count();
-                let elem_type = self.resolve_lambda_recv_type(recv, &before, cursor_line, cursor_col, uri);
+                let elem_type = self.resolve_lambda_recv_type(recv, before, cursor_line, cursor_col, uri);
                 if let Some(elem_type) = elem_type {
-                    let (items, _) = crate::resolver::complete_symbol(self, &prefix, Some(&elem_type), uri, snippets);
+                    let (items, _) = crate::resolver::complete_symbol(self, prefix, Some(&elem_type), uri, snippets);
                     if items.is_empty() {
                         // Type name known (e.g. generic param `T`, `StateType`) but not
                         // indexed — show a single hint item so the user sees the inferred type.
@@ -446,14 +446,14 @@ impl Indexer {
         }
 
         let annotation_only = dot_recv.is_none()
-            && crate::resolver::is_annotation_context(&before, &prefix);
+            && crate::resolver::is_annotation_context(before, prefix);
         let (mut items, hit_cap) = crate::resolver::complete_symbol_with_context(
-            self, &prefix, dot_recv.as_deref(), uri, snippets, annotation_only,
+            self, prefix, dot_recv.as_deref(), uri, snippets, annotation_only,
         );
 
         // Add scope-aware lambda parameter names (bare-word completion only).
         if dot_recv.is_none() {
-            self.add_lambda_param_completions(&mut items, uri, position.line as usize, &prefix);
+            self.add_lambda_param_completions(&mut items, uri, position.line as usize, prefix);
         }
 
         // Store in last_completion cache.
@@ -467,7 +467,7 @@ impl Indexer {
 
 // ─── completion helpers (free functions) ─────────────────────────────────────
 
-/// Returns a copy of `line` up to the UTF-16 column `utf16_col`.
+/// Returns a slice of `line` up to the UTF-16 column `utf16_col`.
 fn before_cursor(line: &str, utf16_col: u32) -> &str {
     let target = utf16_col as usize;
     let mut utf16 = 0usize;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -21,6 +21,7 @@ mod infer;
 pub(crate) use self::infer::{
     // sig.rs
     collect_signature,
+    collect_params_from_line,
     find_fun_signature_full,
     find_fun_signature_with_receiver,
     collect_all_fun_params_texts,

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -460,7 +460,7 @@ impl Indexer {
             tokio::spawn(async move {
                 let _permit = sem.acquire_owned().await.expect("semaphore closed");
                 tokio::task::spawn_blocking(move || {
-                    let locs = crate::resolver::resolve_symbol(&idx, &type_name, None, &uri2);
+                    let locs = idx.resolve_symbol(&type_name, None, &uri2);
                     if let Some(loc) = locs.first() {
                         let file_uri = loc.uri.to_string();
                         if idx.completion_cache.contains_key(&file_uri) { return; }

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -6,6 +6,7 @@
 use tower_lsp::lsp_types::Url;
 
 use crate::indexer::{Indexer, is_id_char, find_enclosing_call_name};
+use crate::indexer::NodeExt;
 use crate::indexer::infer::sig::{find_fun_signature_full, nth_fun_param_type_str, split_params_at_depth_zero};
 use crate::types::CursorPos;
 
@@ -309,63 +310,18 @@ fn cst_call_arg_type(pos: CursorPos, idx: &Indexer, uri: &Url) -> Option<String>
         }
     }?;
 
-    let fn_name = cst_call_fn_name(call_expr, bytes)?;
+    let fn_name = call_expr.call_fn_name(bytes)?;
     let sig = find_fun_signature_full(&fn_name, idx, uri)?;
 
     // Named arg: value_argument has [simple_identifier "="] prefix in grammar.
-    let param_type = if let Some(arg_name) = cst_named_arg_label(value_arg, bytes) {
+    let param_type = if let Some(arg_name) = value_arg.named_arg_label(bytes) {
         find_named_param_type_in_sig(&sig, &arg_name)
     } else {
-        nth_fun_param_type_str(&sig, cst_value_arg_position(value_arg))
+        nth_fun_param_type_str(&sig, value_arg.value_arg_position())
     }?;
 
     let base: String = param_type.trim().chars().take_while(|&c| is_id_char(c)).collect();
     if base.is_empty() { None } else { Some(base) }
-}
-
-/// Extract the function name from a `call_expression` node.
-/// Handles simple calls `foo(...)` and navigation chains `foo.bar(...)`.
-pub(crate) fn cst_call_fn_name(call_expr: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<String> {
-    let callee = call_expr.child(0)?;
-    let name_node = match callee.kind() {
-        "simple_identifier" | "type_identifier" => callee,
-        "navigation_expression" => {
-            let mut walker = callee.walk();
-            callee.children(&mut walker)
-                .filter(|c| c.kind() == "simple_identifier" || c.kind() == "type_identifier")
-                .last()?
-        }
-        _ => return None,
-    };
-    std::str::from_utf8(&bytes[name_node.byte_range()]).ok().map(|s| s.to_string())
-}
-
-/// If `value_argument` has a named-arg label (`simple_identifier "="` prefix),
-/// return the label text; otherwise `None`.
-pub(crate) fn cst_named_arg_label(value_arg: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<String> {
-    let count = value_arg.child_count();
-    for i in 0..count.saturating_sub(1) {
-        let (c, next) = (value_arg.child(i)?, value_arg.child(i + 1)?);
-        if c.kind() == "simple_identifier" && next.kind() == "=" {
-            return std::str::from_utf8(&bytes[c.byte_range()]).ok().map(|s| s.to_string());
-        }
-    }
-    None
-}
-
-/// Count how many `value_argument` siblings precede `value_arg` in its parent.
-pub(crate) fn cst_value_arg_position(value_arg: tree_sitter::Node<'_>) -> usize {
-    let parent = match value_arg.parent() { Some(p) => p, None => return 0 };
-    let target_id = value_arg.id();
-    let mut pos = 0usize;
-    let mut cursor = parent.walk();
-    for child in parent.children(&mut cursor) {
-        if child.kind() == "value_argument" {
-            if child.id() == target_id { break; }
-            pos += 1;
-        }
-    }
-    pos
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -335,7 +335,7 @@ fn cst_it_or_this_type(
                 if result.is_some() { return result; }
             }
         }
-        let Some(p) = cur.parent() else { return None; };
+        let p = cur.parent()?;
         cur = p;
     }
 }

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -32,12 +32,11 @@ use super::{
     find_named_param_type_in_sig,
     has_named_params_not_it,
     extract_first_arg,
-    cst_call_fn_name,
-    cst_named_arg_label,
-    cst_value_arg_position,
     // deps.rs
     InferDeps,
 };
+
+use crate::indexer::NodeExt;
 
 // ── from indexer.rs (parent of infer; descendants can access private items) ──
 use super::super::{
@@ -284,20 +283,11 @@ pub(crate) fn lambda_receiver_type_from_context(
 /// Returns `true` if `lambda_node` (a `lambda_literal` CST node) has a
 /// `lambda_parameters` child that contains at least one named parameter that
 /// is neither `it` nor `_`.
+///
+/// Thin wrapper around [`NodeExt::has_lambda_named_params`] kept for
+/// `super::` access in the companion test module.
 pub(super) fn has_lambda_named_params(lambda_node: tree_sitter::Node<'_>, bytes: &[u8]) -> bool {
-    let Some(lp) = (0..lambda_node.child_count())
-        .filter_map(|i| lambda_node.child(i))
-        .find(|c| c.kind() == "lambda_parameters")
-    else { return false; };
-
-    (0..lp.child_count())
-        .filter_map(|i| lp.child(i))
-        .filter(|c| c.kind() == "variable_declaration")
-        .any(|vd| {
-            let Some(si) = vd.child(0).filter(|n| n.kind() == "simple_identifier") else { return false; };
-            let Ok(name) = std::str::from_utf8(&bytes[si.byte_range()]) else { return false; };
-            name != "it" && name != "_"
-        })
+    lambda_node.has_lambda_named_params(bytes)
 }
 
 /// Walk ancestors from `start_node` looking for a `lambda_literal` without
@@ -315,7 +305,7 @@ fn cst_it_or_this_type(
 ) -> Option<String> {
     let mut cur = start_node;
     loop {
-        if cur.kind() == "lambda_literal" && !has_lambda_named_params(cur, &doc.bytes) {
+        if cur.kind() == "lambda_literal" && !cur.has_lambda_named_params(&doc.bytes) {
             // Extract text of the lambda-opening line up to the `{`.
             let brace_byte = cur.start_byte();
             let line_start = doc.bytes[..brace_byte]
@@ -660,12 +650,12 @@ fn cst_lambda_param_type_via_call(
                     if p.kind() == "call_expression" { break p; }
                     node = p;
                 };
-                let fn_name = cst_call_fn_name(call_expr, bytes)?;
+                let fn_name = call_expr.call_fn_name(bytes)?;
                 let sig = deps.find_fun_params_text(&fn_name, uri)?;
-                let param_type = if let Some(label) = cst_named_arg_label(parent, bytes) {
+                let param_type = if let Some(label) = parent.named_arg_label(bytes) {
                     find_named_param_type_in_sig(&sig, &label)
                 } else {
-                    nth_fun_param_type_str(&sig, cst_value_arg_position(parent))
+                    nth_fun_param_type_str(&sig, parent.value_arg_position())
                 }?;
                 return lambda_type_first_input(&param_type);
             }
@@ -673,7 +663,7 @@ fn cst_lambda_param_type_via_call(
                 // Trailing lambda: `fn(...) { it }` or `fn { it }`.
                 let call_expr = parent.parent()?;
                 if call_expr.kind() != "call_expression" { cur = parent; continue; }
-                let fn_name = cst_call_fn_name(call_expr, bytes)?;
+                let fn_name = call_expr.call_fn_name(bytes)?;
                 let sig = deps.find_fun_params_text(&fn_name, uri)?;
                 let last_type = last_fun_param_type_str(&sig)?;
                 return lambda_type_first_input(&last_type);

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -580,7 +580,7 @@ fn lambda_receiver_type_named_arg_ml(
         let outer = &callee_full[..dot];
         // Find outer class file; try indexed files first (no rg), then rg fallback.
         let outer_file: Option<String> = {
-            let locs = crate::resolver::resolve_symbol_no_rg(idx, outer, uri);
+            let locs = idx.resolve_symbol_no_rg(outer, uri);
             locs.first().map(|l| l.uri.to_string())
                 .or_else(|| {
                     // On-demand: use rg to find and index the outer class.

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -40,9 +40,6 @@ pub(crate) use args::{
     extract_named_arg_name,
     find_named_param_type_in_sig,
     has_named_params_not_it,
-    cst_call_fn_name,
-    cst_named_arg_label,
-    cst_value_arg_position,
 };
 
 pub(crate) use it_this::{

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -26,6 +26,7 @@ pub(crate) use lambda::{
 
 pub(crate) use sig::{
     collect_signature,
+    collect_params_from_line,
     find_fun_signature_full,
     find_fun_signature_with_receiver,
     collect_all_fun_params_texts,

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -60,7 +60,7 @@ pub(crate) fn collect_signature(lines: &[String], start_line: usize) -> String {
 /// Used by signature help (fires on every keystroke).
 fn find_fun_signature(fn_name: &str, idx: &Indexer, uri: &Url) -> Option<String> {
     // 1. Import-aware resolution using only already-indexed files (no rg/disk).
-    let locs = crate::resolver::resolve_symbol_no_rg(idx, fn_name, uri);
+    let locs = idx.resolve_symbol_no_rg(fn_name, uri);
     for loc in &locs {
         let file_uri_str = loc.uri.as_str();
         if let Some(data) = idx.files.get(file_uri_str) {
@@ -274,7 +274,7 @@ pub(crate) fn find_fun_signature_with_receiver(
             // name-only scan that may return a completely unrelated function.
             return String::new();
         };
-        let locs = crate::resolver::resolve_symbol(idx, &rt.outer, None, uri);
+        let locs = idx.resolve_symbol(&rt.outer, None, uri);
         for loc in &locs {
             if let Some(data) = idx.files.get(loc.uri.as_str()) {
                 if let Some(sig) = collect_fun_params_text(name, loc.uri.as_str(), idx) {

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -16,6 +16,7 @@
 use tower_lsp::lsp_types::*;
 
 use crate::types::SymbolEntry;
+use crate::LinesExt;
 use super::Indexer;
 use super::doc::extract_doc_comment;
 
@@ -30,7 +31,7 @@ impl Indexer {
     /// Resolve definition locations for `name` (with optional dot-qualifier).
     #[allow(dead_code)]
     pub fn find_definition(&self, name: &str, from_uri: &Url) -> Vec<Location> {
-        crate::resolver::resolve_symbol(self, name, None, from_uri)
+        self.resolve_symbol(name, None, from_uri)
     }
 
     pub fn find_definition_qualified(
@@ -39,7 +40,7 @@ impl Indexer {
         qualifier: Option<&str>,
         from_uri: &Url,
     ) -> Vec<Location> {
-        crate::resolver::resolve_symbol(self, name, qualifier, from_uri)
+        self.resolve_symbol(name, qualifier, from_uri)
     }
 
     /// Build a Markdown hover snippet for a symbol name.
@@ -74,7 +75,7 @@ impl Indexer {
             .or_else(|| data.symbols.iter().find(|s| s.name == name))?;
 
         let start_line = sym.selection_range.start.line as usize;
-        let sig = super::infer::collect_signature(&data.lines, start_line);
+        let sig = data.lines.collect_signature(start_line);
 
         let lang = if loc.uri.path().ends_with(".kt") { "kotlin" }
                    else if loc.uri.path().ends_with(".swift") { "swift" }

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -1,0 +1,294 @@
+//! Extension trait adding Kotlin/Java CST helper methods to `tree_sitter::Node`.
+//!
+//! All methods are zero-cost thin wrappers around tree-sitter node traversal;
+//! their bodies were extracted from the free functions they replace.
+use tree_sitter::Node;
+
+pub(crate) trait NodeExt<'a>: Sized + Copy {
+    /// Extract the function name from a `call_expression` node.
+    /// Handles simple calls `foo(...)` and navigation chains `foo.bar(...)`.
+    fn call_fn_name(self, bytes: &[u8]) -> Option<String>;
+
+    /// If `value_argument` has a named-arg label (`simple_identifier "="` prefix),
+    /// return the label text; otherwise `None`.
+    fn named_arg_label(self, bytes: &[u8]) -> Option<String>;
+
+    /// Count how many `value_argument` siblings precede `self` in its parent.
+    fn value_arg_position(self) -> usize;
+
+    /// Find the `value_arguments` node within a `call_expression`, searching
+    /// through the optional `call_suffix` intermediate node.
+    fn find_value_arguments(self) -> Option<Node<'a>>;
+
+    /// Returns `true` if `self` (a `lambda_literal` CST node) has a
+    /// `lambda_parameters` child containing at least one named parameter
+    /// that is neither `it` nor `_`.
+    fn has_lambda_named_params(self, bytes: &[u8]) -> bool;
+
+    /// Collect named lambda parameter identifiers from a `lambda_literal` CST node.
+    /// Skips `it`, `_`, uppercase-first (type refs), and deduplicates against `existing`.
+    fn collect_lambda_param_names(self, bytes: &[u8], existing: &[String]) -> Vec<String>;
+
+    /// Extract the type/class name from a CST class/interface/object/companion_object node.
+    fn extract_type_name(self, bytes: &[u8]) -> Option<String>;
+}
+
+impl<'a> NodeExt<'a> for Node<'a> {
+    fn call_fn_name(self, bytes: &[u8]) -> Option<String> {
+        let callee = self.child(0)?;
+        let name_node = match callee.kind() {
+            "simple_identifier" | "type_identifier" => callee,
+            "navigation_expression" => {
+                let mut walker = callee.walk();
+                callee
+                    .children(&mut walker)
+                    .filter(|c| {
+                        c.kind() == "simple_identifier" || c.kind() == "type_identifier"
+                    })
+                    .last()?
+            }
+            _ => return None,
+        };
+        std::str::from_utf8(&bytes[name_node.byte_range()])
+            .ok()
+            .map(|s| s.to_string())
+    }
+
+    fn named_arg_label(self, bytes: &[u8]) -> Option<String> {
+        let count = self.child_count();
+        for i in 0..count.saturating_sub(1) {
+            let (c, next) = (self.child(i)?, self.child(i + 1)?);
+            if c.kind() == "simple_identifier" && next.kind() == "=" {
+                return std::str::from_utf8(&bytes[c.byte_range()])
+                    .ok()
+                    .map(|s| s.to_string());
+            }
+        }
+        None
+    }
+
+    fn value_arg_position(self) -> usize {
+        let parent = match self.parent() {
+            Some(p) => p,
+            None => return 0,
+        };
+        let target_id = self.id();
+        let mut pos = 0usize;
+        let mut cursor = parent.walk();
+        for child in parent.children(&mut cursor) {
+            if child.kind() == "value_argument" {
+                if child.id() == target_id {
+                    break;
+                }
+                pos += 1;
+            }
+        }
+        pos
+    }
+
+    fn find_value_arguments(self) -> Option<Node<'a>> {
+        let mut walker = self.walk();
+        for child in self.children(&mut walker) {
+            if child.kind() == "value_arguments" {
+                return Some(child);
+            }
+            if child.kind() == "call_suffix" {
+                let mut w2 = child.walk();
+                for gc in child.children(&mut w2) {
+                    if gc.kind() == "value_arguments" {
+                        return Some(gc);
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn has_lambda_named_params(self, bytes: &[u8]) -> bool {
+        let Some(lp) = (0..self.child_count())
+            .filter_map(|i| self.child(i))
+            .find(|c| c.kind() == "lambda_parameters")
+        else {
+            return false;
+        };
+
+        (0..lp.child_count())
+            .filter_map(|i| lp.child(i))
+            .filter(|c| c.kind() == "variable_declaration")
+            .any(|vd| {
+                let Some(si) = vd.child(0).filter(|n| n.kind() == "simple_identifier") else {
+                    return false;
+                };
+                let Ok(name) = std::str::from_utf8(&bytes[si.byte_range()]) else {
+                    return false;
+                };
+                name != "it" && name != "_"
+            })
+    }
+
+    fn collect_lambda_param_names(self, bytes: &[u8], existing: &[String]) -> Vec<String> {
+        let Some(lp) = (0..self.child_count())
+            .filter_map(|i| self.child(i))
+            .find(|c| c.kind() == "lambda_parameters")
+        else {
+            return Vec::new();
+        };
+
+        (0..lp.child_count())
+            .filter_map(|i| lp.child(i))
+            .filter(|c| c.kind() == "variable_declaration")
+            .filter_map(|vd| {
+                let si = vd.child(0).filter(|n| n.kind() == "simple_identifier")?;
+                std::str::from_utf8(&bytes[si.byte_range()])
+                    .ok()
+                    .map(|s| s.to_string())
+            })
+            .filter(|name| {
+                name != "it"
+                    && name != "_"
+                    && name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
+                    && !existing.contains(name)
+            })
+            .collect()
+    }
+
+    fn extract_type_name(self, bytes: &[u8]) -> Option<String> {
+        if let Some(n) = self.child_by_field_name("name") {
+            if let Ok(s) = std::str::from_utf8(&bytes[n.byte_range()]) {
+                let s = s.to_string();
+                if s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+                    return Some(s);
+                }
+            }
+        }
+        for i in 0..self.child_count() {
+            if let Some(child) = self.child(i) {
+                if matches!(
+                    child.kind(),
+                    "type_identifier" | "simple_identifier" | "identifier"
+                ) {
+                    if let Ok(s) = std::str::from_utf8(&bytes[child.byte_range()]) {
+                        if s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+                            return Some(s.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::NodeExt;
+
+    fn parse_kotlin(src: &str) -> (tree_sitter::Tree, Vec<u8>) {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_kotlin::language())
+            .unwrap();
+        let bytes = src.as_bytes().to_vec();
+        let tree = parser.parse(src, None).unwrap();
+        (tree, bytes)
+    }
+
+    fn find_node_kind<'a>(
+        node: tree_sitter::Node<'a>,
+        kind: &str,
+    ) -> Option<tree_sitter::Node<'a>> {
+        if node.kind() == kind {
+            return Some(node);
+        }
+        for i in 0..node.child_count() {
+            if let Some(n) = node.child(i).and_then(|c| find_node_kind(c, kind)) {
+                return Some(n);
+            }
+        }
+        None
+    }
+
+    #[test]
+    fn call_fn_name_simple() {
+        let (tree, bytes) = parse_kotlin("val x = foo(1)");
+        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
+        assert_eq!(call.call_fn_name(&bytes), Some("foo".to_string()));
+    }
+
+    #[test]
+    fn call_fn_name_navigation() {
+        // In tree-sitter-kotlin, `obj.bar` is:
+        //   navigation_expression
+        //     simple_identifier: obj   ← direct child
+        //     navigation_suffix: .bar  ← `bar` is nested here, not a direct child
+        // So `call_fn_name` returns the last direct `simple_identifier`, which is "obj".
+        let (tree, bytes) = parse_kotlin("val x = obj.bar(1)");
+        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
+        assert_eq!(call.call_fn_name(&bytes), Some("obj".to_string()));
+    }
+
+    #[test]
+    fn value_arg_position_first_and_second() {
+        let (tree, bytes) = parse_kotlin("foo(a, b)");
+        let _ = bytes; // not needed for position
+        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
+        let value_args_node = find_node_kind(call, "value_arguments").unwrap();
+        let mut args = vec![];
+        for i in 0..value_args_node.child_count() {
+            if let Some(c) = value_args_node.child(i) {
+                if c.kind() == "value_argument" {
+                    args.push(c);
+                }
+            }
+        }
+        assert_eq!(args.len(), 2);
+        assert_eq!(args[0].value_arg_position(), 0, "first arg position should be 0");
+        assert_eq!(args[1].value_arg_position(), 1, "second arg position should be 1");
+    }
+
+    #[test]
+    fn has_lambda_named_params_true_for_named() {
+        let (tree, bytes) = parse_kotlin("val x = foo { item -> item }");
+        let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+        assert!(
+            lambda.has_lambda_named_params(&bytes),
+            "param named `item` should yield true"
+        );
+    }
+
+    #[test]
+    fn has_lambda_named_params_false_for_no_params() {
+        let (tree, bytes) = parse_kotlin("val x = items.map { it.name }");
+        let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+        assert!(
+            !lambda.has_lambda_named_params(&bytes),
+            "no lambda_parameters child should yield false"
+        );
+    }
+
+    #[test]
+    fn collect_lambda_param_names_collects_named() {
+        let (tree, bytes) = parse_kotlin("val x = items.map { item -> item.foo }");
+        let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+        let names = lambda.collect_lambda_param_names(&bytes, &[]);
+        assert_eq!(names, vec!["item".to_string()]);
+    }
+
+    #[test]
+    fn named_arg_label_present() {
+        let (tree, bytes) = parse_kotlin("foo(bar = 1)");
+        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
+        let va = find_node_kind(call, "value_argument").unwrap();
+        assert_eq!(va.named_arg_label(&bytes), Some("bar".to_string()));
+    }
+
+    #[test]
+    fn named_arg_label_absent() {
+        let (tree, bytes) = parse_kotlin("foo(1)");
+        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
+        let va = find_node_kind(call, "value_argument").unwrap();
+        assert_eq!(va.named_arg_label(&bytes), None);
+    }
+}

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -39,13 +39,27 @@ impl<'a> NodeExt<'a> for Node<'a> {
         let name_node = match callee.kind() {
             "simple_identifier" | "type_identifier" => callee,
             "navigation_expression" => {
+                // Prefer the identifier inside the last navigation_suffix (the member name,
+                // e.g. "bar" in `obj.bar(...)`). Fall back to the last direct identifier
+                // for bare qualified names with no suffix.
                 let mut walker = callee.walk();
-                callee
-                    .children(&mut walker)
-                    .filter(|c| {
-                        c.kind() == "simple_identifier" || c.kind() == "type_identifier"
-                    })
-                    .last()?
+                let children: Vec<Node<'a>> = callee.children(&mut walker).collect();
+                if let Some(suffix) =
+                    children.iter().rev().find(|c| c.kind() == "navigation_suffix")
+                {
+                    (0..suffix.child_count())
+                        .filter_map(|i| suffix.child(i))
+                        .find(|c| {
+                            c.kind() == "simple_identifier" || c.kind() == "type_identifier"
+                        })?
+                } else {
+                    children
+                        .into_iter()
+                        .filter(|c| {
+                            c.kind() == "simple_identifier" || c.kind() == "type_identifier"
+                        })
+                        .last()?
+                }
             }
             _ => return None,
         };
@@ -221,12 +235,12 @@ mod tests {
     fn call_fn_name_navigation() {
         // In tree-sitter-kotlin, `obj.bar` is:
         //   navigation_expression
-        //     simple_identifier: obj   ← direct child
-        //     navigation_suffix: .bar  ← `bar` is nested here, not a direct child
-        // So `call_fn_name` returns the last direct `simple_identifier`, which is "obj".
+        //     simple_identifier: obj
+        //     navigation_suffix: .bar  ← `bar` is nested here
+        // `call_fn_name` should return the member name "bar", not the receiver "obj".
         let (tree, bytes) = parse_kotlin("val x = obj.bar(1)");
         let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
-        assert_eq!(call.call_fn_name(&bytes), Some("obj".to_string()));
+        assert_eq!(call.call_fn_name(&bytes), Some("bar".to_string()));
     }
 
     #[test]

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -1,7 +1,7 @@
 //! Extension trait adding Kotlin/Java CST helper methods to `tree_sitter::Node`.
 //!
-//! All methods are zero-cost thin wrappers around tree-sitter node traversal;
-//! their bodies were extracted from the free functions they replace.
+//! These methods are lightweight convenience wrappers around tree-sitter node
+//! traversal; their bodies were extracted from the free functions they replace.
 use tree_sitter::Node;
 
 pub(crate) trait NodeExt<'a>: Sized + Copy {

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -39,27 +39,33 @@ impl<'a> NodeExt<'a> for Node<'a> {
         let name_node = match callee.kind() {
             "simple_identifier" | "type_identifier" => callee,
             "navigation_expression" => {
-                // Prefer the identifier inside the last navigation_suffix (the member name,
-                // e.g. "bar" in `obj.bar(...)`). Fall back to the last direct identifier
-                // for bare qualified names with no suffix.
+                // Single-pass scan: track the last direct identifier and the last
+                // identifier inside a navigation_suffix. Prefer the suffix identifier
+                // (member name, e.g. "bar" in `obj.bar(…)`); fall back to the direct
+                // identifier for bare qualified names with no suffix.
                 let mut walker = callee.walk();
-                let children: Vec<Node<'a>> = callee.children(&mut walker).collect();
-                if let Some(suffix) =
-                    children.iter().rev().find(|c| c.kind() == "navigation_suffix")
-                {
-                    (0..suffix.child_count())
-                        .filter_map(|i| suffix.child(i))
-                        .find(|c| {
-                            c.kind() == "simple_identifier" || c.kind() == "type_identifier"
-                        })?
-                } else {
-                    children
-                        .into_iter()
-                        .filter(|c| {
-                            c.kind() == "simple_identifier" || c.kind() == "type_identifier"
-                        })
-                        .last()?
+                let mut last_identifier = None;
+                let mut last_suffix_identifier = None;
+                for child in callee.children(&mut walker) {
+                    match child.kind() {
+                        "simple_identifier" | "type_identifier" => {
+                            last_identifier = Some(child);
+                        }
+                        "navigation_suffix" => {
+                            let suffix_id = (0..child.child_count())
+                                .filter_map(|i| child.child(i))
+                                .find(|c| {
+                                    c.kind() == "simple_identifier"
+                                        || c.kind() == "type_identifier"
+                                });
+                            if let Some(id) = suffix_id {
+                                last_suffix_identifier = Some(id);
+                            }
+                        }
+                        _ => {}
+                    }
                 }
+                last_suffix_identifier.or(last_identifier)?
             }
             _ => return None,
         };

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -14,6 +14,7 @@ use super::{
     line_has_lambda_param,
     lambda_brace_pos_for_param,
 };
+use crate::indexer::NodeExt;
 use crate::types::CursorPos;
 
 impl Indexer {
@@ -246,7 +247,7 @@ impl Indexer {
                 let mut cur = node;
                 loop {
                     if cur.kind() == "lambda_literal" {
-                        let new_names = collect_lambda_param_names(cur, &doc.bytes, &params);
+                        let new_names = cur.collect_lambda_param_names(&doc.bytes, &params);
                         params.extend(new_names);
                     }
                     let Some(p) = cur.parent() else { break; };
@@ -361,7 +362,7 @@ impl Indexer {
                             // declaration starts on the query row (cursor is on the
                             // class's own declaration line).
                             if cur.start_position().row < row {
-                                if let Some(name) = cst_extract_type_name(&cur, &doc.bytes) {
+                                if let Some(name) = cur.extract_type_name(&doc.bytes) {
                                     return Some(name);
                                 }
                             }
@@ -406,55 +407,15 @@ impl Indexer {
 /// Collect named lambda parameter identifiers from a `lambda_literal` CST node.
 /// Skips `it`, `_`, uppercase-first (type refs), and deduplicates.
 /// Returns an empty `Vec` if the lambda has no `lambda_parameters` child.
+///
+/// Thin wrapper around [`NodeExt::collect_lambda_param_names`] kept for
+/// `super::` access in the companion test module.
 fn collect_lambda_param_names(
     lambda_node: tree_sitter::Node<'_>,
     bytes:       &[u8],
     existing:    &[String],
 ) -> Vec<String> {
-    let Some(lp) = (0..lambda_node.child_count())
-        .filter_map(|i| lambda_node.child(i))
-        .find(|c| c.kind() == "lambda_parameters")
-    else { return Vec::new(); };
-
-    (0..lp.child_count())
-        .filter_map(|i| lp.child(i))
-        .filter(|c| c.kind() == "variable_declaration")
-        .filter_map(|vd| {
-            let si = vd.child(0).filter(|n| n.kind() == "simple_identifier")?;
-            std::str::from_utf8(&bytes[si.byte_range()]).ok().map(|s| s.to_string())
-        })
-        .filter(|name| {
-            name != "it" && name != "_"
-            && name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
-            && !existing.contains(name)
-        })
-        .collect()
-}
-
-/// Extract the type/class name from a CST class/interface/object/companion_object node.
-/// Tries `child_by_field_name("name")` first, then walks direct children for
-/// `type_identifier` or `simple_identifier` that starts with an uppercase letter.
-fn cst_extract_type_name(node: &tree_sitter::Node, bytes: &[u8]) -> Option<String> {
-    if let Some(n) = node.child_by_field_name("name") {
-        if let Ok(s) = std::str::from_utf8(&bytes[n.byte_range()]) {
-            let s = s.to_string();
-            if s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
-                return Some(s);
-            }
-        }
-    }
-    for i in 0..node.child_count() {
-        if let Some(child) = node.child(i) {
-            if matches!(child.kind(), "type_identifier" | "simple_identifier" | "identifier") {
-                if let Ok(s) = std::str::from_utf8(&bytes[child.byte_range()]) {
-                    if s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
-                        return Some(s.to_string());
-                    }
-                }
-            }
-        }
-    }
-    None
+    lambda_node.collect_lambda_param_names(bytes, existing)
 }
 
 /// If `line` is a class/interface/object/sealed declaration, return the type name.

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -14,6 +14,7 @@ use std::sync::Arc;
 use tower_lsp::lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, Position, Range, Url};
 
 use crate::indexer::Indexer;
+use crate::indexer::NodeExt;
 use crate::indexer::live_tree::{lang_for_path, parse_live};
 use crate::resolver::{ReceiverKind, infer_receiver_type};
 
@@ -243,7 +244,7 @@ fn hint_property(
 fn infer_type_from_init(init: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<String> {
     // call_expression: callee(...) or callee<T>(...)
     if init.kind() == "call_expression" {
-        let name = crate::indexer::cst_call_fn_name(init, bytes)?;
+        let name = init.call_fn_name(bytes)?;
         if name.starts_with(|c: char| c.is_uppercase()) {
             return Some(name);
         }

--- a/src/lines_ext.rs
+++ b/src/lines_ext.rs
@@ -1,0 +1,170 @@
+//! Extension trait adding source-line analysis methods to `[String]`.
+//!
+//! Each method is a thin façade over the original free function; no logic
+//! lives here.  The original free functions are kept intact so existing
+//! callers continue to compile during the incremental migration.
+use tower_lsp::lsp_types::Range;
+use crate::types::{ImportEntry, Visibility};
+
+pub(crate) trait LinesExt {
+    /// Concatenate lines from `start_line..=end_line` into a single detail string.
+    fn extract_detail(&self, start_line: u32, end_line: u32) -> String;
+
+    /// Kotlin/Java visibility of the declaration on `line_no`.
+    fn visibility_at(&self, line_no: usize) -> Visibility;
+
+    /// Swift visibility of the declaration on `line_no`.
+    fn swift_visibility_at(&self, line_no: usize) -> Visibility;
+
+    /// Names declared in these lines (for fast lookup without full parsing).
+    fn declared_names(&self) -> Vec<String>;
+
+    /// All import entries found in these lines.
+    fn parse_imports(&self) -> Vec<ImportEntry>;
+
+    /// Collect a multi-line function/class signature starting at `start_line`.
+    fn collect_signature(&self, start_line: usize) -> String;
+
+    /// Collect parameters from the function starting at `start_line`.
+    fn collect_params_from_line(&self, start_line: usize) -> Option<String>;
+
+    /// Find the name of the call expression that encloses `(line_no, col)`.
+    fn find_enclosing_call_name(&self, line_no: usize, col: usize) -> Option<String>;
+
+    /// Line number at which a new `import` statement should be inserted.
+    fn import_insertion_line(&self) -> u32;
+
+    /// Infer the (stripped) type of `var_name` from a type annotation in these lines.
+    fn infer_type(&self, var_name: &str) -> Option<String>;
+
+    /// Like [`infer_type`] but preserves generic parameters.
+    fn infer_type_raw(&self, var_name: &str) -> Option<String>;
+
+    /// Find the declaration range of `name` anywhere in these lines.
+    fn find_declaration_range(&self, name: &str) -> Option<Range>;
+
+    /// Find the declaration range of `name` starting from `start_line`.
+    fn find_declaration_range_after(&self, name: &str, start_line: u32) -> Option<Range>;
+}
+
+impl LinesExt for [String] {
+    fn extract_detail(&self, start_line: u32, end_line: u32) -> String {
+        crate::parser::extract_detail(self, start_line, end_line)
+    }
+
+    fn visibility_at(&self, line_no: usize) -> Visibility {
+        crate::parser::visibility_at_line(self, line_no)
+    }
+
+    fn swift_visibility_at(&self, line_no: usize) -> Visibility {
+        crate::parser::swift_visibility_at_line(self, line_no)
+    }
+
+    fn declared_names(&self) -> Vec<String> {
+        crate::parser::extract_declared_names(self)
+    }
+
+    fn parse_imports(&self) -> Vec<ImportEntry> {
+        crate::parser::parse_imports_from_lines(self)
+    }
+
+    fn collect_signature(&self, start_line: usize) -> String {
+        crate::indexer::collect_signature(self, start_line)
+    }
+
+    fn collect_params_from_line(&self, start_line: usize) -> Option<String> {
+        crate::indexer::collect_params_from_line(self, start_line)
+    }
+
+    fn find_enclosing_call_name(&self, line_no: usize, col: usize) -> Option<String> {
+        crate::indexer::find_enclosing_call_name(self, line_no, col)
+    }
+
+    fn import_insertion_line(&self) -> u32 {
+        crate::resolver::import_insertion_line(self)
+    }
+
+    fn infer_type(&self, var_name: &str) -> Option<String> {
+        crate::resolver::infer::infer_type_in_lines(self, var_name)
+    }
+
+    fn infer_type_raw(&self, var_name: &str) -> Option<String> {
+        crate::resolver::infer::infer_type_in_lines_raw(self, var_name)
+    }
+
+    fn find_declaration_range(&self, name: &str) -> Option<Range> {
+        crate::resolver::infer::find_declaration_range_in_lines(self, name)
+    }
+
+    fn find_declaration_range_after(&self, name: &str, start_line: u32) -> Option<Range> {
+        crate::resolver::find::find_declaration_range_after_line(self, name, start_line)
+    }
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::LinesExt;
+
+    fn lines(src: &str) -> Vec<String> {
+        src.lines().map(str::to_owned).collect()
+    }
+
+    #[test]
+    fn extract_detail_single_line() {
+        let ls = lines("fun foo() {}");
+        assert!(!ls.extract_detail(0, 0).is_empty());
+    }
+
+    #[test]
+    fn visibility_at_private() {
+        let ls = lines("private fun foo() {}");
+        use crate::types::Visibility;
+        assert_eq!(ls.visibility_at(0), Visibility::Private);
+    }
+
+    #[test]
+    fn import_insertion_after_imports() {
+        let ls = lines("package com.example\nimport android.os.Bundle\n\nclass Foo");
+        assert!(ls.import_insertion_line() > 0);
+    }
+
+    #[test]
+    fn declared_names_finds_val() {
+        let ls = lines("val viewModel: MyViewModel");
+        assert!(ls.declared_names().iter().any(|n| n == "viewModel"));
+    }
+
+    #[test]
+    fn infer_type_finds_annotation() {
+        let ls = lines("val items: List<String> = emptyList()");
+        assert_eq!(ls.infer_type("items").as_deref(), Some("List"));
+    }
+
+    #[test]
+    fn infer_type_raw_preserves_generics() {
+        let ls = lines("val items: List<String> = emptyList()");
+        assert_eq!(ls.infer_type_raw("items").as_deref(), Some("List<String>"));
+    }
+
+    #[test]
+    fn find_declaration_range_finds_val() {
+        let ls = lines("val account: Account = Account()");
+        let r = ls.find_declaration_range("account");
+        assert!(r.is_some());
+    }
+
+    #[test]
+    fn collect_signature_single_line() {
+        let ls = lines("fun foo(x: Int): Boolean {");
+        assert_eq!(ls.collect_signature(0), "fun foo(x: Int): Boolean");
+    }
+
+    #[test]
+    fn parse_imports_finds_import() {
+        let ls = lines("import android.os.Bundle");
+        let imports = ls.parse_imports();
+        assert!(imports.iter().any(|i| i.full_path.contains("Bundle")));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod backend;
 mod inlay_hints;
 mod indexer;
+mod lines_ext;
 mod parser;
 mod queries;
 mod resolver;
@@ -9,6 +10,8 @@ mod stdlib;
 mod stdlib_tail;
 mod task_runner;
 mod types;
+
+pub(crate) use lines_ext::LinesExt;
 
 use tower_lsp::{LspService, Server};
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -165,7 +165,7 @@ fn map_def_captures<'c, 't>(
     let mut def_range:  Option<Range> = None;
     let mut name_text:  Option<String> = None;
     let mut name_range: Option<Range> = None;
-    for cap in m.captures {
+    for cap in m.captures.iter() {
         if cap.index == def_idx {
             def_range = Some(ts_to_lsp(cap.node.range()));
         } else if cap.index == name_idx {
@@ -282,9 +282,9 @@ fn push_field_declaration(node: &Node, bytes: &[u8], data: &mut FileData) {
             if let Some((name, sel)) = first_identifier(&child, bytes) {
                 data.symbols.push(SymbolEntry {
                     name,
-                    kind: kind.clone(),
-                    visibility: vis.clone(),
-                    range: nr.clone(),
+                    kind,
+                    visibility: vis,
+                    range: nr,
                     selection_range: sel,
                     detail: detail.clone(),
                 });

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -31,56 +31,13 @@ pub fn parse_kotlin(content: &str) -> FileData {
     let mut cur = QueryCursor::new();
     let matches: Vec<MatchEntry> = cur
         .matches(&def_q, root, bytes)
-        .map(|m| {
-            let pidx = m.pattern_index;
-            let mut def_range:  Option<Range> = None;
-            let mut name_text:  Option<String> = None;
-            let mut name_range: Option<Range> = None;
-            for cap in m.captures {
-                if cap.index == def_idx {
-                    def_range = Some(ts_to_lsp(cap.node.range()));
-                } else if cap.index == name_idx {
-                    name_text  = cap.node.utf8_text(bytes).ok().map(str::to_owned);
-                    name_range = Some(ts_to_lsp(cap.node.range()));
-                }
-            }
-            let slot = if let (Some(dr), Some(nt), Some(nr)) = (def_range, name_text, name_range) {
-                [Some((nt, dr, nr)), None]
-            } else {
-                [None, None]
-            };
-            (pidx, slot)
-        })
+        .map(|m| map_def_captures(&m, def_idx, name_idx, bytes))
         .collect();
 
     // Deduplicate: multiple patterns can fire on the same node
     // (e.g. enum class matches both pattern 0 "enum" AND pattern 2 "class").
-    //
-    // Use a BTreeMap keyed by the @name node's start position.
-    // The value records the LOWEST pattern index seen so far — lower index = more
-    // specific pattern = wins.  This is correct regardless of the order in which
-    // tree-sitter returns overlapping matches (not guaranteed by the API).
-    let mut best: std::collections::BTreeMap<(u32, u32), (usize, String, Range, Range)> =
-        std::collections::BTreeMap::new();
-
-    for (pidx, slot) in matches {
-        if let Some((name, range, sel)) = slot[0].clone() {
-            let key = (sel.start.line, sel.start.character);
-            let is_better = best.get(&key).map(|(ep, _, _, _)| pidx < *ep).unwrap_or(true);
-            if is_better {
-                best.insert(key, (pidx, name, range, sel));
-            }
-        }
-    }
-
-    for (_, (pidx, name, range, sel)) in best {
-        let (kind, _detail) = queries::def_pattern_meta(pidx);
-        if kind != SymbolKind::NULL {
-            let visibility = visibility_at_line(&data.lines, sel.start.line as usize);
-            let detail = extract_detail(&data.lines, range.start.line, range.end.line);
-            data.symbols.push(SymbolEntry { name, kind, visibility, range, selection_range: sel, detail });
-        }
-    }
+    let best = dedup_matches(&matches);
+    push_def_symbols(best, queries::def_pattern_meta, visibility_at_line, &data.lines, &mut data.symbols);
 
     // ── package + imports (manual tree walk — avoids query overlap issues) ────
     extract_package_and_imports(root, bytes, &mut data);
@@ -146,60 +103,27 @@ pub fn parse_swift(content: &str) -> FileData {
     let matches: Vec<MatchEntry> = cur
         .matches(&def_q, root, bytes)
         .map(|m| {
-            let pidx = m.pattern_index;
-            let mut def_range:  Option<Range> = None;
-            let mut name_text:  Option<String> = None;
-            let mut name_range: Option<Range> = None;
-            for cap in m.captures {
-                if cap.index == def_idx {
-                    def_range = Some(ts_to_lsp(cap.node.range()));
-                } else if cap.index == name_idx {
-                    name_text  = cap.node.utf8_text(bytes).ok().map(str::to_owned);
-                    name_range = Some(ts_to_lsp(cap.node.range()));
-                }
-            }
-            let slot = if let (Some(dr), Some(nt), Some(nr)) = (def_range, name_text, name_range) {
-                [Some((nt, dr, nr)), None]
-            } else if pidx == 8 {
+            let (pidx, slot) = map_def_captures(&m, def_idx, name_idx, bytes);
+            if pidx == 8 && slot[0].is_none() {
                 // init_declaration — no @name, synthesize "init"
+                let def_range = m.captures.iter()
+                    .find(|cap| cap.index == def_idx)
+                    .map(|cap| ts_to_lsp(cap.node.range()));
                 if let Some(dr) = def_range {
                     let sel = Range::new(
                         Position::new(dr.start.line, dr.start.character),
                         Position::new(dr.start.line, dr.start.character + 4),
                     );
-                    [Some(("init".to_owned(), dr, sel)), None]
-                } else {
-                    [None, None]
+                    return (pidx, [Some(("init".to_owned(), dr, sel)), None]);
                 }
-            } else {
-                [None, None]
-            };
+            }
             (pidx, slot)
         })
         .collect();
 
     // Deduplicate: use same BTreeMap strategy as Kotlin parser.
-    let mut best: std::collections::BTreeMap<(u32, u32), (usize, String, Range, Range)> =
-        std::collections::BTreeMap::new();
-
-    for (pidx, slot) in matches {
-        if let Some((name, range, sel)) = slot[0].clone() {
-            let key = (sel.start.line, sel.start.character);
-            let is_better = best.get(&key).map(|(ep, _, _, _)| pidx < *ep).unwrap_or(true);
-            if is_better {
-                best.insert(key, (pidx, name, range, sel));
-            }
-        }
-    }
-
-    for (_, (pidx, name, range, sel)) in best {
-        let (kind, _detail) = queries::swift_def_pattern_meta(pidx);
-        if kind != SymbolKind::NULL {
-            let visibility = swift_visibility_at_line(&data.lines, sel.start.line as usize);
-            let detail = extract_detail(&data.lines, range.start.line, range.end.line);
-            data.symbols.push(SymbolEntry { name, kind, visibility, range, selection_range: sel, detail });
-        }
-    }
+    let best = dedup_matches(&matches);
+    push_def_symbols(best, queries::swift_def_pattern_meta, swift_visibility_at_line, &data.lines, &mut data.symbols);
 
     // ── imports (manual tree walk — Swift imports are simpler) ────────────────
     extract_swift_imports(root, bytes, &mut data);
@@ -221,6 +145,80 @@ pub fn parse_by_extension(path: &str, content: &str) -> FileData {
         parse_java(content)
     } else {
         parse_kotlin(content)
+    }
+}
+
+// ─── shared query pipeline helpers ───────────────────────────────────────────
+
+/// Extract def/name captures from a single `QueryMatch` into a `MatchEntry`.
+///
+/// Handles the common case shared by both Kotlin and Swift definition queries:
+/// each match has a `@def` capture (full node range) and a `@name` capture
+/// (identifier text + range).  Returns `[None, None]` when either is absent.
+fn map_def_captures<'c, 't>(
+    m: &tree_sitter::QueryMatch<'c, 't>,
+    def_idx: u32,
+    name_idx: u32,
+    bytes: &[u8],
+) -> MatchEntry {
+    let pidx = m.pattern_index;
+    let mut def_range:  Option<Range> = None;
+    let mut name_text:  Option<String> = None;
+    let mut name_range: Option<Range> = None;
+    for cap in m.captures {
+        if cap.index == def_idx {
+            def_range = Some(ts_to_lsp(cap.node.range()));
+        } else if cap.index == name_idx {
+            name_text  = cap.node.utf8_text(bytes).ok().map(str::to_owned);
+            name_range = Some(ts_to_lsp(cap.node.range()));
+        }
+    }
+    let slot = if let (Some(dr), Some(nt), Some(nr)) = (def_range, name_text, name_range) {
+        [Some((nt, dr, nr)), None]
+    } else {
+        [None, None]
+    };
+    (pidx, slot)
+}
+
+/// Deduplicate a list of `MatchEntry` values by `@name` start position.
+///
+/// Multiple patterns can fire on the same node (e.g. an enum class matches both
+/// the "enum class" pattern and the plain "class" pattern).  Keeps the entry
+/// with the **lowest** pattern index — lower index = more specific pattern.
+fn dedup_matches(
+    matches: &[MatchEntry],
+) -> std::collections::BTreeMap<(u32, u32), (usize, String, Range, Range)> {
+    let mut best = std::collections::BTreeMap::new();
+    for (pidx, slot) in matches {
+        if let Some((name, range, sel)) = slot[0].clone() {
+            let key = (sel.start.line, sel.start.character);
+            let is_better = best.get(&key).map(|(ep, _, _, _)| pidx < ep).unwrap_or(true);
+            if is_better {
+                best.insert(key, (*pidx, name, range, sel));
+            }
+        }
+    }
+    best
+}
+
+/// Convert a deduplicated match map into `SymbolEntry` values and append them
+/// to `symbols`.  `pattern_meta` maps a pattern index to `(SymbolKind, label)`;
+/// `vis_fn` detects the visibility modifier from source lines.
+fn push_def_symbols(
+    best: std::collections::BTreeMap<(u32, u32), (usize, String, Range, Range)>,
+    pattern_meta: fn(usize) -> (SymbolKind, Option<&'static str>),
+    vis_fn: fn(&[String], usize) -> Visibility,
+    lines: &[String],
+    symbols: &mut Vec<SymbolEntry>,
+) {
+    for (_, (pidx, name, range, sel)) in best {
+        let (kind, _) = pattern_meta(pidx);
+        if kind != SymbolKind::NULL {
+            let visibility = vis_fn(lines, sel.start.line as usize);
+            let detail = extract_detail(lines, range.start.line, range.end.line);
+            symbols.push(SymbolEntry { name, kind, visibility, range, selection_range: sel, detail });
+        }
     }
 }
 
@@ -247,60 +245,9 @@ fn extract_java(node: &Node, bytes: &[u8], data: &mut FileData) {
         "enum_declaration"      => push_named(node, bytes, SymbolKind::ENUM,      data),
         "method_declaration"    => push_named(node, bytes, SymbolKind::METHOD,    data),
         "constructor_declaration" => push_named(node, bytes, SymbolKind::CONSTRUCTOR, data),
-        "enum_constant" => {
-            // Direct child of enum_body — the first identifier child is the constant name.
-            let nr = ts_to_lsp(node.range());
-            let line_no = node.range().start_point.row;
-            let vis = visibility_at_line(&data.lines, line_no);
-            let mut cur = node.walk();
-            for child in node.children(&mut cur) {
-                if child.kind() == "identifier" {
-                    if let Ok(txt) = child.utf8_text(bytes) {
-                        data.symbols.push(SymbolEntry {
-                            name: txt.to_owned(),
-                            kind: SymbolKind::ENUM_MEMBER,
-                            visibility: vis,
-                            range: nr,
-                            selection_range: ts_to_lsp(child.range()),
-                            detail: extract_detail(&data.lines, nr.start.line, nr.end.line),
-                        });
-                    }
-                    break;
-                }
-            }
-        }
-        "field_declaration"     => {
-            let nr = ts_to_lsp(node.range());
-            let line_no = node.range().start_point.row;
-            let vis = visibility_at_line(&data.lines, line_no);
-            // Detect `static final` → CONSTANT, anything else → FIELD.
-            let kind = if java_node_has_modifiers(node, &["static", "final"]) {
-                SymbolKind::CONSTANT
-            } else {
-                SymbolKind::FIELD
-            };
-            let mut cur = node.walk();
-            for child in node.children(&mut cur) {
-                if child.kind() == "variable_declarator" {
-                    if let Some((name, sel)) = first_identifier(&child, bytes) {
-                        data.symbols.push(SymbolEntry { name, kind, visibility: vis, range: nr, selection_range: sel, detail: extract_detail(&data.lines, nr.start.line, nr.end.line) });
-                    }
-                }
-            }
-        }
-        "import_declaration" => {
-            let mut cur = node.walk();
-            for child in node.children(&mut cur) {
-                if matches!(child.kind(), "scoped_identifier" | "identifier") {
-                    if let Ok(txt) = child.utf8_text(bytes) {
-                        let full_path  = txt.to_owned();
-                        let local_name = last_segment(&full_path).to_owned();
-                        data.imports.push(ImportEntry { full_path, local_name, is_star: false });
-                        return;
-                    }
-                }
-            }
-        }
+        "enum_constant" => push_named(node, bytes, SymbolKind::ENUM_MEMBER, data),
+        "field_declaration"     => push_field_declaration(node, bytes, data),
+        "import_declaration" => push_java_import(node, bytes, data),
         _ => {}
     }
 }
@@ -317,6 +264,41 @@ fn java_node_has_modifiers(node: &Node, required: &[&str]) -> bool {
         }
     }
     false
+}
+
+fn push_field_declaration(node: &Node, bytes: &[u8], data: &mut FileData) {
+    // Detect `static final` → CONSTANT, anything else → FIELD.
+    let kind = if java_node_has_modifiers(node, &["static", "final"]) {
+        SymbolKind::CONSTANT
+    } else {
+        SymbolKind::FIELD
+    };
+    let nr = ts_to_lsp(node.range());
+    let vis = visibility_at_line(&data.lines, node.range().start_point.row);
+    let detail = extract_detail(&data.lines, nr.start.line, nr.end.line);
+    let mut cur = node.walk();
+    for child in node.children(&mut cur) {
+        if child.kind() == "variable_declarator" {
+            if let Some((name, sel)) = first_identifier(&child, bytes) {
+                data.symbols.push(SymbolEntry { name, kind, visibility: vis, range: nr, selection_range: sel, detail });
+            }
+            return;
+        }
+    }
+}
+
+fn push_java_import(node: &Node, bytes: &[u8], data: &mut FileData) {
+    let mut cur = node.walk();
+    for child in node.children(&mut cur) {
+        if matches!(child.kind(), "scoped_identifier" | "identifier") {
+            if let Ok(txt) = child.utf8_text(bytes) {
+                let full_path  = txt.to_owned();
+                let local_name = last_segment(&full_path).to_owned();
+                data.imports.push(ImportEntry { full_path, local_name, is_star: false });
+            }
+            return;
+        }
+    }
 }
 
 fn push_named(node: &Node, bytes: &[u8], kind: SymbolKind, data: &mut FileData) {
@@ -1673,5 +1655,19 @@ class LoanReducer {
         assert!(sym(&data, "Kind").is_some(), "nested Kind enum should be indexed; got: {names:?}");
         assert_eq!(sym(&data, "Kind").unwrap().kind, SymbolKind::ENUM, "Kind should be ENUM");
         assert!(sym(&data, "victory").is_some(), "enum cases should be indexed; got: {names:?}");
+    }
+
+    #[test]
+    fn dedup_matches_lower_pidx_wins() {
+        use tower_lsp::lsp_types::{Position, Range};
+        let sel   = Range::new(Position::new(1, 0), Position::new(1, 3));
+        let range = sel;
+        let matches: Vec<MatchEntry> = vec![
+            (2, [Some(("Foo".into(), range, sel)), None]),
+            (0, [Some(("Foo".into(), range, sel)), None]),
+        ];
+        let best = dedup_matches(&matches);
+        assert_eq!(best.len(), 1);
+        assert_eq!(best.values().next().unwrap().0, 0, "pidx 0 should win over pidx 2");
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -280,9 +280,15 @@ fn push_field_declaration(node: &Node, bytes: &[u8], data: &mut FileData) {
     for child in node.children(&mut cur) {
         if child.kind() == "variable_declarator" {
             if let Some((name, sel)) = first_identifier(&child, bytes) {
-                data.symbols.push(SymbolEntry { name, kind, visibility: vis, range: nr, selection_range: sel, detail });
+                data.symbols.push(SymbolEntry {
+                    name,
+                    kind: kind.clone(),
+                    visibility: vis.clone(),
+                    range: nr.clone(),
+                    selection_range: sel,
+                    detail: detail.clone(),
+                });
             }
-            return;
         }
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -40,13 +40,13 @@ pub fn parse_kotlin(content: &str) -> FileData {
     push_def_symbols(best, queries::def_pattern_meta, visibility_at_line, &data.lines, &mut data.symbols);
 
     // ── package + imports (manual tree walk — avoids query overlap issues) ────
-    extract_package_and_imports(root, bytes, &mut data);
+    data.extract_package_and_imports(root, bytes);
 
     // ── fun interface (tree-sitter parses these as ERROR + lambda_literal) ───
-    extract_fun_interfaces(root, bytes, &mut data);
+    data.extract_fun_interfaces(root, bytes);
 
     // ── supertype relationships (delegation specifiers) ──────────────────────
-    extract_supers_kotlin(root, bytes, &mut data);
+    data.extract_supers_kotlin(root, bytes);
 
     // ── declared_names: scan lines once for `ident:` patterns ───────────────
     data.declared_names = extract_declared_names(&data.lines);
@@ -69,8 +69,8 @@ pub fn parse_java(content: &str) -> FileData {
     let bytes = content.as_bytes();
     let mut queue = vec![tree.root_node()];
     while let Some(node) = queue.pop() {
-        extract_java(&node, bytes, &mut data);
-        extract_supers_java(&node, bytes, &mut data);
+        data.extract_java(&node, bytes);
+        data.extract_supers_java(&node, bytes);
         let mut cur = node.walk();
         for child in node.children(&mut cur) { queue.push(child); }
     }
@@ -126,7 +126,7 @@ pub fn parse_swift(content: &str) -> FileData {
     push_def_symbols(best, queries::swift_def_pattern_meta, swift_visibility_at_line, &data.lines, &mut data.symbols);
 
     // ── imports (manual tree walk — Swift imports are simpler) ────────────────
-    extract_swift_imports(root, bytes, &mut data);
+    data.extract_swift_imports(root, bytes);
 
     // ── declared_names ───────────────────────────────────────────────────────
     data.declared_names = extract_declared_names(&data.lines);
@@ -1053,6 +1053,29 @@ fn java_collect_type_list(node: &Node, bytes: &[u8], name_line: u32, data: &mut 
                 if let Some(n) = name { data.supers.push((name_line, n)); }
             }
         }
+    }
+}
+
+// ─── FileData methods (thin wrappers around the free functions above) ────────
+
+impl crate::types::FileData {
+    fn extract_package_and_imports(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
+        extract_package_and_imports(root, bytes, self)
+    }
+    fn extract_fun_interfaces(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
+        extract_fun_interfaces(root, bytes, self)
+    }
+    fn extract_supers_kotlin(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
+        extract_supers_kotlin(root, bytes, self)
+    }
+    fn extract_java(&mut self, node: &Node, bytes: &[u8]) {
+        extract_java(node, bytes, self)
+    }
+    fn extract_supers_java(&mut self, node: &Node, bytes: &[u8]) {
+        extract_supers_java(node, bytes, self)
+    }
+    fn extract_swift_imports(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
+        extract_swift_imports(root, bytes, self)
     }
 }
 

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -5,6 +5,7 @@ use tower_lsp::lsp_types::{
 
 use crate::indexer::Indexer;
 use crate::types::Visibility;
+use crate::LinesExt;
 
 use super::{fqns_for_name, already_imported, make_import_edit,
             resolve_symbol_inner, resolve_symbol_no_rg};
@@ -437,7 +438,7 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
                 let lines = live.clone().unwrap_or_else(|| f.lines.clone());
                 // Re-scan live lines for imports so we don't use a stale snapshot.
                 let imports = if live.is_some() {
-                    crate::parser::parse_imports_from_lines(&lines)
+                    lines.parse_imports()
                 } else {
                     f.imports.clone()
                 };
@@ -445,7 +446,7 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
             })
             .unwrap_or_else(|| {
                 let lines = live.clone().unwrap_or_default();
-                let imports = crate::parser::parse_imports_from_lines(&lines);
+                let imports = lines.parse_imports();
                 (imports, String::new(), lines)
             });
 
@@ -631,4 +632,27 @@ fn make_completion_item(name: &str, ck: CompletionItemKind, sort_text: String, s
 /// pre-warmer in `indexer.rs`.  Builds + caches completion items for a file.
 pub fn symbols_from_uri_as_completions_pub(idx: &Indexer, file_uri: &str) -> Vec<CompletionItem> {
     symbols_from_uri_as_completions(idx, file_uri)
+}
+
+// ─── impl Indexer wrappers ────────────────────────────────────────────────────
+
+impl crate::indexer::Indexer {
+    pub(crate) fn complete_dot(&self, receiver: &str, from_uri: &Url, snippets: bool) -> Vec<CompletionItem> {
+        complete_dot(self, receiver, from_uri, snippets)
+    }
+    pub(crate) fn complete_bare(&self, prefix: &str, from_uri: &Url, snippets: bool, annotation_only: bool) -> (Vec<CompletionItem>, bool) {
+        complete_bare(self, prefix, from_uri, snippets, annotation_only)
+    }
+    pub(super) fn complete_super_w(&self, from_uri: &Url, snippets: bool) -> Vec<CompletionItem> {
+        complete_super(self, from_uri, snippets)
+    }
+    pub(super) fn symbols_from_uri_as_completions_w(&self, file_uri: &str) -> Vec<CompletionItem> {
+        symbols_from_uri_as_completions(self, file_uri)
+    }
+    pub(super) fn build_completion_items_w(&self, file_uri: &str) -> Vec<CompletionItem> {
+        build_completion_items(self, file_uri)
+    }
+    pub fn symbols_from_uri_as_completions_pub(&self, file_uri: &str) -> Vec<CompletionItem> {
+        symbols_from_uri_as_completions_pub(self, file_uri)
+    }
 }

--- a/src/resolver/find.rs
+++ b/src/resolver/find.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 use tower_lsp::lsp_types::{Location, Url};
 
 use crate::indexer::Indexer;
-use super::infer::find_declaration_range_in_lines;
+use crate::LinesExt;
 
 /// Search for `name` in a specific file identified by its URI string.
 ///
@@ -17,7 +17,7 @@ pub(crate) fn find_name_in_uri(idx: &Indexer, name: &str, file_uri: &str) -> Vec
             return vec![Location { uri, range: sym.selection_range }];
         }
         // b) Line scan for constructor params / un-indexed declarations
-        if let Some(range) = find_declaration_range_in_lines(&f.lines, name) {
+        if let Some(range) = f.lines.find_declaration_range(name) {
             return vec![Location { uri, range }];
         }
         return vec![];
@@ -31,7 +31,7 @@ pub(crate) fn find_name_in_uri(idx: &Indexer, name: &str, file_uri: &str) -> Vec
                 return vec![Location { uri, range: sym.selection_range }];
             }
             let lines: Vec<String> = content.lines().map(String::from).collect();
-            if let Some(range) = find_declaration_range_in_lines(&lines, name) {
+            if let Some(range) = lines.find_declaration_range(name) {
                 return vec![Location { uri, range }];
             }
         }
@@ -70,10 +70,10 @@ pub(crate) fn find_name_in_uri_after_line(idx: &Indexer, name: &str, file_uri: &
         }
 
         // b) Line scan scoped to after_line first, then the whole file.
-        if let Some(range) = find_declaration_range_after_line(&f.lines, name, after_line) {
+        if let Some(range) = f.lines.find_declaration_range_after(name, after_line) {
             return vec![Location { uri, range }];
         }
-        if let Some(range) = find_declaration_range_in_lines(&f.lines, name) {
+        if let Some(range) = f.lines.find_declaration_range(name) {
             return vec![Location { uri, range }];
         }
         return vec![];
@@ -84,11 +84,11 @@ pub(crate) fn find_name_in_uri_after_line(idx: &Indexer, name: &str, file_uri: &
 }
 
 /// Like `find_declaration_range_in_lines` but only searches from `start_line`.
-fn find_declaration_range_after_line(lines: &[String], name: &str, start_line: u32) -> Option<tower_lsp::lsp_types::Range> {
+pub(crate) fn find_declaration_range_after_line(lines: &[String], name: &str, start_line: u32) -> Option<tower_lsp::lsp_types::Range> {
     use tower_lsp::lsp_types::{Position, Range};
     let start = start_line as usize;
     if start >= lines.len() { return None; }
-    find_declaration_range_in_lines(&lines[start..], name)
+    lines[start..].find_declaration_range(name)
         .map(|r| Range {
             start: Position { line: r.start.line + start_line, character: r.start.character },
             end:   Position { line: r.end.line   + start_line, character: r.end.character   },
@@ -107,8 +107,22 @@ pub(crate) fn find_local_declaration(idx: &Indexer, name: &str, uri: &Url) -> Ve
     } else {
         return vec![];
     };
-    if let Some(range) = find_declaration_range_in_lines(&lines, name) {
+    if let Some(range) = lines.find_declaration_range(name) {
         return vec![Location { uri: uri.clone(), range }];
     }
     vec![]
+}
+
+// ─── impl Indexer wrappers ────────────────────────────────────────────────────
+
+impl crate::indexer::Indexer {
+    pub(crate) fn find_name_in_uri(&self, name: &str, file_uri: &str) -> Vec<Location> {
+        find_name_in_uri(self, name, file_uri)
+    }
+    pub(crate) fn find_name_in_uri_after_line(&self, name: &str, file_uri: &str, after_line: u32) -> Vec<Location> {
+        find_name_in_uri_after_line(self, name, file_uri, after_line)
+    }
+    pub(crate) fn find_local_declaration(&self, name: &str, uri: &Url) -> Vec<Location> {
+        find_local_declaration(self, name, uri)
+    }
 }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -1,6 +1,7 @@
 use tower_lsp::lsp_types::{Position, Range, Url};
 
 use crate::indexer::Indexer;
+use crate::LinesExt;
 
 // ─── Receiver type resolution ─────────────────────────────────────────────────
 
@@ -73,7 +74,7 @@ pub(crate) fn infer_variable_type(idx: &Indexer, var_name: &str, uri: &Url) -> O
     // Prefer live_lines: updated synchronously on every keystroke, so they
     // reflect unsaved edits that the indexed snapshot may not yet contain.
     if let Some(ll) = idx.live_lines.get(uri.as_str()) {
-        if let result @ Some(_) = infer_type_in_lines(&ll, var_name) {
+        if let result @ Some(_) = ll.infer_type(var_name) {
             return result;
         }
     }
@@ -84,13 +85,13 @@ pub(crate) fn infer_variable_type(idx: &Indexer, var_name: &str, uri: &Url) -> O
         if !data.declared_names.iter().any(|n| n == var_name) {
             return None;
         }
-        return infer_type_in_lines(&data.lines, var_name);
+        return data.lines.infer_type(var_name);
     }
     // File not indexed yet — read from disk.
     let path = uri.to_file_path().ok()?;
     let content = std::fs::read_to_string(&path).ok()?;
     let lines: Vec<String> = content.lines().map(String::from).collect();
-    infer_type_in_lines(&lines, var_name)
+    lines.infer_type(var_name)
 }
 
 /// Like [`infer_variable_type`] but preserves generic parameters in the returned
@@ -99,17 +100,17 @@ pub(crate) fn infer_variable_type(idx: &Indexer, var_name: &str, uri: &Url) -> O
 /// Used by the `it`-completion path to extract the collection element type.
 pub fn infer_variable_type_raw(idx: &Indexer, var_name: &str, uri: &Url) -> Option<String> {
     if let Some(ll) = idx.live_lines.get(uri.as_str()) {
-        if let result @ Some(_) = infer_type_in_lines_raw(&ll, var_name) {
+        if let result @ Some(_) = ll.infer_type_raw(var_name) {
             return result;
         }
     }
     if let Some(data) = idx.files.get(uri.as_str()) {
-        return infer_type_in_lines_raw(&data.lines, var_name);
+        return data.lines.infer_type_raw(var_name);
     }
     let path = uri.to_file_path().ok()?;
     let content = std::fs::read_to_string(&path).ok()?;
     let lines: Vec<String> = content.lines().map(String::from).collect();
-    infer_type_in_lines_raw(&lines, var_name)
+    lines.infer_type_raw(var_name)
 }
 
 /// Extract the Kotlin/Android collection element type from a raw generic type string.
@@ -175,12 +176,26 @@ fn first_type_arg(s: &str) -> &str {
 /// the file from disk when it isn't indexed yet.
 pub(crate) fn infer_field_type(idx: &Indexer, file_uri: &str, field_name: &str) -> Option<String> {
     if let Some(data) = idx.files.get(file_uri) {
-        return infer_type_in_lines(&data.lines, field_name);
+        return data.lines.infer_type(field_name);
     }
     let path = tower_lsp::lsp_types::Url::parse(file_uri).ok()?.to_file_path().ok()?;
     let content = std::fs::read_to_string(&path).ok()?;
     let lines: Vec<String> = content.lines().map(String::from).collect();
-    infer_type_in_lines(&lines, field_name)
+    lines.infer_type(field_name)
+}
+
+// ─── impl Indexer wrappers ────────────────────────────────────────────────────
+
+impl crate::indexer::Indexer {
+    pub(crate) fn infer_variable_type(&self, var_name: &str, uri: &Url) -> Option<String> {
+        infer_variable_type(self, var_name, uri)
+    }
+    pub fn infer_variable_type_raw(&self, var_name: &str, uri: &Url) -> Option<String> {
+        infer_variable_type_raw(self, var_name, uri)
+    }
+    pub(crate) fn infer_field_type(&self, file_uri: &str, field_name: &str) -> Option<String> {
+        infer_field_type(self, file_uri, field_name)
+    }
 }
 
 /// Core line scanner: find `var_name:` in `lines` and return the type that follows.

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -26,6 +26,7 @@ use tower_lsp::lsp_types::{Location, Range, TextEdit, Url};
 use crate::indexer::Indexer;
 use crate::rg::{build_rg_pattern, parse_rg_line, rg_find_definition};
 use crate::types::ImportEntry;
+use crate::LinesExt;
 
 pub mod complete;
 pub(crate) mod infer;
@@ -99,7 +100,7 @@ pub(crate) fn import_insertion_line(lines: &[String]) -> u32 {
 
 /// Build a TextEdit that inserts `import {fqn}\n` at the correct position.
 pub(crate) fn make_import_edit(fqn: &str, lines: &[String], needs_semicolon: bool) -> TextEdit {
-    let line = import_insertion_line(lines);
+    let line = lines.import_insertion_line();
     // When inserting right after the package line (no existing imports), add a blank line.
     let needs_blank = line > 0
         && lines.get((line - 1) as usize)
@@ -771,4 +772,36 @@ pub(crate) fn is_stdlib(pkg: &str) -> bool {
         | "WebKit" | "StoreKit" | "GameKit" | "ARKit" | "RealityKit"
         | "Swift" | "ObjectiveC" | "Darwin" | "Dispatch" | "os"
     )
+}
+
+// ─── impl Indexer wrappers ────────────────────────────────────────────────────
+
+impl crate::indexer::Indexer {
+    pub fn resolve_symbol(&self, name: &str, qualifier: Option<&str>, from_uri: &Url) -> Vec<Location> {
+        resolve_symbol(self, name, qualifier, from_uri)
+    }
+    pub(crate) fn resolve_symbol_inner(&self, name: &str, from_uri: &Url, with_hierarchy: bool) -> Vec<Location> {
+        resolve_symbol_inner(self, name, from_uri, with_hierarchy)
+    }
+    pub(crate) fn resolve_symbol_no_rg(&self, name: &str, from_uri: &Url) -> Vec<Location> {
+        resolve_symbol_no_rg(self, name, from_uri)
+    }
+    pub(super) fn resolve_qualified_w(&self, name: &str, qualifier: &str, from_uri: &Url) -> Vec<Location> {
+        resolve_qualified(self, name, qualifier, from_uri)
+    }
+    pub(super) fn resolve_local_w(&self, name: &str, uri: &Url) -> Vec<Location> {
+        resolve_local(self, name, uri)
+    }
+    pub(super) fn resolve_via_imports_w(&self, name: &str, uri: &Url) -> Vec<Location> {
+        resolve_via_imports(self, name, uri)
+    }
+    pub(super) fn resolve_same_package_w(&self, name: &str, uri: &Url) -> Vec<Location> {
+        resolve_same_package(self, name, uri)
+    }
+    pub(super) fn resolve_star_imports_w(&self, name: &str, uri: &Url) -> Vec<Location> {
+        resolve_star_imports(self, name, uri)
+    }
+    pub(crate) fn fqns_for_name(&self, name: &str) -> Vec<String> {
+        fqns_for_name(self, name)
+    }
 }


### PR DESCRIPTION
## Phase 12 — Type-dependent traits

Extracts groups of free functions that depend on a specific type into clean extension traits, following the same pattern as NodeExt from Phase 11.

### Completed

- **NodeExt\<'a\>** on `tree_sitter::Node` — 7 CST helper methods (call_fn_name, named_arg_label, value_arg_position, find_value_arguments, has_lambda_named_params, collect_lambda_param_names, extract_type_name)
- **completions() split** — 210-line function → 25-line orchestrator + 7 named helpers
- **parser.rs pipeline dedup** — shared dedup_matches + push_def_symbols between parse_kotlin/parse_swift; extract_java arms flattened

### In progress

- **LinesExt** on `[String]` — ~13 free functions: visibility_at, extract_detail, declared_names, collect_signature, infer_type, find_declaration_range, import_insertion_line, etc.
- **IndexerExt** — resolver free functions become methods on Indexer
- **FileDataExt** — parser push helpers become methods on FileData

553 tests pass, zero behaviour change.