### PR TITLE
refactor: phases 13-14 — helper extraction, trait methods, nesting reduction

### DIFF
--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -530,49 +530,7 @@ fn cst_call_info(
     }?;
 
     // Extract function name and optional qualifier from the callee.
-    let callee = call_expr.child(0)?;
-    let (fn_name, qualifier) = match callee.kind() {
-        "simple_identifier" | "type_identifier" => {
-            let name = std::str::from_utf8(&bytes[callee.byte_range()]).ok()?.to_string();
-            (name, None)
-        }
-        "navigation_expression" => {
-            // Tree structure: navigation_expression
-            //   simple_identifier "receiver"        ← direct child (the qualifier)
-            //   navigation_suffix                   ← direct child
-            //     "."
-            //     simple_identifier "methodName"    ← fn name lives here
-            //
-            // We must look inside navigation_suffix for the function name, NOT
-            // use direct-children-only iteration which misses the nested identifier.
-            let mut fn_name_opt: Option<String> = None;
-            let mut qualifier_opt: Option<String> = None;
-            let mut walker = callee.walk();
-            for child in callee.children(&mut walker) {
-                match child.kind() {
-                    "simple_identifier" | "type_identifier" => {
-                        // First direct identifier = the receiver/qualifier.
-                        qualifier_opt = std::str::from_utf8(&bytes[child.byte_range()])
-                            .ok().map(|s| s.to_string());
-                    }
-                    "navigation_suffix" => {
-                        // The function name is the simple_identifier inside the suffix.
-                        let mut sw = child.walk();
-                        for sc in child.children(&mut sw) {
-                            if sc.kind() == "simple_identifier" || sc.kind() == "type_identifier" {
-                                fn_name_opt = std::str::from_utf8(&bytes[sc.byte_range()])
-                                    .ok().map(|s| s.to_string());
-                                break;
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            (fn_name_opt?, qualifier_opt)
-        }
-        _ => return None,
-    };
+    let (fn_name, qualifier) = call_expr.call_fn_and_qualifier(bytes)?;
 
     // Find the value_arguments node (may be inside call_suffix).
     let value_arguments = call_expr.find_value_arguments()?;
@@ -594,6 +552,49 @@ fn cst_call_info(
     };
 
     Some((fn_name, qualifier, active_param))
+}
+
+/// Scans up to 10 lines before `line_idx` for an unclosed `fn(` call site.
+/// Returns `(call_name, qualifier, extra_commas)` where `extra_commas` is
+/// the count of commas on the intermediate lines plus the commas in `before`
+/// (to add to `active_param`).
+fn scan_multiline_call_open(
+    lines: &[String],
+    line_idx: usize,
+    before: &str,
+) -> Option<(String, Option<String>, u32)> {
+    let scan_start = line_idx.saturating_sub(10);
+    'outer: for scan_line in (scan_start..line_idx).rev() {
+        let l = &lines[scan_line];
+        if l.contains('{') || l.contains('}') { break; }
+        for (p, _) in l.char_indices().filter(|&(_, c)| c == '(')
+            .collect::<Vec<_>>().into_iter().rev()
+        {
+            let before_paren = &l[..p];
+            let name = crate::indexer::last_ident_in(before_paren);
+            if !name.is_empty() && !is_non_call_keyword(name) {
+                let net: i32 = l[p..].chars()
+                    .map(|c| match c { '(' => 1, ')' => -1, _ => 0 }).sum();
+                if net > 0 {
+                    // Qualifier before the dot on the same line.
+                    let before_name = &before_paren[..before_paren.len() - name.len()];
+                    let qualifier = if before_name.ends_with('.') {
+                        let q = crate::indexer::last_ident_in(before_name.strip_suffix('.').unwrap_or(before_name));
+                        if q.is_empty() { None } else { Some(q.to_owned()) }
+                    } else { None };
+                    let mut extra: u32 = 0;
+                    if scan_line + 1 < line_idx {
+                        for mid in &lines[(scan_line + 1)..line_idx] {
+                            extra += mid.chars().filter(|&c| c == ',').count() as u32;
+                        }
+                    }
+                    extra += before.chars().filter(|&c| c == ',').count() as u32;
+                    return Some((name.to_owned(), qualifier, extra));
+                }
+            }
+        }
+    }
+    None
 }
 
 /// Text-scan fallback: extract `(fn_name, qualifier, active_param)` by walking
@@ -646,37 +647,10 @@ fn text_call_info(
     let in_block_body = before.contains('{') || before.contains('}')
         || lines[line_idx].trim_start().starts_with('}');
     if call_name.is_none() && line_idx > 0 && !in_block_body {
-        let scan_start = line_idx.saturating_sub(10);
-        'outer: for scan_line in (scan_start..line_idx).rev() {
-            let l = &lines[scan_line];
-            if l.contains('{') || l.contains('}') { break; }
-            for (p, _) in l.char_indices().filter(|&(_, c)| c == '(')
-                .collect::<Vec<_>>().into_iter().rev()
-            {
-                let before_paren = &l[..p];
-                let name = crate::indexer::last_ident_in(before_paren);
-                if !name.is_empty() && !is_non_call_keyword(name) {
-                    let net: i32 = l[p..].chars()
-                        .map(|c| match c { '(' => 1, ')' => -1, _ => 0 }).sum();
-                    if net > 0 {
-                        // Qualifier before the dot on the same line.
-                        let before_name = &before_paren[..before_paren.len() - name.len()];
-                        let qualifier = if before_name.ends_with('.') {
-                            let q = crate::indexer::last_ident_in(before_name.strip_suffix('.').unwrap_or(before_name));
-                            if q.is_empty() { None } else { Some(q.to_owned()) }
-                        } else { None };
-                        call_name = Some(name.to_owned());
-                        call_qualifier = qualifier;
-                        if scan_line + 1 < line_idx {
-                            for mid in &lines[(scan_line + 1)..line_idx] {
-                                active_param += mid.chars().filter(|&c| c == ',').count() as u32;
-                            }
-                        }
-                        active_param += before.chars().filter(|&c| c == ',').count() as u32;
-                        break 'outer;
-                    }
-                }
-            }
+        if let Some((name, qual, extra)) = scan_multiline_call_open(lines, line_idx, before) {
+            call_name = Some(name);
+            call_qualifier = qual;
+            active_param += extra;
         }
     }
 

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -554,6 +554,32 @@ fn cst_call_info(
     Some((fn_name, qualifier, active_param))
 }
 
+/// Scans a single source line for an unclosed call-site opening.
+/// Returns `(call_name, qualifier)` if an unbalanced `name(` is found,
+/// where net > 0 means more opens than closes on this line.
+fn find_call_open_on_line(line: &str) -> Option<(String, Option<String>)> {
+    for (p, _) in line.char_indices().filter(|&(_, c)| c == '(')
+        .collect::<Vec<_>>().into_iter().rev()
+    {
+        let before_paren = &line[..p];
+        let name = crate::indexer::last_ident_in(before_paren);
+        if !name.is_empty() && !is_non_call_keyword(name) {
+            let net: i32 = line[p..].chars()
+                .map(|c| match c { '(' => 1, ')' => -1, _ => 0 }).sum();
+            if net > 0 {
+                // Qualifier before the dot on the same line.
+                let before_name = &before_paren[..before_paren.len() - name.len()];
+                let qualifier = if before_name.ends_with('.') {
+                    let q = crate::indexer::last_ident_in(before_name.strip_suffix('.').unwrap_or(before_name));
+                    if q.is_empty() { None } else { Some(q.to_owned()) }
+                } else { None };
+                return Some((name.to_owned(), qualifier));
+            }
+        }
+    }
+    None
+}
+
 /// Scans up to 10 lines before `line_idx` for an unclosed `fn(` call site.
 /// Returns `(call_name, qualifier, extra_commas)` where `extra_commas` is
 /// the count of commas on the intermediate lines plus the commas in `before`
@@ -564,37 +590,36 @@ fn scan_multiline_call_open(
     before: &str,
 ) -> Option<(String, Option<String>, u32)> {
     let scan_start = line_idx.saturating_sub(10);
-    'outer: for scan_line in (scan_start..line_idx).rev() {
+    for scan_line in (scan_start..line_idx).rev() {
         let l = &lines[scan_line];
         if l.contains('{') || l.contains('}') { break; }
-        for (p, _) in l.char_indices().filter(|&(_, c)| c == '(')
-            .collect::<Vec<_>>().into_iter().rev()
-        {
-            let before_paren = &l[..p];
-            let name = crate::indexer::last_ident_in(before_paren);
-            if !name.is_empty() && !is_non_call_keyword(name) {
-                let net: i32 = l[p..].chars()
-                    .map(|c| match c { '(' => 1, ')' => -1, _ => 0 }).sum();
-                if net > 0 {
-                    // Qualifier before the dot on the same line.
-                    let before_name = &before_paren[..before_paren.len() - name.len()];
-                    let qualifier = if before_name.ends_with('.') {
-                        let q = crate::indexer::last_ident_in(before_name.strip_suffix('.').unwrap_or(before_name));
-                        if q.is_empty() { None } else { Some(q.to_owned()) }
-                    } else { None };
-                    let mut extra: u32 = 0;
-                    if scan_line + 1 < line_idx {
-                        for mid in &lines[(scan_line + 1)..line_idx] {
-                            extra += mid.chars().filter(|&c| c == ',').count() as u32;
-                        }
-                    }
-                    extra += before.chars().filter(|&c| c == ',').count() as u32;
-                    return Some((name.to_owned(), qualifier, extra));
+        if let Some((name, qualifier)) = find_call_open_on_line(l) {
+            let mut extra: u32 = 0;
+            if scan_line + 1 < line_idx {
+                for mid in &lines[(scan_line + 1)..line_idx] {
+                    extra += mid.chars().filter(|&c| c == ',').count() as u32;
                 }
             }
+            extra += before.chars().filter(|&c| c == ',').count() as u32;
+            return Some((name, qualifier, extra));
         }
     }
     None
+}
+
+/// Given `chars` and position `j` (start of the identifier), extract
+/// the qualifier immediately before a `.` if present.
+fn extract_dot_qualifier(chars: &[char], j: usize) -> Option<String> {
+    if j > 0 && chars[j - 1] == '.' {
+        let mut k = j - 1;
+        while k > 0 && (chars[k - 1].is_alphanumeric() || chars[k - 1] == '_') {
+            k -= 1;
+        }
+        let q: String = chars[k..j - 1].iter().collect();
+        if !q.is_empty() { Some(q) } else { None }
+    } else {
+        None
+    }
 }
 
 /// Text-scan fallback: extract `(fn_name, qualifier, active_param)` by walking
@@ -625,14 +650,7 @@ fn text_call_info(
                     let candidate: String = chars[j..i].iter().collect();
                     if !candidate.is_empty() && !is_non_call_keyword(&candidate) {
                         call_name = Some(candidate);
-                        if j > 0 && chars[j - 1] == '.' {
-                            let mut k = j - 1;
-                            while k > 0 && (chars[k - 1].is_alphanumeric() || chars[k - 1] == '_') {
-                                k -= 1;
-                            }
-                            let q: String = chars[k..j - 1].iter().collect();
-                            if !q.is_empty() { call_qualifier = Some(q); }
-                        }
+                        call_qualifier = extract_dot_qualifier(&chars, j);
                     }
                     break;
                 }

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -31,6 +31,12 @@ pub(crate) trait NodeExt<'a>: Sized + Copy {
 
     /// Extract the type/class name from a CST class/interface/object/companion_object node.
     fn extract_type_name(self, bytes: &[u8]) -> Option<String>;
+
+    /// For a `call_expression` node, returns `(fn_name, qualifier)`.
+    /// - Simple call `foo(...)` → `("foo", None)`
+    /// - Navigation call `obj.bar(...)` → `("bar", Some("obj"))`
+    /// - Returns `None` if the callee kind is not recognized.
+    fn call_fn_and_qualifier(self, bytes: &[u8]) -> Option<(String, Option<String>)>;
 }
 
 impl<'a> NodeExt<'a> for Node<'a> {
@@ -196,6 +202,38 @@ impl<'a> NodeExt<'a> for Node<'a> {
             }
         }
         None
+    }
+
+    fn call_fn_and_qualifier(self, bytes: &[u8]) -> Option<(String, Option<String>)> {
+        let callee = self.child(0)?;
+        match callee.kind() {
+            "simple_identifier" | "type_identifier" => {
+                let name = std::str::from_utf8(&bytes[callee.byte_range()]).ok()?.to_string();
+                Some((name, None))
+            }
+            "navigation_expression" => {
+                let mut walker = callee.walk();
+                let mut qualifier_opt: Option<String> = None;
+                let mut fn_name_opt: Option<String> = None;
+                for child in callee.children(&mut walker) {
+                    match child.kind() {
+                        "simple_identifier" | "type_identifier" => {
+                            qualifier_opt = std::str::from_utf8(&bytes[child.byte_range()])
+                                .ok().map(|s| s.to_string());
+                        }
+                        "navigation_suffix" => {
+                            fn_name_opt = (0..child.child_count())
+                                .filter_map(|i| child.child(i))
+                                .find(|c| c.kind() == "simple_identifier" || c.kind() == "type_identifier")
+                                .and_then(|c| std::str::from_utf8(&bytes[c.byte_range()]).ok().map(|s| s.to_string()));
+                        }
+                        _ => {}
+                    }
+                }
+                Some((fn_name_opt?, qualifier_opt))
+            }
+            _ => None,
+        }
     }
 }
 

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -37,6 +37,10 @@ pub(crate) trait NodeExt<'a>: Sized + Copy {
     /// - Navigation call `obj.bar(...)` → `("bar", Some("obj"))`
     /// - Returns `None` if the callee kind is not recognized.
     fn call_fn_and_qualifier(self, bytes: &[u8]) -> Option<(String, Option<String>)>;
+
+    /// Returns the line number (0-based) of the first named identifier child,
+    /// or the node's own start line if no named child is found.
+    fn name_line(self) -> u32;
 }
 
 impl<'a> NodeExt<'a> for Node<'a> {
@@ -234,6 +238,20 @@ impl<'a> NodeExt<'a> for Node<'a> {
             }
             _ => None,
         }
+    }
+
+    fn name_line(self) -> u32 {
+        // Java uses field "name"; Kotlin has type_identifier as a direct child.
+        if let Some(n) = self.child_by_field_name("name") {
+            return n.start_position().row as u32;
+        }
+        let mut cur = self.walk();
+        for child in self.children(&mut cur) {
+            if matches!(child.kind(), "type_identifier" | "simple_identifier" | "identifier") {
+                return child.start_position().row as u32;
+            }
+        }
+        self.start_position().row as u32
     }
 }
 

--- a/src/lines_ext.rs
+++ b/src/lines_ext.rs
@@ -3,7 +3,7 @@
 //! Each method is a thin façade over the original free function; no logic
 //! lives here.  The original free functions are kept intact so existing
 //! callers continue to compile during the incremental migration.
-use tower_lsp::lsp_types::Range;
+use tower_lsp::lsp_types::{Range, TextEdit};
 use crate::types::{ImportEntry, Visibility};
 
 pub(crate) trait LinesExt {
@@ -33,6 +33,9 @@ pub(crate) trait LinesExt {
 
     /// Line number at which a new `import` statement should be inserted.
     fn import_insertion_line(&self) -> u32;
+
+    /// Build a TextEdit that inserts an import for `fqn` at the appropriate line.
+    fn make_import_edit(&self, fqn: &str, needs_semicolon: bool) -> TextEdit;
 
     /// Infer the (stripped) type of `var_name` from a type annotation in these lines.
     fn infer_type(&self, var_name: &str) -> Option<String>;
@@ -82,6 +85,10 @@ impl LinesExt for [String] {
 
     fn import_insertion_line(&self) -> u32 {
         crate::resolver::import_insertion_line(self)
+    }
+
+    fn make_import_edit(&self, fqn: &str, needs_semicolon: bool) -> TextEdit {
+        crate::resolver::make_import_edit(fqn, self, needs_semicolon)
     }
 
     fn infer_type(&self, var_name: &str) -> Option<String> {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -105,7 +105,7 @@ pub fn parse_swift(content: &str) -> FileData {
         .matches(&def_q, root, bytes)
         .map(|m| {
             let (pidx, slot) = map_def_captures(&m, def_idx, name_idx, bytes);
-            if pidx == 8 && slot[0].is_none() {
+            if pidx == queries::SWIFT_INIT_PATTERN_IDX && slot[0].is_none() {
                 // init_declaration — no @name, synthesize "init"
                 let def_range = m.captures.iter()
                     .find(|cap| cap.index == def_idx)
@@ -113,9 +113,9 @@ pub fn parse_swift(content: &str) -> FileData {
                 if let Some(dr) = def_range {
                     let sel = Range::new(
                         Position::new(dr.start.line, dr.start.character),
-                        Position::new(dr.start.line, dr.start.character + 4),
+                        Position::new(dr.start.line, dr.start.character + queries::SWIFT_INIT_NAME.len() as u32),
                     );
-                    return (pidx, [Some(("init".to_owned(), dr, sel)), None]);
+                    return (pidx, [Some((queries::SWIFT_INIT_NAME.to_owned(), dr, sel)), None]);
                 }
             }
             (pidx, slot)
@@ -726,29 +726,42 @@ pub fn parse_imports_from_lines(lines: &[String]) -> Vec<crate::types::ImportEnt
 
 // ─── Swift import extraction ─────────────────────────────────────────────────
 
+/// Extract the import path text from an `import_declaration` node, if present.
+fn swift_import_path<'a>(node: tree_sitter::Node<'a>, bytes: &'a [u8]) -> Option<&'a str> {
+    let mut cur = node.walk();
+    for child in node.children(&mut cur) {
+        if child.kind() == "identifier" {
+            return child.utf8_text(bytes).ok();
+        }
+    }
+    None
+}
+
 fn extract_swift_imports(root: tree_sitter::Node, bytes: &[u8], data: &mut FileData) {
     let mut cur = root.walk();
     for node in root.children(&mut cur) {
         if node.kind() == "import_declaration" {
-            let mut ic = node.walk();
-            for child in node.children(&mut ic) {
-                if child.kind() == "identifier" {
-                    if let Ok(txt) = child.utf8_text(bytes) {
-                        let local = last_segment(txt);
-                        data.imports.push(ImportEntry {
-                            full_path:  txt.to_owned(),
-                            local_name: local.to_owned(),
-                            is_star:    false,
-                        });
-                    }
-                    break;
-                }
+            if let Some(txt) = swift_import_path(node, bytes) {
+                let local = last_segment(txt);
+                data.imports.push(ImportEntry {
+                    full_path:  txt.to_owned(),
+                    local_name: local.to_owned(),
+                    is_star:    false,
+                });
             }
         }
     }
 }
 
 // ─── visibility detection ────────────────────────────────────────────────────
+
+/// Returns the portion of `line` before any `{` or `=` — the modifiers region.
+fn decl_prefix(line: &str) -> &str {
+    line.split_once('{').map(|(l, _)| l)
+        .unwrap_or(line)
+        .split_once('=').map(|(l, _)| l)
+        .unwrap_or(line)
+}
 
 /// Detect the Kotlin/Java visibility modifier on `line_no` by scanning that
 /// source line for modifier keywords.
@@ -772,10 +785,7 @@ pub(crate) fn visibility_at_line(lines: &[String], line_no: usize) -> Visibility
     };
     // Work only on the part before any `=`, `{`, or `(` to avoid false positives
     // from string literals / bodies.
-    let decl = line.split_once('{').map(|(l, _)| l)
-        .unwrap_or(line)
-        .split_once('=').map(|(l, _)| l)
-        .unwrap_or(line);
+    let decl = decl_prefix(line);
 
     // Check whole-word tokens.
     if contains_word(decl, "private")   { return Visibility::Private; }
@@ -793,10 +803,7 @@ pub(crate) fn swift_visibility_at_line(lines: &[String], line_no: usize) -> Visi
         Some(l) => l,
         None    => return Visibility::Internal,
     };
-    let decl = line.split_once('{').map(|(l, _)| l)
-        .unwrap_or(line)
-        .split_once('=').map(|(l, _)| l)
-        .unwrap_or(line);
+    let decl = decl_prefix(line);
 
     if contains_word(decl, "private")     { return Visibility::Private; }
     if contains_word(decl, "fileprivate") { return Visibility::Private; }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -412,6 +412,14 @@ fn fun_interface_name_from_fn_decl(node: &Node, bytes: &[u8]) -> Option<(usize, 
     None
 }
 
+fn push_interface_symbol(name: &str, node: &Node, sel_node_range: tree_sitter::Range, data: &mut FileData) {
+    let visibility = visibility_at_line(&data.lines, node.range().start_point.row);
+    let range      = ts_to_lsp(node.range());
+    let sel        = ts_to_lsp(sel_node_range);
+    let detail     = extract_detail(&data.lines, range.start.line, range.end.line);
+    data.symbols.push(SymbolEntry { name: name.to_owned(), kind: SymbolKind::INTERFACE, visibility, range, selection_range: sel, detail });
+}
+
 /// Walk the parse tree and emit INTERFACE symbols for every `fun interface Foo` declaration.
 ///
 /// Tree-sitter produces two different misparsings depending on whether modifiers precede:
@@ -428,18 +436,7 @@ fn extract_fun_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
             for child in node.children(&mut cur) {
                 if child.kind() == "simple_identifier" {
                     if let Ok(name) = child.utf8_text(bytes) {
-                        let visibility = visibility_at_line(&data.lines, node.range().start_point.row);
-                        let range      = ts_to_lsp(node.range());
-                        let sel        = ts_to_lsp(child.range());
-                        let detail     = extract_detail(&data.lines, range.start.line, range.end.line);
-                        data.symbols.push(SymbolEntry {
-                            name: name.to_owned(),
-                            kind: SymbolKind::INTERFACE,
-                            visibility,
-                            range,
-                            selection_range: sel,
-                            detail,
-                        });
+                        push_interface_symbol(name, &node, child.range(), data);
                     }
                     break;
                 }
@@ -450,23 +447,13 @@ fn extract_fun_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
         // Case 2: modifier-prefixed `fun interface` → misparse as function_declaration
         if let Some((name_start, name_end, name_ts_range)) = fun_interface_name_from_fn_decl(&node, bytes) {
             if let Ok(name) = std::str::from_utf8(&bytes[name_start..name_end]) {
-                let visibility = visibility_at_line(&data.lines, node.range().start_point.row);
-                let range      = ts_to_lsp(node.range());
-                let sel        = ts_to_lsp(name_ts_range);
-                let detail     = extract_detail(&data.lines, range.start.line, range.end.line);
+                let sel = ts_to_lsp(name_ts_range);
                 // Remove the incorrectly-added function/method symbol (same name, same line).
                 data.symbols.retain(|s| {
                     !(s.name == name && s.selection_range.start.line == sel.start.line
                       && matches!(s.kind, SymbolKind::FUNCTION | SymbolKind::METHOD))
                 });
-                data.symbols.push(SymbolEntry {
-                    name: name.to_owned(),
-                    kind: SymbolKind::INTERFACE,
-                    visibility,
-                    range,
-                    selection_range: sel,
-                    detail,
-                });
+                push_interface_symbol(name, &node, name_ts_range, data);
             }
             // Still recurse into children to find nested fun interfaces.
         }
@@ -496,6 +483,28 @@ fn has_fun_interface_descendant(node: &Node, bytes: &[u8]) -> bool {
     children.iter().any(|c| has_fun_interface_descendant(c, bytes))
 }
 
+fn report_missing_node(node: &Node, seen: &mut std::collections::HashSet<(u32, u32)>, errors: &mut Vec<SyntaxError>) {
+    let range = ts_to_lsp(node.range());
+    let key = (range.start.line, range.start.character);
+    if seen.insert(key) {
+        let kind = node.kind();
+        errors.push(SyntaxError { range, message: format!("missing `{kind}`") });
+    }
+}
+
+fn report_error_node(node: &Node, bytes: &[u8], seen: &mut std::collections::HashSet<(u32, u32)>, errors: &mut Vec<SyntaxError>) {
+    let range = ts_to_lsp(node.range());
+    let key = (range.start.line, range.start.character);
+    if seen.insert(key) {
+        let text: String = node.utf8_text(bytes).unwrap_or("").chars().take(30).collect();
+        let text = text.lines().next().unwrap_or(&text);
+        errors.push(SyntaxError {
+            range,
+            message: if text.is_empty() { "syntax error".into() } else { format!("unexpected `{text}`") },
+        });
+    }
+}
+
 fn collect_syntax_errors(root: Node, bytes: &[u8]) -> Vec<SyntaxError> {
     if !root.has_error() { return Vec::new(); }
 
@@ -507,37 +516,13 @@ fn collect_syntax_errors(root: Node, bytes: &[u8]) -> Vec<SyntaxError> {
         if errors.len() >= MAX_SYNTAX_ERRORS { break; }
 
         if node.is_missing() {
-            let range = ts_to_lsp(node.range());
-            let key = (range.start.line, range.start.character);
-            if seen.insert(key) {
-                let kind = node.kind();
-                errors.push(SyntaxError {
-                    range,
-                    message: format!("missing `{kind}`"),
-                });
-            }
+            report_missing_node(&node, &mut seen, &mut errors);
         } else if node.is_error() {
             // Skip errors that are actually valid `fun interface` declarations.
             if is_fun_interface_error(&node, bytes) {
                 continue;
             }
-            let range = ts_to_lsp(node.range());
-            let key = (range.start.line, range.start.character);
-            if seen.insert(key) {
-                let text: String = node.utf8_text(bytes).unwrap_or("")
-                    .chars()
-                    .take(30)
-                    .collect();
-                let text = text.lines().next().unwrap_or(&text);
-                errors.push(SyntaxError {
-                    range,
-                    message: if text.is_empty() {
-                        "syntax error".into()
-                    } else {
-                        format!("unexpected `{text}`")
-                    },
-                });
-            }
+            report_error_node(&node, bytes, &mut seen, &mut errors);
             // Recurse into ERROR children to find nested MISSING nodes.
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,7 @@
 use tree_sitter::{Node, Parser, Query, QueryCursor};
 use tower_lsp::lsp_types::{Position, Range, SymbolKind};
 
+use crate::indexer::NodeExt;
 use crate::queries::{self, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS};
 use crate::types::{FileData, ImportEntry, SymbolEntry, SyntaxError, Visibility};
 
@@ -864,7 +865,7 @@ fn extract_supers_kotlin(root: Node, bytes: &[u8], data: &mut FileData) {
     while let Some(node) = stack.pop() {
         match node.kind() {
             "class_declaration" | "object_declaration" => {
-                let name_line = node_name_line(&node);
+                let name_line = node.name_line();
                 let mut cur = node.walk();
                 for child in node.children(&mut cur) {
                     if child.kind() == "delegation_specifier" {
@@ -886,7 +887,7 @@ fn extract_supers_kotlin(root: Node, bytes: &[u8], data: &mut FileData) {
 fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
     match node.kind() {
         "class_declaration" | "record_declaration" | "enum_declaration" => {
-            let name_line = node_name_line(node);
+            let name_line = node.name_line();
             let mut cur = node.walk();
             for child in node.children(&mut cur) {
                 match child.kind() {
@@ -905,7 +906,7 @@ fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
             }
         }
         "interface_declaration" => {
-            let name_line = node_name_line(node);
+            let name_line = node.name_line();
             let mut cur = node.walk();
             for child in node.children(&mut cur) {
                 if child.kind() == "extends_interfaces" {
@@ -916,21 +917,6 @@ fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
         }
         _ => {}
     }
-}
-
-/// Get the start line of the class-name identifier — matches `SymbolEntry::selection_range.start.line`.
-fn node_name_line(node: &Node) -> u32 {
-    // Java uses field "name"; Kotlin has type_identifier as a direct child.
-    if let Some(n) = node.child_by_field_name("name") {
-        return n.start_position().row as u32;
-    }
-    let mut cur = node.walk();
-    for child in node.children(&mut cur) {
-        if matches!(child.kind(), "type_identifier" | "simple_identifier" | "identifier") {
-            return child.start_position().row as u32;
-        }
-    }
-    node.start_position().row as u32
 }
 
 /// Extract the supertype name from a `delegation_specifier` node.

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -332,3 +332,10 @@ pub fn swift_def_pattern_meta(pattern_index: usize) -> (SymbolKind, Option<&'sta
         _  => (SymbolKind::NULL,            None),
     }
 }
+
+/// Pattern index of `init_declaration` in `SWIFT_DEFINITIONS`.
+/// Pattern 8 has no `@name` capture — the parser synthesises `"init"` instead.
+pub const SWIFT_INIT_PATTERN_IDX: usize = 8;
+
+/// Synthesised name for Swift init declarations.
+pub const SWIFT_INIT_NAME: &str = "init";

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -226,6 +226,24 @@ pub(crate) fn complete_dot(idx: &Indexer, receiver: &str, from_uri: &Url, snippe
     items
 }
 
+/// Build a `CompletionItem` for a symbol found inside a nested type body.
+///
+/// Functions/methods get a snippet `name($1)`; all other kinds are plain-text.
+/// The `sort_text` prefix is the `kind_sort_rank` value so the list is ordered
+/// consistently with the rest of the completion results.
+fn completion_item_for_nested_symbol(s: &crate::types::SymbolEntry) -> CompletionItem {
+    let kind  = symbol_kind_to_completion(s.kind);
+    let is_fn = matches!(kind, CompletionItemKind::FUNCTION | CompletionItemKind::METHOD);
+    CompletionItem {
+        label:              s.name.clone(),
+        kind:               Some(kind),
+        insert_text:        if is_fn { Some(format!("{}($1)", s.name)) } else { None },
+        insert_text_format: if is_fn { Some(InsertTextFormat::SNIPPET) } else { None },
+        sort_text:          Some(format!("{:02}:{}", kind_sort_rank(Some(kind)), s.name)),
+        ..Default::default()
+    }
+}
+
 /// Return completions for symbols declared INSIDE `type_name` within the given file.
 /// Uses the symbol's range end (the closing `}` of the class body) to determine
 /// membership — no indentation heuristics needed.
@@ -256,18 +274,7 @@ fn symbols_from_nested_type(
             // Unknown type — return all non-private symbols as a fallback.
             return symbols_ref.iter()
                 .filter(|s| s.visibility != Visibility::Private)
-                .map(|s| {
-                    let kind = symbol_kind_to_completion(s.kind);
-                    let is_fn = matches!(kind, CompletionItemKind::FUNCTION | CompletionItemKind::METHOD);
-                    CompletionItem {
-                        label:              s.name.clone(),
-                        kind:               Some(kind),
-                        insert_text:        if is_fn { Some(format!("{}($1)", s.name)) } else { None },
-                        insert_text_format: if is_fn { Some(InsertTextFormat::SNIPPET) } else { None },
-                        sort_text:          Some(format!("{:02}:{}", kind_sort_rank(Some(kind)), s.name)),
-                        ..Default::default()
-                    }
-                })
+                .map(|s| completion_item_for_nested_symbol(s))
                 .collect();
         }
     };
@@ -288,18 +295,7 @@ fn symbols_from_nested_type(
             starts_after && starts_before
         })
         .filter(|s| s.visibility != Visibility::Private)
-        .map(|s| {
-            let kind = symbol_kind_to_completion(s.kind);
-            let is_fn = matches!(kind, CompletionItemKind::FUNCTION | CompletionItemKind::METHOD);
-            CompletionItem {
-                label:              s.name.clone(),
-                kind:               Some(kind),
-                insert_text:        if is_fn { Some(format!("{}($1)", s.name)) } else { None },
-                insert_text_format: if is_fn { Some(InsertTextFormat::SNIPPET) } else { None },
-                sort_text:          Some(format!("{:02}:{}", kind_sort_rank(Some(kind)), s.name)),
-                ..Default::default()
-            }
-        })
+        .map(|s| completion_item_for_nested_symbol(s))
         .collect()
 }
 

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -7,7 +7,7 @@ use crate::indexer::Indexer;
 use crate::types::Visibility;
 use crate::LinesExt;
 
-use super::{fqns_for_name, already_imported, make_import_edit,
+use super::{fqns_for_name, already_imported,
             resolve_symbol_inner, resolve_symbol_no_rg};
 use super::infer::{infer_variable_type, ReceiverKind, ReceiverType, infer_receiver_type};
 
@@ -488,7 +488,7 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
                     if !seen.insert(item_key) { continue; }
 
                     let import_edit = if needs_import {
-                        Some(vec![make_import_edit(fqn, &cur_lines, is_java)])
+                        Some(vec![cur_lines.make_import_edit(fqn, is_java)])
                     } else {
                         None
                     };

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -225,6 +225,27 @@ pub(crate) fn resolve_symbol_inner(idx: &Indexer, name: &str, from_uri: &Url, wi
     rg_find_definition(name, root.as_deref(), matcher.as_deref())
 }
 
+/// Returns the first Location found by scanning star-import packages.
+fn find_in_star_imports(
+    idx: &Indexer,
+    name: &str,
+    star_pkgs: &[String],
+) -> Option<Location> {
+    for pkg in star_pkgs {
+        let peer_uris: Vec<String> = idx.packages.get(pkg).map(|u| u.clone()).unwrap_or_default();
+        for peer_uri_str in peer_uris {
+            if let Some(f) = idx.files.get(&peer_uri_str) {
+                for sym in f.symbols.iter().filter(|s| s.name == name) {
+                    if let Ok(u) = Url::parse(&peer_uri_str) {
+                        return Some(Location { uri: u, range: sym.selection_range });
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Index-only resolver for use in completion paths.
 ///
 /// Identical to `resolve_symbol_inner` but omits:
@@ -252,17 +273,8 @@ pub(crate) fn resolve_symbol_no_rg(idx: &Indexer, name: &str, from_uri: &Url) ->
             .collect(),
         None => vec![],
     };
-    for pkg in star_pkgs {
-        let peer_uris: Vec<String> = idx.packages.get(&pkg).map(|u| u.clone()).unwrap_or_default();
-        for peer_uri_str in peer_uris {
-            if let Some(f) = idx.files.get(&peer_uri_str) {
-                for sym in f.symbols.iter().filter(|s| s.name == name) {
-                    if let Ok(u) = Url::parse(&peer_uri_str) {
-                        return vec![Location { uri: u, range: sym.selection_range }];
-                    }
-                }
-            }
-        }
+    if let Some(loc) = find_in_star_imports(idx, name, &star_pkgs) {
+        return vec![loc];
     }
 
     // Check the global definitions index as a final fast fallback.
@@ -611,6 +623,25 @@ fn resolve_same_package(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
     vec![]
 }
 
+/// Check all indexed files whose package starts with `pkg_prefix` for a symbol named `name`.
+fn symbols_in_package(
+    idx: &Indexer,
+    name: &str,
+    pkg_prefix: &str,
+) -> Vec<Location> {
+    let peer_uris: Vec<String> = idx.packages.get(pkg_prefix).map(|u| u.clone()).unwrap_or_default();
+    for peer_uri_str in peer_uris {
+        if let Some(f) = idx.files.get(&peer_uri_str) {
+            for sym in f.symbols.iter().filter(|s| s.name == name) {
+                if let Ok(u) = Url::parse(&peer_uri_str) {
+                    return vec![Location { uri: u, range: sym.selection_range }];
+                }
+            }
+        }
+    }
+    vec![]
+}
+
 /// Step 4 — star imports: `import com.example.*`.
 ///
 /// For each star import:
@@ -630,16 +661,8 @@ fn resolve_star_imports(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
 
     for pkg in star_pkgs {
         // a) indexed files in this package
-        let peer_uris: Vec<String> = idx.packages.get(&pkg).map(|u| u.clone()).unwrap_or_default();
-        for peer_uri_str in peer_uris {
-            if let Some(f) = idx.files.get(&peer_uri_str) {
-                for sym in f.symbols.iter().filter(|s| s.name == name) {
-                    if let Ok(u) = Url::parse(&peer_uri_str) {
-                        return vec![Location { uri: u, range: sym.selection_range }];
-                    }
-                }
-            }
-        }
+        let locs = symbols_in_package(idx, name, &pkg);
+        if !locs.is_empty() { return locs; }
 
         // b) rg scoped to the package directory for unindexed files
         let root_guard = idx.workspace_root.read().unwrap();


### PR DESCRIPTION
Zero-behaviour-change refactoring — phases 13 and 14.

## Phase 13 — helper extraction
- `push_interface_symbol`, `report_missing_node`/`report_error_node` dedup in `parser.rs`
- `NodeExt::call_fn_and_qualifier` replaces 42-line manual navigation in `handlers.rs`
- `scan_multiline_call_open` extracted from `text_call_info`
- `completion_item_for_nested_symbol` dedup in `resolver/complete.rs`

## Phase 14 — nesting reduction + trait additions
- `find_in_star_imports`, `symbols_in_package` flatten 4-deep loop in `resolver/mod.rs`
- `find_call_open_on_line`, `extract_dot_qualifier` extracted in `handlers.rs`
- `NodeExt::name_line`, `LinesExt::make_import_edit` added as trait methods
- Swift: `decl_prefix` helper deduplicates visibility functions; `swift_import_path` flattens inner loop
- Swift: `SWIFT_INIT_PATTERN_IDX`/`SWIFT_INIT_NAME` constants replace magic values

**Followed by**: PR #32 (phase 15 — named constants + review fixes)