### PR TITLE
refactor: phases 16-17 — string/char helpers, NodeExt extensions, walker loop cleanup

### DIFF
--- a/src/backend/actions.rs
+++ b/src/backend/actions.rs
@@ -3,6 +3,7 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use super::Backend;
 use super::rename::whole_word_replace_file;
+use crate::StrExt;
 
 /// Returns true if `name` is a keyword that precedes a block but is NOT
 /// a function call — i.e. we should NOT show signature help for it.
@@ -64,7 +65,7 @@ fn derive_var_name(expr: &str) -> String {
     let result = if seg.starts_with("get") && seg.len() > "get".len() {
         let rest = &seg["get".len()..];
         // Only strip if next char is uppercase (proper camelCase).
-        if crate::indexer::starts_with_uppercase(rest) {
+        if rest.starts_with_uppercase() {
             let r = if let Some(first) = rest.chars().next() {
                 let mut s = first.to_lowercase().collect::<String>();
                 s.push_str(&rest[first.len_utf8()..]);
@@ -257,7 +258,7 @@ impl Backend {
         //       User then does  %s_Word<ret>cNewName<esc>  in Helix.
         // Only for Kotlin/KTS files — Java/Swift use different rename flows.
         if is_kotlin && !is_import_line && !cursor_word.is_empty()
-            && crate::indexer::starts_with_uppercase(&cursor_word)
+            && cursor_word.starts_with_uppercase()
         {
             // Combined: add `as _Word` to matching import + rename Word→_Word in body (single action).
             if !all_lines.is_empty() {

--- a/src/backend/actions.rs
+++ b/src/backend/actions.rs
@@ -64,7 +64,7 @@ fn derive_var_name(expr: &str) -> String {
     let result = if seg.starts_with("get") && seg.len() > "get".len() {
         let rest = &seg["get".len()..];
         // Only strip if next char is uppercase (proper camelCase).
-        if rest.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+        if crate::indexer::starts_with_uppercase(rest) {
             let r = if let Some(first) = rest.chars().next() {
                 let mut s = first.to_lowercase().collect::<String>();
                 s.push_str(&rest[first.len_utf8()..]);
@@ -257,7 +257,7 @@ impl Backend {
         //       User then does  %s_Word<ret>cNewName<esc>  in Helix.
         // Only for Kotlin/KTS files — Java/Swift use different rename flows.
         if is_kotlin && !is_import_line && !cursor_word.is_empty()
-            && cursor_word.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
+            && crate::indexer::starts_with_uppercase(&cursor_word)
         {
             // Combined: add `as _Word` to matching import + rename Word→_Word in body (single action).
             if !all_lines.is_empty() {

--- a/src/backend/actions.rs
+++ b/src/backend/actions.rs
@@ -61,8 +61,8 @@ fn derive_var_name(expr: &str) -> String {
 
     // Strip common accessor prefixes: getXxx → xxx, isXxx → isXxx (keep),
     // hasXxx → hasXxx (keep), setXxx → skip (nothing useful).
-    let result = if seg.starts_with("get") && seg.len() > 3 {
-        let rest = &seg[3..];
+    let result = if seg.starts_with("get") && seg.len() > "get".len() {
+        let rest = &seg["get".len()..];
         // Only strip if next char is uppercase (proper camelCase).
         if rest.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
             let r = if let Some(first) = rest.chars().next() {

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -594,7 +594,6 @@ const MAX_SCAN_BACK_LINES: usize = 10;
 fn scan_multiline_call_open(
     lines: &[String],
     line_idx: usize,
-    before: &str,
 ) -> Option<(String, Option<String>, u32)> {
     let scan_start = line_idx.saturating_sub(MAX_SCAN_BACK_LINES);
     for scan_line in (scan_start..line_idx).rev() {
@@ -671,7 +670,7 @@ fn text_call_info(
     let in_block_body = before.contains('{') || before.contains('}')
         || lines[line_idx].trim_start().starts_with('}');
     if call_name.is_none() && line_idx > 0 && !in_block_body {
-        if let Some((name, qual, extra)) = scan_multiline_call_open(lines, line_idx, before) {
+        if let Some((name, qual, extra)) = scan_multiline_call_open(lines, line_idx) {
             call_name = Some(name);
             call_qualifier = qual;
             active_param += extra;

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -8,6 +8,9 @@ use super::cursor::CursorContext;
 use super::helpers::resolve_references_scope;
 use super::actions::is_non_call_keyword;
 
+/// Maximum number of workspace symbol results to return.
+const WORKSPACE_SYMBOL_CAP: usize = 512;
+
 impl Backend {
     pub(super) async fn hover_impl(&self, params: HoverParams) -> Result<Option<Hover>> {
         let pp       = params.text_document_position_params;
@@ -298,11 +301,11 @@ impl Backend {
                     },
                     container_name: if sym.detail.is_empty() { None } else { Some(sym.detail.clone()) },
                 });
-                if results.len() >= 512 {
+                if results.len() >= WORKSPACE_SYMBOL_CAP {
                     break;
                 }
             }
-            if results.len() >= 512 {
+            if results.len() >= WORKSPACE_SYMBOL_CAP {
                 break;
             }
         }
@@ -584,12 +587,15 @@ fn find_call_open_on_line(line: &str) -> Option<(String, Option<String>)> {
 /// Returns `(call_name, qualifier, extra_commas)` where `extra_commas` is
 /// the count of commas on the intermediate lines plus the commas in `before`
 /// (to add to `active_param`).
+/// Maximum number of lines to scan backward when looking for a multi-line call opener.
+const MAX_SCAN_BACK_LINES: usize = 10;
+
 fn scan_multiline_call_open(
     lines: &[String],
     line_idx: usize,
     before: &str,
 ) -> Option<(String, Option<String>, u32)> {
-    let scan_start = line_idx.saturating_sub(10);
+    let scan_start = line_idx.saturating_sub(MAX_SCAN_BACK_LINES);
     for scan_line in (scan_start..line_idx).rev() {
         let l = &lines[scan_line];
         if l.contains('{') || l.contains('}') { break; }

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -530,49 +530,7 @@ fn cst_call_info(
     }?;
 
     // Extract function name and optional qualifier from the callee.
-    let callee = call_expr.child(0)?;
-    let (fn_name, qualifier) = match callee.kind() {
-        "simple_identifier" | "type_identifier" => {
-            let name = std::str::from_utf8(&bytes[callee.byte_range()]).ok()?.to_string();
-            (name, None)
-        }
-        "navigation_expression" => {
-            // Tree structure: navigation_expression
-            //   simple_identifier "receiver"        ← direct child (the qualifier)
-            //   navigation_suffix                   ← direct child
-            //     "."
-            //     simple_identifier "methodName"    ← fn name lives here
-            //
-            // We must look inside navigation_suffix for the function name, NOT
-            // use direct-children-only iteration which misses the nested identifier.
-            let mut fn_name_opt: Option<String> = None;
-            let mut qualifier_opt: Option<String> = None;
-            let mut walker = callee.walk();
-            for child in callee.children(&mut walker) {
-                match child.kind() {
-                    "simple_identifier" | "type_identifier" => {
-                        // First direct identifier = the receiver/qualifier.
-                        qualifier_opt = std::str::from_utf8(&bytes[child.byte_range()])
-                            .ok().map(|s| s.to_string());
-                    }
-                    "navigation_suffix" => {
-                        // The function name is the simple_identifier inside the suffix.
-                        let mut sw = child.walk();
-                        for sc in child.children(&mut sw) {
-                            if sc.kind() == "simple_identifier" || sc.kind() == "type_identifier" {
-                                fn_name_opt = std::str::from_utf8(&bytes[sc.byte_range()])
-                                    .ok().map(|s| s.to_string());
-                                break;
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            (fn_name_opt?, qualifier_opt)
-        }
-        _ => return None,
-    };
+    let (fn_name, qualifier) = call_expr.call_fn_and_qualifier(bytes)?;
 
     // Find the value_arguments node (may be inside call_suffix).
     let value_arguments = call_expr.find_value_arguments()?;
@@ -594,6 +552,74 @@ fn cst_call_info(
     };
 
     Some((fn_name, qualifier, active_param))
+}
+
+/// Scans a single source line for an unclosed call-site opening.
+/// Returns `(call_name, qualifier)` if an unbalanced `name(` is found,
+/// where net > 0 means more opens than closes on this line.
+fn find_call_open_on_line(line: &str) -> Option<(String, Option<String>)> {
+    for (p, _) in line.char_indices().filter(|&(_, c)| c == '(')
+        .collect::<Vec<_>>().into_iter().rev()
+    {
+        let before_paren = &line[..p];
+        let name = crate::indexer::last_ident_in(before_paren);
+        if !name.is_empty() && !is_non_call_keyword(name) {
+            let net: i32 = line[p..].chars()
+                .map(|c| match c { '(' => 1, ')' => -1, _ => 0 }).sum();
+            if net > 0 {
+                // Qualifier before the dot on the same line.
+                let before_name = &before_paren[..before_paren.len() - name.len()];
+                let qualifier = if before_name.ends_with('.') {
+                    let q = crate::indexer::last_ident_in(before_name.strip_suffix('.').unwrap_or(before_name));
+                    if q.is_empty() { None } else { Some(q.to_owned()) }
+                } else { None };
+                return Some((name.to_owned(), qualifier));
+            }
+        }
+    }
+    None
+}
+
+/// Scans up to 10 lines before `line_idx` for an unclosed `fn(` call site.
+/// Returns `(call_name, qualifier, extra_commas)` where `extra_commas` is
+/// the count of commas on the intermediate lines plus the commas in `before`
+/// (to add to `active_param`).
+fn scan_multiline_call_open(
+    lines: &[String],
+    line_idx: usize,
+    before: &str,
+) -> Option<(String, Option<String>, u32)> {
+    let scan_start = line_idx.saturating_sub(10);
+    for scan_line in (scan_start..line_idx).rev() {
+        let l = &lines[scan_line];
+        if l.contains('{') || l.contains('}') { break; }
+        if let Some((name, qualifier)) = find_call_open_on_line(l) {
+            let mut extra: u32 = 0;
+            if scan_line + 1 < line_idx {
+                for mid in &lines[(scan_line + 1)..line_idx] {
+                    extra += mid.chars().filter(|&c| c == ',').count() as u32;
+                }
+            }
+            extra += before.chars().filter(|&c| c == ',').count() as u32;
+            return Some((name, qualifier, extra));
+        }
+    }
+    None
+}
+
+/// Given `chars` and position `j` (start of the identifier), extract
+/// the qualifier immediately before a `.` if present.
+fn extract_dot_qualifier(chars: &[char], j: usize) -> Option<String> {
+    if j > 0 && chars[j - 1] == '.' {
+        let mut k = j - 1;
+        while k > 0 && (chars[k - 1].is_alphanumeric() || chars[k - 1] == '_') {
+            k -= 1;
+        }
+        let q: String = chars[k..j - 1].iter().collect();
+        if !q.is_empty() { Some(q) } else { None }
+    } else {
+        None
+    }
 }
 
 /// Text-scan fallback: extract `(fn_name, qualifier, active_param)` by walking
@@ -624,14 +650,7 @@ fn text_call_info(
                     let candidate: String = chars[j..i].iter().collect();
                     if !candidate.is_empty() && !is_non_call_keyword(&candidate) {
                         call_name = Some(candidate);
-                        if j > 0 && chars[j - 1] == '.' {
-                            let mut k = j - 1;
-                            while k > 0 && (chars[k - 1].is_alphanumeric() || chars[k - 1] == '_') {
-                                k -= 1;
-                            }
-                            let q: String = chars[k..j - 1].iter().collect();
-                            if !q.is_empty() { call_qualifier = Some(q); }
-                        }
+                        call_qualifier = extract_dot_qualifier(&chars, j);
                     }
                     break;
                 }
@@ -646,37 +665,10 @@ fn text_call_info(
     let in_block_body = before.contains('{') || before.contains('}')
         || lines[line_idx].trim_start().starts_with('}');
     if call_name.is_none() && line_idx > 0 && !in_block_body {
-        let scan_start = line_idx.saturating_sub(10);
-        'outer: for scan_line in (scan_start..line_idx).rev() {
-            let l = &lines[scan_line];
-            if l.contains('{') || l.contains('}') { break; }
-            for (p, _) in l.char_indices().filter(|&(_, c)| c == '(')
-                .collect::<Vec<_>>().into_iter().rev()
-            {
-                let before_paren = &l[..p];
-                let name = crate::indexer::last_ident_in(before_paren);
-                if !name.is_empty() && !is_non_call_keyword(name) {
-                    let net: i32 = l[p..].chars()
-                        .map(|c| match c { '(' => 1, ')' => -1, _ => 0 }).sum();
-                    if net > 0 {
-                        // Qualifier before the dot on the same line.
-                        let before_name = &before_paren[..before_paren.len() - name.len()];
-                        let qualifier = if before_name.ends_with('.') {
-                            let q = crate::indexer::last_ident_in(before_name.strip_suffix('.').unwrap_or(before_name));
-                            if q.is_empty() { None } else { Some(q.to_owned()) }
-                        } else { None };
-                        call_name = Some(name.to_owned());
-                        call_qualifier = qualifier;
-                        if scan_line + 1 < line_idx {
-                            for mid in &lines[(scan_line + 1)..line_idx] {
-                                active_param += mid.chars().filter(|&c| c == ',').count() as u32;
-                            }
-                        }
-                        active_param += before.chars().filter(|&c| c == ',').count() as u32;
-                        break 'outer;
-                    }
-                }
-            }
+        if let Some((name, qual, extra)) = scan_multiline_call_open(lines, line_idx, before) {
+            call_name = Some(name);
+            call_qualifier = qual;
+            active_param += extra;
         }
     }
 

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -583,10 +583,10 @@ fn find_call_open_on_line(line: &str) -> Option<(String, Option<String>)> {
     None
 }
 
-/// Scans up to 10 lines before `line_idx` for an unclosed `fn(` call site.
-/// Returns `(call_name, qualifier, extra_commas)` where `extra_commas` is
-/// the count of commas on the intermediate lines plus the commas in `before`
-/// (to add to `active_param`).
+/// Scans up to `MAX_SCAN_BACK_LINES` lines before `line_idx` for an unclosed `fn(` call site.
+/// Returns `(call_name, qualifier, extra_commas)` where `extra_commas` counts commas on the
+/// intermediate lines only (between the opening line and `line_idx`, exclusive). Commas on
+/// `line_idx` itself (in `before`) are already counted by the caller.
 /// Maximum number of lines to scan backward when looking for a multi-line call opener.
 const MAX_SCAN_BACK_LINES: usize = 10;
 
@@ -606,7 +606,6 @@ fn scan_multiline_call_open(
                     extra += mid.chars().filter(|&c| c == ',').count() as u32;
                 }
             }
-            extra += before.chars().filter(|&c| c == ',').count() as u32;
             return Some((name, qualifier, extra));
         }
     }

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -3,6 +3,7 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use crate::indexer::find_fun_signature_with_receiver;
 use crate::indexer::NodeExt;
+use crate::queries::KIND_VALUE_ARG;
 use super::Backend;
 use super::cursor::CursorContext;
 use super::helpers::resolve_references_scope;
@@ -547,7 +548,7 @@ fn cst_call_info(
         let mut count = 0u32;
         let mut walker = value_arguments.walk();
         for child in value_arguments.children(&mut walker) {
-            if child.kind() == "value_argument" {
+            if child.kind() == KIND_VALUE_ARG {
                 if child.end_byte() <= cursor_byte { count += 1; } else { break; }
             }
         }

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -2,6 +2,7 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use crate::indexer::find_fun_signature_with_receiver;
 use crate::indexer::NodeExt;
+use crate::StrExt;
 use crate::queries::KIND_VALUE_ARG;
 use super::Backend;
 use super::cursor::CursorContext;
@@ -565,7 +566,7 @@ fn find_call_open_on_line(line: &str) -> Option<(String, Option<String>)> {
         .collect::<Vec<_>>().into_iter().rev()
     {
         let before_paren = &line[..p];
-        let name = crate::indexer::last_ident_in(before_paren);
+        let name = before_paren.last_ident_in();
         if !name.is_empty() && !is_non_call_keyword(name) {
             let net: i32 = line[p..].chars()
                 .map(|c| match c { '(' => 1, ')' => -1, _ => 0 }).sum();
@@ -573,7 +574,7 @@ fn find_call_open_on_line(line: &str) -> Option<(String, Option<String>)> {
                 // Qualifier before the dot on the same line.
                 let before_name = &before_paren[..before_paren.len() - name.len()];
                 let qualifier = if before_name.ends_with('.') {
-                    let q = crate::indexer::last_ident_in(before_name.strip_suffix('.').unwrap_or(before_name));
+                    let q = before_name.strip_suffix('.').unwrap_or(before_name).last_ident_in();
                     if q.is_empty() { None } else { Some(q.to_owned()) }
                 } else { None };
                 return Some((name.to_owned(), qualifier));

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -4,6 +4,7 @@ use crate::indexer::find_fun_signature_with_receiver;
 use crate::indexer::NodeExt;
 use crate::StrExt;
 use crate::queries::KIND_VALUE_ARG;
+use crate::inlay_hints::compute_inlay_hints;
 use super::Backend;
 use super::cursor::CursorContext;
 use super::helpers::resolve_references_scope;
@@ -246,7 +247,7 @@ impl Backend {
     ) -> Result<Option<Vec<InlayHint>>> {
         let uri   = &params.text_document.uri;
         let range = params.range;
-        let hints = crate::inlay_hints::compute_inlay_hints(&self.indexer, uri, range);
+        let hints = compute_inlay_hints(&self.indexer, uri, range);
         Ok(if hints.is_empty() { None } else { Some(hints) })
     }
 

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -1,4 +1,3 @@
-use std::sync::Arc;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use crate::indexer::find_fun_signature_with_receiver;

--- a/src/backend/helpers.rs
+++ b/src/backend/helpers.rs
@@ -1,5 +1,6 @@
 use tower_lsp::lsp_types::*;
 use crate::types::SyntaxError;
+use crate::StrExt;
 
 /// Determine the `(parent_class, declared_pkg)` scope for a `findReferences` request.
 ///
@@ -18,7 +19,7 @@ pub(super) fn resolve_references_scope(
     line: u32,
     name: &str,
 ) -> (Option<String>, Option<String>) {
-    if !crate::indexer::starts_with_uppercase(name) {
+    if !name.starts_with_uppercase() {
         return (None, None);
     }
     let on_decl = idx.is_declared_in(uri, name)

--- a/src/backend/helpers.rs
+++ b/src/backend/helpers.rs
@@ -18,7 +18,7 @@ pub(super) fn resolve_references_scope(
     line: u32,
     name: &str,
 ) -> (Option<String>, Option<String>) {
-    if !name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+    if !crate::indexer::starts_with_uppercase(name) {
         return (None, None);
     }
     let on_decl = idx.is_declared_in(uri, name)

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -7,7 +7,7 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{async_trait, Client, LanguageServer};
 
-use crate::indexer::{Indexer, IgnoreMatcher};
+use crate::indexer::{Indexer, IgnoreMatcher, workspace_cache_path};
 use self::helpers::syntax_diagnostics;
 
 pub mod nav;
@@ -301,7 +301,7 @@ impl LanguageServer for Backend {
                     }
                 }
             };
-            let cache_path = crate::indexer::workspace_cache_path(&target_root);
+            let cache_path = workspace_cache_path(&target_root);
             if let Some(cache_dir) = cache_path.parent() {
                 match std::fs::remove_dir_all(cache_dir) {
                     Ok(_) => {

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -2,6 +2,7 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use super::Backend;
 use super::cursor::CursorContext;
+use crate::parser::parse_by_extension;
 
 fn locs_to_response(locs: Vec<Location>) -> GotoDefinitionResponse {
     match locs.len() {
@@ -200,7 +201,7 @@ impl Backend {
         // Fallback: parse live_lines for the open file itself.
         if let Some(lines) = self.indexer.live_lines.get(uri.as_str()) {
             let content = lines.join("\n");
-            let names: Vec<String> = crate::parser::parse_by_extension(uri.path(), &content)
+            let names: Vec<String> = parse_by_extension(uri.path(), &content)
                 .supers.into_iter().map(|(_, n)| n).collect();
             if !names.is_empty() { return names; }
         }

--- a/src/backend/rename.rs
+++ b/src/backend/rename.rs
@@ -181,7 +181,7 @@ impl Backend {
         };
 
         // ── Resolve scoping (same logic as `references`) ────────────────────
-        let (parent_class, declared_pkg) = if name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+        let (parent_class, declared_pkg) = if crate::indexer::starts_with_uppercase(&name) {
             let on_decl = self.indexer.is_declared_in(uri, &name)
                 && self.indexer.definitions.get(&name)
                     .map(|locs| locs.iter().any(|l| l.uri == *uri && l.range.start.line == pos.line))

--- a/src/backend/rename.rs
+++ b/src/backend/rename.rs
@@ -2,6 +2,7 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use super::Backend;
 use super::actions::is_non_call_keyword;
+use crate::StrExt;
 
 /// Replace all whole-word occurrences of `word` in `lines` with `replacement`.
 /// Returns the full new file content as a single string (lines joined with `\n`).
@@ -181,7 +182,7 @@ impl Backend {
         };
 
         // ── Resolve scoping (same logic as `references`) ────────────────────
-        let (parent_class, declared_pkg) = if crate::indexer::starts_with_uppercase(&name) {
+        let (parent_class, declared_pkg) = if name.starts_with_uppercase() {
             let on_decl = self.indexer.is_declared_in(uri, &name)
                 && self.indexer.definitions.get(&name)
                     .map(|locs| locs.iter().any(|l| l.uri == *uri && l.range.start.line == pos.line))

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -523,6 +523,20 @@ pub(crate) fn starts_with_lowercase(s: &str) -> bool {
     s.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
 }
 
+/// Returns the leading identifier portion of `s` — all leading chars satisfying `is_id_char`.
+/// `"foo.bar()"` → `"foo"`;  `"Bar<T>"` → `"Bar"`.
+#[inline]
+pub(crate) fn ident_prefix(s: &str) -> String {
+    s.chars().take_while(|&c| is_id_char(c)).collect()
+}
+
+/// Returns the leading dotted-identifier portion of `s` — all leading chars satisfying `is_id_char` or `.`.
+/// `"foo.Bar.baz()"` → `"foo.Bar.baz"`.
+#[inline]
+pub(crate) fn dotted_ident_prefix(s: &str) -> String {
+    s.chars().take_while(|&c| is_id_char(c) || c == '.').collect()
+}
+
 // ─── rg cross-file fallback ──────────────────────────────────────────────────
 
 // ─── tests ───────────────────────────────────────────────────────────────────

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -509,14 +509,14 @@ fn dot_receiver(before_prefix: &str) -> Option<String> {
     Some(inner.to_owned())
 }
 
-/// Returns `true` if `s` starts with an uppercase ASCII letter.
+/// Returns `true` if `s` starts with an uppercase letter (Unicode-aware).
 /// Returns `false` for empty strings.
 #[inline]
 pub(crate) fn starts_with_uppercase(s: &str) -> bool {
     s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
 }
 
-/// Returns `true` if `s` starts with a lowercase ASCII letter.
+/// Returns `true` if `s` starts with a lowercase letter (Unicode-aware).
 /// Returns `false` for empty strings.
 #[inline]
 pub(crate) fn starts_with_lowercase(s: &str) -> bool {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -2080,11 +2080,11 @@ class Foo @Inject constructor(
 
     #[test]
     fn last_ident_in_simple() {
-        assert_eq!(crate::indexer::last_ident_in("foo.barBaz"), "barBaz");
+        assert_eq!("foo.barBaz".last_ident_in(), "barBaz");
     }
     #[test]
     fn last_ident_in_whole_string() {
-        assert_eq!(crate::indexer::last_ident_in("identifier"), "identifier");
+        assert_eq!("identifier".last_ident_in(), "identifier");
     }
     #[test]
     fn last_ident_in_empty() {
@@ -2092,11 +2092,11 @@ class Foo @Inject constructor(
     }
     #[test]
     fn last_ident_in_no_ident() {
-        assert_eq!(crate::indexer::last_ident_in("foo.bar("), "");
+        assert_eq!("foo.bar(".last_ident_in(), "");
     }
     #[test]
     fn last_ident_in_with_spaces() {
-        assert_eq!(crate::indexer::last_ident_in("  someIdent"), "someIdent");
+        assert_eq!("  someIdent".last_ident_in(), "someIdent");
     }
 
     // ── completion helpers ───────────────────────────────────────────────────

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -6,6 +6,7 @@ use std::sync::{Arc, RwLock};
 use dashmap::{DashMap, DashSet};
 use tower_lsp::lsp_types::*;
 
+use crate::StrExt;
 use crate::types::{FileData, CursorPos};
 
 // Re-export rg-module items that existing callers reach via `crate::indexer::`.
@@ -497,50 +498,16 @@ fn dot_receiver(before_prefix: &str) -> Option<String> {
     if inner.is_empty() { return None; }
     let remaining = &before_dot[..before_dot.len() - inner.len()];
     if remaining.ends_with('.')
-        && starts_with_uppercase(inner)
+        && inner.starts_with_uppercase()
     {
         let outer = last_ident_in(&remaining[..remaining.len() - 1]);
         if !outer.is_empty()
-            && starts_with_uppercase(outer)
+            && outer.starts_with_uppercase()
         {
             return Some(format!("{outer}.{inner}"));
         }
     }
     Some(inner.to_owned())
-}
-
-/// Returns `true` if `s` starts with an uppercase letter (Unicode-aware).
-/// Returns `false` for empty strings.
-#[inline]
-pub(crate) fn starts_with_uppercase(s: &str) -> bool {
-    s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
-}
-
-/// Returns `true` if `s` starts with a lowercase letter (Unicode-aware).
-/// Returns `false` for empty strings.
-#[inline]
-pub(crate) fn starts_with_lowercase(s: &str) -> bool {
-    s.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
-}
-
-/// Returns the leading identifier portion of `s` — all leading chars satisfying `is_id_char`.
-/// `"foo.bar()"` → `"foo"`;  `"Bar<T>"` → `"Bar"`.
-#[inline]
-pub(crate) fn ident_prefix(s: &str) -> String {
-    s.chars().take_while(|&c| is_id_char(c)).collect()
-}
-
-/// Returns the leading dotted-identifier portion of `s` — all leading chars satisfying `is_id_char` or `.`.
-/// `"foo.Bar.baz()"` → `"foo.Bar.baz"`.
-#[inline]
-pub(crate) fn dotted_ident_prefix(s: &str) -> String {
-    s.chars().take_while(|&c| is_id_char(c) || c == '.').collect()
-}
-
-/// Returns the trailing dot-separated segment of a dotted path.
-/// E.g. `"com.example.Foo"` → `"Foo"`, `"Foo"` → `"Foo"`.
-pub(crate) fn last_segment(dotted: &str) -> &str {
-    dotted.rsplit('.').next().unwrap_or(dotted)
 }
 
 // ─── rg cross-file fallback ──────────────────────────────────────────────────

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -83,6 +83,7 @@ use self::cache::{FileCacheEntry, cache_entry_to_file_result};
 use crate::types::{IndexStats, FileIndexResult};
 #[cfg(test)]
 use crate::rg::regex_escape;
+use crate::resolver::{complete_symbol, complete_symbol_with_context, is_annotation_context, infer_variable_type_raw};
 #[cfg(test)]
 use std::path::Path;
 
@@ -202,7 +203,7 @@ impl crate::indexer::infer::InferDeps for Indexer {
         find_fun_signature_full(fn_name, self, uri)
     }
     fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String> {
-        crate::resolver::infer_variable_type_raw(self, var_name, uri)
+        infer_variable_type_raw(self, var_name, uri)
     }
 }
 
@@ -427,7 +428,7 @@ impl Indexer {
                 let cursor_col  = before.chars().count();
                 let elem_type = self.resolve_lambda_recv_type(recv, before, cursor_line, cursor_col, uri);
                 if let Some(elem_type) = elem_type {
-                    let (items, _) = crate::resolver::complete_symbol(self, prefix, Some(&elem_type), uri, snippets);
+                    let (items, _) = complete_symbol(self, prefix, Some(&elem_type), uri, snippets);
                     if items.is_empty() {
                         // Type name known (e.g. generic param `T`, `StateType`) but not
                         // indexed — show a single hint item so the user sees the inferred type.
@@ -447,8 +448,8 @@ impl Indexer {
         }
 
         let annotation_only = dot_recv.is_none()
-            && crate::resolver::is_annotation_context(before, prefix);
-        let (mut items, hit_cap) = crate::resolver::complete_symbol_with_context(
+            && is_annotation_context(before, prefix);
+        let (mut items, hit_cap) = complete_symbol_with_context(
             self, prefix, dot_recv.as_deref(), uri, snippets, annotation_only,
         );
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -537,6 +537,12 @@ pub(crate) fn dotted_ident_prefix(s: &str) -> String {
     s.chars().take_while(|&c| is_id_char(c) || c == '.').collect()
 }
 
+/// Returns the trailing dot-separated segment of a dotted path.
+/// E.g. `"com.example.Foo"` → `"Foo"`, `"Foo"` → `"Foo"`.
+pub(crate) fn last_segment(dotted: &str) -> &str {
+    dotted.rsplit('.').next().unwrap_or(dotted)
+}
+
 // ─── rg cross-file fallback ──────────────────────────────────────────────────
 
 // ─── tests ───────────────────────────────────────────────────────────────────

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -497,16 +497,30 @@ fn dot_receiver(before_prefix: &str) -> Option<String> {
     if inner.is_empty() { return None; }
     let remaining = &before_dot[..before_dot.len() - inner.len()];
     if remaining.ends_with('.')
-        && inner.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
+        && starts_with_uppercase(inner)
     {
         let outer = last_ident_in(&remaining[..remaining.len() - 1]);
         if !outer.is_empty()
-            && outer.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
+            && starts_with_uppercase(outer)
         {
             return Some(format!("{outer}.{inner}"));
         }
     }
     Some(inner.to_owned())
+}
+
+/// Returns `true` if `s` starts with an uppercase ASCII letter.
+/// Returns `false` for empty strings.
+#[inline]
+pub(crate) fn starts_with_uppercase(s: &str) -> bool {
+    s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
+}
+
+/// Returns `true` if `s` starts with a lowercase ASCII letter.
+/// Returns `false` for empty strings.
+#[inline]
+pub(crate) fn starts_with_lowercase(s: &str) -> bool {
+    s.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
 }
 
 // ─── rg cross-file fallback ──────────────────────────────────────────────────

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -436,9 +436,7 @@ impl Indexer {
                 let mut rest = t;
                 while let Some(ci) = rest.find(':') {
                     let after = rest[ci + 1..].trim_start();
-                    let type_name: String = after.chars()
-                        .take_while(|&c| c.is_alphanumeric() || c == '_')
-                        .collect();
+                    let type_name = crate::indexer::ident_prefix(after);
                     if !type_name.is_empty()
                         && crate::indexer::starts_with_uppercase(&type_name)
                         && seen.insert(type_name.clone())

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -25,6 +25,7 @@ use tower_lsp::lsp_types::*;
 
 use crate::indexer::discover::find_source_files_unconstrained;
 use crate::types::{FileData, FileIndexResult, WorkspaceIndexResult};
+use crate::StrExt;
 use super::{FileContributions, StaleKeys, Indexer};
 
 // ─── hash helper ─────────────────────────────────────────────────────────────
@@ -436,9 +437,9 @@ impl Indexer {
                 let mut rest = t;
                 while let Some(ci) = rest.find(':') {
                     let after = rest[ci + 1..].trim_start();
-                    let type_name = crate::indexer::ident_prefix(after);
+                    let type_name = after.ident_prefix();
                     if !type_name.is_empty()
-                        && crate::indexer::starts_with_uppercase(&type_name)
+                        && type_name.starts_with_uppercase()
                         && seen.insert(type_name.clone())
                     {
                         type_names.push(type_name);

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -26,6 +26,8 @@ use tower_lsp::lsp_types::*;
 use crate::indexer::discover::find_source_files_unconstrained;
 use crate::types::{FileData, FileIndexResult, WorkspaceIndexResult};
 use crate::StrExt;
+use crate::parser::parse_by_extension;
+use crate::resolver::symbols_from_uri_as_completions_pub;
 use super::{FileContributions, StaleKeys, Indexer};
 
 // ─── hash helper ─────────────────────────────────────────────────────────────
@@ -128,7 +130,7 @@ impl Indexer {
     /// Parse a single file via tree-sitter and extract symbols, supertypes, and a
     /// content hash.  Pure — no writes to any `Indexer` field.
     pub fn parse_file(uri: &Url, content: &str) -> FileIndexResult {
-        let data = crate::parser::parse_by_extension(uri.path(), content);
+        let data = parse_by_extension(uri.path(), content);
         let hash = hash_str(content);
 
         // Extract supertype relationships for goToImplementation.
@@ -463,7 +465,7 @@ impl Indexer {
                     if let Some(loc) = locs.first() {
                         let file_uri = loc.uri.to_string();
                         if idx.completion_cache.contains_key(&file_uri) { return; }
-                        crate::resolver::symbols_from_uri_as_completions_pub(&idx, &file_uri);
+                        symbols_from_uri_as_completions_pub(&idx, &file_uri);
                     }
                 }).await.ok();
             });

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -440,7 +440,7 @@ impl Indexer {
                         .take_while(|&c| c.is_alphanumeric() || c == '_')
                         .collect();
                     if !type_name.is_empty()
-                        && type_name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
+                        && crate::indexer::starts_with_uppercase(&type_name)
                         && seen.insert(type_name.clone())
                     {
                         type_names.push(type_name);

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -67,8 +67,7 @@ pub(crate) fn find_as_call_arg_type(
                         if let Some(fn_name) = fn_full.split('.').next_back().filter(|n| !n.is_empty()) {
                             if let Some(sig) = find_fun_signature_full(fn_name, idx, uri) {
                                 if let Some(param_type) = find_named_param_type_in_sig(&sig, named_arg) {
-                                    let base: String = param_type.trim()
-                                        .chars().take_while(|&c| is_id_char(c)).collect();
+                                    let base = crate::indexer::ident_prefix(param_type.trim());
                                     if !base.is_empty() { return Some(base); }
                                 }
                             }
@@ -125,8 +124,7 @@ pub(crate) fn find_as_call_arg_type(
                             .split('.').next_back().filter(|n| !n.is_empty())?;
                         let sig = find_fun_signature_full(fn_name, idx, uri)?;
                         let param_type = nth_fun_param_type_str(&sig, arg_pos)?;
-                        let base: String = param_type.trim()
-                            .chars().take_while(|&c| is_id_char(c)).collect();
+                        let base = crate::indexer::ident_prefix(param_type.trim());
                         return if base.is_empty() { None } else { Some(base) };
                     }
                 }
@@ -323,7 +321,7 @@ fn cst_call_arg_type(pos: CursorPos, idx: &Indexer, uri: &Url) -> Option<String>
         nth_fun_param_type_str(&sig, value_arg.value_arg_position())
     }?;
 
-    let base: String = param_type.trim().chars().take_while(|&c| is_id_char(c)).collect();
+    let base = crate::indexer::ident_prefix(param_type.trim());
     if base.is_empty() { None } else { Some(base) }
 }
 

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -12,6 +12,9 @@ use crate::types::CursorPos;
 
 // ─── Type-directed call-argument inference ────────────────────────────────────
 
+/// Lines to scan backward when searching for the enclosing function call in inlay-hint inference.
+const ARG_SCAN_BACK_LINES: usize = 20;
+
 /// Type-directed inference for `it` or `this` used as a call argument.
 ///
 /// When `it`/`this` appears as an argument to a function — either as a **named arg**
@@ -86,7 +89,7 @@ pub(crate) fn find_as_call_arg_type(
     let mut depth: i32 = 0;
     let mut brace_depth: i32 = 0;
     let mut arg_pos: usize = 0;
-    let scan_start = pos.line.saturating_sub(20);
+    let scan_start = pos.line.saturating_sub(ARG_SCAN_BACK_LINES);
 
     for ln in (scan_start..=pos.line).rev() {
         let chars: Vec<char> = lines[ln].chars().collect();

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -162,7 +162,7 @@ pub(crate) fn extract_named_arg_name(before_brace: &str) -> Option<&str> {
     let ident = &s[ident_start..];
     if ident.is_empty() { return None; }
     // Named args start with a lowercase letter
-    if !ident.starts_with_lowercase() { return None; }
+    if ident.starts_with_uppercase() { return None; }
     // Require the prefix to be only whitespace (optionally preceded by a comma).
     // This prevents `(isRefresh = {` from matching — the `(` before `isRefresh`
     // makes the prefix non-empty after stripping commas and whitespace.

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -10,6 +10,7 @@ use crate::indexer::NodeExt;
 use crate::indexer::infer::sig::{find_fun_signature_full, nth_fun_param_type_str, split_params_at_depth_zero};
 use crate::queries::KIND_CALL_EXPR;
 use crate::types::CursorPos;
+use crate::StrExt;
 
 // ─── Type-directed call-argument inference ────────────────────────────────────
 
@@ -68,7 +69,7 @@ pub(crate) fn find_as_call_arg_type(
                         if let Some(fn_name) = fn_full.split('.').next_back().filter(|n| !n.is_empty()) {
                             if let Some(sig) = find_fun_signature_full(fn_name, idx, uri) {
                                 if let Some(param_type) = find_named_param_type_in_sig(&sig, named_arg) {
-                                    let base = crate::indexer::ident_prefix(param_type.trim());
+                                    let base = param_type.trim().ident_prefix();
                                     if !base.is_empty() { return Some(base); }
                                 }
                             }
@@ -125,7 +126,7 @@ pub(crate) fn find_as_call_arg_type(
                             .split('.').next_back().filter(|n| !n.is_empty())?;
                         let sig = find_fun_signature_full(fn_name, idx, uri)?;
                         let param_type = nth_fun_param_type_str(&sig, arg_pos)?;
-                        let base = crate::indexer::ident_prefix(param_type.trim());
+                        let base = param_type.trim().ident_prefix();
                         return if base.is_empty() { None } else { Some(base) };
                     }
                 }
@@ -161,7 +162,7 @@ pub(crate) fn extract_named_arg_name(before_brace: &str) -> Option<&str> {
     let ident = &s[ident_start..];
     if ident.is_empty() { return None; }
     // Named args start with a lowercase letter
-    if !crate::indexer::starts_with_lowercase(ident) { return None; }
+    if !ident.starts_with_lowercase() { return None; }
     // Require the prefix to be only whitespace (optionally preceded by a comma).
     // This prevents `(isRefresh = {` from matching — the `(` before `isRefresh`
     // makes the prefix non-empty after stripping commas and whitespace.
@@ -322,7 +323,7 @@ fn cst_call_arg_type(pos: CursorPos, idx: &Indexer, uri: &Url) -> Option<String>
         nth_fun_param_type_str(&sig, value_arg.value_arg_position())
     }?;
 
-    let base = crate::indexer::ident_prefix(param_type.trim());
+    let base = param_type.trim().ident_prefix();
     if base.is_empty() { None } else { Some(base) }
 }
 

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -162,7 +162,7 @@ pub(crate) fn extract_named_arg_name(before_brace: &str) -> Option<&str> {
     let ident = &s[ident_start..];
     if ident.is_empty() { return None; }
     // Named args start with a lowercase letter
-    if ident.chars().next().map(|c| c.is_uppercase()).unwrap_or(true) { return None; }
+    if !crate::indexer::starts_with_lowercase(ident) { return None; }
     // Require the prefix to be only whitespace (optionally preceded by a comma).
     // This prevents `(isRefresh = {` from matching — the `(` before `isRefresh`
     // makes the prefix non-empty after stripping commas and whitespace.

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -8,6 +8,7 @@ use tower_lsp::lsp_types::Url;
 use crate::indexer::{Indexer, is_id_char, find_enclosing_call_name};
 use crate::indexer::NodeExt;
 use crate::indexer::infer::sig::{find_fun_signature_full, nth_fun_param_type_str, split_params_at_depth_zero};
+use crate::queries::KIND_CALL_EXPR;
 use crate::types::CursorPos;
 
 // ─── Type-directed call-argument inference ────────────────────────────────────
@@ -305,7 +306,7 @@ fn cst_call_arg_type(pos: CursorPos, idx: &Indexer, uri: &Url) -> Option<String>
     let mut node = value_arg;
     let call_expr = loop {
         match node.parent() {
-            Some(p) if p.kind() == "call_expression" => break Some(p),
+            Some(p) if p.kind() == KIND_CALL_EXPR => break Some(p),
             Some(p) => node = p,
             None => break None,
         }

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -39,6 +39,7 @@ use super::{
 use crate::indexer::NodeExt;
 use crate::queries::{KIND_LAMBDA_LIT, KIND_CALL_EXPR};
 use crate::StrExt;
+use crate::resolver::extract_collection_element_type;
 
 // ── from indexer.rs (parent of infer; descendants can access private items) ──
 use super::super::{
@@ -234,7 +235,7 @@ pub(crate) fn lambda_receiver_type_from_context(
 
         if !receiver_var.is_empty() {
             if let Some(raw) = deps.find_var_type(receiver_var, uri) {
-                if let Some(elem) = crate::resolver::extract_collection_element_type(&raw) {
+                if let Some(elem) = extract_collection_element_type(&raw) {
                     return Some(elem);
                 }
                 // Non-collection receiver: prefer the method's own lambda param type when

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -38,6 +38,7 @@ use super::{
 
 use crate::indexer::NodeExt;
 use crate::queries::{KIND_LAMBDA_LIT, KIND_CALL_EXPR};
+use crate::StrExt;
 
 // ── from indexer.rs (parent of infer; descendants can access private items) ──
 use super::super::{
@@ -187,7 +188,7 @@ pub(crate) fn is_lambda_param(
 ) -> bool {
     // Fast reject: if `recv` starts with uppercase or contains `.` it's a type/qualified
     // name, never a lambda parameter name.
-    if crate::indexer::starts_with_uppercase(recv) { return false; }
+    if recv.starts_with_uppercase() { return false; }
     if recv.contains('.') { return false; }
 
     // Same-line fast check: the lambda declaration may be on the cursor line
@@ -230,7 +231,7 @@ pub(crate) fn lambda_receiver_type_from_context(
         let receiver_expr = callee[..dot_pos].trim_end();
         let receiver_var = last_ident_in(receiver_expr);
         // Extract method name (everything after the dot up to the first non-id char).
-        let method = crate::indexer::ident_prefix(callee[dot_pos + 1..].trim_start());
+        let method = callee[dot_pos + 1..].trim_start().ident_prefix();
 
         if !receiver_var.is_empty() {
             if let Some(raw) = deps.find_var_type(receiver_var, uri) {
@@ -246,12 +247,12 @@ pub(crate) fn lambda_receiver_type_from_context(
                         return Some(ty);
                     }
                 }
-                let base = crate::indexer::ident_prefix(&raw);
-                if !base.is_empty() && crate::indexer::starts_with_uppercase(&base) {
+                let base = raw.ident_prefix();
+                if !base.is_empty() && base.starts_with_uppercase() {
                     return Some(base);
                 }
             }
-            if crate::indexer::starts_with_uppercase(receiver_var) {
+            if receiver_var.starts_with_uppercase() {
                 return Some(receiver_var.to_owned());
             }
         }
@@ -268,12 +269,12 @@ pub(crate) fn lambda_receiver_type_from_context(
         if trailing_fn == "with" {
             if let Some(recv_name) = extract_first_arg(trimmed) {
                 if let Some(raw) = deps.find_var_type(recv_name, uri) {
-                    let base = crate::indexer::ident_prefix(&raw);
+                    let base = raw.ident_prefix();
                     if !base.is_empty() { return Some(base); }
                 }
                 // If recv_name starts uppercase it IS the type (companion / object ref).
-                let base = crate::indexer::ident_prefix(recv_name);
-                if crate::indexer::starts_with_uppercase(&base) {
+                let base = recv_name.ident_prefix();
+                if base.starts_with_uppercase() {
                     return Some(base);
                 }
             }
@@ -446,14 +447,14 @@ fn lambda_brace_arrows(line: &str) -> impl Iterator<Item = (usize, &str)> {
 
 fn names_has_param(names_str: &str, param_name: &str) -> bool {
     names_str.split(',').any(|tok| {
-        let n = crate::indexer::ident_prefix(tok.trim());
+        let n = tok.trim().ident_prefix();
         n == param_name
     })
 }
 
 fn param_index_in(names_str: &str, param_name: &str) -> Option<usize> {
     names_str.split(',').enumerate().find_map(|(i, tok)| {
-        let n = crate::indexer::ident_prefix(tok.trim());
+        let n = tok.trim().ident_prefix();
         if n == param_name { Some(i) } else { None }
     })
 }
@@ -517,7 +518,7 @@ fn lambda_receiver_this_type_from_context(
     if let Some(dot_pos) = find_last_dot_at_depth_zero(callee) {
         let receiver_expr = callee[..dot_pos].trim_end();
         let receiver_var = last_ident_in(receiver_expr);
-        let method = crate::indexer::ident_prefix(callee[dot_pos + 1..].trim_start());
+        let method = callee[dot_pos + 1..].trim_start().ident_prefix();
 
         if !receiver_var.is_empty() && !method.is_empty() {
             // Prefer the method's own receiver-lambda type (only for indexed fns).
@@ -528,10 +529,10 @@ fn lambda_receiver_this_type_from_context(
             // receiver-`this` lambdas; `also`/`let` are intentionally excluded.
             if RECEIVER_THIS_FNS.contains(&method.as_str()) {
                 if let Some(raw) = deps.find_var_type(receiver_var, uri) {
-                    let base = crate::indexer::ident_prefix(&raw);
+                    let base = raw.ident_prefix();
                     if !base.is_empty() { return Some(base); }
                 }
-                if crate::indexer::starts_with_uppercase(receiver_var) {
+                if receiver_var.starts_with_uppercase() {
                     return Some(receiver_var.to_owned());
                 }
             }
@@ -544,11 +545,11 @@ fn lambda_receiver_this_type_from_context(
     if trailing_fn == "with" {
         if let Some(recv_name) = extract_first_arg(trimmed) {
             if let Some(raw) = deps.find_var_type(recv_name, uri) {
-                let base = crate::indexer::ident_prefix(&raw);
+                let base = raw.ident_prefix();
                 if !base.is_empty() { return Some(base); }
             }
-            let base = crate::indexer::ident_prefix(recv_name);
-            if crate::indexer::starts_with_uppercase(&base) {
+            let base = recv_name.ident_prefix();
+            if base.starts_with_uppercase() {
                 return Some(base);
             }
         }

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -37,6 +37,7 @@ use super::{
 };
 
 use crate::indexer::NodeExt;
+use crate::queries::{KIND_LAMBDA_LIT, KIND_CALL_EXPR};
 
 // ── from indexer.rs (parent of infer; descendants can access private items) ──
 use super::super::{
@@ -315,7 +316,7 @@ fn cst_it_or_this_type(
 ) -> Option<String> {
     let mut cur = start_node;
     loop {
-        if cur.kind() == "lambda_literal" && !cur.has_lambda_named_params(&doc.bytes) {
+        if cur.kind() == KIND_LAMBDA_LIT && !cur.has_lambda_named_params(&doc.bytes) {
             // Extract text of the lambda-opening line up to the `{`.
             let brace_byte = cur.start_byte();
             let line_start = doc.bytes[..brace_byte]
@@ -655,7 +656,7 @@ fn cst_lambda_param_type_via_call(
                 let mut node = parent;
                 let call_expr = loop {
                     let p = node.parent()?;
-                    if p.kind() == "call_expression" { break p; }
+                    if p.kind() == KIND_CALL_EXPR { break p; }
                     node = p;
                 };
                 let fn_name = call_expr.call_fn_name(bytes)?;
@@ -670,7 +671,7 @@ fn cst_lambda_param_type_via_call(
             "call_suffix" => {
                 // Trailing lambda: `fn(...) { it }` or `fn { it }`.
                 let call_expr = parent.parent()?;
-                if call_expr.kind() != "call_expression" { cur = parent; continue; }
+                if call_expr.kind() != KIND_CALL_EXPR { cur = parent; continue; }
                 let fn_name = call_expr.call_fn_name(bytes)?;
                 let sig = deps.find_fun_params_text(&fn_name, uri)?;
                 let last_type = last_fun_param_type_str(&sig)?;

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -229,9 +229,7 @@ pub(crate) fn lambda_receiver_type_from_context(
         let receiver_expr = callee[..dot_pos].trim_end();
         let receiver_var = last_ident_in(receiver_expr);
         // Extract method name (everything after the dot up to the first non-id char).
-        let method: String = callee[dot_pos + 1..].trim_start()
-            .chars().take_while(|&c| is_id_char(c))
-            .collect();
+        let method = crate::indexer::ident_prefix(callee[dot_pos + 1..].trim_start());
 
         if !receiver_var.is_empty() {
             if let Some(raw) = deps.find_var_type(receiver_var, uri) {
@@ -247,7 +245,7 @@ pub(crate) fn lambda_receiver_type_from_context(
                         return Some(ty);
                     }
                 }
-                let base: String = raw.chars().take_while(|&c| is_id_char(c)).collect();
+                let base = crate::indexer::ident_prefix(&raw);
                 if !base.is_empty() && crate::indexer::starts_with_uppercase(&base) {
                     return Some(base);
                 }
@@ -269,11 +267,11 @@ pub(crate) fn lambda_receiver_type_from_context(
         if trailing_fn == "with" {
             if let Some(recv_name) = extract_first_arg(trimmed) {
                 if let Some(raw) = deps.find_var_type(recv_name, uri) {
-                    let base: String = raw.chars().take_while(|&c| is_id_char(c)).collect();
+                    let base = crate::indexer::ident_prefix(&raw);
                     if !base.is_empty() { return Some(base); }
                 }
                 // If recv_name starts uppercase it IS the type (companion / object ref).
-                let base: String = recv_name.chars().take_while(|&c| is_id_char(c)).collect();
+                let base = crate::indexer::ident_prefix(recv_name);
                 if crate::indexer::starts_with_uppercase(&base) {
                     return Some(base);
                 }
@@ -518,9 +516,7 @@ fn lambda_receiver_this_type_from_context(
     if let Some(dot_pos) = find_last_dot_at_depth_zero(callee) {
         let receiver_expr = callee[..dot_pos].trim_end();
         let receiver_var = last_ident_in(receiver_expr);
-        let method: String = callee[dot_pos + 1..].trim_start()
-            .chars().take_while(|&c| is_id_char(c))
-            .collect();
+        let method = crate::indexer::ident_prefix(callee[dot_pos + 1..].trim_start());
 
         if !receiver_var.is_empty() && !method.is_empty() {
             // Prefer the method's own receiver-lambda type (only for indexed fns).
@@ -531,7 +527,7 @@ fn lambda_receiver_this_type_from_context(
             // receiver-`this` lambdas; `also`/`let` are intentionally excluded.
             if RECEIVER_THIS_FNS.contains(&method.as_str()) {
                 if let Some(raw) = deps.find_var_type(receiver_var, uri) {
-                    let base: String = raw.chars().take_while(|&c| is_id_char(c)).collect();
+                    let base = crate::indexer::ident_prefix(&raw);
                     if !base.is_empty() { return Some(base); }
                 }
                 if crate::indexer::starts_with_uppercase(receiver_var) {
@@ -547,10 +543,10 @@ fn lambda_receiver_this_type_from_context(
     if trailing_fn == "with" {
         if let Some(recv_name) = extract_first_arg(trimmed) {
             if let Some(raw) = deps.find_var_type(recv_name, uri) {
-                let base: String = raw.chars().take_while(|&c| is_id_char(c)).collect();
+                let base = crate::indexer::ident_prefix(&raw);
                 if !base.is_empty() { return Some(base); }
             }
-            let base: String = recv_name.chars().take_while(|&c| is_id_char(c)).collect();
+            let base = crate::indexer::ident_prefix(recv_name);
             if crate::indexer::starts_with_uppercase(&base) {
                 return Some(base);
             }

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -186,7 +186,7 @@ pub(crate) fn is_lambda_param(
 ) -> bool {
     // Fast reject: if `recv` starts with uppercase or contains `.` it's a type/qualified
     // name, never a lambda parameter name.
-    if recv.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) { return false; }
+    if crate::indexer::starts_with_uppercase(recv) { return false; }
     if recv.contains('.') { return false; }
 
     // Same-line fast check: the lambda declaration may be on the cursor line
@@ -248,11 +248,11 @@ pub(crate) fn lambda_receiver_type_from_context(
                     }
                 }
                 let base: String = raw.chars().take_while(|&c| is_id_char(c)).collect();
-                if !base.is_empty() && base.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+                if !base.is_empty() && crate::indexer::starts_with_uppercase(&base) {
                     return Some(base);
                 }
             }
-            if receiver_var.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+            if crate::indexer::starts_with_uppercase(receiver_var) {
                 return Some(receiver_var.to_owned());
             }
         }
@@ -274,7 +274,7 @@ pub(crate) fn lambda_receiver_type_from_context(
                 }
                 // If recv_name starts uppercase it IS the type (companion / object ref).
                 let base: String = recv_name.chars().take_while(|&c| is_id_char(c)).collect();
-                if base.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+                if crate::indexer::starts_with_uppercase(&base) {
                     return Some(base);
                 }
             }
@@ -534,7 +534,7 @@ fn lambda_receiver_this_type_from_context(
                     let base: String = raw.chars().take_while(|&c| is_id_char(c)).collect();
                     if !base.is_empty() { return Some(base); }
                 }
-                if receiver_var.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+                if crate::indexer::starts_with_uppercase(receiver_var) {
                     return Some(receiver_var.to_owned());
                 }
             }
@@ -551,7 +551,7 @@ fn lambda_receiver_this_type_from_context(
                 if !base.is_empty() { return Some(base); }
             }
             let base: String = recv_name.chars().take_while(|&c| is_id_char(c)).collect();
-            if base.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+            if crate::indexer::starts_with_uppercase(&base) {
                 return Some(base);
             }
         }

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -445,14 +445,14 @@ fn lambda_brace_arrows(line: &str) -> impl Iterator<Item = (usize, &str)> {
 
 fn names_has_param(names_str: &str, param_name: &str) -> bool {
     names_str.split(',').any(|tok| {
-        let n: String = tok.trim().chars().take_while(|&c| c.is_alphanumeric() || c == '_').collect();
+        let n = crate::indexer::ident_prefix(tok.trim());
         n == param_name
     })
 }
 
 fn param_index_in(names_str: &str, param_name: &str) -> Option<usize> {
     names_str.split(',').enumerate().find_map(|(i, tok)| {
-        let n: String = tok.trim().chars().take_while(|&c| c.is_alphanumeric() || c == '_').collect();
+        let n = crate::indexer::ident_prefix(tok.trim());
         if n == param_name { Some(i) } else { None }
     })
 }

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -48,6 +48,18 @@ use super::super::{
 
 use crate::types::CursorPos;
 
+/// Lines to scan backward for `{ param_name ->` in the multiline hover/goto path
+/// (full-file scan from `find_named_lambda_param_type_in_lines`).
+const LAMBDA_PARAM_SCAN_BACK_LINES: usize = 40;
+
+/// Lines to scan backward for `{ param_name ->` in the single-line completion path
+/// (from `find_named_lambda_param_type`).
+const LAMBDA_PARAM_SCAN_BACK: usize = 20;
+
+/// Lines to scan backward when searching for the enclosing lambda opener
+/// in the text-fallback path of `find_it_element_type_in_lines_impl`.
+const IT_SCAN_BACK_LINES: usize = 15;
+
 // ─── public API ──────────────────────────────────────────────────────────────
 
 /// Resolve the element type of `it` when inside a lambda.
@@ -104,7 +116,7 @@ pub(crate) fn find_named_lambda_param_type_in_lines(
     idx:         &Indexer,
     uri:         &Url,
 ) -> Option<String> {
-    let scan_start = cursor_line.saturating_sub(40);
+    let scan_start = cursor_line.saturating_sub(LAMBDA_PARAM_SCAN_BACK_LINES);
     // Include cursor_line itself (different from completion path which is exclusive).
     for ln in (scan_start..=cursor_line).rev() {
         let line = match lines.get(ln) { Some(l) => l, None => continue };
@@ -148,7 +160,7 @@ pub(crate) fn find_named_lambda_param_type(
 
     // 2. Scan backward through previous lines.
     let lines = lines?;
-    let scan_start = cursor_line.saturating_sub(20);
+    let scan_start = cursor_line.saturating_sub(LAMBDA_PARAM_SCAN_BACK);
     for ln in (scan_start..cursor_line).rev() {
         let line = match lines.get(ln) { Some(l) => l, None => continue };
         let Some((brace_pos, pos)) = find_lambda_brace_for_param(line, param_name) else { continue; };
@@ -368,7 +380,7 @@ fn find_it_element_type_in_lines_impl(
     // Characters to the right of the cursor (e.g., closing `}`) must not affect
     // the depth; otherwise a balanced `{ it.name }` would never trigger depth < 0.
     let mut depth: i32 = 0;
-    let scan_start = pos.line.saturating_sub(15);
+    let scan_start = pos.line.saturating_sub(IT_SCAN_BACK_LINES);
 
     for ln in (scan_start..=pos.line).rev() {
         let line = match lines.get(ln) { Some(l) => l, None => continue };

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -43,7 +43,6 @@ use crate::StrExt;
 // ── from indexer.rs (parent of infer; descendants can access private items) ──
 use super::super::{
     Indexer,
-    is_id_char,
     last_ident_in,
     find_enclosing_call_name,
 };

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -8,6 +8,7 @@
 use super::*;
 use tower_lsp::lsp_types::Url;
 use super::super::super::Indexer;
+use crate::queries::KIND_LAMBDA_LIT;
 
 fn uri(path: &str) -> Url {
     Url::parse(&format!("file:///test{path}")).unwrap()
@@ -420,7 +421,7 @@ fn has_lambda_named_params_false_for_no_params() {
     let src = "val x = items.map { it.name }";
     let bytes = src.as_bytes();
     let tree = parse_kotlin(src);
-    let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+    let lambda = find_node_kind(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
     assert!(!super::has_lambda_named_params(lambda, bytes),
         "no lambda_parameters child should yield false");
 }
@@ -431,7 +432,7 @@ fn has_lambda_named_params_false_for_it() {
     let src = "val x = items.map { it -> it.name }";
     let bytes = src.as_bytes();
     let tree = parse_kotlin(src);
-    let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+    let lambda = find_node_kind(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
     assert!(!super::has_lambda_named_params(lambda, bytes),
         "param named `it` should yield false");
 }
@@ -442,7 +443,7 @@ fn has_lambda_named_params_true_for_named() {
     let src = "val x = items.map { item -> item.name }";
     let bytes = src.as_bytes();
     let tree = parse_kotlin(src);
-    let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+    let lambda = find_node_kind(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
     assert!(super::has_lambda_named_params(lambda, bytes),
         "param named `item` should yield true");
 }
@@ -453,7 +454,7 @@ fn has_lambda_named_params_false_for_underscore() {
     let src = "val x = items.map { _ -> 42 }";
     let bytes = src.as_bytes();
     let tree = parse_kotlin(src);
-    let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+    let lambda = find_node_kind(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
     assert!(!super::has_lambda_named_params(lambda, bytes),
         "param named `_` should yield false");
 }

--- a/src/indexer/infer/lambda.rs
+++ b/src/indexer/infer/lambda.rs
@@ -7,6 +7,8 @@
 #[path = "lambda_tests.rs"]
 mod tests;
 
+use crate::StrExt;
+
 /// Kotlin stdlib scope functions whose lambda receives the object as `this` (receiver lambdas).
 /// For these, `this` inside the lambda refers to `T` (the receiver), so a type hint is valid.
 ///
@@ -69,10 +71,10 @@ pub(crate) fn lambda_type_nth_input(ty: &str, n: usize) -> Option<String> {
     // Strip `suspend` keyword from function-type args like `suspend (T) -> Unit`.
     let arg = strip_suspend(arg);
     // Allow dots for qualified types like `CreditCardDashboardInteractor.CardProduct`.
-    let base: String = crate::indexer::dotted_ident_prefix(arg);
+    let base: String = arg.dotted_ident_prefix();
     // Trim any trailing dots.
     let base = base.trim_end_matches('.');
-    if base.is_empty() || !crate::indexer::starts_with_uppercase(base) {
+    if base.is_empty() || !base.starts_with_uppercase() {
         return None;
     }
     Some(base.to_owned())
@@ -85,7 +87,7 @@ pub(crate) fn lambda_type_receiver(ty: &str) -> Option<String> {
     let ty = strip_suspend(ty.trim());
     if let Some(dot_paren) = ty.find(".(") {
         let receiver = ty[..dot_paren].trim();
-        let base: String = crate::indexer::dotted_ident_prefix(receiver);
+        let base: String = receiver.dotted_ident_prefix();
         let base = base.trim_end_matches('.');
         if !base.is_empty() {
             return Some(base.to_owned());
@@ -110,9 +112,9 @@ pub(crate) fn lambda_type_first_input(ty: &str) -> Option<String> {
     // The implicit receiver is the `it`/`this`-equivalent inside the lambda.
     if let Some(dot_paren) = ty.find(".(") {
         let receiver = ty[..dot_paren].trim();
-        let base: String = crate::indexer::dotted_ident_prefix(receiver);
+        let base: String = receiver.dotted_ident_prefix();
         let base = base.trim_end_matches('.');
-        if !base.is_empty() && crate::indexer::starts_with_uppercase(base) {
+        if !base.is_empty() && base.starts_with_uppercase() {
             return Some(base.to_owned());
         }
     }
@@ -164,9 +166,9 @@ pub(crate) fn lambda_type_first_input(ty: &str) -> Option<String> {
     };
 
     // Return the base type name (allow qualified names like `Outer.Inner`, strip generics).
-    let base: String = crate::indexer::dotted_ident_prefix(first);
+    let base: String = first.dotted_ident_prefix();
     let base = base.trim_end_matches('.');
-    if base.is_empty() || !crate::indexer::starts_with_uppercase(base) {
+    if base.is_empty() || !base.starts_with_uppercase() {
         return None;
     }
     Some(base.to_owned())

--- a/src/indexer/infer/lambda.rs
+++ b/src/indexer/infer/lambda.rs
@@ -72,7 +72,7 @@ pub(crate) fn lambda_type_nth_input(ty: &str, n: usize) -> Option<String> {
     let base: String = arg.chars().take_while(|&c| is_id_char(c) || c == '.').collect();
     // Trim any trailing dots.
     let base = base.trim_end_matches('.');
-    if base.is_empty() || !base.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+    if base.is_empty() || !crate::indexer::starts_with_uppercase(base) {
         return None;
     }
     Some(base.to_owned())
@@ -112,7 +112,7 @@ pub(crate) fn lambda_type_first_input(ty: &str) -> Option<String> {
         let receiver = ty[..dot_paren].trim();
         let base: String = receiver.chars().take_while(|&c| is_id_char(c) || c == '.').collect();
         let base = base.trim_end_matches('.');
-        if !base.is_empty() && base.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+        if !base.is_empty() && crate::indexer::starts_with_uppercase(base) {
             return Some(base.to_owned());
         }
     }
@@ -166,7 +166,7 @@ pub(crate) fn lambda_type_first_input(ty: &str) -> Option<String> {
     // Return the base type name (allow qualified names like `Outer.Inner`, strip generics).
     let base: String = first.chars().take_while(|&c| is_id_char(c) || c == '.').collect();
     let base = base.trim_end_matches('.');
-    if base.is_empty() || !base.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+    if base.is_empty() || !crate::indexer::starts_with_uppercase(base) {
         return None;
     }
     Some(base.to_owned())

--- a/src/indexer/infer/lambda.rs
+++ b/src/indexer/infer/lambda.rs
@@ -69,7 +69,7 @@ pub(crate) fn lambda_type_nth_input(ty: &str, n: usize) -> Option<String> {
     // Strip `suspend` keyword from function-type args like `suspend (T) -> Unit`.
     let arg = strip_suspend(arg);
     // Allow dots for qualified types like `CreditCardDashboardInteractor.CardProduct`.
-    let base: String = arg.chars().take_while(|&c| is_id_char(c) || c == '.').collect();
+    let base: String = crate::indexer::dotted_ident_prefix(arg);
     // Trim any trailing dots.
     let base = base.trim_end_matches('.');
     if base.is_empty() || !crate::indexer::starts_with_uppercase(base) {
@@ -85,7 +85,7 @@ pub(crate) fn lambda_type_receiver(ty: &str) -> Option<String> {
     let ty = strip_suspend(ty.trim());
     if let Some(dot_paren) = ty.find(".(") {
         let receiver = ty[..dot_paren].trim();
-        let base: String = receiver.chars().take_while(|&c| is_id_char(c) || c == '.').collect();
+        let base: String = crate::indexer::dotted_ident_prefix(receiver);
         let base = base.trim_end_matches('.');
         if !base.is_empty() {
             return Some(base.to_owned());
@@ -110,7 +110,7 @@ pub(crate) fn lambda_type_first_input(ty: &str) -> Option<String> {
     // The implicit receiver is the `it`/`this`-equivalent inside the lambda.
     if let Some(dot_paren) = ty.find(".(") {
         let receiver = ty[..dot_paren].trim();
-        let base: String = receiver.chars().take_while(|&c| is_id_char(c) || c == '.').collect();
+        let base: String = crate::indexer::dotted_ident_prefix(receiver);
         let base = base.trim_end_matches('.');
         if !base.is_empty() && crate::indexer::starts_with_uppercase(base) {
             return Some(base.to_owned());
@@ -164,7 +164,7 @@ pub(crate) fn lambda_type_first_input(ty: &str) -> Option<String> {
     };
 
     // Return the base type name (allow qualified names like `Outer.Inner`, strip generics).
-    let base: String = first.chars().take_while(|&c| is_id_char(c) || c == '.').collect();
+    let base: String = crate::indexer::dotted_ident_prefix(first);
     let base = base.trim_end_matches('.');
     if base.is_empty() || !crate::indexer::starts_with_uppercase(base) {
         return None;

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -53,7 +53,6 @@ pub(crate) use it_this::{
     lambda_receiver_type_from_context,
     line_has_lambda_param,
     lambda_brace_pos_for_param,
-    find_lambda_brace_for_param,
     lambda_param_position_on_line,
     find_last_dot_at_depth_zero,
 };

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -13,6 +13,12 @@ use crate::resolver::{ReceiverKind, infer_receiver_type};
 
 // ─── Multiline signature collector ───────────────────────────────────────────
 
+/// Maximum number of lines to scan when collecting a multi-line function signature.
+const SIGNATURE_SCAN_LINES: usize = 15;
+
+/// Maximum number of lines to scan when collecting a function parameter list.
+const FUN_PARAMS_SCAN_LINES: usize = 20;
+
 /// Collect a human-readable function/class signature starting at `start_line`.
 ///
 /// Rules:
@@ -26,7 +32,7 @@ pub(crate) fn collect_signature(lines: &[String], start_line: usize) -> String {
     let mut parts: Vec<String> = Vec::new();
     let mut depth: i32 = 0;
 
-    for raw_line in lines[start_line..(start_line + 15).min(lines.len())].iter() {
+    for raw_line in lines[start_line..(start_line + SIGNATURE_SCAN_LINES).min(lines.len())].iter() {
         let raw = raw_line.trim();
 
         // Count parens in this line.
@@ -144,7 +150,7 @@ pub(crate) fn collect_params_from_line(lines: &[String], start_line: usize) -> O
     let mut found_open = false;
     let mut params = String::new();
 
-    'outer: for ln in start_line..start_line + 20 {
+    'outer: for ln in start_line..start_line + FUN_PARAMS_SCAN_LINES {
         let line = match lines.get(ln) { Some(l) => l, None => break };
         let chars = line.char_indices().peekable();
         for (_, ch) in chars {

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -18,6 +18,7 @@ use tower_lsp::lsp_types::*;
 use crate::types::SymbolEntry;
 use crate::LinesExt;
 use crate::StrExt;
+use crate::stdlib::hover;
 use super::Indexer;
 use super::doc::extract_doc_comment;
 
@@ -48,7 +49,7 @@ impl Indexer {
     pub fn hover_info(&self, name: &str) -> Option<String> {
         // Check stdlib first so well-known symbols (run, apply, map, …) get
         // proper signatures even when no project source contains them.
-        if let Some(md) = crate::stdlib::hover(name) { return Some(md); }
+        if let Some(md) = hover(name) { return Some(md); }
 
         // Drop the dashmap ref before taking the second one.
         let loc: Location = {

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -170,7 +170,7 @@ impl Indexer {
             if last == name && segments.len() >= 2 {
                 let pkg = segments[..segments.len() - 1].join(".");
                 let parent = segments.get(segments.len() - 2)
-                    .filter(|s| s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false))
+                    .filter(|s| crate::indexer::starts_with_uppercase(s))
                     .map(|s| s.to_string());
                 return (parent, Some(pkg));
             }

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -17,6 +17,7 @@ use tower_lsp::lsp_types::*;
 
 use crate::types::SymbolEntry;
 use crate::LinesExt;
+use crate::StrExt;
 use super::Indexer;
 use super::doc::extract_doc_comment;
 
@@ -170,7 +171,7 @@ impl Indexer {
             if last == name && segments.len() >= 2 {
                 let pkg = segments[..segments.len() - 1].join(".");
                 let parent = segments.get(segments.len() - 2)
-                    .filter(|s| crate::indexer::starts_with_uppercase(s))
+                    .filter(|s| s.starts_with_uppercase())
                     .map(|s| s.to_string());
                 return (parent, Some(pkg));
             }

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -5,6 +5,13 @@
 use tree_sitter::Node;
 
 pub(crate) trait NodeExt<'a>: Sized + Copy {
+    /// Extract the node's text as an owned `String`.  Returns `None` if the bytes
+    /// are not valid UTF-8 (should never happen in practice for Kotlin/Java source).
+    fn utf8_text_owned(self, bytes: &[u8]) -> Option<String>;
+
+    /// Find the first direct child whose `kind()` equals `kind`.
+    fn first_child_of_kind(self, kind: &str) -> Option<Node<'a>>;
+
     /// Extract the function name from a `call_expression` node.
     /// Handles simple calls `foo(...)` and navigation chains `foo.bar(...)`.
     fn call_fn_name(self, bytes: &[u8]) -> Option<String>;
@@ -44,6 +51,16 @@ pub(crate) trait NodeExt<'a>: Sized + Copy {
 }
 
 impl<'a> NodeExt<'a> for Node<'a> {
+    fn utf8_text_owned(self, bytes: &[u8]) -> Option<String> {
+        self.utf8_text(bytes).ok().map(|s| s.to_owned())
+    }
+
+    fn first_child_of_kind(self, kind: &str) -> Option<Node<'a>> {
+        (0..self.child_count())
+            .filter_map(|i| self.child(i))
+            .find(|c| c.kind() == kind)
+    }
+
     fn call_fn_name(self, bytes: &[u8]) -> Option<String> {
         self.call_fn_and_qualifier(bytes).map(|(name, _)| name)
     }
@@ -53,9 +70,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
         for i in 0..count.saturating_sub(1) {
             let (c, next) = (self.child(i)?, self.child(i + 1)?);
             if c.kind() == "simple_identifier" && next.kind() == "=" {
-                return std::str::from_utf8(&bytes[c.byte_range()])
-                    .ok()
-                    .map(|s| s.to_string());
+                return c.utf8_text_owned(bytes);
             }
         }
         None
@@ -99,9 +114,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
     }
 
     fn has_lambda_named_params(self, bytes: &[u8]) -> bool {
-        let Some(lp) = (0..self.child_count())
-            .filter_map(|i| self.child(i))
-            .find(|c| c.kind() == "lambda_parameters")
+        let Some(lp) = self.first_child_of_kind("lambda_parameters")
         else {
             return false;
         };
@@ -121,9 +134,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
     }
 
     fn collect_lambda_param_names(self, bytes: &[u8], existing: &[String]) -> Vec<String> {
-        let Some(lp) = (0..self.child_count())
-            .filter_map(|i| self.child(i))
-            .find(|c| c.kind() == "lambda_parameters")
+        let Some(lp) = self.first_child_of_kind("lambda_parameters")
         else {
             return Vec::new();
         };
@@ -133,14 +144,12 @@ impl<'a> NodeExt<'a> for Node<'a> {
             .filter(|c| c.kind() == "variable_declaration")
             .filter_map(|vd| {
                 let si = vd.child(0).filter(|n| n.kind() == "simple_identifier")?;
-                std::str::from_utf8(&bytes[si.byte_range()])
-                    .ok()
-                    .map(|s| s.to_string())
+                si.utf8_text_owned(bytes)
             })
             .filter(|name| {
                 name != "it"
                     && name != "_"
-                    && name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
+                    && crate::indexer::starts_with_lowercase(name)
                     && !existing.contains(name)
             })
             .collect()
@@ -148,9 +157,8 @@ impl<'a> NodeExt<'a> for Node<'a> {
 
     fn extract_type_name(self, bytes: &[u8]) -> Option<String> {
         if let Some(n) = self.child_by_field_name("name") {
-            if let Ok(s) = std::str::from_utf8(&bytes[n.byte_range()]) {
-                let s = s.to_string();
-                if s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+            if let Some(s) = n.utf8_text_owned(bytes) {
+                if crate::indexer::starts_with_uppercase(&s) {
                     return Some(s);
                 }
             }
@@ -161,9 +169,9 @@ impl<'a> NodeExt<'a> for Node<'a> {
                     child.kind(),
                     "type_identifier" | "simple_identifier" | "identifier"
                 ) {
-                    if let Ok(s) = std::str::from_utf8(&bytes[child.byte_range()]) {
-                        if s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
-                            return Some(s.to_string());
+                    if let Some(s) = child.utf8_text_owned(bytes) {
+                        if crate::indexer::starts_with_uppercase(&s) {
+                            return Some(s);
                         }
                     }
                 }
@@ -176,7 +184,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
         let callee = self.child(0)?;
         match callee.kind() {
             "simple_identifier" | "type_identifier" => {
-                let name = std::str::from_utf8(&bytes[callee.byte_range()]).ok()?.to_string();
+                let name = callee.utf8_text_owned(bytes)?;
                 Some((name, None))
             }
             "navigation_expression" => {
@@ -186,14 +194,13 @@ impl<'a> NodeExt<'a> for Node<'a> {
                 for child in callee.children(&mut walker) {
                     match child.kind() {
                         "simple_identifier" | "type_identifier" => {
-                            qualifier_opt = std::str::from_utf8(&bytes[child.byte_range()])
-                                .ok().map(|s| s.to_string());
+                            qualifier_opt = child.utf8_text_owned(bytes);
                         }
                         "navigation_suffix" => {
                             fn_name_opt = (0..child.child_count())
                                 .filter_map(|i| child.child(i))
                                 .find(|c| c.kind() == "simple_identifier" || c.kind() == "type_identifier")
-                                .and_then(|c| std::str::from_utf8(&bytes[c.byte_range()]).ok().map(|s| s.to_string()));
+                                .and_then(|c| c.utf8_text_owned(bytes));
                         }
                         _ => {}
                     }

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -45,43 +45,7 @@ pub(crate) trait NodeExt<'a>: Sized + Copy {
 
 impl<'a> NodeExt<'a> for Node<'a> {
     fn call_fn_name(self, bytes: &[u8]) -> Option<String> {
-        let callee = self.child(0)?;
-        let name_node = match callee.kind() {
-            "simple_identifier" | "type_identifier" => callee,
-            "navigation_expression" => {
-                // Single-pass scan: track the last direct identifier and the last
-                // identifier inside a navigation_suffix. Prefer the suffix identifier
-                // (member name, e.g. "bar" in `obj.bar(…)`); fall back to the direct
-                // identifier for bare qualified names with no suffix.
-                let mut walker = callee.walk();
-                let mut last_identifier = None;
-                let mut last_suffix_identifier = None;
-                for child in callee.children(&mut walker) {
-                    match child.kind() {
-                        "simple_identifier" | "type_identifier" => {
-                            last_identifier = Some(child);
-                        }
-                        "navigation_suffix" => {
-                            let suffix_id = (0..child.child_count())
-                                .filter_map(|i| child.child(i))
-                                .find(|c| {
-                                    c.kind() == "simple_identifier"
-                                        || c.kind() == "type_identifier"
-                                });
-                            if let Some(id) = suffix_id {
-                                last_suffix_identifier = Some(id);
-                            }
-                        }
-                        _ => {}
-                    }
-                }
-                last_suffix_identifier.or(last_identifier)?
-            }
-            _ => return None,
-        };
-        std::str::from_utf8(&bytes[name_node.byte_range()])
-            .ok()
-            .map(|s| s.to_string())
+        self.call_fn_and_qualifier(bytes).map(|(name, _)| name)
     }
 
     fn named_arg_label(self, bytes: &[u8]) -> Option<String> {
@@ -366,5 +330,34 @@ mod tests {
         let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
         let va = find_node_kind(call, "value_argument").unwrap();
         assert_eq!(va.named_arg_label(&bytes), None);
+    }
+
+    #[test]
+    fn call_fn_and_qualifier_simple_call() {
+        let (tree, bytes) = parse_kotlin("val x = foo(1)");
+        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
+        assert_eq!(call.call_fn_and_qualifier(&bytes), Some(("foo".to_string(), None)));
+    }
+
+    #[test]
+    fn call_fn_and_qualifier_navigation_call() {
+        let (tree, bytes) = parse_kotlin("val x = obj.bar(1)");
+        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
+        assert_eq!(
+            call.call_fn_and_qualifier(&bytes),
+            Some(("bar".to_string(), Some("obj".to_string())))
+        );
+    }
+
+    #[test]
+    fn call_fn_name_delegates_to_and_qualifier() {
+        // call_fn_name is now implemented via call_fn_and_qualifier —
+        // verify both return the same name for navigation and simple calls.
+        let (tree, bytes) = parse_kotlin("val x = obj.bar(1)");
+        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
+        let via_and_qualifier = call.call_fn_and_qualifier(&bytes).map(|(n, _)| n);
+        let via_name = call.call_fn_name(&bytes);
+        assert_eq!(via_name, via_and_qualifier);
+        assert_eq!(via_name, Some("bar".to_string()));
     }
 }

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -17,7 +17,13 @@ pub(crate) trait NodeExt<'a>: Sized + Copy {
     fn first_child_of_kind(self, kind: &str) -> Option<Node<'a>>;
 
     /// Collect all direct children whose `kind()` equals `kind`.
+    /// Allocates a `Vec`; child counts are typically small (< 20), so this is acceptable
+    /// for indexing paths. For very hot loops, prefer `for_each_child_of_kind`.
     fn children_of_kind(self, kind: &str) -> Vec<Node<'a>>;
+
+    /// Call `f` for each direct child whose `kind()` equals `kind`.
+    /// Non-allocating alternative to `children_of_kind` for performance-sensitive code.
+    fn for_each_child_of_kind(self, kind: &str, f: impl FnMut(Node<'a>));
 
     /// Extract the function name from a `call_expression` node.
     /// Handles simple calls `foo(...)` and navigation chains `foo.bar(...)`.
@@ -73,6 +79,14 @@ impl<'a> NodeExt<'a> for Node<'a> {
             .filter_map(|i| self.child(i))
             .filter(|c| c.kind() == kind)
             .collect()
+    }
+
+    fn for_each_child_of_kind(self, kind: &str, mut f: impl FnMut(Node<'a>)) {
+        for i in 0..self.child_count() {
+            if let Some(c) = self.child(i) {
+                if c.kind() == kind { f(c); }
+            }
+        }
     }
 
     fn call_fn_name(self, bytes: &[u8]) -> Option<String> {

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -3,6 +3,7 @@
 //! These methods are lightweight convenience wrappers around tree-sitter node
 //! traversal; their bodies were extracted from the free functions they replace.
 use tree_sitter::Node;
+use crate::StrExt;
 use crate::queries::{
     KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_VALUE_ARG, KIND_VALUE_ARGS,
     KIND_LAMBDA_PARAMS, KIND_CALL_EXPR, KIND_NAV_EXPR,
@@ -177,7 +178,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
             .filter(|name| {
                 name != "it"
                     && name != "_"
-                    && crate::indexer::starts_with_lowercase(name)
+                    && name.starts_with_lowercase()
                     && !existing.contains(name)
             })
             .collect()
@@ -186,7 +187,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
     fn extract_type_name(self, bytes: &[u8]) -> Option<String> {
         if let Some(n) = self.child_by_field_name("name") {
             if let Some(s) = n.utf8_text_owned(bytes) {
-                if crate::indexer::starts_with_uppercase(&s) {
+                if s.starts_with_uppercase() {
                     return Some(s);
                 }
             }
@@ -198,7 +199,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
                     "type_identifier" | "simple_identifier" | "identifier"
                 ) {
                     if let Some(s) = child.utf8_text_owned(bytes) {
-                        if crate::indexer::starts_with_uppercase(&s) {
+                        if s.starts_with_uppercase() {
                             return Some(s);
                         }
                     }

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -31,6 +31,16 @@ pub(crate) trait NodeExt<'a>: Sized + Copy {
 
     /// Extract the type/class name from a CST class/interface/object/companion_object node.
     fn extract_type_name(self, bytes: &[u8]) -> Option<String>;
+
+    /// For a `call_expression` node, returns `(fn_name, qualifier)`.
+    /// - Simple call `foo(...)` → `("foo", None)`
+    /// - Navigation call `obj.bar(...)` → `("bar", Some("obj"))`
+    /// - Returns `None` if the callee kind is not recognized.
+    fn call_fn_and_qualifier(self, bytes: &[u8]) -> Option<(String, Option<String>)>;
+
+    /// Returns the line number (0-based) of the first named identifier child,
+    /// or the node's own start line if no named child is found.
+    fn name_line(self) -> u32;
 }
 
 impl<'a> NodeExt<'a> for Node<'a> {
@@ -196,6 +206,52 @@ impl<'a> NodeExt<'a> for Node<'a> {
             }
         }
         None
+    }
+
+    fn call_fn_and_qualifier(self, bytes: &[u8]) -> Option<(String, Option<String>)> {
+        let callee = self.child(0)?;
+        match callee.kind() {
+            "simple_identifier" | "type_identifier" => {
+                let name = std::str::from_utf8(&bytes[callee.byte_range()]).ok()?.to_string();
+                Some((name, None))
+            }
+            "navigation_expression" => {
+                let mut walker = callee.walk();
+                let mut qualifier_opt: Option<String> = None;
+                let mut fn_name_opt: Option<String> = None;
+                for child in callee.children(&mut walker) {
+                    match child.kind() {
+                        "simple_identifier" | "type_identifier" => {
+                            qualifier_opt = std::str::from_utf8(&bytes[child.byte_range()])
+                                .ok().map(|s| s.to_string());
+                        }
+                        "navigation_suffix" => {
+                            fn_name_opt = (0..child.child_count())
+                                .filter_map(|i| child.child(i))
+                                .find(|c| c.kind() == "simple_identifier" || c.kind() == "type_identifier")
+                                .and_then(|c| std::str::from_utf8(&bytes[c.byte_range()]).ok().map(|s| s.to_string()));
+                        }
+                        _ => {}
+                    }
+                }
+                Some((fn_name_opt?, qualifier_opt))
+            }
+            _ => None,
+        }
+    }
+
+    fn name_line(self) -> u32 {
+        // Java uses field "name"; Kotlin has type_identifier as a direct child.
+        if let Some(n) = self.child_by_field_name("name") {
+            return n.start_position().row as u32;
+        }
+        let mut cur = self.walk();
+        for child in self.children(&mut cur) {
+            if matches!(child.kind(), "type_identifier" | "simple_identifier" | "identifier") {
+                return child.start_position().row as u32;
+            }
+        }
+        self.start_position().row as u32
     }
 }
 

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -12,6 +12,9 @@ pub(crate) trait NodeExt<'a>: Sized + Copy {
     /// Find the first direct child whose `kind()` equals `kind`.
     fn first_child_of_kind(self, kind: &str) -> Option<Node<'a>>;
 
+    /// Collect all direct children whose `kind()` equals `kind`.
+    fn children_of_kind(self, kind: &str) -> Vec<Node<'a>>;
+
     /// Extract the function name from a `call_expression` node.
     /// Handles simple calls `foo(...)` and navigation chains `foo.bar(...)`.
     fn call_fn_name(self, bytes: &[u8]) -> Option<String>;
@@ -59,6 +62,13 @@ impl<'a> NodeExt<'a> for Node<'a> {
         (0..self.child_count())
             .filter_map(|i| self.child(i))
             .find(|c| c.kind() == kind)
+    }
+
+    fn children_of_kind(self, kind: &str) -> Vec<Node<'a>> {
+        (0..self.child_count())
+            .filter_map(|i| self.child(i))
+            .filter(|c| c.kind() == kind)
+            .collect()
     }
 
     fn call_fn_name(self, bytes: &[u8]) -> Option<String> {

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -6,7 +6,7 @@ use tree_sitter::Node;
 use crate::StrExt;
 use crate::queries::{
     KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_VALUE_ARG, KIND_VALUE_ARGS,
-    KIND_LAMBDA_PARAMS, KIND_CALL_EXPR, KIND_NAV_EXPR,
+    KIND_LAMBDA_PARAMS,
 };
 
 pub(crate) trait NodeExt<'a>: Sized + Copy {

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -3,6 +3,10 @@
 //! These methods are lightweight convenience wrappers around tree-sitter node
 //! traversal; their bodies were extracted from the free functions they replace.
 use tree_sitter::Node;
+use crate::queries::{
+    KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_VALUE_ARG, KIND_VALUE_ARGS,
+    KIND_LAMBDA_PARAMS, KIND_CALL_EXPR, KIND_NAV_EXPR,
+};
 
 pub(crate) trait NodeExt<'a>: Sized + Copy {
     /// Extract the node's text as an owned `String`.  Returns `None` if the bytes
@@ -79,7 +83,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
         let count = self.child_count();
         for i in 0..count.saturating_sub(1) {
             let (c, next) = (self.child(i)?, self.child(i + 1)?);
-            if c.kind() == "simple_identifier" && next.kind() == "=" {
+            if c.kind() == KIND_SIMPLE_IDENT && next.kind() == "=" {
                 return c.utf8_text_owned(bytes);
             }
         }
@@ -95,7 +99,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
         let mut pos = 0usize;
         let mut cursor = parent.walk();
         for child in parent.children(&mut cursor) {
-            if child.kind() == "value_argument" {
+            if child.kind() == KIND_VALUE_ARG {
                 if child.id() == target_id {
                     break;
                 }
@@ -108,13 +112,13 @@ impl<'a> NodeExt<'a> for Node<'a> {
     fn find_value_arguments(self) -> Option<Node<'a>> {
         let mut walker = self.walk();
         for child in self.children(&mut walker) {
-            if child.kind() == "value_arguments" {
+            if child.kind() == KIND_VALUE_ARGS {
                 return Some(child);
             }
             if child.kind() == "call_suffix" {
                 let mut w2 = child.walk();
                 for gc in child.children(&mut w2) {
-                    if gc.kind() == "value_arguments" {
+                    if gc.kind() == KIND_VALUE_ARGS {
                         return Some(gc);
                     }
                 }
@@ -124,7 +128,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
     }
 
     fn has_lambda_named_params(self, bytes: &[u8]) -> bool {
-        let Some(lp) = self.first_child_of_kind("lambda_parameters")
+        let Some(lp) = self.first_child_of_kind(KIND_LAMBDA_PARAMS)
         else {
             return false;
         };
@@ -133,7 +137,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
             .filter_map(|i| lp.child(i))
             .filter(|c| c.kind() == "variable_declaration")
             .any(|vd| {
-                let Some(si) = vd.child(0).filter(|n| n.kind() == "simple_identifier") else {
+                let Some(si) = vd.child(0).filter(|n| n.kind() == KIND_SIMPLE_IDENT) else {
                     return false;
                 };
                 let Ok(name) = std::str::from_utf8(&bytes[si.byte_range()]) else {
@@ -144,7 +148,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
     }
 
     fn collect_lambda_param_names(self, bytes: &[u8], existing: &[String]) -> Vec<String> {
-        let Some(lp) = self.first_child_of_kind("lambda_parameters")
+        let Some(lp) = self.first_child_of_kind(KIND_LAMBDA_PARAMS)
         else {
             return Vec::new();
         };
@@ -153,7 +157,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
             .filter_map(|i| lp.child(i))
             .filter(|c| c.kind() == "variable_declaration")
             .filter_map(|vd| {
-                let si = vd.child(0).filter(|n| n.kind() == "simple_identifier")?;
+                let si = vd.child(0).filter(|n| n.kind() == KIND_SIMPLE_IDENT)?;
                 si.utf8_text_owned(bytes)
             })
             .filter(|name| {
@@ -209,7 +213,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
                         "navigation_suffix" => {
                             fn_name_opt = (0..child.child_count())
                                 .filter_map(|i| child.child(i))
-                                .find(|c| c.kind() == "simple_identifier" || c.kind() == "type_identifier")
+                                .find(|c| c.kind() == KIND_SIMPLE_IDENT || c.kind() == KIND_TYPE_IDENT)
                                 .and_then(|c| c.utf8_text_owned(bytes));
                         }
                         _ => {}
@@ -241,6 +245,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
 #[cfg(test)]
 mod tests {
     use super::NodeExt;
+    use crate::queries::{KIND_CALL_EXPR, KIND_VALUE_ARGS, KIND_VALUE_ARG, KIND_LAMBDA_LIT};
 
     fn parse_kotlin(src: &str) -> (tree_sitter::Tree, Vec<u8>) {
         let mut parser = tree_sitter::Parser::new();
@@ -270,7 +275,7 @@ mod tests {
     #[test]
     fn call_fn_name_simple() {
         let (tree, bytes) = parse_kotlin("val x = foo(1)");
-        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
+        let call = find_node_kind(tree.root_node(), KIND_CALL_EXPR).unwrap();
         assert_eq!(call.call_fn_name(&bytes), Some("foo".to_string()));
     }
 
@@ -282,7 +287,7 @@ mod tests {
         //     navigation_suffix: .bar  ← `bar` is nested here
         // `call_fn_name` should return the member name "bar", not the receiver "obj".
         let (tree, bytes) = parse_kotlin("val x = obj.bar(1)");
-        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
+        let call = find_node_kind(tree.root_node(), KIND_CALL_EXPR).unwrap();
         assert_eq!(call.call_fn_name(&bytes), Some("bar".to_string()));
     }
 
@@ -290,12 +295,12 @@ mod tests {
     fn value_arg_position_first_and_second() {
         let (tree, bytes) = parse_kotlin("foo(a, b)");
         let _ = bytes; // not needed for position
-        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
-        let value_args_node = find_node_kind(call, "value_arguments").unwrap();
+        let call = find_node_kind(tree.root_node(), KIND_CALL_EXPR).unwrap();
+        let value_args_node = find_node_kind(call, KIND_VALUE_ARGS).unwrap();
         let mut args = vec![];
         for i in 0..value_args_node.child_count() {
             if let Some(c) = value_args_node.child(i) {
-                if c.kind() == "value_argument" {
+                if c.kind() == KIND_VALUE_ARG {
                     args.push(c);
                 }
             }
@@ -308,7 +313,7 @@ mod tests {
     #[test]
     fn has_lambda_named_params_true_for_named() {
         let (tree, bytes) = parse_kotlin("val x = foo { item -> item }");
-        let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+        let lambda = find_node_kind(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
         assert!(
             lambda.has_lambda_named_params(&bytes),
             "param named `item` should yield true"
@@ -318,7 +323,7 @@ mod tests {
     #[test]
     fn has_lambda_named_params_false_for_no_params() {
         let (tree, bytes) = parse_kotlin("val x = items.map { it.name }");
-        let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+        let lambda = find_node_kind(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
         assert!(
             !lambda.has_lambda_named_params(&bytes),
             "no lambda_parameters child should yield false"
@@ -328,7 +333,7 @@ mod tests {
     #[test]
     fn collect_lambda_param_names_collects_named() {
         let (tree, bytes) = parse_kotlin("val x = items.map { item -> item.foo }");
-        let lambda = find_node_kind(tree.root_node(), "lambda_literal").unwrap();
+        let lambda = find_node_kind(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
         let names = lambda.collect_lambda_param_names(&bytes, &[]);
         assert_eq!(names, vec!["item".to_string()]);
     }
@@ -336,30 +341,30 @@ mod tests {
     #[test]
     fn named_arg_label_present() {
         let (tree, bytes) = parse_kotlin("foo(bar = 1)");
-        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
-        let va = find_node_kind(call, "value_argument").unwrap();
+        let call = find_node_kind(tree.root_node(), KIND_CALL_EXPR).unwrap();
+        let va = find_node_kind(call, KIND_VALUE_ARG).unwrap();
         assert_eq!(va.named_arg_label(&bytes), Some("bar".to_string()));
     }
 
     #[test]
     fn named_arg_label_absent() {
         let (tree, bytes) = parse_kotlin("foo(1)");
-        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
-        let va = find_node_kind(call, "value_argument").unwrap();
+        let call = find_node_kind(tree.root_node(), KIND_CALL_EXPR).unwrap();
+        let va = find_node_kind(call, KIND_VALUE_ARG).unwrap();
         assert_eq!(va.named_arg_label(&bytes), None);
     }
 
     #[test]
     fn call_fn_and_qualifier_simple_call() {
         let (tree, bytes) = parse_kotlin("val x = foo(1)");
-        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
+        let call = find_node_kind(tree.root_node(), KIND_CALL_EXPR).unwrap();
         assert_eq!(call.call_fn_and_qualifier(&bytes), Some(("foo".to_string(), None)));
     }
 
     #[test]
     fn call_fn_and_qualifier_navigation_call() {
         let (tree, bytes) = parse_kotlin("val x = obj.bar(1)");
-        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
+        let call = find_node_kind(tree.root_node(), KIND_CALL_EXPR).unwrap();
         assert_eq!(
             call.call_fn_and_qualifier(&bytes),
             Some(("bar".to_string(), Some("obj".to_string())))
@@ -371,7 +376,7 @@ mod tests {
         // call_fn_name is now implemented via call_fn_and_qualifier —
         // verify both return the same name for navigation and simple calls.
         let (tree, bytes) = parse_kotlin("val x = obj.bar(1)");
-        let call = find_node_kind(tree.root_node(), "call_expression").unwrap();
+        let call = find_node_kind(tree.root_node(), KIND_CALL_EXPR).unwrap();
         let via_and_qualifier = call.call_fn_and_qualifier(&bytes).map(|(n, _)| n);
         let via_name = call.call_fn_name(&bytes);
         assert_eq!(via_name, via_and_qualifier);

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -22,6 +22,7 @@ use crate::indexer::{
     discover::{find_source_files, warm_discover_files},
 };
 use crate::rg::{IgnoreMatcher, SOURCE_EXTENSIONS, regex_escape};
+use crate::task_runner::run_concurrent;
 use crate::types::{FileIndexResult, WorkspaceIndexResult, IndexStats};
 
 // ─── LSP progress notification ────────────────────────────────────────────────
@@ -620,7 +621,7 @@ impl Indexer {
         let url_failed2 = Arc::clone(&url_failed);
         let panic_failed2 = Arc::clone(&panic_failed);
 
-        let results = crate::task_runner::run_concurrent(
+        let results = run_concurrent(
             work_items,
             sem,
             move |item, sem| {

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -13,6 +13,9 @@ use std::sync::Arc;
 
 use tower_lsp::lsp_types::*;
 
+/// Maximum number of file-read failures to log before suppressing further warnings.
+const MAX_READ_FAILURES_LOGGED: usize = 5;
+
 use crate::indexer::{
     Indexer, MAX_FILES_UNLIMITED,
     cache::{try_load_cache, save_cache, cache_entry_to_file_result, write_status_file},
@@ -643,7 +646,7 @@ impl Indexer {
                         Err(e) => {
                             let n =
                                 read_failed.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                            if n < 5 {
+                            if n < MAX_READ_FAILURES_LOGGED {
                                 log::warn!(
                                     "Could not read {}: {}",
                                     item.path.display(),

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -300,9 +300,7 @@ impl Indexer {
                             if let Some(arrow_pos) = after.find("->") {
                                 let names_str = &after[..arrow_pos];
                                 for tok in names_str.split(',') {
-                                    let name: String = tok.trim()
-                                        .chars().take_while(|&c| c.is_alphanumeric() || c == '_')
-                                        .collect();
+                                    let name = crate::indexer::ident_prefix(tok.trim());
                                     if !name.is_empty() && name != "it" && name != "_"
                                         && crate::indexer::starts_with_lowercase(&name)
                                         && !params.contains(&name) { params.push(name.clone()); }

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -15,6 +15,7 @@ use super::{
     lambda_brace_pos_for_param,
 };
 use crate::indexer::NodeExt;
+use crate::queries::KIND_LAMBDA_LIT;
 use crate::types::CursorPos;
 
 /// Lines to scan backward when resolving variable types and lambda receivers from scope.
@@ -255,7 +256,7 @@ impl Indexer {
                 let mut params: Vec<String> = Vec::new();
                 let mut cur = node;
                 loop {
-                    if cur.kind() == "lambda_literal" {
+                    if cur.kind() == KIND_LAMBDA_LIT {
                         let new_names = cur.collect_lambda_param_names(&doc.bytes, &params);
                         params.extend(new_names);
                     }

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -17,6 +17,7 @@ use super::{
 use crate::indexer::NodeExt;
 use crate::queries::KIND_LAMBDA_LIT;
 use crate::types::CursorPos;
+use crate::StrExt;
 
 /// Lines to scan backward when resolving variable types and lambda receivers from scope.
 const SCOPE_SCAN_BACK_LINES: usize = 50;
@@ -301,9 +302,9 @@ impl Indexer {
                             if let Some(arrow_pos) = after.find("->") {
                                 let names_str = &after[..arrow_pos];
                                 for tok in names_str.split(',') {
-                                    let name = crate::indexer::ident_prefix(tok.trim());
+                                    let name = tok.trim().ident_prefix();
                                     if !name.is_empty() && name != "it" && name != "_"
-                                        && crate::indexer::starts_with_lowercase(&name)
+                                        && name.starts_with_lowercase()
                                         && !params.contains(&name) { params.push(name.clone()); }
                                 }
                             }
@@ -455,7 +456,7 @@ pub(super) fn extract_class_decl_name(line: &str) -> Option<String> {
         .or_else(|| rest.strip_prefix("extension "))?;
     // Extract the identifier
     let name: String = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '_').collect();
-    if name.is_empty() || !crate::indexer::starts_with_uppercase(&name) {
+    if name.is_empty() || !name.starts_with_uppercase() {
         return None;
     }
     Some(name)
@@ -539,7 +540,7 @@ fn callee_to_qualifier(full_callee: &str) -> Option<String> {
     let last = *segments.last()?;
 
     // Constructor call: last segment is a type name (uppercase first char).
-    if crate::indexer::starts_with_uppercase(last) {
+    if last.starts_with_uppercase() {
         return Some(last.to_string());
     }
 
@@ -548,7 +549,7 @@ fn callee_to_qualifier(full_callee: &str) -> Option<String> {
     // `viewModel.state.copy`   → no uppercase in receiver → None
     let receiver = &segments[..segments.len() - 1];
     receiver.iter().rev()
-        .find(|s| crate::indexer::starts_with_uppercase(s))
+        .find(|s| s.starts_with_uppercase())
         .map(|s| s.to_string())
 }
 

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -17,6 +17,15 @@ use super::{
 use crate::indexer::NodeExt;
 use crate::types::CursorPos;
 
+/// Lines to scan backward when resolving variable types and lambda receivers from scope.
+const SCOPE_SCAN_BACK_LINES: usize = 50;
+
+/// Lines to scan upward when looking for a local variable declaration.
+const DECL_SCAN_UP_LINES: usize = 15;
+
+/// Lines to scan backward when looking for a visibility modifier.
+const VISIBILITY_SCAN_BACK: usize = 20;
+
 impl Indexer {
     /// LSP positions are UTF-16; for ASCII-heavy Kotlin/Java identifiers the
     /// character offset is identical to the UTF-16 unit offset.
@@ -265,7 +274,7 @@ impl Indexer {
 
         let mut params: Vec<String> = Vec::new();
         let mut depth: i32 = 0;
-        let scan_start = cursor_line.saturating_sub(50);
+        let scan_start = cursor_line.saturating_sub(SCOPE_SCAN_BACK_LINES);
 
         for ln in (scan_start..=cursor_line).rev() {
             let line = match lines.get(ln) { Some(l) => l, None => continue };
@@ -317,7 +326,7 @@ impl Indexer {
             .map(|ll| ll.clone())
             .or_else(|| self.files.get(uri.as_str()).map(|f| f.lines.clone()))?;
 
-        let scan_start = cursor_line.saturating_sub(50);
+        let scan_start = cursor_line.saturating_sub(SCOPE_SCAN_BACK_LINES);
         for ln in (scan_start..=cursor_line).rev() {
             let line = match lines.get(ln) { Some(l) => l, None => continue };
             if !line_has_lambda_param(line, param_name) { continue; }
@@ -389,7 +398,7 @@ impl Indexer {
             if depth < 0 && i < row {
                 let t = line.trim();
                 if let Some(name) = extract_class_decl_name(t) { return Some(name); }
-                let scan_up = i.saturating_sub(15);
+                let scan_up = i.saturating_sub(DECL_SCAN_UP_LINES);
                 for j in (scan_up..i).rev() {
                     if let Some(prev) = file.lines.get(j) {
                         if let Some(name) = extract_class_decl_name(prev.trim()) { return Some(name); }
@@ -483,7 +492,7 @@ pub(crate) fn last_ident_in(s: &str) -> &str {
 /// `()` still balance) so we don't need special-case brace handling.
 pub(crate) fn find_enclosing_call_name(lines: &[String], line_no: usize, col: usize) -> Option<String> {
     let mut depth: i32 = 0;
-    let scan_range_start = line_no.saturating_sub(20);
+    let scan_range_start = line_no.saturating_sub(VISIBILITY_SCAN_BACK);
 
     for ln in (scan_range_start..=line_no).rev() {
         let line_chars: Vec<char> = lines[ln].chars().collect();

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -304,7 +304,7 @@ impl Indexer {
                                         .chars().take_while(|&c| c.is_alphanumeric() || c == '_')
                                         .collect();
                                     if !name.is_empty() && name != "it" && name != "_"
-                                        && name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
+                                        && crate::indexer::starts_with_lowercase(&name)
                                         && !params.contains(&name) { params.push(name.clone()); }
                                 }
                             }
@@ -456,7 +456,7 @@ pub(super) fn extract_class_decl_name(line: &str) -> Option<String> {
         .or_else(|| rest.strip_prefix("extension "))?;
     // Extract the identifier
     let name: String = rest.chars().take_while(|c| c.is_alphanumeric() || *c == '_').collect();
-    if name.is_empty() || !name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+    if name.is_empty() || !crate::indexer::starts_with_uppercase(&name) {
         return None;
     }
     Some(name)
@@ -540,7 +540,7 @@ fn callee_to_qualifier(full_callee: &str) -> Option<String> {
     let last = *segments.last()?;
 
     // Constructor call: last segment is a type name (uppercase first char).
-    if last.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+    if crate::indexer::starts_with_uppercase(last) {
         return Some(last.to_string());
     }
 
@@ -549,7 +549,7 @@ fn callee_to_qualifier(full_callee: &str) -> Option<String> {
     // `viewModel.state.copy`   → no uppercase in receiver → None
     let receiver = &segments[..segments.len() - 1];
     receiver.iter().rev()
-        .find(|s| s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false))
+        .find(|s| crate::indexer::starts_with_uppercase(s))
         .map(|s| s.to_string())
 }
 

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -23,8 +23,8 @@ const SCOPE_SCAN_BACK_LINES: usize = 50;
 /// Lines to scan upward when looking for a local variable declaration.
 const DECL_SCAN_UP_LINES: usize = 15;
 
-/// Lines to scan backward when looking for a visibility modifier.
-const VISIBILITY_SCAN_BACK: usize = 20;
+/// Lines to scan backward when looking for an enclosing call during named-argument scanning.
+const ENCLOSING_CALL_SCAN_BACK: usize = 20;
 
 impl Indexer {
     /// LSP positions are UTF-16; for ASCII-heavy Kotlin/Java identifiers the
@@ -490,7 +490,7 @@ pub(crate) fn last_ident_in(s: &str) -> &str {
 /// `()` still balance) so we don't need special-case brace handling.
 pub(crate) fn find_enclosing_call_name(lines: &[String], line_no: usize, col: usize) -> Option<String> {
     let mut depth: i32 = 0;
-    let scan_range_start = line_no.saturating_sub(VISIBILITY_SCAN_BACK);
+    let scan_range_start = line_no.saturating_sub(ENCLOSING_CALL_SCAN_BACK);
 
     for ln in (scan_range_start..=line_no).rev() {
         let line_chars: Vec<char> = lines[ln].chars().collect();

--- a/src/indexer/scope_tests.rs
+++ b/src/indexer/scope_tests.rs
@@ -9,6 +9,7 @@ use crate::indexer::{
     line_has_lambda_param,
     lambda_brace_pos_for_param,
 };
+use crate::queries::KIND_LAMBDA_LIT;
 use super::extract_class_decl_name;
 
 fn uri(path: &str) -> Url {
@@ -555,7 +556,7 @@ fn collect_lambda_param_names_named() {
     let src = "val x = items.map { item -> item.foo }";
     let bytes = src.as_bytes();
     let tree = parse_kotlin_scope(src);
-    let lambda = find_node_scope(tree.root_node(), "lambda_literal").unwrap();
+    let lambda = find_node_scope(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
     let names = super::collect_lambda_param_names(lambda, bytes, &[]);
     assert_eq!(names, vec!["item".to_string()],
         "should collect 'item', got: {names:?}");
@@ -566,7 +567,7 @@ fn collect_lambda_param_names_skips_it() {
     let src = "val x = items.map { it -> it.foo }";
     let bytes = src.as_bytes();
     let tree = parse_kotlin_scope(src);
-    let lambda = find_node_scope(tree.root_node(), "lambda_literal").unwrap();
+    let lambda = find_node_scope(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
     let names = super::collect_lambda_param_names(lambda, bytes, &[]);
     assert!(names.is_empty(), "should skip 'it', got: {names:?}");
 }
@@ -576,7 +577,7 @@ fn collect_lambda_param_names_multi() {
     let src = "val x = items.zip(other) { a, b -> a.id }";
     let bytes = src.as_bytes();
     let tree = parse_kotlin_scope(src);
-    let lambda = find_node_scope(tree.root_node(), "lambda_literal").unwrap();
+    let lambda = find_node_scope(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
     let names = super::collect_lambda_param_names(lambda, bytes, &[]);
     assert!(names.contains(&"a".to_string()), "should contain 'a', got: {names:?}");
     assert!(names.contains(&"b".to_string()), "should contain 'b', got: {names:?}");

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -18,6 +18,7 @@ use crate::indexer::NodeExt;
 use crate::indexer::live_tree::{lang_for_path, parse_live};
 use crate::queries::{KIND_LAMBDA_PARAMS, KIND_CALL_EXPR};
 use crate::resolver::{ReceiverKind, infer_receiver_type};
+use crate::StrExt;
 
 pub fn compute_inlay_hints(idx: &Arc<Indexer>, uri: &Url, range: Range) -> Vec<InlayHint> {
     // Fast path: editor has the file open → use pre-parsed live tree.
@@ -157,7 +158,7 @@ fn hint_lambda(
             let Ok(name)     = name_n.utf8_text(bytes)      else { continue };
             let name = name.trim();
             if name.is_empty() || name == "_" { continue; }
-            if !crate::indexer::starts_with_lowercase(name) { continue; }
+            if !name.starts_with_lowercase() { continue; }
 
             let start_pos = ts_pos_to_lsp(name_n.start_position(), starts, bytes);
             let end_pos   = ts_pos_to_lsp(name_n.end_position(),   starts, bytes);

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -247,7 +247,7 @@ fn infer_type_from_init(init: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<Str
     // call_expression: callee(...) or callee<T>(...)
     if init.kind() == KIND_CALL_EXPR {
         let name = init.call_fn_name(bytes)?;
-        if name.starts_with(|c: char| c.is_uppercase()) {
+        if name.starts_with_uppercase() {
             return Some(name);
         }
     }

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -16,6 +16,7 @@ use tower_lsp::lsp_types::{InlayHint, InlayHintKind, InlayHintLabel, Position, R
 use crate::indexer::Indexer;
 use crate::indexer::NodeExt;
 use crate::indexer::live_tree::{lang_for_path, parse_live};
+use crate::queries::{KIND_LAMBDA_PARAMS, KIND_CALL_EXPR};
 use crate::resolver::{ReceiverKind, infer_receiver_type};
 
 pub fn compute_inlay_hints(idx: &Arc<Indexer>, uri: &Url, range: Range) -> Vec<InlayHint> {
@@ -133,7 +134,7 @@ fn hint_lambda(
 ) {
     let mut nc = node.walk();
     for child in node.children(&mut nc) {
-        if child.kind() != "lambda_parameters" { continue; }
+        if child.kind() != KIND_LAMBDA_PARAMS { continue; }
 
         let mut pc = child.walk();
         for param in child.children(&mut pc) {
@@ -243,7 +244,7 @@ fn hint_property(
 /// the same as the callee (`val user = User(…)` → `"User"`).
 fn infer_type_from_init(init: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<String> {
     // call_expression: callee(...) or callee<T>(...)
-    if init.kind() == "call_expression" {
+    if init.kind() == KIND_CALL_EXPR {
         let name = init.call_fn_name(bytes)?;
         if name.starts_with(|c: char| c.is_uppercase()) {
             return Some(name);

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -156,7 +156,7 @@ fn hint_lambda(
             let Ok(name)     = name_n.utf8_text(bytes)      else { continue };
             let name = name.trim();
             if name.is_empty() || name == "_" { continue; }
-            if !name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false) { continue; }
+            if !crate::indexer::starts_with_lowercase(name) { continue; }
 
             let start_pos = ts_pos_to_lsp(name_n.start_position(), starts, bytes);
             let end_pos   = ts_pos_to_lsp(name_n.end_position(),   starts, bytes);

--- a/src/lines_ext.rs
+++ b/src/lines_ext.rs
@@ -3,7 +3,7 @@
 //! Each method is a thin façade over the original free function; no logic
 //! lives here.  The original free functions are kept intact so existing
 //! callers continue to compile during the incremental migration.
-use tower_lsp::lsp_types::Range;
+use tower_lsp::lsp_types::{Range, TextEdit};
 use crate::types::{ImportEntry, Visibility};
 
 pub(crate) trait LinesExt {
@@ -33,6 +33,9 @@ pub(crate) trait LinesExt {
 
     /// Line number at which a new `import` statement should be inserted.
     fn import_insertion_line(&self) -> u32;
+
+    /// Build a TextEdit that inserts an import for `fqn` at the appropriate line.
+    fn make_import_edit(&self, fqn: &str, needs_semicolon: bool) -> TextEdit;
 
     /// Infer the (stripped) type of `var_name` from a type annotation in these lines.
     fn infer_type(&self, var_name: &str) -> Option<String>;
@@ -82,6 +85,10 @@ impl LinesExt for [String] {
 
     fn import_insertion_line(&self) -> u32 {
         crate::resolver::import_insertion_line(self)
+    }
+
+    fn make_import_edit(&self, fqn: &str, needs_semicolon: bool) -> TextEdit {
+        crate::resolver::make_import_edit(fqn, self, needs_semicolon)
     }
 
     fn infer_type(&self, var_name: &str) -> Option<String> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,10 +8,12 @@ mod resolver;
 mod rg;
 mod stdlib;
 mod stdlib_tail;
+mod str_ext;
 mod task_runner;
 mod types;
 
 pub(crate) use lines_ext::LinesExt;
+pub(crate) use str_ext::StrExt;
 
 use tower_lsp::{LspService, Server};
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -170,7 +170,7 @@ fn map_def_captures<'c, 't>(
         if cap.index == def_idx {
             def_range = Some(ts_to_lsp(cap.node.range()));
         } else if cap.index == name_idx {
-            name_text  = cap.node.utf8_text(bytes).ok().map(str::to_owned);
+            name_text  = cap.node.utf8_text_owned(bytes);
             name_range = Some(ts_to_lsp(cap.node.range()));
         }
     }
@@ -655,14 +655,14 @@ fn parse_import_header(header: &tree_sitter::Node, bytes: &[u8], data: &mut File
     for child in header.children(&mut cur) {
         match child.kind() {
             "identifier" => {
-                path_text = child.utf8_text(bytes).ok().map(str::to_owned);
+                path_text = child.utf8_text_owned(bytes);
             }
             "import_alias" => {
                 // (import_alias "as" (type_identifier))
                 let mut ac = child.walk();
                 for ac_child in child.children(&mut ac) {
                     if ac_child.kind() == "type_identifier" {
-                        alias_text = ac_child.utf8_text(bytes).ok().map(str::to_owned);
+                        alias_text = ac_child.utf8_text_owned(bytes);
                         break;
                     }
                 }
@@ -996,7 +996,7 @@ fn java_first_type_name(node: &Node, bytes: &[u8]) -> Option<String> {
     while let Some(n) = stack.pop() {
         match n.kind() {
             "type_identifier" => {
-                return n.utf8_text(bytes).ok().map(str::to_owned);
+                return n.utf8_text_owned(bytes);
             }
             "scoped_type_identifier" => {
                 // Return the full dotted name (e.g. `pkg.Base`), stripping any trailing
@@ -1028,7 +1028,7 @@ fn java_collect_type_list(node: &Node, bytes: &[u8], name_line: u32, data: &mut 
                 // type_list children may be leaf type_identifier nodes directly,
                 // or wrapper nodes (generic_type, scoped_type_identifier) containing one.
                 let name = if type_node.kind() == "type_identifier" {
-                    type_node.utf8_text(bytes).ok().map(str::to_owned)
+                    type_node.utf8_text_owned(bytes)
                 } else {
                     java_first_type_name(&type_node, bytes)
                 };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -498,10 +498,10 @@ fn report_error_node(node: &Node, bytes: &[u8], seen: &mut std::collections::Has
     let key = (range.start.line, range.start.character);
     if seen.insert(key) {
         let text: String = node.utf8_text(bytes).unwrap_or("").chars().take(30).collect();
-        let text = text.lines().next().unwrap_or(&text);
+        let first_line = text.lines().next().unwrap_or(&text);
         errors.push(SyntaxError {
             range,
-            message: if text.is_empty() { "syntax error".into() } else { format!("unexpected `{text}`") },
+            message: if first_line.is_empty() { "syntax error".into() } else { format!("unexpected `{first_line}`") },
         });
     }
 }
@@ -565,6 +565,9 @@ fn collect_syntax_errors(root: Node, bytes: &[u8]) -> Vec<SyntaxError> {
 ///   `fun addBiometryToPowerAuth(isAllowedForActiveOp: Boolean): Boolean`
 ///   `class CreatePinViewModel @Inject constructor(`
 ///   `val isChecked: Boolean`
+/// Maximum number of characters in an extracted detail string before truncation.
+const MAX_DETAIL_CHARS: usize = 120;
+
 pub(crate) fn extract_detail(lines: &[String], start_line: u32, end_line: u32) -> String {
     let start = start_line as usize;
     let end   = (end_line as usize + 1).min(lines.len());
@@ -589,8 +592,8 @@ pub(crate) fn extract_detail(lines: &[String], start_line: u32, end_line: u32) -
     };
     // Strip trailing `)` then `: ReturnType` to keep it compact, or keep if short.
     // Cap at 120 chars.
-    if trimmed.chars().count() > 120 {
-        let s: String = trimmed.chars().take(119).collect();
+    if trimmed.chars().count() > MAX_DETAIL_CHARS {
+        let s: String = trimmed.chars().take(MAX_DETAIL_CHARS - 1).collect();
         format!("{}…", s)
     } else {
         trimmed
@@ -703,12 +706,12 @@ pub fn parse_imports_from_lines(lines: &[String]) -> Vec<crate::types::ImportEnt
         let rest = rest.strip_prefix("static ").map(str::trim_start).unwrap_or(rest);
         let is_star = rest.ends_with(".*");
         let (path_part, alias) = if let Some(idx) = rest.find(" as ") {
-            (&rest[..idx], Some(rest[idx + 4..].trim().to_owned()))
+            (&rest[..idx], Some(rest[idx + " as ".len()..].trim().to_owned()))
         } else {
             (rest, None)
         };
         let full_path = if is_star {
-            path_part[..path_part.len() - 2].to_owned() // strip ".*"
+            path_part.strip_suffix(".*").unwrap_or(path_part).to_owned()
         } else {
             path_part.to_owned()
         };
@@ -926,32 +929,27 @@ fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
     }
 }
 
+/// Returns the name of the first `user_type` child of `node`, if any.
+fn first_user_type_child_name(node: &Node, bytes: &[u8]) -> Option<String> {
+    let mut cur = node.walk();
+    for child in node.children(&mut cur) {
+        if child.kind() == "user_type" {
+            return user_type_name(&child, bytes);
+        }
+    }
+    None
+}
+
 /// Extract the supertype name from a `delegation_specifier` node.
 fn super_name_from_delegation(node: &Node, bytes: &[u8]) -> Option<String> {
     let mut cur = node.walk();
     for child in node.children(&mut cur) {
         match child.kind() {
-            "constructor_invocation" => {
-                // constructor_invocation → user_type value_arguments
-                let mut cc = child.walk();
-                for gc in child.children(&mut cc) {
-                    if gc.kind() == "user_type" {
-                        return user_type_name(&gc, bytes);
-                    }
-                }
+            "constructor_invocation" | "explicit_delegation" => {
+                return first_user_type_child_name(&child, bytes);
             }
-            "user_type" | "explicit_delegation" => {
-                // explicit_delegation → user_type "by" expression
-                if child.kind() == "explicit_delegation" {
-                    let mut cc = child.walk();
-                    for gc in child.children(&mut cc) {
-                        if gc.kind() == "user_type" {
-                            return user_type_name(&gc, bytes);
-                        }
-                    }
-                } else {
-                    return user_type_name(&child, bytes);
-                }
+            "user_type" => {
+                return user_type_name(&child, bytes);
             }
             _ => {}
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -612,14 +612,8 @@ fn extract_package_and_imports(root: tree_sitter::Node, bytes: &[u8], data: &mut
         match node.kind() {
             "package_header" => {
                 // (package_header "package" (identifier ...))
-                let mut c = node.walk();
-                for child in node.children(&mut c) {
-                    if child.kind() == "identifier" {
-                        if let Ok(txt) = child.utf8_text(bytes) {
-                            data.package = Some(txt.to_owned());
-                        }
-                        break;
-                    }
+                if let Some(child) = node.first_child_of_kind("identifier") {
+                    data.package = child.utf8_text_owned(bytes);
                 }
             }
             "import_list" => {
@@ -645,13 +639,8 @@ fn parse_import_header(header: &tree_sitter::Node, bytes: &[u8], data: &mut File
             }
             "import_alias" => {
                 // (import_alias "as" (type_identifier))
-                let mut ac = child.walk();
-                for ac_child in child.children(&mut ac) {
-                    if ac_child.kind() == "type_identifier" {
-                        alias_text = ac_child.utf8_text_owned(bytes);
-                        break;
-                    }
-                }
+                alias_text = child.first_child_of_kind("type_identifier")
+                    .and_then(|c| c.utf8_text_owned(bytes));
             }
             "wildcard_import" => {
                 is_star = true;
@@ -717,13 +706,8 @@ pub fn parse_imports_from_lines(lines: &[String]) -> Vec<crate::types::ImportEnt
 
 /// Extract the import path text from an `import_declaration` node, if present.
 fn swift_import_path<'a>(node: tree_sitter::Node<'a>, bytes: &'a [u8]) -> Option<&'a str> {
-    let mut cur = node.walk();
-    for child in node.children(&mut cur) {
-        if child.kind() == "identifier" {
-            return child.utf8_text(bytes).ok();
-        }
-    }
-    None
+    node.first_child_of_kind("identifier")
+        .and_then(|c| c.utf8_text(bytes).ok())
 }
 
 fn extract_swift_imports(root: tree_sitter::Node, bytes: &[u8], data: &mut FileData) {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,8 @@
 use tree_sitter::{Node, Parser, Query, QueryCursor};
 use tower_lsp::lsp_types::{Position, Range, SymbolKind};
 
-use crate::indexer::{last_segment, NodeExt};
+use crate::indexer::NodeExt;
+use crate::StrExt;
 use crate::queries::{self, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
     KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_IDENTIFIER,
     KIND_USER_TYPE, KIND_FUN_DECL};
@@ -295,7 +296,7 @@ fn push_java_import(node: &Node, bytes: &[u8], data: &mut FileData) {
         if matches!(child.kind(), "scoped_identifier" | "identifier") {
             if let Ok(txt) = child.utf8_text(bytes) {
                 let full_path  = txt.to_owned();
-                let local_name = last_segment(&full_path).to_owned();
+                let local_name = full_path.last_segment().to_owned();
                 data.imports.push(ImportEntry { full_path, local_name, is_star: false });
             }
             return;
@@ -655,7 +656,7 @@ fn parse_import_header(header: &tree_sitter::Node, bytes: &[u8], data: &mut File
         let local_name = if is_star {
             "*".to_owned()
         } else {
-            alias_text.unwrap_or_else(|| last_segment(&full_path).to_owned())
+            alias_text.unwrap_or_else(|| full_path.last_segment().to_owned())
         };
         data.imports.push(ImportEntry { full_path, local_name, is_star });
     }
@@ -717,7 +718,7 @@ fn extract_swift_imports(root: tree_sitter::Node, bytes: &[u8], data: &mut FileD
     for node in root.children(&mut cur) {
         if node.kind() == "import_declaration" {
             if let Some(txt) = swift_import_path(node, bytes) {
-                let local = last_segment(txt);
+                let local = txt.last_segment();
                 data.imports.push(ImportEntry {
                     full_path:  txt.to_owned(),
                     local_name: local.to_owned(),
@@ -826,7 +827,7 @@ pub(crate) fn extract_declared_names(lines: &[String]) -> Vec<String> {
                 .rev()
                 .collect();
             if word.len() > 1
-                && crate::indexer::starts_with_lowercase(&word)
+                && word.starts_with_lowercase()
                 && seen.insert(word.clone())
             {
                 names.push(word);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -914,13 +914,7 @@ fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
 
 /// Returns the name of the first `user_type` child of `node`, if any.
 fn first_user_type_child_name(node: &Node, bytes: &[u8]) -> Option<String> {
-    let mut cur = node.walk();
-    for child in node.children(&mut cur) {
-        if child.kind() == "user_type" {
-            return user_type_name(&child, bytes);
-        }
-    }
-    None
+    node.first_child_of_kind("user_type").and_then(|c| user_type_name(&c, bytes))
 }
 
 /// Extract the supertype name from a `delegation_specifier` node.
@@ -1003,21 +997,17 @@ fn java_first_type_name(node: &Node, bytes: &[u8]) -> Option<String> {
 /// Walk a `super_interfaces` or `extends_interfaces` node, collecting all type names
 /// from its `type_list` child into `data.supers`.
 fn java_collect_type_list(node: &Node, bytes: &[u8], name_line: u32, data: &mut FileData) {
-    let mut cur = node.walk();
-    for child in node.children(&mut cur) {
-        if child.kind() == "type_list" {
-            let mut cc = child.walk();
-            for type_node in child.children(&mut cc) {
-                // type_list children may be leaf type_identifier nodes directly,
-                // or wrapper nodes (generic_type, scoped_type_identifier) containing one.
-                let name = if type_node.kind() == "type_identifier" {
-                    type_node.utf8_text_owned(bytes)
-                } else {
-                    java_first_type_name(&type_node, bytes)
-                };
-                if let Some(n) = name { data.supers.push((name_line, n)); }
-            }
-        }
+    let Some(type_list) = node.first_child_of_kind("type_list") else { return };
+    let mut cc = type_list.walk();
+    for type_node in type_list.children(&mut cc) {
+        // type_list children may be leaf type_identifier nodes directly,
+        // or wrapper nodes (generic_type, scoped_type_identifier) containing one.
+        let name = if type_node.kind() == "type_identifier" {
+            type_node.utf8_text_owned(bytes)
+        } else {
+            java_first_type_name(&type_node, bytes)
+        };
+        if let Some(n) = name { data.supers.push((name_line, n)); }
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -854,7 +854,7 @@ pub(crate) fn extract_declared_names(lines: &[String]) -> Vec<String> {
                 .rev()
                 .collect();
             if word.len() > 1
-                && word.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
+                && crate::indexer::starts_with_lowercase(&word)
                 && seen.insert(word.clone())
             {
                 names.push(word);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -2,7 +2,9 @@ use tree_sitter::{Node, Parser, Query, QueryCursor};
 use tower_lsp::lsp_types::{Position, Range, SymbolKind};
 
 use crate::indexer::{last_segment, NodeExt};
-use crate::queries::{self, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS};
+use crate::queries::{self, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
+    KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_IDENTIFIER,
+    KIND_USER_TYPE, KIND_FUN_DECL};
 use crate::types::{FileData, ImportEntry, SymbolEntry, SyntaxError, Visibility};
 
 type MatchEntry = (usize, [Option<(String, Range, Range)>; 2]);
@@ -376,14 +378,14 @@ fn is_fun_interface_error(node: &Node, bytes: &[u8]) -> bool {
 /// simple_identifier present after it (directly or as first child of ERROR).
 /// Returns (name_start_byte, name_end_byte, node_range) or None.
 fn fun_interface_name_from_fn_decl(node: &Node, bytes: &[u8]) -> Option<(usize, usize, tree_sitter::Range)> {
-    if node.kind() != "function_declaration" { return None; }
+    if node.kind() != KIND_FUN_DECL { return None; }
     if !node.has_error() { return None; }
     let mut after_interface = false;
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if after_interface {
             // Direct simple_identifier child (@annotation case: "simple_identifier Factory")
-            if child.kind() == "simple_identifier" {
+            if child.kind() == KIND_SIMPLE_IDENT {
                 return Some((child.start_byte(), child.end_byte(), child.range()));
             }
             // ERROR child containing simple_identifier as first meaningful child
@@ -392,14 +394,14 @@ fn fun_interface_name_from_fn_decl(node: &Node, bytes: &[u8]) -> Option<(usize, 
                 let mut ec = child.walk();
                 let info = child.children(&mut ec)
                     .next()
-                    .filter(|c| c.kind() == "simple_identifier")
+                    .filter(|c| c.kind() == KIND_SIMPLE_IDENT)
                     .map(|c| (c.start_byte(), c.end_byte(), c.range()));
                 if let Some(loc) = info {
                     return Some(loc);
                 }
             }
         }
-        if child.kind() == "user_type" && child.utf8_text(bytes).unwrap_or("") == "interface" {
+        if child.kind() == KIND_USER_TYPE && child.utf8_text(bytes).unwrap_or("") == "interface" {
             after_interface = true;
         }
     }
@@ -426,7 +428,7 @@ fn extract_fun_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
     while let Some(node) = stack.pop() {
         // Case 1: no-modifier `fun interface` → ERROR node
         if node.is_error() && is_fun_interface_error(&node, bytes) {
-            if let Some(child) = node.first_child_of_kind("simple_identifier") {
+            if let Some(child) = node.first_child_of_kind(KIND_SIMPLE_IDENT) {
                 if let Ok(name) = child.utf8_text(bytes) {
                     push_interface_symbol(name, &node, child.range(), data);
                 }
@@ -612,7 +614,7 @@ fn extract_package_and_imports(root: tree_sitter::Node, bytes: &[u8], data: &mut
         match node.kind() {
             "package_header" => {
                 // (package_header "package" (identifier ...))
-                if let Some(child) = node.first_child_of_kind("identifier") {
+                if let Some(child) = node.first_child_of_kind(KIND_IDENTIFIER) {
                     data.package = child.utf8_text_owned(bytes);
                 }
             }
@@ -639,7 +641,7 @@ fn parse_import_header(header: &tree_sitter::Node, bytes: &[u8], data: &mut File
             }
             "import_alias" => {
                 // (import_alias "as" (type_identifier))
-                alias_text = child.first_child_of_kind("type_identifier")
+                alias_text = child.first_child_of_kind(KIND_TYPE_IDENT)
                     .and_then(|c| c.utf8_text_owned(bytes));
             }
             "wildcard_import" => {
@@ -706,7 +708,7 @@ pub fn parse_imports_from_lines(lines: &[String]) -> Vec<crate::types::ImportEnt
 
 /// Extract the import path text from an `import_declaration` node, if present.
 fn swift_import_path<'a>(node: tree_sitter::Node<'a>, bytes: &'a [u8]) -> Option<&'a str> {
-    node.first_child_of_kind("identifier")
+    node.first_child_of_kind(KIND_IDENTIFIER)
         .and_then(|c| c.utf8_text(bytes).ok())
 }
 
@@ -895,7 +897,7 @@ fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
 
 /// Returns the name of the first `user_type` child of `node`, if any.
 fn first_user_type_child_name(node: &Node, bytes: &[u8]) -> Option<String> {
-    node.first_child_of_kind("user_type").and_then(|c| user_type_name(&c, bytes))
+    node.first_child_of_kind(KIND_USER_TYPE).and_then(|c| user_type_name(&c, bytes))
 }
 
 /// Extract the supertype name from a `delegation_specifier` node.
@@ -983,7 +985,7 @@ fn java_collect_type_list(node: &Node, bytes: &[u8], name_line: u32, data: &mut 
     for type_node in type_list.children(&mut cc) {
         // type_list children may be leaf type_identifier nodes directly,
         // or wrapper nodes (generic_type, scoped_type_identifier) containing one.
-        let name = if type_node.kind() == "type_identifier" {
+        let name = if type_node.kind() == KIND_TYPE_IDENT {
             type_node.utf8_text_owned(bytes)
         } else {
             java_first_type_name(&type_node, bytes)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -255,16 +255,12 @@ fn extract_java(node: &Node, bytes: &[u8], data: &mut FileData) {
 
 /// Returns true if the Java node's modifiers child contains ALL of `required` keywords.
 fn java_node_has_modifiers(node: &Node, required: &[&str]) -> bool {
-    let mut cur = node.walk();
-    for child in node.children(&mut cur) {
-        if child.kind() == "modifiers" {
-            // Collect modifier keyword kinds into a Vec first to avoid walker lifetime issues.
-            let mut mc = child.walk();
-            let found_kinds: Vec<&str> = child.children(&mut mc).map(|k| k.kind()).collect();
-            return required.iter().all(|&req| found_kinds.contains(&req));
-        }
-    }
-    false
+    let Some(mods) = node.first_child_of_kind("modifiers") else { return false; };
+    let found_kinds: Vec<&str> = (0..mods.child_count())
+        .filter_map(|i| mods.child(i))
+        .map(|c| c.kind())
+        .collect();
+    required.iter().all(|&req| found_kinds.contains(&req))
 }
 
 fn push_field_declaration(node: &Node, bytes: &[u8], data: &mut FileData) {
@@ -277,19 +273,16 @@ fn push_field_declaration(node: &Node, bytes: &[u8], data: &mut FileData) {
     let nr = ts_to_lsp(node.range());
     let vis = visibility_at_line(&data.lines, node.range().start_point.row);
     let detail = extract_detail(&data.lines, nr.start.line, nr.end.line);
-    let mut cur = node.walk();
-    for child in node.children(&mut cur) {
-        if child.kind() == "variable_declarator" {
-            if let Some((name, sel)) = first_identifier(&child, bytes) {
-                data.symbols.push(SymbolEntry {
-                    name,
-                    kind,
-                    visibility: vis,
-                    range: nr,
-                    selection_range: sel,
-                    detail: detail.clone(),
-                });
-            }
+    for child in node.children_of_kind("variable_declarator") {
+        if let Some((name, sel)) = first_identifier(&child, bytes) {
+            data.symbols.push(SymbolEntry {
+                name,
+                kind,
+                visibility: vis,
+                range: nr,
+                selection_range: sel,
+                detail: detail.clone(),
+            });
         }
     }
 }
@@ -433,13 +426,9 @@ fn extract_fun_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
     while let Some(node) = stack.pop() {
         // Case 1: no-modifier `fun interface` → ERROR node
         if node.is_error() && is_fun_interface_error(&node, bytes) {
-            let mut cur = node.walk();
-            for child in node.children(&mut cur) {
-                if child.kind() == "simple_identifier" {
-                    if let Ok(name) = child.utf8_text(bytes) {
-                        push_interface_symbol(name, &node, child.range(), data);
-                    }
-                    break;
+            if let Some(child) = node.first_child_of_kind("simple_identifier") {
+                if let Ok(name) = child.utf8_text(bytes) {
+                    push_interface_symbol(name, &node, child.range(), data);
                 }
             }
             // Don't recurse further into ERROR children.
@@ -634,11 +623,8 @@ fn extract_package_and_imports(root: tree_sitter::Node, bytes: &[u8], data: &mut
                 }
             }
             "import_list" => {
-                let mut lc = node.walk();
-                for header in node.children(&mut lc) {
-                    if header.kind() == "import_header" {
-                        parse_import_header(&header, bytes, data);
-                    }
+                for header in node.children_of_kind("import_header") {
+                    parse_import_header(&header, bytes, data);
                 }
             }
             _ => {}
@@ -876,12 +862,9 @@ fn extract_supers_kotlin(root: Node, bytes: &[u8], data: &mut FileData) {
         match node.kind() {
             "class_declaration" | "object_declaration" => {
                 let name_line = node.name_line();
-                let mut cur = node.walk();
-                for child in node.children(&mut cur) {
-                    if child.kind() == "delegation_specifier" {
-                        if let Some(name) = super_name_from_delegation(&child, bytes) {
-                            data.supers.push((name_line, name));
-                        }
+                for child in node.children_of_kind("delegation_specifier") {
+                    if let Some(name) = super_name_from_delegation(&child, bytes) {
+                        data.supers.push((name_line, name));
                     }
                 }
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -884,12 +884,9 @@ fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
         }
         "interface_declaration" => {
             let name_line = node.name_line();
-            let mut cur = node.walk();
-            for child in node.children(&mut cur) {
-                if child.kind() == "extends_interfaces" {
-                    // (extends_interfaces "extends" (type_list ...))
-                    java_collect_type_list(&child, bytes, name_line, data);
-                }
+            if let Some(ext) = node.first_child_of_kind("extends_interfaces") {
+                // (extends_interfaces "extends" (type_list ...))
+                java_collect_type_list(&ext, bytes, name_line, data);
             }
         }
         _ => {}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 use tree_sitter::{Node, Parser, Query, QueryCursor};
 use tower_lsp::lsp_types::{Position, Range, SymbolKind};
 
-use crate::indexer::NodeExt;
+use crate::indexer::{last_segment, NodeExt};
 use crate::queries::{self, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS};
 use crate::types::{FileData, ImportEntry, SymbolEntry, SyntaxError, Visibility};
 
@@ -606,14 +606,14 @@ fn is_ident(s: &str) -> bool {
         && s.chars().all(|c| c.is_alphanumeric() || c == '_')
 }
 
-fn last_segment(dotted: &str) -> &str {
-    dotted.rsplit('.').next().unwrap_or(dotted)
-}
-
 // ─── package + import extraction ─────────────────────────────────────────────
 //
 // Uses a manual BFS rather than queries to avoid the pattern-overlap problem
 // (plain-import query would also fire on star / alias imports).
+
+const IMPORT_KW: &str = "import ";
+const STATIC_KW: &str = "static ";
+const IMPORT_ALIAS_KW: &str = " as ";
 
 fn extract_package_and_imports(root: tree_sitter::Node, bytes: &[u8], data: &mut FileData) {
     // Only need the top of the file: package_header and import_list are always
@@ -691,8 +691,8 @@ pub fn parse_imports_from_lines(lines: &[String]) -> Vec<crate::types::ImportEnt
     let mut imports = Vec::new();
     for line in lines {
         let trimmed = line.trim_start();
-        if !trimmed.starts_with("import ") { continue; }
-        let rest_raw = trimmed["import ".len()..].trim();
+        if !trimmed.starts_with(IMPORT_KW) { continue; }
+        let rest_raw = trimmed[IMPORT_KW.len()..].trim();
         if rest_raw.is_empty() { continue; }
         // Strip inline comments (e.g. `import foo.Bar // generated`)
         let rest = if let Some(ci) = rest_raw.find("//") {
@@ -703,10 +703,10 @@ pub fn parse_imports_from_lines(lines: &[String]) -> Vec<crate::types::ImportEnt
         if rest.is_empty() { continue; }
         // Trim optional trailing `;` (Java-style imports) and skip Java's `static` modifier.
         let rest = rest.trim_end_matches(';').trim_end();
-        let rest = rest.strip_prefix("static ").map(str::trim_start).unwrap_or(rest);
+        let rest = rest.strip_prefix(STATIC_KW).map(str::trim_start).unwrap_or(rest);
         let is_star = rest.ends_with(".*");
-        let (path_part, alias) = if let Some(idx) = rest.find(" as ") {
-            (&rest[..idx], Some(rest[idx + " as ".len()..].trim().to_owned()))
+        let (path_part, alias) = if let Some(idx) = rest.find(IMPORT_ALIAS_KW) {
+            (&rest[..idx], Some(rest[idx + IMPORT_ALIAS_KW.len()..].trim().to_owned()))
         } else {
             (rest, None)
         };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,7 @@
 use tree_sitter::{Node, Parser, Query, QueryCursor};
 use tower_lsp::lsp_types::{Position, Range, SymbolKind};
 
+use crate::indexer::NodeExt;
 use crate::queries::{self, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS};
 use crate::types::{FileData, ImportEntry, SymbolEntry, SyntaxError, Visibility};
 
@@ -104,7 +105,7 @@ pub fn parse_swift(content: &str) -> FileData {
         .matches(&def_q, root, bytes)
         .map(|m| {
             let (pidx, slot) = map_def_captures(&m, def_idx, name_idx, bytes);
-            if pidx == 8 && slot[0].is_none() {
+            if pidx == queries::SWIFT_INIT_PATTERN_IDX && slot[0].is_none() {
                 // init_declaration — no @name, synthesize "init"
                 let def_range = m.captures.iter()
                     .find(|cap| cap.index == def_idx)
@@ -112,9 +113,9 @@ pub fn parse_swift(content: &str) -> FileData {
                 if let Some(dr) = def_range {
                     let sel = Range::new(
                         Position::new(dr.start.line, dr.start.character),
-                        Position::new(dr.start.line, dr.start.character + 4),
+                        Position::new(dr.start.line, dr.start.character + queries::SWIFT_INIT_NAME.len() as u32),
                     );
-                    return (pidx, [Some(("init".to_owned(), dr, sel)), None]);
+                    return (pidx, [Some((queries::SWIFT_INIT_NAME.to_owned(), dr, sel)), None]);
                 }
             }
             (pidx, slot)
@@ -412,6 +413,14 @@ fn fun_interface_name_from_fn_decl(node: &Node, bytes: &[u8]) -> Option<(usize, 
     None
 }
 
+fn push_interface_symbol(name: &str, node: &Node, sel_node_range: tree_sitter::Range, data: &mut FileData) {
+    let visibility = visibility_at_line(&data.lines, node.range().start_point.row);
+    let range      = ts_to_lsp(node.range());
+    let sel        = ts_to_lsp(sel_node_range);
+    let detail     = extract_detail(&data.lines, range.start.line, range.end.line);
+    data.symbols.push(SymbolEntry { name: name.to_owned(), kind: SymbolKind::INTERFACE, visibility, range, selection_range: sel, detail });
+}
+
 /// Walk the parse tree and emit INTERFACE symbols for every `fun interface Foo` declaration.
 ///
 /// Tree-sitter produces two different misparsings depending on whether modifiers precede:
@@ -428,18 +437,7 @@ fn extract_fun_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
             for child in node.children(&mut cur) {
                 if child.kind() == "simple_identifier" {
                     if let Ok(name) = child.utf8_text(bytes) {
-                        let visibility = visibility_at_line(&data.lines, node.range().start_point.row);
-                        let range      = ts_to_lsp(node.range());
-                        let sel        = ts_to_lsp(child.range());
-                        let detail     = extract_detail(&data.lines, range.start.line, range.end.line);
-                        data.symbols.push(SymbolEntry {
-                            name: name.to_owned(),
-                            kind: SymbolKind::INTERFACE,
-                            visibility,
-                            range,
-                            selection_range: sel,
-                            detail,
-                        });
+                        push_interface_symbol(name, &node, child.range(), data);
                     }
                     break;
                 }
@@ -450,23 +448,13 @@ fn extract_fun_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
         // Case 2: modifier-prefixed `fun interface` → misparse as function_declaration
         if let Some((name_start, name_end, name_ts_range)) = fun_interface_name_from_fn_decl(&node, bytes) {
             if let Ok(name) = std::str::from_utf8(&bytes[name_start..name_end]) {
-                let visibility = visibility_at_line(&data.lines, node.range().start_point.row);
-                let range      = ts_to_lsp(node.range());
-                let sel        = ts_to_lsp(name_ts_range);
-                let detail     = extract_detail(&data.lines, range.start.line, range.end.line);
+                let sel = ts_to_lsp(name_ts_range);
                 // Remove the incorrectly-added function/method symbol (same name, same line).
                 data.symbols.retain(|s| {
                     !(s.name == name && s.selection_range.start.line == sel.start.line
                       && matches!(s.kind, SymbolKind::FUNCTION | SymbolKind::METHOD))
                 });
-                data.symbols.push(SymbolEntry {
-                    name: name.to_owned(),
-                    kind: SymbolKind::INTERFACE,
-                    visibility,
-                    range,
-                    selection_range: sel,
-                    detail,
-                });
+                push_interface_symbol(name, &node, name_ts_range, data);
             }
             // Still recurse into children to find nested fun interfaces.
         }
@@ -496,6 +484,28 @@ fn has_fun_interface_descendant(node: &Node, bytes: &[u8]) -> bool {
     children.iter().any(|c| has_fun_interface_descendant(c, bytes))
 }
 
+fn report_missing_node(node: &Node, seen: &mut std::collections::HashSet<(u32, u32)>, errors: &mut Vec<SyntaxError>) {
+    let range = ts_to_lsp(node.range());
+    let key = (range.start.line, range.start.character);
+    if seen.insert(key) {
+        let kind = node.kind();
+        errors.push(SyntaxError { range, message: format!("missing `{kind}`") });
+    }
+}
+
+fn report_error_node(node: &Node, bytes: &[u8], seen: &mut std::collections::HashSet<(u32, u32)>, errors: &mut Vec<SyntaxError>) {
+    let range = ts_to_lsp(node.range());
+    let key = (range.start.line, range.start.character);
+    if seen.insert(key) {
+        let text: String = node.utf8_text(bytes).unwrap_or("").chars().take(30).collect();
+        let text = text.lines().next().unwrap_or(&text);
+        errors.push(SyntaxError {
+            range,
+            message: if text.is_empty() { "syntax error".into() } else { format!("unexpected `{text}`") },
+        });
+    }
+}
+
 fn collect_syntax_errors(root: Node, bytes: &[u8]) -> Vec<SyntaxError> {
     if !root.has_error() { return Vec::new(); }
 
@@ -507,37 +517,13 @@ fn collect_syntax_errors(root: Node, bytes: &[u8]) -> Vec<SyntaxError> {
         if errors.len() >= MAX_SYNTAX_ERRORS { break; }
 
         if node.is_missing() {
-            let range = ts_to_lsp(node.range());
-            let key = (range.start.line, range.start.character);
-            if seen.insert(key) {
-                let kind = node.kind();
-                errors.push(SyntaxError {
-                    range,
-                    message: format!("missing `{kind}`"),
-                });
-            }
+            report_missing_node(&node, &mut seen, &mut errors);
         } else if node.is_error() {
             // Skip errors that are actually valid `fun interface` declarations.
             if is_fun_interface_error(&node, bytes) {
                 continue;
             }
-            let range = ts_to_lsp(node.range());
-            let key = (range.start.line, range.start.character);
-            if seen.insert(key) {
-                let text: String = node.utf8_text(bytes).unwrap_or("")
-                    .chars()
-                    .take(30)
-                    .collect();
-                let text = text.lines().next().unwrap_or(&text);
-                errors.push(SyntaxError {
-                    range,
-                    message: if text.is_empty() {
-                        "syntax error".into()
-                    } else {
-                        format!("unexpected `{text}`")
-                    },
-                });
-            }
+            report_error_node(&node, bytes, &mut seen, &mut errors);
             // Recurse into ERROR children to find nested MISSING nodes.
             let mut cursor = node.walk();
             for child in node.children(&mut cursor) {
@@ -740,29 +726,42 @@ pub fn parse_imports_from_lines(lines: &[String]) -> Vec<crate::types::ImportEnt
 
 // ─── Swift import extraction ─────────────────────────────────────────────────
 
+/// Extract the import path text from an `import_declaration` node, if present.
+fn swift_import_path<'a>(node: tree_sitter::Node<'a>, bytes: &'a [u8]) -> Option<&'a str> {
+    let mut cur = node.walk();
+    for child in node.children(&mut cur) {
+        if child.kind() == "identifier" {
+            return child.utf8_text(bytes).ok();
+        }
+    }
+    None
+}
+
 fn extract_swift_imports(root: tree_sitter::Node, bytes: &[u8], data: &mut FileData) {
     let mut cur = root.walk();
     for node in root.children(&mut cur) {
         if node.kind() == "import_declaration" {
-            let mut ic = node.walk();
-            for child in node.children(&mut ic) {
-                if child.kind() == "identifier" {
-                    if let Ok(txt) = child.utf8_text(bytes) {
-                        let local = last_segment(txt);
-                        data.imports.push(ImportEntry {
-                            full_path:  txt.to_owned(),
-                            local_name: local.to_owned(),
-                            is_star:    false,
-                        });
-                    }
-                    break;
-                }
+            if let Some(txt) = swift_import_path(node, bytes) {
+                let local = last_segment(txt);
+                data.imports.push(ImportEntry {
+                    full_path:  txt.to_owned(),
+                    local_name: local.to_owned(),
+                    is_star:    false,
+                });
             }
         }
     }
 }
 
 // ─── visibility detection ────────────────────────────────────────────────────
+
+/// Returns the portion of `line` before any `{` or `=` — the modifiers region.
+fn decl_prefix(line: &str) -> &str {
+    line.split_once('{').map(|(l, _)| l)
+        .unwrap_or(line)
+        .split_once('=').map(|(l, _)| l)
+        .unwrap_or(line)
+}
 
 /// Detect the Kotlin/Java visibility modifier on `line_no` by scanning that
 /// source line for modifier keywords.
@@ -786,10 +785,7 @@ pub(crate) fn visibility_at_line(lines: &[String], line_no: usize) -> Visibility
     };
     // Work only on the part before any `=`, `{`, or `(` to avoid false positives
     // from string literals / bodies.
-    let decl = line.split_once('{').map(|(l, _)| l)
-        .unwrap_or(line)
-        .split_once('=').map(|(l, _)| l)
-        .unwrap_or(line);
+    let decl = decl_prefix(line);
 
     // Check whole-word tokens.
     if contains_word(decl, "private")   { return Visibility::Private; }
@@ -807,10 +803,7 @@ pub(crate) fn swift_visibility_at_line(lines: &[String], line_no: usize) -> Visi
         Some(l) => l,
         None    => return Visibility::Internal,
     };
-    let decl = line.split_once('{').map(|(l, _)| l)
-        .unwrap_or(line)
-        .split_once('=').map(|(l, _)| l)
-        .unwrap_or(line);
+    let decl = decl_prefix(line);
 
     if contains_word(decl, "private")     { return Visibility::Private; }
     if contains_word(decl, "fileprivate") { return Visibility::Private; }
@@ -879,7 +872,7 @@ fn extract_supers_kotlin(root: Node, bytes: &[u8], data: &mut FileData) {
     while let Some(node) = stack.pop() {
         match node.kind() {
             "class_declaration" | "object_declaration" => {
-                let name_line = node_name_line(&node);
+                let name_line = node.name_line();
                 let mut cur = node.walk();
                 for child in node.children(&mut cur) {
                     if child.kind() == "delegation_specifier" {
@@ -901,7 +894,7 @@ fn extract_supers_kotlin(root: Node, bytes: &[u8], data: &mut FileData) {
 fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
     match node.kind() {
         "class_declaration" | "record_declaration" | "enum_declaration" => {
-            let name_line = node_name_line(node);
+            let name_line = node.name_line();
             let mut cur = node.walk();
             for child in node.children(&mut cur) {
                 match child.kind() {
@@ -920,7 +913,7 @@ fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
             }
         }
         "interface_declaration" => {
-            let name_line = node_name_line(node);
+            let name_line = node.name_line();
             let mut cur = node.walk();
             for child in node.children(&mut cur) {
                 if child.kind() == "extends_interfaces" {
@@ -931,21 +924,6 @@ fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
         }
         _ => {}
     }
-}
-
-/// Get the start line of the class-name identifier — matches `SymbolEntry::selection_range.start.line`.
-fn node_name_line(node: &Node) -> u32 {
-    // Java uses field "name"; Kotlin has type_identifier as a direct child.
-    if let Some(n) = node.child_by_field_name("name") {
-        return n.start_position().row as u32;
-    }
-    let mut cur = node.walk();
-    for child in node.children(&mut cur) {
-        if matches!(child.kind(), "type_identifier" | "simple_identifier" | "identifier") {
-            return child.start_position().row as u32;
-        }
-    }
-    node.start_position().row as u32
 }
 
 /// Extract the supertype name from a `delegation_specifier` node.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1024,6 +1024,7 @@ impl crate::types::FileData {
 mod tests {
     use super::*;
     use tower_lsp::lsp_types::{Position, SymbolKind};
+    use crate::resolver::complete_symbol;
 
     fn uri(path: &str) -> tower_lsp::lsp_types::Url {
         tower_lsp::lsp_types::Url::parse(&format!("file:///test{path}")).unwrap()
@@ -1335,7 +1336,7 @@ mod tests {
 
         let (items, _) = idx.completions(&vm_uri, tower_lsp::lsp_types::Position::new(2, 24), true); // after "private val repo: Repo"
         // Trigger a dot completion manually through resolver
-        let (items, _) = crate::resolver::complete_symbol(
+        let (items, _) = complete_symbol(
             &idx, "", Some("repo"), &vm_uri, true
         );
         let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -353,6 +353,4 @@ pub(crate) const KIND_LAMBDA_PARAMS: &str = "lambda_parameters";
 pub(crate) const KIND_VALUE_ARG:     &str = "value_argument";
 pub(crate) const KIND_VALUE_ARGS:    &str = "value_arguments";
 pub(crate) const KIND_USER_TYPE:     &str = "user_type";
-pub(crate) const KIND_NAV_EXPR:      &str = "navigation_expression";
 pub(crate) const KIND_FUN_DECL:      &str = "function_declaration";
-pub(crate) const KIND_CLASS_DECL:    &str = "class_declaration";

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -339,3 +339,20 @@ pub const SWIFT_INIT_PATTERN_IDX: usize = 8;
 
 /// Synthesised name for Swift init declarations.
 pub const SWIFT_INIT_NAME: &str = "init";
+
+// ─── tree-sitter node kind constants ─────────────────────────────────────────
+// These match the `node.kind()` strings produced by tree-sitter-kotlin,
+// tree-sitter-java, and tree-sitter-swift grammars.
+
+pub(crate) const KIND_SIMPLE_IDENT:  &str = "simple_identifier";
+pub(crate) const KIND_TYPE_IDENT:    &str = "type_identifier";
+pub(crate) const KIND_IDENTIFIER:    &str = "identifier";
+pub(crate) const KIND_CALL_EXPR:     &str = "call_expression";
+pub(crate) const KIND_LAMBDA_LIT:    &str = "lambda_literal";
+pub(crate) const KIND_LAMBDA_PARAMS: &str = "lambda_parameters";
+pub(crate) const KIND_VALUE_ARG:     &str = "value_argument";
+pub(crate) const KIND_VALUE_ARGS:    &str = "value_arguments";
+pub(crate) const KIND_USER_TYPE:     &str = "user_type";
+pub(crate) const KIND_NAV_EXPR:      &str = "navigation_expression";
+pub(crate) const KIND_FUN_DECL:      &str = "function_declaration";
+pub(crate) const KIND_CLASS_DECL:    &str = "class_declaration";

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -332,3 +332,10 @@ pub fn swift_def_pattern_meta(pattern_index: usize) -> (SymbolKind, Option<&'sta
         _  => (SymbolKind::NULL,            None),
     }
 }
+
+/// Pattern index of `init_declaration` in `SWIFT_DEFINITIONS`.
+/// Pattern 8 has no `@name` capture — the parser synthesises `"init"` instead.
+pub const SWIFT_INIT_PATTERN_IDX: usize = 8;
+
+/// Synthesised name for Swift init declarations.
+pub const SWIFT_INIT_NAME: &str = "init";

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -7,7 +7,7 @@ use crate::indexer::Indexer;
 use crate::types::Visibility;
 use crate::LinesExt;
 
-use super::{fqns_for_name, already_imported, make_import_edit,
+use super::{fqns_for_name, already_imported,
             resolve_symbol_inner, resolve_symbol_no_rg};
 use super::infer::{infer_variable_type, ReceiverKind, ReceiverType, infer_receiver_type};
 
@@ -226,6 +226,24 @@ pub(crate) fn complete_dot(idx: &Indexer, receiver: &str, from_uri: &Url, snippe
     items
 }
 
+/// Build a `CompletionItem` for a symbol found inside a nested type body.
+///
+/// Functions/methods get a snippet `name($1)`; all other kinds are plain-text.
+/// The `sort_text` prefix is the `kind_sort_rank` value so the list is ordered
+/// consistently with the rest of the completion results.
+fn completion_item_for_nested_symbol(s: &crate::types::SymbolEntry) -> CompletionItem {
+    let kind  = symbol_kind_to_completion(s.kind);
+    let is_fn = matches!(kind, CompletionItemKind::FUNCTION | CompletionItemKind::METHOD);
+    CompletionItem {
+        label:              s.name.clone(),
+        kind:               Some(kind),
+        insert_text:        if is_fn { Some(format!("{}($1)", s.name)) } else { None },
+        insert_text_format: if is_fn { Some(InsertTextFormat::SNIPPET) } else { None },
+        sort_text:          Some(format!("{:02}:{}", kind_sort_rank(Some(kind)), s.name)),
+        ..Default::default()
+    }
+}
+
 /// Return completions for symbols declared INSIDE `type_name` within the given file.
 /// Uses the symbol's range end (the closing `}` of the class body) to determine
 /// membership — no indentation heuristics needed.
@@ -256,18 +274,7 @@ fn symbols_from_nested_type(
             // Unknown type — return all non-private symbols as a fallback.
             return symbols_ref.iter()
                 .filter(|s| s.visibility != Visibility::Private)
-                .map(|s| {
-                    let kind = symbol_kind_to_completion(s.kind);
-                    let is_fn = matches!(kind, CompletionItemKind::FUNCTION | CompletionItemKind::METHOD);
-                    CompletionItem {
-                        label:              s.name.clone(),
-                        kind:               Some(kind),
-                        insert_text:        if is_fn { Some(format!("{}($1)", s.name)) } else { None },
-                        insert_text_format: if is_fn { Some(InsertTextFormat::SNIPPET) } else { None },
-                        sort_text:          Some(format!("{:02}:{}", kind_sort_rank(Some(kind)), s.name)),
-                        ..Default::default()
-                    }
-                })
+                .map(|s| completion_item_for_nested_symbol(s))
                 .collect();
         }
     };
@@ -288,18 +295,7 @@ fn symbols_from_nested_type(
             starts_after && starts_before
         })
         .filter(|s| s.visibility != Visibility::Private)
-        .map(|s| {
-            let kind = symbol_kind_to_completion(s.kind);
-            let is_fn = matches!(kind, CompletionItemKind::FUNCTION | CompletionItemKind::METHOD);
-            CompletionItem {
-                label:              s.name.clone(),
-                kind:               Some(kind),
-                insert_text:        if is_fn { Some(format!("{}($1)", s.name)) } else { None },
-                insert_text_format: if is_fn { Some(InsertTextFormat::SNIPPET) } else { None },
-                sort_text:          Some(format!("{:02}:{}", kind_sort_rank(Some(kind)), s.name)),
-                ..Default::default()
-            }
-        })
+        .map(|s| completion_item_for_nested_symbol(s))
         .collect()
 }
 
@@ -492,7 +488,7 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
                     if !seen.insert(item_key) { continue; }
 
                     let import_edit = if needs_import {
-                        Some(vec![make_import_edit(fqn, &cur_lines, is_java)])
+                        Some(vec![cur_lines.make_import_edit(fqn, is_java)])
                     } else {
                         None
                     };

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -10,7 +10,7 @@ use crate::StrExt;
 
 use super::{fqns_for_name, already_imported,
             resolve_symbol_inner, resolve_symbol_no_rg};
-use super::infer::{infer_variable_type, ReceiverKind, ReceiverType, infer_receiver_type};
+use super::infer::{ReceiverKind, ReceiverType, infer_receiver_type};
 
 // ─── match scoring ────────────────────────────────────────────────────────────
 

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -6,6 +6,7 @@ use tower_lsp::lsp_types::{
 use crate::indexer::Indexer;
 use crate::types::Visibility;
 use crate::LinesExt;
+use crate::StrExt;
 
 use super::{fqns_for_name, already_imported,
             resolve_symbol_inner, resolve_symbol_no_rg};
@@ -193,7 +194,7 @@ pub(crate) fn complete_dot(idx: &Indexer, receiver: &str, from_uri: &Url, snippe
         Some(r) => r,
         None => {
             // Could be an uppercase class/object — look it up directly.
-            if crate::indexer::starts_with_uppercase(receiver) {
+            if receiver.starts_with_uppercase() {
                 ReceiverType::from_raw(receiver.to_string())
             } else {
                 return vec![];
@@ -370,10 +371,10 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
             return;
         }
         // Case gates: match user intent by the capitalisation of what they typed.
-        if lowercase_mode && crate::indexer::starts_with_uppercase(name) {
+        if lowercase_mode && name.starts_with_uppercase() {
             return;
         }
-        if uppercase_mode && crate::indexer::starts_with_lowercase(name) {
+        if uppercase_mode && name.starts_with_lowercase() {
             return;
         }
         // CamelCase prefix → hide SCREAMING_SNAKE_CASE names (constants, enum variants).
@@ -455,7 +456,7 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
         if let Ok(cache) = idx.bare_name_cache.read() {
             for name in cache.iter() {
                 // Case gate + match quality gate (prefix or acronym only).
-                if crate::indexer::starts_with_lowercase(name) { continue; }
+                if name.starts_with_lowercase() { continue; }
                 if camel_mode && is_screaming_snake(name) { continue; }
                 let score = match match_score(name, prefix) {
                     Some(s) if s <= 1 => s,
@@ -517,7 +518,7 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
     // 4. Stdlib top-level / scope functions — src_tier 3.
     for mut item in crate::stdlib::bare_completions(snippets) {
         let label = item.label.clone();
-        if lowercase_mode && crate::indexer::starts_with_uppercase(&label) {
+        if lowercase_mode && label.starts_with_uppercase() {
             continue;
         }
         if camel_mode && is_screaming_snake(&label) { continue; }

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -83,6 +83,12 @@ fn camel_acronym_match(name: &str, prefix: &str) -> bool {
 /// When capped, `is_incomplete` should be set so the client re-queries.
 pub(crate) const COMPLETION_CAP: usize = 150;
 
+/// Prefix length at which local-symbol relevance score is reduced (longer prefix → more confident match).
+const MIN_PREFIX_SCORE_REDUCTION: usize = 4;
+
+/// Minimum prefix length to enable case-insensitive completion matching.
+const MIN_CASE_INSENSITIVE_PREFIX: usize = 2;
+
 /// Provide completion candidates for `prefix` at the current position.
 ///
 /// Returns `(items, hit_cap)` — when `hit_cap` is true the caller should set
@@ -346,7 +352,7 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
     // hits from filling the cap and crowding out precise tier-2 cross-package matches
     // (e.g. typing "ChildDash" must surface ChildDashboardViewModel even if the same
     // package has many classes that contain "child" as a substring).
-    let local_max_score: u8 = if prefix.len() >= 4 { 1 } else { 2 };
+    let local_max_score: u8 = if prefix.len() >= MIN_PREFIX_SCORE_REDUCTION { 1 } else { 2 };
     let mut seen = std::collections::HashSet::new();
     let mut items: Vec<CompletionItem> = Vec::new();
 
@@ -424,7 +430,7 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
     // 3. Cross-package symbols — src_tier 2, uppercase mode only, prefix ≥ 2 chars,
     //    prefix/acronym matches only (max_score=1) — no substring flood.
     // Emits one CompletionItem per distinct FQN, with additionalTextEdits for auto-import.
-    if !lowercase_mode && prefix.len() >= 2 {
+    if !lowercase_mode && prefix.len() >= MIN_CASE_INSENSITIVE_PREFIX {
         let is_java = from_uri.as_str().ends_with(".java");
         // Prefer live_lines (updated on every keystroke) over the indexed snapshot so that
         // import deduplication and insertion position are based on the current buffer state.

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -193,7 +193,7 @@ pub(crate) fn complete_dot(idx: &Indexer, receiver: &str, from_uri: &Url, snippe
         Some(r) => r,
         None => {
             // Could be an uppercase class/object — look it up directly.
-            if receiver.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+            if crate::indexer::starts_with_uppercase(receiver) {
                 ReceiverType::from_raw(receiver.to_string())
             } else {
                 return vec![];
@@ -370,10 +370,10 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
             return;
         }
         // Case gates: match user intent by the capitalisation of what they typed.
-        if lowercase_mode && name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+        if lowercase_mode && crate::indexer::starts_with_uppercase(name) {
             return;
         }
-        if uppercase_mode && name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false) {
+        if uppercase_mode && crate::indexer::starts_with_lowercase(name) {
             return;
         }
         // CamelCase prefix → hide SCREAMING_SNAKE_CASE names (constants, enum variants).
@@ -455,7 +455,7 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
         if let Ok(cache) = idx.bare_name_cache.read() {
             for name in cache.iter() {
                 // Case gate + match quality gate (prefix or acronym only).
-                if name.chars().next().map(|c| c.is_lowercase()).unwrap_or(false) { continue; }
+                if crate::indexer::starts_with_lowercase(name) { continue; }
                 if camel_mode && is_screaming_snake(name) { continue; }
                 let score = match match_score(name, prefix) {
                     Some(s) if s <= 1 => s,
@@ -517,7 +517,7 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
     // 4. Stdlib top-level / scope functions — src_tier 3.
     for mut item in crate::stdlib::bare_completions(snippets) {
         let label = item.label.clone();
-        if lowercase_mode && label.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+        if lowercase_mode && crate::indexer::starts_with_uppercase(&label) {
             continue;
         }
         if camel_mode && is_screaming_snake(&label) { continue; }

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -7,6 +7,7 @@ use crate::indexer::Indexer;
 use crate::types::Visibility;
 use crate::LinesExt;
 use crate::StrExt;
+use crate::parser::parse_by_extension;
 
 use super::{fqns_for_name, already_imported,
             resolve_symbol_inner, resolve_symbol_no_rg};
@@ -270,7 +271,7 @@ fn symbols_from_nested_type(
         let url = match Url::parse(file_uri) { Ok(u) => u, Err(_) => return vec![] };
         let path = match url.to_file_path() { Ok(p) => p, Err(_) => return vec![] };
         let content = match std::fs::read_to_string(&path) { Ok(c) => c, Err(_) => return vec![] };
-        owned = crate::parser::parse_by_extension(file_uri, &content);
+        owned = parse_by_extension(file_uri, &content);
         &owned.symbols
     };
 
@@ -582,7 +583,7 @@ fn build_completion_items(idx: &Indexer, file_uri: &str) -> Vec<CompletionItem> 
     if let Ok(url) = Url::parse(file_uri) {
         if let Ok(path) = url.to_file_path() {
             if let Ok(content) = std::fs::read_to_string(&path) {
-                let file_data = crate::parser::parse_by_extension(file_uri, &content);
+                let file_data = parse_by_extension(file_uri, &content);
                 for sym in &file_data.symbols {
                     let ck       = symbol_kind_to_completion(sym.kind);
                     let vt       = vis_tag(sym.visibility);

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -8,6 +8,8 @@ use crate::types::Visibility;
 use crate::LinesExt;
 use crate::StrExt;
 use crate::parser::parse_by_extension;
+use crate::stdlib::bare_completions;
+use crate::stdlib_tail::dot_completions_for_lang;
 
 use super::{fqns_for_name, already_imported,
             resolve_symbol_inner, resolve_symbol_no_rg};
@@ -230,7 +232,7 @@ pub(crate) fn complete_dot(idx: &Indexer, receiver: &str, from_uri: &Url, snippe
     // Append stdlib extensions filtered to the receiver type. Only add Kotlin stdlib
     // when the current file is a Kotlin file; add Swift-specific snippets for Swift.
     let from_path = from_uri.path();
-    items.extend(crate::stdlib_tail::dot_completions_for_lang(from_path, &rt.qualified, snippets));
+    items.extend(dot_completions_for_lang(from_path, &rt.qualified, snippets));
     items
 }
 
@@ -517,7 +519,7 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
     }
 
     // 4. Stdlib top-level / scope functions — src_tier 3.
-    for mut item in crate::stdlib::bare_completions(snippets) {
+    for mut item in bare_completions(snippets) {
         let label = item.label.clone();
         if lowercase_mode && label.starts_with_uppercase() {
             continue;

--- a/src/resolver/find.rs
+++ b/src/resolver/find.rs
@@ -3,6 +3,7 @@ use tower_lsp::lsp_types::{Location, Url};
 
 use crate::indexer::Indexer;
 use crate::LinesExt;
+use crate::parser::parse_by_extension;
 
 /// Search for `name` in a specific file identified by its URI string.
 ///
@@ -26,7 +27,7 @@ pub(crate) fn find_name_in_uri(idx: &Indexer, name: &str, file_uri: &str) -> Vec
     // c) File not yet indexed — parse on demand using the correct parser
     if let Ok(path) = uri.to_file_path() {
         if let Ok(content) = std::fs::read_to_string(&path) {
-            let file_data = crate::parser::parse_by_extension(file_uri, &content);
+            let file_data = parse_by_extension(file_uri, &content);
             if let Some(sym) = file_data.symbols.iter().find(|s| s.name == name) {
                 return vec![Location { uri, range: sym.selection_range }];
             }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -149,7 +149,7 @@ pub fn extract_collection_element_type(raw_type: &str) -> Option<String> {
 
     // Strip to the base class name only.
     let elem: String = first.chars().take_while(|&c| c.is_alphanumeric() || c == '_').collect();
-    if elem.is_empty() || !elem.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+    if elem.is_empty() || !crate::indexer::starts_with_uppercase(&elem) {
         return None;
     }
     Some(elem)
@@ -235,7 +235,7 @@ pub(crate) fn infer_type_in_lines(lines: &[String], var_name: &str) -> Option<St
             // Trim any trailing dots.
             let type_name = type_name.trim_end_matches('.').to_owned();
             if !type_name.is_empty()
-                && type_name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
+                && crate::indexer::starts_with_uppercase(&type_name)
             {
                 return Some(type_name);
             }
@@ -265,7 +265,7 @@ pub(crate) fn infer_type_in_lines_raw(lines: &[String], var_name: &str) -> Optio
             let after = &line[pos + var_name.len()..];
             let after = after.trim_start_matches(':').trim_start();
             let raw = extract_type_with_generics(after);
-            if !raw.is_empty() && raw.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+            if !raw.is_empty() && crate::indexer::starts_with_uppercase(&raw) {
                 return Some(raw);
             }
         }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -136,7 +136,7 @@ pub fn extract_collection_element_type(raw_type: &str) -> Option<String> {
         "Array",
     ];
 
-    let base: String = raw_type.chars().take_while(|&c| c.is_alphanumeric() || c == '_').collect();
+    let base = crate::indexer::ident_prefix(raw_type);
     if !COLLECTION_TYPES.contains(&base.as_str()) { return None; }
 
     let open  = raw_type.find('<')?;
@@ -148,7 +148,7 @@ pub fn extract_collection_element_type(raw_type: &str) -> Option<String> {
     let first = first_type_arg(inner).trim().trim_matches('?');
 
     // Strip to the base class name only.
-    let elem: String = first.chars().take_while(|&c| c.is_alphanumeric() || c == '_').collect();
+    let elem = crate::indexer::ident_prefix(first);
     if elem.is_empty() || !crate::indexer::starts_with_uppercase(&elem) {
         return None;
     }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -2,6 +2,7 @@ use tower_lsp::lsp_types::{Position, Range, Url};
 
 use crate::indexer::Indexer;
 use crate::LinesExt;
+use crate::StrExt;
 
 // ─── Receiver type resolution ─────────────────────────────────────────────────
 
@@ -136,7 +137,7 @@ pub fn extract_collection_element_type(raw_type: &str) -> Option<String> {
         "Array",
     ];
 
-    let base = crate::indexer::ident_prefix(raw_type);
+    let base = raw_type.ident_prefix();
     if !COLLECTION_TYPES.contains(&base.as_str()) { return None; }
 
     let open  = raw_type.find('<')?;
@@ -148,8 +149,8 @@ pub fn extract_collection_element_type(raw_type: &str) -> Option<String> {
     let first = first_type_arg(inner).trim().trim_matches('?');
 
     // Strip to the base class name only.
-    let elem = crate::indexer::ident_prefix(first);
-    if elem.is_empty() || !crate::indexer::starts_with_uppercase(&elem) {
+    let elem = first.ident_prefix();
+    if elem.is_empty() || !elem.starts_with_uppercase() {
         return None;
     }
     Some(elem)
@@ -235,7 +236,7 @@ pub(crate) fn infer_type_in_lines(lines: &[String], var_name: &str) -> Option<St
             // Trim any trailing dots.
             let type_name = type_name.trim_end_matches('.').to_owned();
             if !type_name.is_empty()
-                && crate::indexer::starts_with_uppercase(&type_name)
+                && type_name.starts_with_uppercase()
             {
                 return Some(type_name);
             }
@@ -265,7 +266,7 @@ pub(crate) fn infer_type_in_lines_raw(lines: &[String], var_name: &str) -> Optio
             let after = &line[pos + var_name.len()..];
             let after = after.trim_start_matches(':').trim_start();
             let raw = extract_type_with_generics(after);
-            if !raw.is_empty() && crate::indexer::starts_with_uppercase(&raw) {
+            if !raw.is_empty() && raw.starts_with_uppercase() {
                 return Some(raw);
             }
         }

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -28,6 +28,7 @@ use crate::StrExt;
 use crate::rg::{build_rg_pattern, parse_rg_line, rg_find_definition};
 use crate::types::ImportEntry;
 use crate::LinesExt;
+use crate::parser::parse_by_extension;
 
 pub mod complete;
 pub(crate) mod infer;
@@ -569,7 +570,7 @@ fn parse_fd_hits(stdout: &[u8], symbol_name: &str, expected_pkg: Option<&str>) -
         let Ok(uri) = tower_lsp::lsp_types::Url::from_file_path(path) else { continue };
         let Ok(content) = std::fs::read_to_string(path) else { continue };
 
-        let file_data = crate::parser::parse_by_extension(path_str, &content);
+        let file_data = parse_by_extension(path_str, &content);
         let Some(sym) = file_data.symbols.iter().find(|s| s.name == symbol_name) else { continue };
 
         let loc = tower_lsp::lsp_types::Location { uri, range: sym.selection_range };
@@ -707,7 +708,7 @@ fn resolve_from_class_hierarchy(
         let path = from_uri.to_file_path().ok();
         let content = path.and_then(|p| std::fs::read_to_string(p).ok());
         match content {
-            Some(c) => crate::parser::parse_by_extension(from_uri.path(), &c)
+            Some(c) => parse_by_extension(from_uri.path(), &c)
                 .supers.iter().map(|(_, n)| n.clone()).collect(),
             None => return vec![],
         }

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -181,7 +181,7 @@ pub(crate) fn resolve_symbol_inner(idx: &Indexer, name: &str, from_uri: &Url, wi
     // Catches function parameters without val/var that aren't in the symbol index.
     // Also catches named lambda parameters: `{ item -> ...}` found via the
     // `name ->` pattern in find_declaration_range_in_lines.
-    if name.chars().next().map(|c| c.is_lowercase()).unwrap_or(true) {
+    if !crate::indexer::starts_with_uppercase(name) {
         let decl = find_local_declaration(idx, name, from_uri);
         if !decl.is_empty() { return decl; }
     }
@@ -194,7 +194,7 @@ pub(crate) fn resolve_symbol_inner(idx: &Indexer, name: &str, from_uri: &Url, wi
     // Swift files have no package declarations, so same-package and star-import
     // steps return empty. Use the in-memory definitions index directly to avoid
     // expensive project-wide rg fallback at step 5.
-    if from_uri.path().ends_with(".swift") && name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+    if from_uri.path().ends_with(".swift") && crate::indexer::starts_with_uppercase(name) {
         if let Some(locs_ref) = idx.definitions.get(name) {
             let locs: Vec<Location> = locs_ref.clone();
             // Prefer definitions from .swift files when available.
@@ -314,7 +314,7 @@ fn resolve_qualified(idx: &Indexer, name: &str, qualifier: &str, from_uri: &Url)
         return resolve_from_class_hierarchy(idx, name, from_uri, 0, &mut visited);
     }
 
-    if root.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+    if crate::indexer::starts_with_uppercase(root) {
         // ── Uppercase chain: find the root's file and search it for `name` ──
         // Pass the qualifier's own line as a hint so that when the same field name
         // appears in multiple classes in the same file (e.g. State and Effect both
@@ -354,7 +354,7 @@ fn resolve_qualified(idx: &Indexer, name: &str, qualifier: &str, from_uri: &Url)
     // Traverse remaining qualifier segments (plus any from the nested type).
     for &seg in extra_segments.iter().chain(segments[1..].iter()) {
         let Some(ref uri) = current_file else { return vec![]; };
-        if seg.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+        if crate::indexer::starts_with_uppercase(seg) {
             // Nested class / companion object — likely in the same file.
             // Search current file first; fall back to a global resolve.
             let locs = find_name_in_uri(idx, seg, uri);
@@ -458,7 +458,7 @@ fn resolve_via_imports(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
 fn package_prefix(import_path: &str) -> String {
     import_path
         .split('.')
-        .take_while(|s| s.chars().next().map(|c| c.is_lowercase()).unwrap_or(false))
+        .take_while(|s| crate::indexer::starts_with_lowercase(s))
         .collect::<Vec<_>>()
         .join(".")
 }
@@ -470,7 +470,7 @@ fn package_prefix(import_path: &str) -> String {
 fn import_file_stems(import_path: &str) -> Vec<String> {
     let upper: Vec<&str> = import_path
         .split('.')
-        .filter(|s| s.chars().next().map(|c| c.is_uppercase()).unwrap_or(false))
+        .filter(|s| crate::indexer::starts_with_uppercase(s))
         .collect();
     match upper.as_slice() {
         []             => vec![],

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -23,7 +23,8 @@ use std::process::Command;
 
 use tower_lsp::lsp_types::{Location, Range, TextEdit, Url};
 
-use crate::indexer::{last_segment, Indexer};
+use crate::indexer::Indexer;
+use crate::StrExt;
 use crate::rg::{build_rg_pattern, parse_rg_line, rg_find_definition};
 use crate::types::ImportEntry;
 use crate::LinesExt;
@@ -181,7 +182,7 @@ pub(crate) fn resolve_symbol_inner(idx: &Indexer, name: &str, from_uri: &Url, wi
     // Catches function parameters without val/var that aren't in the symbol index.
     // Also catches named lambda parameters: `{ item -> ...}` found via the
     // `name ->` pattern in find_declaration_range_in_lines.
-    if !crate::indexer::starts_with_uppercase(name) {
+    if !name.starts_with_uppercase() {
         let decl = find_local_declaration(idx, name, from_uri);
         if !decl.is_empty() { return decl; }
     }
@@ -194,7 +195,7 @@ pub(crate) fn resolve_symbol_inner(idx: &Indexer, name: &str, from_uri: &Url, wi
     // Swift files have no package declarations, so same-package and star-import
     // steps return empty. Use the in-memory definitions index directly to avoid
     // expensive project-wide rg fallback at step 5.
-    if from_uri.path().ends_with(".swift") && crate::indexer::starts_with_uppercase(name) {
+    if from_uri.path().ends_with(".swift") && name.starts_with_uppercase() {
         if let Some(locs_ref) = idx.definitions.get(name) {
             let locs: Vec<Location> = locs_ref.clone();
             // Prefer definitions from .swift files when available.
@@ -314,7 +315,7 @@ fn resolve_qualified(idx: &Indexer, name: &str, qualifier: &str, from_uri: &Url)
         return resolve_from_class_hierarchy(idx, name, from_uri, 0, &mut visited);
     }
 
-    if crate::indexer::starts_with_uppercase(root) {
+    if root.starts_with_uppercase() {
         // ── Uppercase chain: find the root's file and search it for `name` ──
         // Pass the qualifier's own line as a hint so that when the same field name
         // appears in multiple classes in the same file (e.g. State and Effect both
@@ -354,7 +355,7 @@ fn resolve_qualified(idx: &Indexer, name: &str, qualifier: &str, from_uri: &Url)
     // Traverse remaining qualifier segments (plus any from the nested type).
     for &seg in extra_segments.iter().chain(segments[1..].iter()) {
         let Some(ref uri) = current_file else { return vec![]; };
-        if crate::indexer::starts_with_uppercase(seg) {
+        if seg.starts_with_uppercase() {
             // Nested class / companion object — likely in the same file.
             // Search current file first; fall back to a global resolve.
             let locs = find_name_in_uri(idx, seg, uri);
@@ -426,7 +427,7 @@ fn resolve_via_imports(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
         //     For `…AccountPickerContract.Event` the expected package is
         //     `…accountpicker` (all-lowercase prefix segments).
         //     This avoids returning an unrelated `Event` from another package.
-        let short       = last_segment(&imp.full_path);
+        let short       = imp.full_path.last_segment();
         let expected_pkg = package_prefix(&imp.full_path);
         if let Some(locs) = idx.definitions.get(short) {
             let filtered: Vec<_> = locs.iter()
@@ -458,7 +459,7 @@ fn resolve_via_imports(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
 fn package_prefix(import_path: &str) -> String {
     import_path
         .split('.')
-        .take_while(|s| crate::indexer::starts_with_lowercase(s))
+        .take_while(|s| s.starts_with_lowercase())
         .collect::<Vec<_>>()
         .join(".")
 }
@@ -470,7 +471,7 @@ fn package_prefix(import_path: &str) -> String {
 fn import_file_stems(import_path: &str) -> Vec<String> {
     let upper: Vec<&str> = import_path
         .split('.')
-        .filter(|s| crate::indexer::starts_with_uppercase(s))
+        .filter(|s| s.starts_with_uppercase())
         .collect();
     match upper.as_slice() {
         []             => vec![],

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -616,7 +616,8 @@ fn resolve_same_package(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
     vec![]
 }
 
-/// Check all indexed files in the exact package `pkg` for a symbol named `name`.
+/// Returns the first symbol named `name` found in the exact package `pkg`,
+/// or an empty Vec if none is found.
 fn symbols_in_package(
     idx: &Indexer,
     name: &str,

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -225,6 +225,27 @@ pub(crate) fn resolve_symbol_inner(idx: &Indexer, name: &str, from_uri: &Url, wi
     rg_find_definition(name, root.as_deref(), matcher.as_deref())
 }
 
+/// Returns the first Location found by scanning star-import packages.
+fn find_in_star_imports(
+    idx: &Indexer,
+    name: &str,
+    star_pkgs: &[String],
+) -> Option<Location> {
+    for pkg in star_pkgs {
+        let peer_uris: Vec<String> = idx.packages.get(pkg).map(|u| u.clone()).unwrap_or_default();
+        for peer_uri_str in peer_uris {
+            if let Some(f) = idx.files.get(&peer_uri_str) {
+                for sym in f.symbols.iter().filter(|s| s.name == name) {
+                    if let Ok(u) = Url::parse(&peer_uri_str) {
+                        return Some(Location { uri: u, range: sym.selection_range });
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
 /// Index-only resolver for use in completion paths.
 ///
 /// Identical to `resolve_symbol_inner` but omits:
@@ -252,17 +273,8 @@ pub(crate) fn resolve_symbol_no_rg(idx: &Indexer, name: &str, from_uri: &Url) ->
             .collect(),
         None => vec![],
     };
-    for pkg in star_pkgs {
-        let peer_uris: Vec<String> = idx.packages.get(&pkg).map(|u| u.clone()).unwrap_or_default();
-        for peer_uri_str in peer_uris {
-            if let Some(f) = idx.files.get(&peer_uri_str) {
-                for sym in f.symbols.iter().filter(|s| s.name == name) {
-                    if let Ok(u) = Url::parse(&peer_uri_str) {
-                        return vec![Location { uri: u, range: sym.selection_range }];
-                    }
-                }
-            }
-        }
+    if let Some(loc) = find_in_star_imports(idx, name, &star_pkgs) {
+        return vec![loc];
     }
 
     // Check the global definitions index as a final fast fallback.
@@ -611,6 +623,25 @@ fn resolve_same_package(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
     vec![]
 }
 
+/// Check all indexed files whose package starts with `pkg_prefix` for a symbol named `name`.
+fn symbols_in_package(
+    idx: &Indexer,
+    name: &str,
+    pkg_prefix: &str,
+) -> Vec<Location> {
+    let peer_uris: Vec<String> = idx.packages.get(pkg_prefix).map(|u| u.clone()).unwrap_or_default();
+    for peer_uri_str in peer_uris {
+        if let Some(f) = idx.files.get(&peer_uri_str) {
+            for sym in f.symbols.iter().filter(|s| s.name == name) {
+                if let Ok(u) = Url::parse(&peer_uri_str) {
+                    return vec![Location { uri: u, range: sym.selection_range }];
+                }
+            }
+        }
+    }
+    vec![]
+}
+
 /// Step 4 — star imports: `import com.example.*`.
 ///
 /// For each star import:
@@ -630,16 +661,8 @@ fn resolve_star_imports(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
 
     for pkg in star_pkgs {
         // a) indexed files in this package
-        let peer_uris: Vec<String> = idx.packages.get(&pkg).map(|u| u.clone()).unwrap_or_default();
-        for peer_uri_str in peer_uris {
-            if let Some(f) = idx.files.get(&peer_uri_str) {
-                for sym in f.symbols.iter().filter(|s| s.name == name) {
-                    if let Ok(u) = Url::parse(&peer_uri_str) {
-                        return vec![Location { uri: u, range: sym.selection_range }];
-                    }
-                }
-            }
-        }
+        let locs = symbols_in_package(idx, name, &pkg);
+        if !locs.is_empty() { return locs; }
 
         // b) rg scoped to the package directory for unindexed files
         let root_guard = idx.workspace_root.read().unwrap();

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -23,7 +23,7 @@ use std::process::Command;
 
 use tower_lsp::lsp_types::{Location, Range, TextEdit, Url};
 
-use crate::indexer::Indexer;
+use crate::indexer::{last_segment, Indexer};
 use crate::rg::{build_rg_pattern, parse_rg_line, rg_find_definition};
 use crate::types::ImportEntry;
 use crate::LinesExt;
@@ -770,10 +770,6 @@ fn rg_in_package_dir(name: &str, package: &str, root: Option<&Path>, matcher: Op
 }
 
 // ─── shared helpers ───────────────────────────────────────────────────────────
-
-fn last_segment(dotted: &str) -> &str {
-    dotted.rsplit('.').next().unwrap_or(dotted)
-}
 
 /// Returns true for packages whose sources aren't present in a typical project.
 ///

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -232,15 +232,8 @@ fn find_in_star_imports(
     star_pkgs: &[String],
 ) -> Option<Location> {
     for pkg in star_pkgs {
-        let peer_uris: Vec<String> = idx.packages.get(pkg).map(|u| u.clone()).unwrap_or_default();
-        for peer_uri_str in peer_uris {
-            if let Some(f) = idx.files.get(&peer_uri_str) {
-                for sym in f.symbols.iter().filter(|s| s.name == name) {
-                    if let Ok(u) = Url::parse(&peer_uri_str) {
-                        return Some(Location { uri: u, range: sym.selection_range });
-                    }
-                }
-            }
+        if let Some(loc) = find_symbol_in_package(idx, name, pkg) {
+            return Some(loc);
         }
     }
     None
@@ -623,23 +616,28 @@ fn resolve_same_package(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
     vec![]
 }
 
-/// Check all indexed files whose package starts with `pkg_prefix` for a symbol named `name`.
+/// Check all indexed files in the exact package `pkg` for a symbol named `name`.
 fn symbols_in_package(
     idx: &Indexer,
     name: &str,
-    pkg_prefix: &str,
+    pkg: &str,
 ) -> Vec<Location> {
-    let peer_uris: Vec<String> = idx.packages.get(pkg_prefix).map(|u| u.clone()).unwrap_or_default();
+    find_symbol_in_package(idx, name, pkg).map_or(vec![], |l| vec![l])
+}
+
+/// Scan all indexed files in `pkg` for the first symbol named `name`.
+fn find_symbol_in_package(idx: &Indexer, name: &str, pkg: &str) -> Option<Location> {
+    let peer_uris: Vec<String> = idx.packages.get(pkg).map(|u| u.clone()).unwrap_or_default();
     for peer_uri_str in peer_uris {
         if let Some(f) = idx.files.get(&peer_uri_str) {
             for sym in f.symbols.iter().filter(|s| s.name == name) {
                 if let Ok(u) = Url::parse(&peer_uri_str) {
-                    return vec![Location { uri: u, range: sym.selection_range }];
+                    return Some(Location { uri: u, range: sym.selection_range });
                 }
             }
         }
     }
-    vec![]
+    None
 }
 
 /// Step 4 — star imports: `import com.example.*`.

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -1,5 +1,7 @@
     use super::*;
     use crate::indexer::Indexer;
+    use crate::parser::{parse_java, parse_kotlin};
+    use crate::stdlib::dot_completions_for;
     use tower_lsp::lsp_types::Url;
 
     fn uri(path: &str) -> Url {
@@ -399,7 +401,7 @@
     // ── supers CST extraction (via parse_kotlin / parse_java) ────────────────
 
     fn kotlin_supers(src: &str) -> Vec<String> {
-        crate::parser::parse_kotlin(src).supers.into_iter().map(|(_, n)| n).collect()
+        parse_kotlin(src).supers.into_iter().map(|(_, n)| n).collect()
     }
 
     #[test]
@@ -434,14 +436,14 @@
     #[test]
     fn supers_java_extends() {
         let src = "public class FlexiEntryVM extends BaseFlexikreditVM {}";
-        let s: Vec<String> = crate::parser::parse_java(src).supers.into_iter().map(|(_, n)| n).collect();
+        let s: Vec<String> = parse_java(src).supers.into_iter().map(|(_, n)| n).collect();
         assert!(s.contains(&"BaseFlexikreditVM".to_string()), "got {s:?}");
     }
 
     #[test]
     fn supers_java_implements() {
         let src = "public class Foo extends Base implements Runnable, Serializable {}";
-        let s: Vec<String> = crate::parser::parse_java(src).supers.into_iter().map(|(_, n)| n).collect();
+        let s: Vec<String> = parse_java(src).supers.into_iter().map(|(_, n)| n).collect();
         assert!(s.contains(&"Base".to_string()),         "got {s:?}");
         assert!(s.contains(&"Runnable".to_string()),     "got {s:?}");
         assert!(s.contains(&"Serializable".to_string()), "got {s:?}");
@@ -450,7 +452,7 @@
     #[test]
     fn supers_java_generic_extends() {
         let java = |src: &str| -> Vec<String> {
-            crate::parser::parse_java(src).supers.into_iter().map(|(_, n)| n).collect()
+            parse_java(src).supers.into_iter().map(|(_, n)| n).collect()
         };
 
         let s = java("public class Foo extends Base<String> {}");
@@ -757,7 +759,7 @@ data class State(
 
     #[test]
     fn dot_completions_string_receiver_has_string_fns() {
-        let items = crate::stdlib::dot_completions_for("String", false);
+        let items = dot_completions_for("String", false);
         let names: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
         assert!(names.contains(&"trim"),    "String should have trim()");
         assert!(names.contains(&"split"),   "String should have split()");
@@ -769,7 +771,7 @@ data class State(
 
     #[test]
     fn dot_completions_list_receiver_has_collection_fns() {
-        let items = crate::stdlib::dot_completions_for("List", false);
+        let items = dot_completions_for("List", false);
         let names: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
         assert!(names.contains(&"map"),      "List should have map()");
         assert!(names.contains(&"filter"),   "List should have filter()");
@@ -782,7 +784,7 @@ data class State(
 
     #[test]
     fn dot_completions_custom_type_has_scope_fns_only() {
-        let items = crate::stdlib::dot_completions_for("MyDomainClass", false);
+        let items = dot_completions_for("MyDomainClass", false);
         let names: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
         assert!(names.contains(&"let"),     "domain type should have let()");
         assert!(names.contains(&"apply"),   "domain type should have apply()");

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -251,7 +251,7 @@ fn build_bare_completions(snippets: bool) -> Vec<tower_lsp::lsp_types::Completio
     let mut items = Vec::new();
     for e in SCOPE_FUNS.iter().chain(TOP_LEVEL_FUNS) {
         if !items.iter().any(|i: &tower_lsp::lsp_types::CompletionItem| i.label == e.name) {
-            let kind = if e.name.chars().next().map(|c| c.is_uppercase()).unwrap_or(false) {
+            let kind = if crate::indexer::starts_with_uppercase(e.name) {
                 CompletionItemKind::CLASS
             } else {
                 CompletionItemKind::FUNCTION

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -242,6 +242,7 @@ pub fn hover(name: &str) -> Option<String> {
 // files. Cache the two variants (snippets=true / snippets=false) statically.
 
 use std::sync::OnceLock;
+use crate::StrExt;
 
 static BARE_COMPLETIONS_SNIPPETS:    OnceLock<Vec<tower_lsp::lsp_types::CompletionItem>> = OnceLock::new();
 static BARE_COMPLETIONS_NO_SNIPPETS: OnceLock<Vec<tower_lsp::lsp_types::CompletionItem>> = OnceLock::new();
@@ -251,7 +252,7 @@ fn build_bare_completions(snippets: bool) -> Vec<tower_lsp::lsp_types::Completio
     let mut items = Vec::new();
     for e in SCOPE_FUNS.iter().chain(TOP_LEVEL_FUNS) {
         if !items.iter().any(|i: &tower_lsp::lsp_types::CompletionItem| i.label == e.name) {
-            let kind = if crate::indexer::starts_with_uppercase(e.name) {
+            let kind = if e.name.starts_with_uppercase() {
                 CompletionItemKind::CLASS
             } else {
                 CompletionItemKind::FUNCTION

--- a/src/stdlib_tail.rs
+++ b/src/stdlib_tail.rs
@@ -1,10 +1,12 @@
 
+use crate::stdlib::dot_completions_for;
+
 /// Language-aware dot completions: only return Kotlin stdlib for .kt files,
 /// add Swift-specific templates for .swift files. `from_path` should be the
 /// file path portion of the request URI (e.g., "/home/user/project/src/Foo.kt").
 pub fn dot_completions_for_lang(from_path: &str, receiver_type: &str, snippets: bool) -> Vec<tower_lsp::lsp_types::CompletionItem> {
     if from_path.ends_with(".kt") {
-        crate::stdlib::dot_completions_for(receiver_type, snippets)
+        dot_completions_for(receiver_type, snippets)
     } else if from_path.ends_with(".swift") {
         // Very small Swift snippet set: common patterns
         swift_dot_completions(snippets)

--- a/src/str_ext.rs
+++ b/src/str_ext.rs
@@ -21,6 +21,10 @@ pub(crate) trait StrExt {
     /// Returns the trailing dot-separated segment of a dotted path.
     /// `"com.example.Foo"` → `"Foo"`, `"Foo"` → `"Foo"`.
     fn last_segment(&self) -> &str;
+
+    /// Returns the trailing identifier at the end of `self` — all trailing chars satisfying `is_id_char`.
+    /// `"foo.barBaz"` → `"barBaz"`;  `"foo.bar("` → `""`.
+    fn last_ident_in(&self) -> &str;
 }
 
 impl StrExt for str {
@@ -47,5 +51,14 @@ impl StrExt for str {
     #[inline]
     fn last_segment(&self) -> &str {
         self.rsplit('.').next().unwrap_or(self)
+    }
+
+    #[inline]
+    fn last_ident_in(&self) -> &str {
+        let ident_bytes: usize = self.chars().rev()
+            .take_while(|&c| is_id_char(c))
+            .map(|c| c.len_utf8())
+            .sum();
+        &self[self.len() - ident_bytes..]
     }
 }

--- a/src/str_ext.rs
+++ b/src/str_ext.rs
@@ -1,0 +1,51 @@
+//! Extension trait adding string-analysis helper methods to `str`.
+use crate::indexer::is_id_char;
+
+pub(crate) trait StrExt {
+    /// Returns `true` if `self` starts with an uppercase letter (Unicode-aware).
+    /// Returns `false` for empty strings.
+    fn starts_with_uppercase(&self) -> bool;
+
+    /// Returns `true` if `self` starts with a lowercase letter (Unicode-aware).
+    /// Returns `false` for empty strings.
+    fn starts_with_lowercase(&self) -> bool;
+
+    /// Returns the leading identifier portion of `self` — all leading chars satisfying `is_id_char`.
+    /// `"foo.bar()"` → `"foo"`;  `"Bar<T>"` → `"Bar"`.
+    fn ident_prefix(&self) -> String;
+
+    /// Returns the leading dotted-identifier portion of `self` — all leading chars satisfying
+    /// `is_id_char` or `.`. `"foo.Bar.baz()"` → `"foo.Bar.baz"`.
+    fn dotted_ident_prefix(&self) -> String;
+
+    /// Returns the trailing dot-separated segment of a dotted path.
+    /// `"com.example.Foo"` → `"Foo"`, `"Foo"` → `"Foo"`.
+    fn last_segment(&self) -> &str;
+}
+
+impl StrExt for str {
+    #[inline]
+    fn starts_with_uppercase(&self) -> bool {
+        self.chars().next().map(|c| c.is_uppercase()).unwrap_or(false)
+    }
+
+    #[inline]
+    fn starts_with_lowercase(&self) -> bool {
+        self.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
+    }
+
+    #[inline]
+    fn ident_prefix(&self) -> String {
+        self.chars().take_while(|&c| is_id_char(c)).collect()
+    }
+
+    #[inline]
+    fn dotted_ident_prefix(&self) -> String {
+        self.chars().take_while(|&c| is_id_char(c) || c == '.').collect()
+    }
+
+    #[inline]
+    fn last_segment(&self) -> &str {
+        self.rsplit('.').next().unwrap_or(self)
+    }
+}


### PR DESCRIPTION
## Summary

Zero-behaviour-change refactor stacked on top of PR #32.

### Phase 16 — string/char helper extraction (replaces 50+ inline patterns)

| Helper | Location | Replacements |
|---|---|---|
| `starts_with_uppercase(s)` / `starts_with_lowercase(s)` | `src/indexer.rs` | 38 inline char-check patterns across 15 files |
| `NodeExt::utf8_text_owned()` | `src/indexer/node_ext.rs` | 11 `utf8_text().ok().map(to_owned)` patterns |
| `NodeExt::first_child_of_kind()` | `src/indexer/node_ext.rs` | applied in `has_lambda_named_params`, `collect_lambda_param_names` |
| `ident_prefix(s)` / `dotted_ident_prefix(s)` | `src/indexer.rs` | 22 `take_while(is_id_char)` patterns across 6 files |

### Phase 17 — dedup and walker loop simplification

- **`last_segment(dotted)`** moved to `src/indexer.rs` (was duplicated in `parser.rs` + `resolver/mod.rs`)
- **`IMPORT_KW` / `STATIC_KW` / `IMPORT_ALIAS_KW`** constants extracted in `parser.rs`
- **`NodeExt::children_of_kind(kind)`** added — index-based, returns `Vec<Node<'a>>`
- **Walker loops simplified** in `parser.rs`: 22 → 17 remaining
  - 5 `children(&mut walker)` loops → `children_of_kind()`
  - 8 single-kind-with-break loops → `first_child_of_kind()`
  - Includes: `package_header`, `import_list`, `import_alias`, `swift_import_path`, `delegation_specifier`, `extends_interfaces`, `variable_declarator`, `first_user_type_child_name`, `java_collect_type_list`

### Review fixes (from PR #32 / PR #31 comments)

- **`VISIBILITY_SCAN_BACK` renamed** → `ENCLOSING_CALL_SCAN_BACK` (was misnamed; only used in `find_enclosing_call_name`)
- **`symbols_in_package` doc clarified** — returns at most one match (first found)
- **Bug fix: `scan_multiline_call_open` double-counting** — removed duplicate `before` comma count; `text_call_info` already counts commas on the current line

## Files changed

| File | What changed |
|---|---|
| `src/indexer.rs` | +`starts_with_uppercase`, `starts_with_lowercase`, `ident_prefix`, `dotted_ident_prefix`, `last_segment` |
| `src/indexer/node_ext.rs` | +`utf8_text_owned`, `children_of_kind`; `first_child_of_kind` applied more widely |
| `src/parser.rs` | Walker loops simplified; `IMPORT_KW`/`STATIC_KW`/`IMPORT_ALIAS_KW` constants; `last_segment` removed |
| `src/resolver/mod.rs` | `last_segment` removed; `symbols_in_package` doc fixed |
| `src/indexer/scope.rs` | `VISIBILITY_SCAN_BACK` → `ENCLOSING_CALL_SCAN_BACK` |
| `src/backend/handlers.rs` | Bug fix: `scan_multiline_call_open` comma double-count |
| 15 other files | `starts_with_uppercase`/`lowercase`/`ident_prefix` call sites |

**Test count: 565 passing (unchanged)**