### PR TITLE
feat: type inference improvements — RHS, method return type, inherited members

### DIFF
--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -42,7 +42,7 @@ impl Backend {
                 let leaf = type_name.rsplit('.').next().unwrap_or(type_name.as_str());
                 let locs = self.indexer.find_definition_qualified(leaf, None, uri);
                 let type_hover = if let Some(loc) = locs.first() {
-                    self.indexer.hover_info_at_location(loc, leaf, Some(uri.as_str()))
+                    self.indexer.hover_info_at_location(loc, leaf, Some(uri.as_str()), Some(position.line))
                 } else {
                     self.indexer.hover_info(leaf, Some(uri.as_str()))
                 };
@@ -75,7 +75,7 @@ impl Backend {
             if let Some(ref rt) = ctx.contextual {
                 let locs = self.resolve_with_receiver_fallback(&ctx.word, rt, uri);
                 if let Some(loc) = locs.first() {
-                    if let Some(md) = self.indexer.hover_info_at_location(loc, &ctx.word, Some(uri.as_str())) {
+                    if let Some(md) = self.indexer.hover_info_at_location(loc, &ctx.word, Some(uri.as_str()), Some(position.line)) {
                         return Ok(Some(Hover {
                             contents: HoverContents::Markup(MarkupContent {
                                 kind:  MarkupKind::Markdown,
@@ -90,7 +90,7 @@ impl Backend {
 
         let locs = self.indexer.find_definition_qualified(&ctx.word, ctx.qualifier.as_deref(), uri);
         let hover_md = if let Some(loc) = locs.first() {
-            self.indexer.hover_info_at_location(loc, &ctx.word, Some(uri.as_str()))
+            self.indexer.hover_info_at_location(loc, &ctx.word, Some(uri.as_str()), Some(position.line))
         } else {
             // Index lookup — works for already-indexed symbols + stdlib.
             let from_index = self.indexer.hover_info(&ctx.word, Some(uri.as_str()));
@@ -105,7 +105,7 @@ impl Backend {
                     (crate::rg::effective_rg_root(wr.as_deref(), file_path.as_deref()), m)
                 };
                 let rg_locs = crate::rg::rg_find_definition(&ctx.word, rg_root.as_deref(), matcher.as_deref());
-                rg_locs.first().and_then(|loc| self.indexer.hover_info_at_location(loc, &ctx.word, Some(uri.as_str())))
+                rg_locs.first().and_then(|loc| self.indexer.hover_info_at_location(loc, &ctx.word, Some(uri.as_str()), Some(position.line)))
             }
         };
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -48,6 +48,7 @@ pub(crate) use self::infer::{
     line_has_lambda_param,
     lambda_brace_pos_for_param,
     find_last_dot_at_depth_zero,
+    is_inside_receiver_lambda,
 };
 
 mod cache;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -16,6 +16,7 @@ pub use crate::rg::SOURCE_EXTENSIONS;
 mod doc;
 
 mod infer;
+mod resolution;
 // Re-export pure helpers from submodules so existing callers within this file
 // and the inline test module (`use super::*`) continue to resolve them by name.
 #[allow(unused_imports)]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -67,7 +67,6 @@ pub(crate) use lookup::apply_type_subst;
 
 mod node_ext;
 pub(crate) use node_ext::NodeExt;
-pub(crate) use node_ext::parse_type_params_from_decl;
 
 mod scope;
 pub(crate) use scope::is_id_char;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -67,6 +67,7 @@ pub(crate) use lookup::apply_type_subst;
 
 mod node_ext;
 pub(crate) use node_ext::NodeExt;
+pub(crate) use node_ext::parse_type_params_from_decl;
 
 mod scope;
 pub(crate) use scope::is_id_char;

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -21,7 +21,7 @@ use crate::types::{FileData, FileIndexResult};
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Bump when the serialized format changes; invalidates any older cache files.
-pub(crate) const CACHE_VERSION: u32 = 6;
+pub(crate) const CACHE_VERSION: u32 = 7;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -21,7 +21,7 @@ use crate::types::{FileData, FileIndexResult};
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Bump when the serialized format changes; invalidates any older cache files.
-pub(crate) const CACHE_VERSION: u32 = 7;
+pub(crate) const CACHE_VERSION: u32 = 8;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/src/indexer/cache_tests.rs
+++ b/src/indexer/cache_tests.rs
@@ -30,6 +30,7 @@ fn cache_entry_to_file_result_supertypes_extracted() {
         range: Default::default(),
         selection_range: Default::default(),
         detail: String::new(),
+        type_params: Vec::new(),
     });
     data.supers.push((0, "IAnimal".into(), vec![]));
 
@@ -61,6 +62,7 @@ fn cache_entry_to_file_result_preserves_hash() {
         range: Default::default(),
         selection_range: Default::default(),
         detail: String::new(),
+        type_params: Vec::new(),
     });
 
     let entry = FileCacheEntry {

--- a/src/indexer/cache_tests.rs
+++ b/src/indexer/cache_tests.rs
@@ -31,6 +31,7 @@ fn cache_entry_to_file_result_supertypes_extracted() {
         selection_range: Default::default(),
         detail: String::new(),
         type_params: Vec::new(),
+        extension_receiver: String::new(),
     });
     data.supers.push((0, "IAnimal".into(), vec![]));
 
@@ -63,6 +64,7 @@ fn cache_entry_to_file_result_preserves_hash() {
         selection_range: Default::default(),
         detail: String::new(),
         type_params: Vec::new(),
+        extension_receiver: String::new(),
     });
 
     let entry = FileCacheEntry {

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -321,8 +321,14 @@ fn cst_it_or_this_type(
             let ln = cur.start_position().row;
 
             if for_this {
-                if let Some(t) = lambda_receiver_this_type_from_context(before_brace, idx, uri) {
-                    return Some(t);
+                match classify_this_lambda_context(before_brace, idx, uri) {
+                    ThisLambdaCtx::Resolved(t) => return Some(t),
+                    // Receiver-lambda context but type not found: stop walking up.
+                    // `this` here is the receiver, not an outer lambda's receiver.
+                    ThisLambdaCtx::Receiver => return None,
+                    // Non-receiver lambda (forEach, map…): keep walking outward.
+                    // `this` inside these lambdas is the enclosing class / outer receiver.
+                    ThisLambdaCtx::NotReceiver => {}
                 }
             } else {
                 // CST structural fallback: walk up the call tree to find
@@ -496,24 +502,40 @@ pub(super) fn has_lambda_named_params(lambda_node: tree_sitter::Node<'_>, bytes:
     lambda_node.has_lambda_named_params(bytes)
 }
 
+/// Tri-state result of classifying a lambda's `this`-receiver context.
 ///
-/// `this` in Kotlin refers to the implicit receiver only inside a **receiver lambda**
-/// (`T.() -> R`).  In a regular lambda (`(T) -> R`) `this` is the enclosing class —
-/// we must NOT emit a hint from the lambda in that case.
+/// Distinguishes between "receiver lambda with type resolved", "receiver lambda
+/// but type not found", and "not a receiver-`this` lambda at all".  The last
+/// case is important: in a non-receiver lambda (e.g. `forEach`) `this` refers
+/// to the enclosing class, so the walk-up to outer lambdas and the
+/// `enclosing_class_at` fallback should still be allowed.
+#[derive(Debug)]
+pub(crate) enum ThisLambdaCtx {
+    /// Receiver-`this` type resolved to the given name.
+    Resolved(String),
+    /// Lambda is a known receiver context (`apply`/`run`/`with`/indexed
+    /// receiver-lambda fn) but the receiver object's type could not be found.
+    /// Callers must NOT walk outward or fall back to the enclosing class.
+    Receiver,
+    /// Not a receiver-`this` lambda (e.g. `forEach`, `map`).
+    /// `this` refers to the enclosing class; fallback is valid.
+    NotReceiver,
+}
+
+/// Classify the `this` receiver context from the text before a lambda `{`.
 ///
 /// Rules:
-///  - Case A `receiver.method { this }`: check if `method` has a receiver-lambda last
-///    param (`T.() -> R`) — if so return `T`.  If method not indexed but is a known
-///    stdlib scope function listed in `RECEIVER_THIS_FNS` (`run`, `apply`), return the
-///    receiver type.  `also` and `let` are intentionally excluded — they expose the
-///    receiver as `it`, not `this`.
-///  - Case B `with(receiver) { this }`: return the receiver's type (special-cased).
-///  - Everything else: return `None` (don't hint `this` from the lambda).
-fn lambda_receiver_this_type_from_context(
+///  - Case A `receiver.method { this }`: if `method` has an indexed receiver-lambda
+///    type → `Resolved`.  If `method` ∈ `RECEIVER_THIS_FNS` (`run`, `apply`):
+///    resolve receiver → `Resolved`; if unresolvable → `Receiver`.
+///    Other dot-call methods → `NotReceiver`.
+///  - Case B `with(receiver) { this }` → `Resolved` or `Receiver`.
+///  - Everything else → `NotReceiver`.
+pub(crate) fn classify_this_lambda_context(
     before_brace: &str,
     deps:         &impl InferDeps,
     uri:          &Url,
-) -> Option<String> {
+) -> ThisLambdaCtx {
     let trimmed = before_brace.trim_end();
     let callee_raw = strip_trailing_call_args(trimmed).replace("?.", ".");
     let callee = callee_raw.trim();
@@ -525,23 +547,25 @@ fn lambda_receiver_this_type_from_context(
         let method = callee[dot_pos + 1..].trim_start().ident_prefix();
 
         if !receiver_var.is_empty() && !method.is_empty() {
-            // Prefer the method's own receiver-lambda type (only for indexed fns).
+            // Indexed function with a receiver-lambda last param → always Resolved.
             if let Some(ty) = fun_trailing_lambda_this_type(&method, deps, uri) {
-                return Some(ty);
+                return ThisLambdaCtx::Resolved(ty);
             }
-            // Only functions listed in `RECEIVER_THIS_FNS` (`run`, `apply`) are treated as
-            // receiver-`this` lambdas; `also`/`let` are intentionally excluded.
+            // Known stdlib scope functions (`run`, `apply`).
             if RECEIVER_THIS_FNS.contains(&method.as_str()) {
                 if let Some(raw) = deps.find_var_type(receiver_var, uri) {
                     let base = raw.ident_prefix();
-                    if !base.is_empty() { return Some(base); }
+                    if !base.is_empty() { return ThisLambdaCtx::Resolved(base); }
                 }
                 if receiver_var.starts_with_uppercase() {
-                    return Some(receiver_var.to_owned());
+                    return ThisLambdaCtx::Resolved(receiver_var.to_owned());
                 }
+                // In a known scope-fn lambda but type not found.
+                return ThisLambdaCtx::Receiver;
             }
         }
-        return None; // Non-scope, non-receiver-lambda: `this` is enclosing class.
+        // Other dot-call (forEach, map, …): `this` = enclosing class.
+        return ThisLambdaCtx::NotReceiver;
     }
 
     // ── Case B: `with(receiver) { this }` ───────────────────────────────────
@@ -550,16 +574,79 @@ fn lambda_receiver_this_type_from_context(
         if let Some(recv_name) = extract_first_arg(trimmed) {
             if let Some(raw) = deps.find_var_type(recv_name, uri) {
                 let base = raw.ident_prefix();
-                if !base.is_empty() { return Some(base); }
+                if !base.is_empty() { return ThisLambdaCtx::Resolved(base); }
             }
             let base = recv_name.ident_prefix();
             if base.starts_with_uppercase() {
-                return Some(base);
+                return ThisLambdaCtx::Resolved(base);
+            }
+        }
+        return ThisLambdaCtx::Receiver;
+    }
+
+    ThisLambdaCtx::NotReceiver
+}
+
+/// Thin wrapper kept for callers that only need `Option<String>`.
+fn lambda_receiver_this_type_from_context(
+    before_brace: &str,
+    deps:         &impl InferDeps,
+    uri:          &Url,
+) -> Option<String> {
+    match classify_this_lambda_context(before_brace, deps, uri) {
+        ThisLambdaCtx::Resolved(ty) => Some(ty),
+        _ => None,
+    }
+}
+
+/// Return `true` when the text-scan of `lines` around `pos` determines that
+/// the cursor is inside a **receiver-`this` lambda** whose receiver type is
+/// either resolved or simply not found — either way `this` refers to the
+/// lambda receiver, NOT the enclosing class.
+///
+/// Used in `infer_lambda_param_type_at` to suppress the `enclosing_class_at`
+/// fallback when `find_this_element_type_in_lines` returned `None` only
+/// because the receiver variable's type couldn't be resolved.
+pub(crate) fn is_inside_receiver_lambda(
+    lines: &[String],
+    pos:   CursorPos,
+    deps:  &impl InferDeps,
+    uri:   &Url,
+) -> bool {
+    let mut depth: i32 = 0;
+    let scan_start = pos.line.saturating_sub(IT_SCAN_BACK_LINES);
+
+    for ln in (scan_start..=pos.line).rev() {
+        let line = match lines.get(ln) { Some(l) => l, None => continue };
+        let scan_slice: &str = if ln == pos.line {
+            let byte_end = crate::indexer::live_tree::utf16_col_to_byte(line, pos.utf16_col);
+            &line[..byte_end]
+        } else {
+            line.as_str()
+        };
+
+        for (bi, ch) in scan_slice.char_indices().rev() {
+            match ch {
+                '}' => depth += 1,
+                '{' => {
+                    depth -= 1;
+                    if depth < 0 {
+                        let before_brace = &scan_slice[..bi];
+                        if before_brace.ends_with('$') { depth = 0; continue; }
+                        if has_named_params_not_it(scan_slice[bi + 1..].trim_start()) {
+                            depth = 0; continue;
+                        }
+                        return !matches!(
+                            classify_this_lambda_context(before_brace, deps, uri),
+                            ThisLambdaCtx::NotReceiver
+                        );
+                    }
+                }
+                _ => {}
             }
         }
     }
-
-    None
+    false
 }
 
 /// Handles named-arg lambdas spread across multiple lines:

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -521,3 +521,72 @@ fn test_deps_unknown_fn_returns_none() {
     let result = lambda_receiver_type_from_context("unknownFn", &deps, &u);
     assert_eq!(result, None, "unknown function should return None");
 }
+
+// ── classify_this_lambda_context / is_inside_receiver_lambda ─────────────────
+
+#[test]
+fn apply_this_resolved_receiver() {
+    // `obj.apply { this }` where obj type is known → Resolved("Foo")
+    let src = "val obj: Foo = Foo()";
+    let (u, idx) = indexed("/t.kt", src);
+    let ctx = super::classify_this_lambda_context("obj.apply ", &idx, &u);
+    let is_resolved_foo = matches!(&ctx, super::ThisLambdaCtx::Resolved(t) if t == "Foo");
+    assert!(is_resolved_foo, "expected Resolved(Foo), got: {ctx:?}");
+}
+
+#[test]
+fn apply_this_unresolved_receiver_returns_receiver_ctx() {
+    // `unknown.apply { this }` — type of `unknown` not in index → Receiver (NOT NotReceiver)
+    let u = uri("/t.kt");
+    let deps = super::super::TestDeps::new();
+    let ctx = super::classify_this_lambda_context("unknown.apply ", &deps, &u);
+    assert!(matches!(ctx, super::ThisLambdaCtx::Receiver),
+        "apply with unresolvable receiver should be Receiver, got: {ctx:?}");
+}
+
+#[test]
+fn foreach_lambda_is_not_receiver_ctx() {
+    // `list.forEach { this }` — forEach is NOT a scope function → NotReceiver
+    let u = uri("/t.kt");
+    let deps = super::super::TestDeps::new();
+    let ctx = super::classify_this_lambda_context("list.forEach ", &deps, &u);
+    assert!(matches!(ctx, super::ThisLambdaCtx::NotReceiver),
+        "forEach should yield NotReceiver, got: {ctx:?}");
+}
+
+#[test]
+fn with_this_unresolved_receiver_returns_receiver_ctx() {
+    // `with(expr) { this }` — type of expr not found → Receiver
+    let u = uri("/t.kt");
+    let deps = super::super::TestDeps::new();
+    let ctx = super::classify_this_lambda_context("with(someExpr) ", &deps, &u);
+    assert!(matches!(ctx, super::ThisLambdaCtx::Receiver),
+        "with() with unresolvable arg should be Receiver, got: {ctx:?}");
+}
+
+#[test]
+fn is_inside_receiver_lambda_apply() {
+    // Cursor inside `obj.apply { <here> }` with unknown obj type.
+    // is_inside_receiver_lambda should return true (it IS inside a receiver lambda).
+    let src = "val _x = unknown.apply {\n    this\n}";
+    let u = uri("/t.kt");
+    let idx = Indexer::new();
+    idx.index_content(&u, src);
+    let lines: Vec<String> = src.lines().map(String::from).collect();
+    let pos = crate::types::CursorPos { line: 1, utf16_col: 8 };
+    let result = super::is_inside_receiver_lambda(&lines, pos, &idx, &u);
+    assert!(result, "cursor inside unknown.apply{{}} should be inside receiver lambda");
+}
+
+#[test]
+fn is_inside_receiver_lambda_foreach_is_false() {
+    // Cursor inside `list.forEach { <here> }` — NOT a receiver lambda.
+    let src = "val list = listOf(1)\nlist.forEach {\n    this\n}";
+    let u = uri("/t.kt");
+    let idx = Indexer::new();
+    idx.index_content(&u, src);
+    let lines: Vec<String> = src.lines().map(String::from).collect();
+    let pos = crate::types::CursorPos { line: 2, utf16_col: 8 };
+    let result = super::is_inside_receiver_lambda(&lines, pos, &idx, &u);
+    assert!(!result, "cursor inside forEach{{}} should NOT be inside receiver lambda");
+}

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -55,4 +55,5 @@ pub(crate) use it_this::{
     lambda_brace_pos_for_param,
     lambda_param_position_on_line,
     find_last_dot_at_depth_zero,
+    is_inside_receiver_lambda,
 };

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -418,8 +418,7 @@ fn build_enclosing_class_subst(
         None => return Default::default(),
     };
     let class_line = class_sym.selection_range.start.line;
-
-    // Gather all supers with type args for this class
+    let class_end_line = class_sym.range.end.line;
     let mut result = std::collections::HashMap::new();
 
     for (line, base_name, type_args) in data.supers.iter() {
@@ -452,6 +451,7 @@ fn build_enclosing_class_subst(
     // type param → concrete arg mappings.
     for sym in data.symbols.iter() {
         if sym.selection_range.start.line <= class_line { continue; }
+        if sym.selection_range.start.line > class_end_line { continue; }
         if !matches!(sym.kind, SymbolKind::FIELD | SymbolKind::PROPERTY) { continue; }
         // Extract type name from detail (e.g., "private val foo: SomeType by lazy")
         let type_name = extract_property_type_name(&sym.detail);

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -323,15 +323,6 @@ fn find_containing_class_name(data: &crate::types::FileData, sym_line: u32) -> O
         .map(|s| s.name.clone())
 }
 
-/// Parse type parameter names from a class/interface declaration line or detail string.
-///
-/// e.g. `"interface FlowReducer<EventType, out EffectType, StateType>"` → `["EventType", "EffectType", "StateType"]`
-///
-/// Handles variance annotations (`in`, `out`) and type constraints (`T : Bound`).
-fn parse_type_params(decl: &str) -> Vec<String> {
-    super::parse_type_params_from_decl(decl)
-}
-
 /// Build a type-parameter → concrete-type substitution map for a symbol declared
 /// inside a generic class/interface when viewed from a specialised subtype.
 ///
@@ -353,51 +344,25 @@ fn build_type_param_subst(
 
     let sym_data = match idx.files.get(sym_uri) {
         Some(d) => d,
-        None => {
-            return Default::default();
-        }
+        None => return Default::default(),
     };
 
     let container_name = match find_containing_class_name(&sym_data, sym_line) {
         Some(n) => n,
-        None => {
-            return Default::default();
-        }
+        None    => return Default::default(),
     };
 
     let container_sym = match sym_data.symbols.iter().find(|s| s.name == container_name) {
         Some(s) => s,
-        None => {
-            return Default::default();
-        }
+        None    => return Default::default(),
     };
-    let decl_text = if !container_sym.detail.is_empty() {
-        container_sym.detail.clone()
-    } else {
-        let line_idx = container_sym.selection_range.start.line as usize;
-        sym_data.lines.get(line_idx).cloned().unwrap_or_default()
-    };
-    let mut type_params = parse_type_params(&decl_text);
-    // If detail is truncated (e.g. annotation only), scan source lines for type params
-    if type_params.is_empty() {
-        let start_line = container_sym.selection_range.start.line as usize;
-        for offset in 0..5 {
-            if let Some(line) = sym_data.lines.get(start_line + offset) {
-                let params = parse_type_params(line);
-                if !params.is_empty() {
-                    type_params = params;
-                    break;
-                }
-            }
-        }
-    }
+
+    let type_params = &container_sym.type_params;
     if type_params.is_empty() { return Default::default(); }
 
     let calling_data = match idx.files.get(calling_uri) {
         Some(d) => d,
-        None => {
-            return Default::default();
-        }
+        None    => return Default::default(),
     };
     let type_args = calling_data.supers.iter()
         .find(|(_, base, _)| base == &container_name)
@@ -406,10 +371,9 @@ fn build_type_param_subst(
 
     if type_args.is_empty() { return Default::default(); }
 
-    let result: std::collections::HashMap<String, String> = type_params.iter().zip(type_args.iter())
+    type_params.iter().zip(type_args.iter())
         .map(|(k, v)| (k.clone(), v.clone()))
-        .collect();
-    result
+        .collect()
 }
 
 /// Build a substitution map from ALL supertypes of the enclosing class at `cursor_line`.
@@ -461,28 +425,7 @@ fn build_enclosing_class_subst(
             continue;
         };
 
-        let decl_text = if !sym.detail.is_empty() {
-            &sym.detail
-        } else {
-            continue;
-        };
-
-        // Try detail first; if it doesn't have type params (e.g. truncated at annotation),
-        // scan subsequent source lines for the actual class/interface declaration.
-        let mut type_params = parse_type_params(decl_text);
-        if type_params.is_empty() {
-            let start_line = sym.selection_range.start.line as usize;
-            // Look at up to 5 lines starting from the symbol's line
-            for offset in 0..5 {
-                if let Some(line) = super_data.lines.get(start_line + offset) {
-                    let params = parse_type_params(line);
-                    if !params.is_empty() {
-                        type_params = params;
-                        break;
-                    }
-                }
-            }
-        }
+        let type_params = &sym.type_params;
         // Zip params → args
         for (param, arg) in type_params.iter().zip(type_args.iter()) {
             result.insert(param.clone(), arg.clone());
@@ -516,16 +459,7 @@ fn build_enclosing_class_subst(
             let Some(super_loc) = super_locs.first() else { continue };
             let Some(super_file) = idx.files.get(super_loc.uri.as_str()) else { continue };
             let Some(super_sym) = super_file.symbols.iter().find(|s| s.name == *base_name) else { continue };
-            let mut type_params = parse_type_params(&super_sym.detail);
-            if type_params.is_empty() {
-                let start = super_sym.selection_range.start.line as usize;
-                for offset in 0..5 {
-                    if let Some(line) = super_file.lines.get(start + offset) {
-                        let params = parse_type_params(line);
-                        if !params.is_empty() { type_params = params; break; }
-                    }
-                }
-            }
+            let type_params = &super_sym.type_params;
             for (param, arg) in type_params.iter().zip(type_args.iter()) {
                 result.entry(param.clone()).or_insert_with(|| arg.clone());
             }

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -472,7 +472,7 @@ fn build_enclosing_class_subst(
 /// Extract the simple type name from a property detail string.
 /// E.g. "private val foo: DashboardProductsReducer by lazy" → "DashboardProductsReducer"
 /// E.g. "val x: List<String>" → "List"
-fn extract_property_type_name(detail: &str) -> &str {
+pub(crate) fn extract_property_type_name(detail: &str) -> &str {
     // Find ": Type" pattern
     let colon_pos = match detail.find(':') {
         Some(p) => p,

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -329,45 +329,7 @@ fn find_containing_class_name(data: &crate::types::FileData, sym_line: u32) -> O
 ///
 /// Handles variance annotations (`in`, `out`) and type constraints (`T : Bound`).
 fn parse_type_params(decl: &str) -> Vec<String> {
-    // Type params always appear before the first '(' (constructor/function params).
-    // Limit search to avoid picking up angle brackets from constructor parameter types.
-    let search_region = match decl.find('(') {
-        Some(paren) => &decl[..paren],
-        None => decl,
-    };
-    let start = match search_region.find('<') { Some(i) => i + 1, None => return Vec::new() };
-    let end   = match search_region.rfind('>') { Some(i) => i, None => return Vec::new() };
-    if end <= start { return Vec::new(); }
-    let inner = &decl[start..end];
-
-    // Re-implement depth-0 comma split here to avoid depending on node_ext internals.
-    let mut raw_params = Vec::new();
-    let mut depth = 0usize;
-    let mut seg_start = 0;
-    for (i, ch) in inner.char_indices() {
-        match ch {
-            '<' => depth += 1,
-            '>' => depth = depth.saturating_sub(1),
-            ',' if depth == 0 => {
-                let seg = inner[seg_start..i].trim();
-                if !seg.is_empty() { raw_params.push(seg); }
-                seg_start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    let last = inner[seg_start..].trim();
-    if !last.is_empty() { raw_params.push(last); }
-
-    raw_params.into_iter().map(|s| {
-        // Strip variance keywords
-        let s = s.strip_prefix("in ").unwrap_or(s);
-        let s = s.strip_prefix("out ").unwrap_or(s);
-        let s = s.trim();
-        // Strip type constraint (everything from ":" onward) and whitespace
-        let end_pos = s.find(|c: char| c == ':' || c.is_whitespace()).unwrap_or(s.len());
-        s[..end_pos].trim().to_owned()
-    }).filter(|s| !s.is_empty()).collect()
+    super::parse_type_params_from_decl(decl)
 }
 
 /// Build a type-parameter → concrete-type substitution map for a symbol declared

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -56,7 +56,7 @@ impl Indexer {
             let r = self.definitions.get(name)?;
             r.first()?.clone()
         };
-        self.hover_info_at_location(&loc, name, calling_uri)
+        self.hover_info_at_location(&loc, name, calling_uri, None)
     }
 
     /// Build hover markdown for `name` at a specific resolved `Location`.
@@ -64,7 +64,9 @@ impl Indexer {
     ///
     /// `calling_uri` — the file where the cursor is (used to substitute generic type
     /// parameters with concrete types when the symbol is from a base class).
-    pub fn hover_info_at_location(&self, loc: &Location, name: &str, calling_uri: Option<&str>) -> Option<String> {
+    /// `cursor_line` — the line of the cursor in `calling_uri`; used to disambiguate
+    /// when multiple classes in the same file extend the same generic base.
+    pub fn hover_info_at_location(&self, loc: &Location, name: &str, calling_uri: Option<&str>, cursor_line: Option<u32>) -> Option<String> {
         // On-demand index: the file may have been found by rg but not yet indexed.
         if !self.files.contains_key(loc.uri.as_str()) {
             if let Ok(path) = loc.uri.to_file_path() {
@@ -85,7 +87,7 @@ impl Indexer {
         // Apply generic type parameter substitution when the cursor is in a different
         // file (subtype) than where the symbol is defined.
         let sig = if let Some(cu) = calling_uri {
-            let subst = build_type_param_subst(self, loc.uri.as_str(), sym.selection_range.start.line, cu);
+            let subst = build_type_param_subst(self, loc.uri.as_str(), sym.selection_range.start.line, cu, cursor_line);
             if subst.is_empty() { raw_sig } else { apply_subst(&raw_sig, &subst) }
         } else {
             raw_sig
@@ -125,7 +127,7 @@ impl Indexer {
             sym.detail.clone()
         };
         if let Some(cu) = calling_uri {
-            let subst = build_type_param_subst(self, uri_str, sym.selection_range.start.line, cu);
+            let subst = build_type_param_subst(self, uri_str, sym.selection_range.start.line, cu, None);
             if !subst.is_empty() { return Some(apply_subst(&raw, &subst)); }
         }
         Some(raw)
@@ -163,7 +165,7 @@ impl Indexer {
 
         // Apply generic type parameter substitution when requested.
         let detail = if let Some(cu) = calling_uri {
-            let subst = build_type_param_subst(self, uri_str, sym.selection_range.start.line, cu);
+            let subst = build_type_param_subst(self, uri_str, sym.selection_range.start.line, cu, None);
             if subst.is_empty() { raw_detail } else { apply_subst(&raw_detail, &subst) }
         } else {
             raw_detail
@@ -262,7 +264,7 @@ impl Indexer {
     /// when viewed from `calling_uri`.  Returns the substituted string, or the original if
     /// no substitution is applicable.
     pub(crate) fn type_subst_sig(&self, sym_uri: &str, sym_line: u32, calling_uri: &str, sig: &str) -> String {
-        let subst = build_type_param_subst(self, sym_uri, sym_line, calling_uri);
+        let subst = build_type_param_subst(self, sym_uri, sym_line, calling_uri, None);
         if subst.is_empty() { sig.to_owned() } else { apply_subst(sig, &subst) }
     }
 
@@ -337,6 +339,7 @@ fn build_type_param_subst(
     sym_uri:     &str,
     sym_line:    u32,
     calling_uri: &str,
+    cursor_line: Option<u32>,
 ) -> std::collections::HashMap<String, String> {
     if sym_uri == calling_uri {
         return Default::default();
@@ -364,8 +367,19 @@ fn build_type_param_subst(
         Some(d) => d,
         None    => return Default::default(),
     };
+
+    // When multiple classes in the same file extend the same base, use cursor_line
+    // to identify the specific calling class and scope the supers lookup.
+    let calling_class_line = cursor_line
+        .and_then(|line| find_containing_class_name(&calling_data, line))
+        .and_then(|name| calling_data.symbols.iter().find(|s| s.name == name))
+        .map(|s| s.selection_range.start.line);
+
     let type_args = calling_data.supers.iter()
-        .find(|(_, base, _)| base == &container_name)
+        .find(|(line, base, _)| {
+            base == &container_name
+                && calling_class_line.map_or(true, |class_line| *line == class_line)
+        })
         .map(|(_, _, args)| args.clone())
         .unwrap_or_default();
 

--- a/src/indexer/lookup_tests.rs
+++ b/src/indexer/lookup_tests.rs
@@ -31,6 +31,7 @@ fn swift_hover_uses_func_keyword() {
         &Location { uri: u.clone(), range: Default::default() },
         "greet",
         None,
+        None,
     ).unwrap_or_default();
     assert!(
         hover.contains("func"),
@@ -49,6 +50,7 @@ fn kotlin_hover_still_uses_fun_keyword() {
     let hover = idx.hover_info_at_location(
         &Location { uri: u.clone(), range: Default::default() },
         "greet",
+        None,
         None,
     ).unwrap_or_default();
     assert!(
@@ -96,7 +98,7 @@ class Foo(
     assert!(!locs.is_empty(), "repo should be found via find_definition_qualified");
 
     // 3. hover_info_at_location should return something
-    let hover = idx.hover_info_at_location(locs.first().unwrap(), "repo", None);
+    let hover = idx.hover_info_at_location(locs.first().unwrap(), "repo", None, None);
     assert!(hover.is_some(), "hover on val repo should produce result");
     let md = hover.unwrap();
     assert!(md.contains("repo"), "hover should mention 'repo', got: {md}");
@@ -120,7 +122,7 @@ internal class ContactAddressInteractor @Inject constructor(
     // hover on `repo` (line 2, col ~14)
     let locs = idx.find_definition_qualified("repo", None, &u);
     assert!(!locs.is_empty(), "repo should be found");
-    let hover = idx.hover_info_at_location(locs.first().unwrap(), "repo", None);
+    let hover = idx.hover_info_at_location(locs.first().unwrap(), "repo", None, None);
     assert!(hover.is_some(), "hover on val repo should work");
     let md = hover.unwrap();
     assert!(md.contains("repo"), "hover should mention repo: {md}");
@@ -224,7 +226,7 @@ class DashboardProductsReducer : FlowReducer<Event, Effect, State> {
         range: reduce_sym.selection_range,
     };
 
-    let hover = idx.hover_info_at_location(&loc, "reduce", Some(sub_u.as_str()))
+    let hover = idx.hover_info_at_location(&loc, "reduce", Some(sub_u.as_str()), None)
         .expect("hover should return Some");
 
     // Type params should be substituted: StateType→State, EventType→Event
@@ -249,6 +251,104 @@ interface FlowReducer<EventType, out EffectType, StateType> {
     let loc = tower_lsp::lsp_types::Location { uri: u.clone(), range: reduce_sym.selection_range };
 
     // calling_uri == sym_uri → no substitution
-    let hover = idx.hover_info_at_location(&loc, "reduce", Some(u.as_str())).unwrap();
+    let hover = idx.hover_info_at_location(&loc, "reduce", Some(u.as_str()), None).unwrap();
     assert!(hover.contains("StateType"), "same-file hover should keep raw type params, got: {hover}");
+}
+
+// ── Port-regression: property-type harvesting ─────────────────────────────────
+
+/// When the enclosing class's supers contain generic type args, the inlay-hint
+/// substitution path (`type_subst_for_enclosing_class`) must return the correct
+/// mapping. This tests the "UncC" scenario: build_enclosing_class_subst must
+/// perform phase 2 (member property harvesting) so that a property whose type
+/// extends a generic base contributes its type-param mappings to the enclosing class.
+#[test]
+fn inlay_hints_generic_subst_via_property_type_harvesting() {
+    let idx = Indexer::new();
+
+    let base_u = uri("/FlowReducer.kt");
+    idx.index_content(&base_u, "\
+interface FlowReducer<E, S> {
+    fun reduce(event: E, state: S): S
+}
+");
+
+    let reducer_u = uri("/DashReducer.kt");
+    idx.index_content(&reducer_u, "\
+class DashReducer : FlowReducer<DashEvent, DashState> {
+    override fun reduce(event: DashEvent, state: DashState): DashState = state
+}
+");
+
+    let owner_u = uri("/DashViewModel.kt");
+    idx.index_content(&owner_u, "\
+class DashViewModel {
+    val reducer: DashReducer = DashReducer()
+    fun process(event: DashEvent) {}
+}
+");
+
+    // Inlay hint substitution from inside DashViewModel (line 2 = inside the class):
+    // Phase 2 of build_enclosing_class_subst should trace:
+    //   property `reducer: DashReducer` → DashReducer supers → FlowReducer<E=DashEvent, S=DashState>
+    let subst = idx.type_subst_for_enclosing_class(owner_u.as_str(), 2);
+    assert!(subst.contains_key("E") || subst.contains_key("S"),
+        "property harvesting should produce substitution for FlowReducer params, got: {subst:?}");
+    if let Some(e_val) = subst.get("E") {
+        assert_eq!(e_val, "DashEvent", "E should map to DashEvent, got: {e_val}");
+    }
+    if let Some(s_val) = subst.get("S") {
+        assert_eq!(s_val, "DashState", "S should map to DashState, got: {s_val}");
+    }
+}
+
+// ── Port-regression: two callers in same file ─────────────────────────────────
+
+/// When two classes in the same file extend the same generic base with different
+/// type args, hovering inside each class must use the correct substitution.
+/// This is the "Unb5/TRjS" regression — fixed by adding cursor_line to
+/// build_type_param_subst / hover_info_at_location.
+#[test]
+fn hover_generic_subst_disambiguates_two_callers_in_same_file() {
+    let idx = Indexer::new();
+
+    let base_u = uri("/Processor.kt");
+    idx.index_content(&base_u, "\
+interface Processor<IN, OUT> {
+    fun process(input: IN): OUT
+}
+");
+
+    let caller_u = uri("/Callers.kt");
+    idx.index_content(&caller_u, "\
+class StringProcessor : Processor<String, Int> {
+    override fun process(input: String): Int = input.length
+}
+
+class BoolProcessor : Processor<Boolean, String> {
+    override fun process(input: Boolean): String = input.toString()
+}
+");
+
+    let base_data = idx.files.get(base_u.as_str()).unwrap();
+    let process_sym = base_data.symbols.iter().find(|s| s.name == "process").cloned()
+        .expect("process not found");
+    let loc = tower_lsp::lsp_types::Location {
+        uri: base_u.clone(),
+        range: process_sym.selection_range,
+    };
+
+    // Cursor on line 1 (inside StringProcessor): should use String/Int
+    let hover_string = idx.hover_info_at_location(&loc, "process", Some(caller_u.as_str()), Some(1))
+        .expect("hover should resolve for StringProcessor");
+    assert!(!hover_string.contains("Boolean"),
+        "StringProcessor hover (line 1) must not show Boolean, got: {hover_string}");
+
+    // Cursor on line 6 (inside BoolProcessor): should use Boolean/String
+    let hover_bool = idx.hover_info_at_location(&loc, "process", Some(caller_u.as_str()), Some(6))
+        .expect("hover should resolve for BoolProcessor");
+    assert!(hover_bool.contains("Boolean"),
+        "BoolProcessor hover (line 6) should show Boolean, got: {hover_bool}");
+    assert!(!hover_bool.contains("Int"),
+        "BoolProcessor hover (line 6) must not show Int, got: {hover_bool}");
 }

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -434,12 +434,23 @@ fn type_params_from_angle_brackets(text: &str) -> Vec<String> {
         Some(i) => i,
         None => return Vec::new(),
     };
-    // Only accept simple identifier names (no bounds, variance annotations, etc.)
+    // Strip variance prefix (Kotlin `out`/`in`) and upper bounds (`T : Any`) so that
+    // `out T`, `in T`, and `T : Comparable` all reduce to the simple name `T`.
     rest[..close]
         .split(',')
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty() && s.chars().all(|c| c.is_alphanumeric() || c == '_'))
-        .map(|s| s.to_owned())
+        .filter_map(|s| {
+            let s = s.trim();
+            // Strip variance annotation prefix
+            let s = s.strip_prefix("out ").or_else(|| s.strip_prefix("in "))
+                .unwrap_or(s).trim();
+            // Strip upper bound suffix (e.g. `T : Any`, `T: Comparable`)
+            let s = s.split(':').next().unwrap_or(s).trim();
+            if !s.is_empty() && s.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                Some(s.to_owned())
+            } else {
+                None
+            }
+        })
         .collect()
 }
 

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -66,6 +66,17 @@ pub(crate) trait NodeExt<'a>: Sized + Copy {
     /// Returns an empty vec when no `type_arguments` child exists.
     fn type_arg_strings(self, bytes: &[u8]) -> Vec<String>;
 
+    /// Extract type parameter *names* from the `type_parameters` child of a class,
+    /// interface, function, or protocol declaration node.
+    ///
+    /// Works identically for Kotlin, Java, and Swift:
+    ///   `type_parameters → type_parameter → type_identifier`
+    ///
+    /// Variance annotations (`in`/`out` in Kotlin) and bounds (`: Bound`) are
+    /// sibling nodes, not part of the `type_identifier`, so they are naturally
+    /// skipped.  Returns an empty vec for non-generic nodes.
+    fn extract_type_params(self, bytes: &[u8]) -> Vec<String>;
+
     /// Returns the line number (0-based) of the first named identifier child,
     /// or the node's own start line if no named child is found.
     fn name_line(self) -> u32;
@@ -279,6 +290,19 @@ impl<'a> NodeExt<'a> for Node<'a> {
         // text is like "<Event, Effect, State>" or "<Map<K,V>, String>"
         let inner = text.trim_start_matches('<').trim_end_matches('>');
         split_depth0_commas(inner)
+    }
+
+    fn extract_type_params(self, bytes: &[u8]) -> Vec<String> {
+        let Some(tp) = self.first_child_of_kind("type_parameters") else { return Vec::new() };
+        let mut result = Vec::new();
+        for param in tp.children_of_kind("type_parameter") {
+            if let Some(id) = param.first_child_of_kind("type_identifier") {
+                if let Some(name) = id.utf8_text_owned(bytes) {
+                    result.push(name);
+                }
+            }
+        }
+        result
     }
 
     fn name_line(self) -> u32 {

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -341,6 +341,18 @@ impl<'a> NodeExt<'a> for Node<'a> {
             if child.is_error() {
                 let params = child.extract_type_params(bytes);
                 if !params.is_empty() { return params; }
+                // `<T>` may land as raw tokens (no type_parameters node) — scan bytes directly.
+                if let Ok(text) = child.utf8_text(bytes) {
+                    let params = type_params_from_angle_brackets(text);
+                    if !params.is_empty() { return params; }
+                }
+            }
+        }
+        // No-modifiers case: the whole `fun interface Foo<T>` is an ERROR node itself,
+        // so `<T>` is a direct child token rather than nested in an ERROR child.
+        if self.is_error() {
+            if let Ok(text) = self.utf8_text(bytes) {
+                return type_params_from_angle_brackets(text);
             }
         }
         Vec::new()
@@ -396,6 +408,40 @@ impl<'a> NodeExt<'a> for Node<'a> {
     }
 }
 
+
+/// Scan `text` for the first `<…>` block and return simple identifier names inside.
+/// Used as a last-resort fallback when tree-sitter ERROR nodes don't produce a
+/// `type_parameters` child (e.g. `fun interface Foo<T>` in tree-sitter-kotlin 0.3).
+fn type_params_from_angle_brackets(text: &str) -> Vec<String> {
+    let open = match text.find('<') {
+        Some(i) => i,
+        None => return Vec::new(),
+    };
+    let rest = &text[open + 1..];
+    let mut depth: usize = 1;
+    let mut close = None;
+    for (i, c) in rest.char_indices() {
+        match c {
+            '<' => depth += 1,
+            '>' => {
+                depth -= 1;
+                if depth == 0 { close = Some(i); break; }
+            }
+            _ => {}
+        }
+    }
+    let close = match close {
+        Some(i) => i,
+        None => return Vec::new(),
+    };
+    // Only accept simple identifier names (no bounds, variance annotations, etc.)
+    rest[..close]
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty() && s.chars().all(|c| c.is_alphanumeric() || c == '_'))
+        .map(|s| s.to_owned())
+        .collect()
+}
 
 fn collect_user_type_segments(node: Node<'_>, bytes: &[u8], segments: &mut Vec<String>) {
     let mut cur = node.walk();

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -7,6 +7,7 @@ use crate::StrExt;
 use crate::queries::{
     KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_IDENTIFIER, KIND_VALUE_ARG, KIND_VALUE_ARGS,
     KIND_LAMBDA_PARAMS, KIND_TYPE_PARAMS, KIND_TYPE_PARAM, KIND_TYPE_ARGS,
+    KIND_USER_TYPE, KIND_TYPE_LIST,
 };
 
 pub(crate) trait NodeExt<'a>: Sized + Copy {
@@ -84,6 +85,19 @@ pub(crate) trait NodeExt<'a>: Sized + Copy {
     /// Used for `fun interface` recovery: tree-sitter may wrap the `<T>` in an ERROR
     /// child.  Search is depth-limited to one ERROR level to avoid entering class bodies.
     fn extract_type_params_or_error_child(self, bytes: &[u8]) -> Vec<String>;
+
+    /// Extract the supertype name from a Kotlin `delegation_specifier` node.
+    ///
+    /// Handles `constructor_invocation`, `explicit_delegation`, and bare `user_type`
+    /// forms.  Returns `(name, type_args)` or `None` if no supertype is found.
+    fn super_from_delegation(self, bytes: &[u8]) -> Option<(String, Vec<String>)>;
+
+    /// Collect all type names from the `type_list` child of a Java
+    /// `super_interfaces` or `extends_interfaces` node.
+    ///
+    /// Returns `(name, type_args)` pairs; the caller is responsible for supplying
+    /// the `name_line` and appending to `FileData.supers`.
+    fn java_type_list(self, bytes: &[u8]) -> Vec<(String, Vec<String>)>;
 
     /// Returns the line number (0-based) of the first named identifier child,
     /// or the node's own start line if no named child is found.
@@ -330,6 +344,38 @@ impl<'a> NodeExt<'a> for Node<'a> {
             }
         }
         Vec::new()
+    }
+
+    fn super_from_delegation(self, bytes: &[u8]) -> Option<(String, Vec<String>)> {
+        let mut cur = self.walk();
+        for child in self.children(&mut cur) {
+            let kind = child.kind();
+            if kind == "constructor_invocation" || kind == "explicit_delegation" {
+                if let Some(ut) = child.first_child_of_kind(KIND_USER_TYPE) {
+                    return ut.user_type_name(bytes).map(|n| (n, ut.type_arg_strings(bytes)));
+                }
+            } else if kind == KIND_USER_TYPE {
+                return child.user_type_name(bytes).map(|n| (n, child.type_arg_strings(bytes)));
+            }
+        }
+        None
+    }
+
+    fn java_type_list(self, bytes: &[u8]) -> Vec<(String, Vec<String>)> {
+        let Some(type_list) = self.first_child_of_kind(KIND_TYPE_LIST) else { return Vec::new() };
+        let mut result = Vec::new();
+        let mut cc = type_list.walk();
+        for type_node in type_list.children(&mut cc) {
+            // type_list children may be leaf type_identifier nodes directly,
+            // or wrapper nodes (generic_type, scoped_type_identifier) containing one.
+            let (name, type_args) = if type_node.kind() == KIND_TYPE_IDENT {
+                (type_node.utf8_text_owned(bytes), Vec::new())
+            } else {
+                (type_node.java_first_type_name(bytes), type_node.type_arg_strings(bytes))
+            };
+            if let Some(n) = name { result.push((n, type_args)); }
+        }
+        result
     }
 
     fn name_line(self) -> u32 {

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -61,9 +61,11 @@ pub(crate) trait NodeExt<'a>: Sized + Copy {
     /// Extract the first type name from a Java type node.
     fn java_first_type_name(self, bytes: &[u8]) -> Option<String>;
 
-    /// Extract the type argument strings from a `type_arguments` child of this node.
-    /// Splits `<Event, Effect, State>` at depth-0 commas.
-    /// Returns an empty vec when no `type_arguments` child exists.
+    /// Extract the type argument strings from the `type_arguments` child of this node.
+    ///
+    /// Uses CST children (named children of `type_arguments` are the type nodes;
+    /// `,`/`<`/`>` are anonymous).  Returns an empty vec when no `type_arguments`
+    /// child exists.
     fn type_arg_strings(self, bytes: &[u8]) -> Vec<String>;
 
     /// Extract type parameter *names* from the `type_parameters` child of a class,
@@ -76,6 +78,12 @@ pub(crate) trait NodeExt<'a>: Sized + Copy {
     /// sibling nodes, not part of the `type_identifier`, so they are naturally
     /// skipped.  Returns an empty vec for non-generic nodes.
     fn extract_type_params(self, bytes: &[u8]) -> Vec<String>;
+
+    /// Like `extract_type_params`, but also searches direct ERROR children of the node.
+    ///
+    /// Used for `fun interface` recovery: tree-sitter may wrap the `<T>` in an ERROR
+    /// child.  Search is depth-limited to one ERROR level to avoid entering class bodies.
+    fn extract_type_params_or_error_child(self, bytes: &[u8]) -> Vec<String>;
 
     /// Returns the line number (0-based) of the first named identifier child,
     /// or the node's own start line if no named child is found.
@@ -264,9 +272,12 @@ impl<'a> NodeExt<'a> for Node<'a> {
                     return n.utf8_text_owned(bytes);
                 }
                 "scoped_type_identifier" => {
-                    let text = n.utf8_text(bytes).ok()?;
-                    let name = text.split('<').next().unwrap_or(text).trim();
-                    return if name.is_empty() { None } else { Some(name.to_owned()) };
+                    // Collect all identifier/type_identifier segments while skipping
+                    // type_arguments children (handles `Outer<String>.Inner` correctly).
+                    let mut segments = Vec::new();
+                    collect_user_type_segments(n, bytes, &mut segments);
+                    let name = segments.join(".");
+                    return if name.is_empty() { None } else { Some(name) };
                 }
                 "type_arguments" => continue,
                 _ => {}
@@ -283,13 +294,13 @@ impl<'a> NodeExt<'a> for Node<'a> {
         let Some(args_node) = self.first_child_of_kind("type_arguments") else {
             return Vec::new();
         };
-        let text = match args_node.utf8_text(bytes) {
-            Ok(t) => t.trim(),
-            Err(_) => return Vec::new(),
-        };
-        // text is like "<Event, Effect, State>" or "<Map<K,V>, String>"
-        let inner = text.trim_start_matches('<').trim_end_matches('>');
-        split_depth0_commas(inner)
+        let mut cur = args_node.walk();
+        args_node.children(&mut cur)
+            .filter(|c| c.is_named())
+            .filter_map(|c| c.utf8_text(bytes).ok())
+            .map(|t| t.trim().to_owned())
+            .filter(|t| !t.is_empty())
+            .collect()
     }
 
     fn extract_type_params(self, bytes: &[u8]) -> Vec<String> {
@@ -303,6 +314,22 @@ impl<'a> NodeExt<'a> for Node<'a> {
             }
         }
         result
+    }
+
+    fn extract_type_params_or_error_child(self, bytes: &[u8]) -> Vec<String> {
+        let direct = self.extract_type_params(bytes);
+        if !direct.is_empty() { return direct; }
+        // For `fun interface Foo<T>` misparsing, tree-sitter may wrap `<T>` in an
+        // ERROR child.  Search only ERROR children — not the full subtree — to
+        // avoid picking up type params from methods inside the interface body.
+        let mut cur = self.walk();
+        for child in self.children(&mut cur) {
+            if child.is_error() {
+                let params = child.extract_type_params(bytes);
+                if !params.is_empty() { return params; }
+            }
+        }
+        Vec::new()
     }
 
     fn name_line(self) -> u32 {
@@ -320,56 +347,6 @@ impl<'a> NodeExt<'a> for Node<'a> {
     }
 }
 
-// ─── Shared helpers ──────────────────────────────────────────────────────────
-
-/// Split `s` at depth-0 commas (ignoring commas inside nested `<...>`).
-/// Returns trimmed, non-empty segments.
-pub(super) fn split_depth0_commas(s: &str) -> Vec<String> {
-    let mut args = Vec::new();
-    let mut depth = 0usize;
-    let mut start = 0usize;
-    for (i, ch) in s.char_indices() {
-        match ch {
-            '<' => depth += 1,
-            '>' => depth = depth.saturating_sub(1),
-            ',' if depth == 0 => {
-                let seg = s[start..i].trim();
-                if !seg.is_empty() { args.push(seg.to_owned()); }
-                start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    let seg = s[start..].trim();
-    if !seg.is_empty() { args.push(seg.to_owned()); }
-    args
-}
-
-/// Parse type parameter names from a declaration string.
-///
-/// e.g. `"interface FlowReducer<EventType, out EffectType, StateType>"` → `["EventType", "EffectType", "StateType"]`
-///
-/// Handles variance annotations (`in`, `out`) and type constraints (`T : Bound`).
-pub(crate) fn parse_type_params_from_decl(decl: &str) -> Vec<String> {
-    let search_region = match decl.find('(') {
-        Some(paren) => &decl[..paren],
-        None => decl,
-    };
-    let start = match search_region.find('<') { Some(i) => i + 1, None => return Vec::new() };
-    let end = match search_region.rfind('>') { Some(i) => i, None => return Vec::new() };
-    if end <= start { return Vec::new(); }
-
-    split_depth0_commas(&decl[start..end])
-        .into_iter()
-        .map(|s| {
-            let s = s.strip_prefix("in ").unwrap_or(&s);
-            let s = s.strip_prefix("out ").unwrap_or(s).trim();
-            let end_pos = s.find(|c: char| c == ':' || c.is_whitespace()).unwrap_or(s.len());
-            s[..end_pos].trim().to_owned()
-        })
-        .filter(|s| !s.is_empty())
-        .collect()
-}
 
 fn collect_user_type_segments(node: Node<'_>, bytes: &[u8], segments: &mut Vec<String>) {
     let mut cur = node.walk();

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -5,8 +5,8 @@
 use tree_sitter::Node;
 use crate::StrExt;
 use crate::queries::{
-    KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_VALUE_ARG, KIND_VALUE_ARGS,
-    KIND_LAMBDA_PARAMS,
+    KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_IDENTIFIER, KIND_VALUE_ARG, KIND_VALUE_ARGS,
+    KIND_LAMBDA_PARAMS, KIND_TYPE_PARAMS, KIND_TYPE_PARAM, KIND_TYPE_ARGS,
 };
 
 pub(crate) trait NodeExt<'a>: Sized + Copy {
@@ -268,7 +268,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
         let mut stack = vec![self];
         while let Some(n) = stack.pop() {
             match n.kind() {
-                "type_identifier" => {
+                KIND_TYPE_IDENT => {
                     return n.utf8_text_owned(bytes);
                 }
                 "scoped_type_identifier" => {
@@ -279,7 +279,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
                     let name = segments.join(".");
                     return if name.is_empty() { None } else { Some(name) };
                 }
-                "type_arguments" => continue,
+                KIND_TYPE_ARGS => continue,
                 _ => {}
             }
             let mut cur = n.walk();
@@ -291,7 +291,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
     }
 
     fn type_arg_strings(self, bytes: &[u8]) -> Vec<String> {
-        let Some(args_node) = self.first_child_of_kind("type_arguments") else {
+        let Some(args_node) = self.first_child_of_kind(KIND_TYPE_ARGS) else {
             return Vec::new();
         };
         let mut cur = args_node.walk();
@@ -304,10 +304,10 @@ impl<'a> NodeExt<'a> for Node<'a> {
     }
 
     fn extract_type_params(self, bytes: &[u8]) -> Vec<String> {
-        let Some(tp) = self.first_child_of_kind("type_parameters") else { return Vec::new() };
+        let Some(tp) = self.first_child_of_kind(KIND_TYPE_PARAMS) else { return Vec::new() };
         let mut result = Vec::new();
-        for param in tp.children_of_kind("type_parameter") {
-            if let Some(id) = param.first_child_of_kind("type_identifier") {
+        for param in tp.children_of_kind(KIND_TYPE_PARAM) {
+            if let Some(id) = param.first_child_of_kind(KIND_TYPE_IDENT) {
                 if let Some(name) = id.utf8_text_owned(bytes) {
                     result.push(name);
                 }
@@ -339,7 +339,10 @@ impl<'a> NodeExt<'a> for Node<'a> {
         }
         let mut cur = self.walk();
         for child in self.children(&mut cur) {
-            if matches!(child.kind(), "type_identifier" | "simple_identifier" | "identifier") {
+            if child.kind() == KIND_TYPE_IDENT
+                || child.kind() == KIND_SIMPLE_IDENT
+                || child.kind() == KIND_IDENTIFIER
+            {
                 return child.start_position().row as u32;
             }
         }
@@ -351,16 +354,16 @@ impl<'a> NodeExt<'a> for Node<'a> {
 fn collect_user_type_segments(node: Node<'_>, bytes: &[u8], segments: &mut Vec<String>) {
     let mut cur = node.walk();
     for child in node.children(&mut cur) {
-        match child.kind() {
-            "type_arguments" => {}  // skip generic parameters entirely
-            "simple_identifier" | "type_identifier" | "identifier" => {
-                if let Ok(text) = child.utf8_text(bytes) {
-                    let text = text.trim();
-                    if !text.is_empty() { segments.push(text.to_owned()); }
-                }
+        let kind = child.kind();
+        if kind == KIND_TYPE_ARGS {
+            // skip generic parameters entirely
+        } else if kind == KIND_SIMPLE_IDENT || kind == KIND_TYPE_IDENT || kind == KIND_IDENTIFIER {
+            if let Ok(text) = child.utf8_text(bytes) {
+                let text = text.trim();
+                if !text.is_empty() { segments.push(text.to_owned()); }
             }
-            _ if child.is_named() => collect_user_type_segments(child, bytes, segments),
-            _ => {}
+        } else if child.is_named() {
+            collect_user_type_segments(child, bytes, segments);
         }
     }
 }

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -296,7 +296,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
     }
 }
 
-// ─── Private helpers ──────────────────────────────────────────────────────────
+// ─── Shared helpers ──────────────────────────────────────────────────────────
 
 /// Split `s` at depth-0 commas (ignoring commas inside nested `<...>`).
 /// Returns trimmed, non-empty segments.
@@ -319,6 +319,32 @@ pub(super) fn split_depth0_commas(s: &str) -> Vec<String> {
     let seg = s[start..].trim();
     if !seg.is_empty() { args.push(seg.to_owned()); }
     args
+}
+
+/// Parse type parameter names from a declaration string.
+///
+/// e.g. `"interface FlowReducer<EventType, out EffectType, StateType>"` → `["EventType", "EffectType", "StateType"]`
+///
+/// Handles variance annotations (`in`, `out`) and type constraints (`T : Bound`).
+pub(crate) fn parse_type_params_from_decl(decl: &str) -> Vec<String> {
+    let search_region = match decl.find('(') {
+        Some(paren) => &decl[..paren],
+        None => decl,
+    };
+    let start = match search_region.find('<') { Some(i) => i + 1, None => return Vec::new() };
+    let end = match search_region.rfind('>') { Some(i) => i, None => return Vec::new() };
+    if end <= start { return Vec::new(); }
+
+    split_depth0_commas(&decl[start..end])
+        .into_iter()
+        .map(|s| {
+            let s = s.strip_prefix("in ").unwrap_or(&s);
+            let s = s.strip_prefix("out ").unwrap_or(s).trim();
+            let end_pos = s.find(|c: char| c == ':' || c.is_whitespace()).unwrap_or(s.len());
+            s[..end_pos].trim().to_owned()
+        })
+        .filter(|s| !s.is_empty())
+        .collect()
 }
 
 fn collect_user_type_segments(node: Node<'_>, bytes: &[u8], segments: &mut Vec<String>) {

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -38,7 +38,7 @@ impl ResolveOptions {
 /// Substitution context used by the pipeline.
 pub enum SubstitutionContext<'a> {
     None,
-    CrossFile { calling_uri: &'a str },
+    CrossFile { calling_uri: &'a str, cursor_line: u32 },
     EnclosingClass { uri: &'a str, cursor_line: u32 },
     Precomputed(&'a HashMap<String, String>),
 }
@@ -194,8 +194,8 @@ fn build_subst_if_needed<I: IndexRead>(
 
     match subst_ctx {
         SubstitutionContext::None => HashMap::new(),
-        SubstitutionContext::CrossFile { calling_uri } => {
-            build_type_param_subst_impl(index, location.uri.as_str(), location.range.start.line, calling_uri)
+        SubstitutionContext::CrossFile { calling_uri, cursor_line } => {
+            build_type_param_subst_impl(index, location.uri.as_str(), location.range.start.line, calling_uri, cursor_line)
         }
         SubstitutionContext::EnclosingClass { uri, cursor_line } => {
             build_enclosing_class_subst_impl(index, uri, cursor_line)
@@ -212,6 +212,7 @@ fn build_type_param_subst_impl<I: IndexRead>(
     sym_uri: &str,
     sym_line: u32,
     calling_uri: &str,
+    caller_cursor_line: u32,
 ) -> HashMap<String, String> {
     if sym_uri == calling_uri {
         return HashMap::new();
@@ -239,8 +240,19 @@ fn build_type_param_subst_impl<I: IndexRead>(
         Some(d) => d,
         None => return HashMap::new(),
     };
+
+    // Use `caller_cursor_line` to identify the specific calling class — when multiple
+    // classes in the same file extend the same base with different type args,
+    // this ensures we pick the correct substitution for the caller.
+    let calling_class_line = find_containing_class_name(&calling_data, caller_cursor_line)
+        .and_then(|name| calling_data.symbols.iter().find(|s| s.name == name))
+        .map(|s| s.selection_range.start.line);
+
     let type_args = calling_data.supers.iter()
-        .find(|(_, base, _)| base == &container_name)
+        .find(|(line, base, _)| {
+            base == &container_name
+                && calling_class_line.map_or(true, |class_line| *line == class_line)
+        })
         .map(|(_, _, args)| args.clone())
         .unwrap_or_default();
 
@@ -303,6 +315,31 @@ fn build_enclosing_class_subst_impl<I: IndexRead>(
         }
         for (param, arg) in base_type_params.iter().zip(type_args.iter()) {
             result.entry(param.clone()).or_insert_with(|| arg.clone());
+        }
+    }
+    // Phase 2: collect substitutions from member property types.
+    // E.g. if the enclosing class has `val reducer: DashboardProductsReducer`
+    // and that type extends `FlowReducer<Event, State>`, include
+    // `{Event→…, State→…}` mappings from FlowReducer's type params.
+    for sym in data.symbols.iter() {
+        if sym.selection_range.start.line <= class_line { continue; }
+        if !matches!(sym.kind, SymbolKind::FIELD | SymbolKind::PROPERTY) { continue; }
+        let type_name = super::lookup::extract_property_type_name(&sym.detail);
+        if type_name.is_empty() { continue; }
+        let Some(locs) = index.get_definitions(type_name) else { continue };
+        let Some(loc) = locs.into_iter().next() else { continue };
+        let Some(prop_type_data) = index.get_file_data(loc.uri.as_str()) else { continue };
+        let Some(prop_sym) = prop_type_data.symbols.iter().find(|s| s.name == type_name) else { continue };
+        let prop_class_line = prop_sym.selection_range.start.line;
+        for (line, super_name, type_args) in prop_type_data.supers.iter() {
+            if *line != prop_class_line || type_args.is_empty() { continue; }
+            let Some(super_locs) = index.get_definitions(super_name) else { continue };
+            let Some(super_loc) = super_locs.into_iter().next() else { continue };
+            let Some(super_file_data) = index.get_file_data(super_loc.uri.as_str()) else { continue };
+            let Some(super_sym) = super_file_data.symbols.iter().find(|s| s.name == *super_name) else { continue };
+            for (param, arg) in super_sym.type_params.iter().zip(type_args.iter()) {
+                result.entry(param.clone()).or_insert_with(|| arg.clone());
+            }
         }
     }
     result
@@ -659,5 +696,94 @@ mod tests {
         let r = result.unwrap();
         assert!(r.signature.contains("String"), "signature should have substituted T→String: {}", r.signature);
         assert!(!r.signature.contains(": T"), "raw T should be replaced: {}", r.signature);
+    }
+
+    // ── Unb5/TRjS regression: CrossFile with cursor_line ─────────────────────
+
+    /// When two classes in the same file extend the same base with different type
+    /// args, `CrossFile { cursor_line }` must pick the right class for substitution.
+    #[test]
+    fn crossfile_cursor_line_disambiguates_multiple_callers() {
+        use crate::types::Visibility;
+
+        let base_uri   = "file:///base.kt";
+        let caller_uri = "file:///caller.kt";
+
+        // Base: class FlowReducer<E, S>  with fun reduce(e: E): S
+        let base_class = {
+            let mut s = make_sym("FlowReducer", SymbolKind::CLASS, 0, 10);
+            s.type_params = vec!["E".to_owned(), "S".to_owned()];
+            s
+        };
+        let base_method = {
+            let mut s = make_sym("reduce", SymbolKind::FUNCTION, 5, 7);
+            s.detail = "fun reduce(e: E): S".to_owned();
+            s
+        };
+        let base_data = Arc::new(crate::types::FileData {
+            symbols: vec![base_class, base_method],
+            lines: std::sync::Arc::new(vec![
+                "class FlowReducer<E, S> {".to_owned(),
+                String::new(),
+                String::new(),
+                String::new(),
+                String::new(),
+                "    fun reduce(e: E): S {}".to_owned(),
+                "}".to_owned(),
+            ]),
+            ..Default::default()
+        });
+
+        // Caller file has TWO classes extending FlowReducer with different args:
+        //   class DashReducer : FlowReducer<DashEvent, DashState>  (line 0)
+        //   class SettingsReducer : FlowReducer<SettEvent, SettState> (line 10)
+        let dash_class = {
+            let mut s = make_sym("DashReducer", SymbolKind::CLASS, 0, 8);
+            s.selection_range = make_range(0, 0);
+            s
+        };
+        let sett_class = {
+            let mut s = make_sym("SettingsReducer", SymbolKind::CLASS, 10, 18);
+            s.selection_range = make_range(10, 10);
+            s
+        };
+        let caller_data = Arc::new(crate::types::FileData {
+            symbols: vec![dash_class, sett_class],
+            supers: vec![
+                (0, "FlowReducer".to_owned(), vec!["DashEvent".to_owned(), "DashState".to_owned()]),
+                (10, "FlowReducer".to_owned(), vec!["SettEvent".to_owned(), "SettState".to_owned()]),
+            ],
+            ..Default::default()
+        });
+
+        let mut files = HashMap::new();
+        files.insert(base_uri.to_owned(), base_data);
+        files.insert(caller_uri.to_owned(), caller_data);
+        let mut definitions = HashMap::new();
+        definitions.insert("FlowReducer".to_owned(), vec![make_location(base_uri, 0)]);
+        definitions.insert("reduce".to_owned(), vec![make_location(base_uri, 5)]);
+        let idx = RealTestIndex { files, definitions };
+
+        // Cursor inside DashReducer (line 4): should use DashEvent/DashState
+        let result_dash = resolve_symbol_info(
+            &idx, "reduce", None,
+            &Url::parse(caller_uri).unwrap(),
+            SubstitutionContext::CrossFile { calling_uri: caller_uri, cursor_line: 4 },
+            &ResolveOptions::hover(),
+        );
+        let dash = result_dash.expect("should resolve reduce");
+        assert!(dash.signature.contains("DashEvent"), "dash: {}", dash.signature);
+        assert!(dash.signature.contains("DashState"), "dash: {}", dash.signature);
+
+        // Cursor inside SettingsReducer (line 14): should use SettEvent/SettState
+        let result_sett = resolve_symbol_info(
+            &idx, "reduce", None,
+            &Url::parse(caller_uri).unwrap(),
+            SubstitutionContext::CrossFile { calling_uri: caller_uri, cursor_line: 14 },
+            &ResolveOptions::hover(),
+        );
+        let sett = result_sett.expect("should resolve reduce");
+        assert!(sett.signature.contains("SettEvent"), "sett: {}", sett.signature);
+        assert!(sett.signature.contains("SettState"), "sett: {}", sett.signature);
     }
 }

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -461,13 +461,14 @@ mod tests {
     fn make_sym(name: &str, kind: SymbolKind, start_line: u32, end_line: u32) -> SymbolEntry {
         use crate::types::Visibility;
         SymbolEntry {
-            name:            name.to_owned(),
+            name:               name.to_owned(),
             kind,
-            visibility:      Visibility::Public,
-            range:           make_range(start_line, end_line),
-            selection_range: make_range(start_line, start_line),
-            detail:          String::new(),
-            type_params:     Vec::new(),
+            visibility:         Visibility::Public,
+            range:              make_range(start_line, end_line),
+            selection_range:    make_range(start_line, start_line),
+            detail:             String::new(),
+            type_params:        Vec::new(),
+            extension_receiver: String::new(),
         }
     }
 

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -90,10 +90,13 @@ pub fn resolve_contextual_info<I: IndexRead>(
     cursor_line: u32,
     options: &ResolveOptions,
 ) -> Option<ResolvedSymbol> {
+    // For qualified types like `Outer.Inner`, pass `outer` as qualifier so the
+    // resolver can narrow to the right file before searching for `leaf`.
+    let qualifier = if rt.leaf != rt.qualified { Some(rt.outer.as_str()) } else { None };
     resolve_symbol_info(
         index,
         &rt.leaf,
-        None,
+        qualifier,
         from_uri,
         SubstitutionContext::EnclosingClass {
             uri: from_uri.as_str(),
@@ -110,13 +113,14 @@ pub fn build_subst_map<I: IndexRead>(index: &I, uri: &str, cursor_line: u32) -> 
 
 // ─── Pure Data Transformation Functions ──────────────────────────────────
 
-/// Extract canonical signature (prefer cached detail, fall back to source).
+/// Extract canonical signature (prefer full source, fall back to cached detail).
+///
+/// `detail` is truncated to ~120 chars at index time; `collect_signature` reads
+/// the original source lines and returns the complete declaration up to `{`/`=`.
+/// We prefer the full source version so callers see untruncated signatures.
 fn extract_canonical_signature(sym: &SymbolEntry, data: &FileData) -> String {
-    if !sym.detail.is_empty() {
-        sym.detail.clone()
-    } else {
-        data.lines.collect_signature(sym.selection_range.start.line as usize)
-    }
+    let full = data.lines.collect_signature(sym.selection_range.start.line as usize);
+    if !full.is_empty() { full } else { sym.detail.clone() }
 }
 
 /// Apply type-parameter substitution to a signature string.
@@ -268,18 +272,36 @@ fn build_enclosing_class_subst_impl<I: IndexRead>(
         None => return HashMap::new(),
     };
 
-    let type_params = &class_sym.type_params;
-    if type_params.is_empty() { return HashMap::new(); }
-
     let class_line = class_sym.selection_range.start.line;
 
-    // Collect all supers of this class, zipping their type args against the class's type params.
+    // For each supertype with concrete type args, look up the BASE class's own
+    // type parameters (e.g., `[T, U]` from `class Base<T, U>`), then zip with
+    // the concrete args (e.g., `[Event, State]`) to build `{T→Event, U→State}`.
+    // Using the enclosing class's own type_params here would be wrong: for
+    // `class Child : Base<Event, State>`, Child itself has no type params.
     let mut result = HashMap::new();
-    for (line, _base_name, type_args) in data.supers.iter() {
+    for (line, base_name, type_args) in data.supers.iter() {
         if *line != class_line || type_args.is_empty() {
             continue;
         }
-        for (param, arg) in type_params.iter().zip(type_args.iter()) {
+
+        let base_type_params: Vec<String> = index
+            .get_definitions(base_name)
+            .and_then(|locs| locs.into_iter().next())
+            .and_then(|loc| {
+                index.get_file_data(loc.uri.as_str()).and_then(|base_data| {
+                    base_data.symbols
+                        .iter()
+                        .find(|s| s.name == *base_name)
+                        .map(|s| s.type_params.clone())
+                })
+            })
+            .unwrap_or_default();
+
+        if base_type_params.is_empty() {
+            continue;
+        }
+        for (param, arg) in base_type_params.iter().zip(type_args.iter()) {
             result.entry(param.clone()).or_insert_with(|| arg.clone());
         }
     }
@@ -327,6 +349,18 @@ impl IndexRead for super::Indexer {
         if allow_rg {
             self.resolve_symbol(name, qualifier, from_uri)
         } else {
+            if let Some(qual) = qualifier {
+                // Index-only qualified resolution: resolve the qualifier without rg,
+                // then search that file for `name`. Avoids silently dropping the
+                // qualifier and returning results for an unrelated top-level symbol.
+                let qual_locs = self.resolve_symbol_no_rg(qual, from_uri);
+                if let Some(loc) = qual_locs.into_iter().next() {
+                    let locs = self.find_name_in_uri(name, loc.uri.as_str());
+                    if !locs.is_empty() {
+                        return locs;
+                    }
+                }
+            }
             self.resolve_symbol_no_rg(name, from_uri)
         }
     }
@@ -336,6 +370,9 @@ impl IndexRead for super::Indexer {
 mod tests {
     use super::*;
     use tower_lsp::lsp_types::Url;
+    use std::collections::HashMap;
+
+    // ── Minimal stub (for tests that don't need real data) ───────────────────
 
     struct TestIndex;
     impl IndexRead for TestIndex {
@@ -344,22 +381,35 @@ mod tests {
         fn get_file_data(&self, _uri: &str) -> Option<Arc<FileData>> { None }
     }
 
-    #[test]
-    fn stub_resolve_returns_none() {
-        let idx = TestIndex;
-        let res = resolve_symbol_info(&idx, "Foo", None, &Url::parse("file:///x").unwrap(), SubstitutionContext::None, &ResolveOptions::hover());
-        assert!(res.is_none());
+    // ── Fully-populated index for end-to-end tests ───────────────────────────
+
+    struct RealTestIndex {
+        files: HashMap<String, Arc<FileData>>,
+        definitions: HashMap<String, Vec<Location>>,
     }
 
-    #[test]
-    fn apply_subst_replaces_identifiers() {
-        let mut subst = HashMap::new();
-        subst.insert("T".to_string(), "String".to_string());
-        subst.insert("U".to_string(), "Int".to_string());
-        let sig = "fun foo(x: T, y: U): T";
-        let result = apply_subst(sig, &subst);
-        assert_eq!(result, "fun foo(x: String, y: Int): String");
+    impl IndexRead for RealTestIndex {
+        fn get_file_lines(&self, uri: &str) -> Option<Vec<String>> {
+            self.files.get(uri).map(|f| f.lines.as_ref().to_vec())
+        }
+        fn get_definitions(&self, name: &str) -> Option<Vec<Location>> {
+            self.definitions.get(name).cloned()
+        }
+        fn get_file_data(&self, uri: &str) -> Option<Arc<FileData>> {
+            self.files.get(uri).cloned()
+        }
+        fn resolve_locations(
+            &self,
+            name: &str,
+            _qualifier: Option<&str>,
+            _from_uri: &Url,
+            _allow_rg: bool,
+        ) -> Vec<Location> {
+            self.definitions.get(name).cloned().unwrap_or_default()
+        }
     }
+
+    // ── Shared helpers ────────────────────────────────────────────────────────
 
     fn make_range(start_line: u32, end_line: u32) -> tower_lsp::lsp_types::Range {
         use tower_lsp::lsp_types::Position;
@@ -382,6 +432,36 @@ mod tests {
         }
     }
 
+    fn make_location(uri: &str, line: u32) -> Location {
+        Location { uri: Url::parse(uri).unwrap(), range: make_range(line, line) }
+    }
+
+    // ── Basic stub tests ──────────────────────────────────────────────────────
+
+    #[test]
+    fn stub_resolve_returns_none() {
+        let idx = TestIndex;
+        let res = resolve_symbol_info(
+            &idx, "Foo", None,
+            &Url::parse("file:///x").unwrap(),
+            SubstitutionContext::None,
+            &ResolveOptions::hover(),
+        );
+        assert!(res.is_none());
+    }
+
+    #[test]
+    fn apply_subst_replaces_identifiers() {
+        let mut subst = HashMap::new();
+        subst.insert("T".to_string(), "String".to_string());
+        subst.insert("U".to_string(), "Int".to_string());
+        let sig = "fun foo(x: T, y: U): T";
+        let result = apply_subst(sig, &subst);
+        assert_eq!(result, "fun foo(x: String, y: Int): String");
+    }
+
+    // ── find_containing_class tests ───────────────────────────────────────────
+
     #[test]
     fn find_containing_class_returns_innermost() {
         use crate::types::FileData;
@@ -392,9 +472,7 @@ mod tests {
             ],
             ..Default::default()
         };
-        // Line 7 is inside both Outer (0-20) and Inner (5-15); should return Inner.
-        let result = find_containing_class_name(&data, 7);
-        assert_eq!(result.as_deref(), Some("Inner"));
+        assert_eq!(find_containing_class_name(&data, 7).as_deref(), Some("Inner"));
     }
 
     #[test]
@@ -404,9 +482,7 @@ mod tests {
             symbols: vec![make_sym("Outer", SymbolKind::CLASS, 5, 15)],
             ..Default::default()
         };
-        // Line 1 is outside any class.
-        let result = find_containing_class_name(&data, 1);
-        assert!(result.is_none());
+        assert!(find_containing_class_name(&data, 1).is_none());
     }
 
     #[test]
@@ -421,5 +497,167 @@ mod tests {
         };
         assert_eq!(find_containing_class_name(&data, 5).as_deref(), Some("MyEnum"));
         assert_eq!(find_containing_class_name(&data, 15).as_deref(), Some("MyObject"));
+    }
+
+    // ── build_subst_map end-to-end tests ─────────────────────────────────────
+
+    /// `class Child : Base<String, Int>` — subst should be `{T→String, U→Int}`
+    /// where T and U come from Base's declaration, NOT from Child.
+    #[test]
+    fn build_subst_map_uses_base_class_type_params() {
+        let base_uri = "file:///base.kt";
+        let child_uri = "file:///child.kt";
+
+        let mut base_sym = make_sym("Base", SymbolKind::CLASS, 0, 10);
+        base_sym.type_params = vec!["T".to_owned(), "U".to_owned()];
+
+        let base_data = Arc::new(crate::types::FileData {
+            symbols: vec![base_sym],
+            ..Default::default()
+        });
+
+        let child_data = Arc::new(crate::types::FileData {
+            symbols: vec![make_sym("Child", SymbolKind::CLASS, 0, 20)],
+            supers: vec![(0, "Base".to_owned(), vec!["String".to_owned(), "Int".to_owned()])],
+            ..Default::default()
+        });
+
+        let mut files = HashMap::new();
+        files.insert(base_uri.to_owned(), base_data);
+        files.insert(child_uri.to_owned(), child_data);
+
+        let mut definitions = HashMap::new();
+        definitions.insert("Base".to_owned(), vec![make_location(base_uri, 0)]);
+
+        let idx = RealTestIndex { files, definitions };
+
+        let subst = build_subst_map(&idx, child_uri, 5);
+        assert_eq!(subst.get("T").map(|s| s.as_str()), Some("String"));
+        assert_eq!(subst.get("U").map(|s| s.as_str()), Some("Int"));
+    }
+
+    /// A class with no type params itself but inheriting a generic base.
+    /// Previously the bug caused an empty map; now it correctly builds the map.
+    #[test]
+    fn build_subst_map_child_has_no_own_type_params() {
+        let base_uri = "file:///reducer.kt";
+        let child_uri = "file:///dashboard.kt";
+
+        let mut base_sym = make_sym("FlowReducer", SymbolKind::CLASS, 0, 5);
+        base_sym.type_params = vec!["Event".to_owned(), "State".to_owned()];
+
+        let base_data = Arc::new(crate::types::FileData {
+            symbols: vec![base_sym],
+            ..Default::default()
+        });
+
+        // DashboardReducer has NO own type params, inherits FlowReducer<DashEvent, DashState>
+        let child_data = Arc::new(crate::types::FileData {
+            symbols: vec![make_sym("DashboardReducer", SymbolKind::CLASS, 0, 50)],
+            supers: vec![(
+                0,
+                "FlowReducer".to_owned(),
+                vec!["DashEvent".to_owned(), "DashState".to_owned()],
+            )],
+            ..Default::default()
+        });
+
+        let mut files = HashMap::new();
+        files.insert(base_uri.to_owned(), base_data);
+        files.insert(child_uri.to_owned(), child_data);
+
+        let mut definitions = HashMap::new();
+        definitions.insert("FlowReducer".to_owned(), vec![make_location(base_uri, 0)]);
+
+        let idx = RealTestIndex { files, definitions };
+
+        let subst = build_subst_map(&idx, child_uri, 10);
+        assert_eq!(subst.get("Event").map(|s| s.as_str()), Some("DashEvent"));
+        assert_eq!(subst.get("State").map(|s| s.as_str()), Some("DashState"));
+    }
+
+    // ── resolve_symbol_info end-to-end tests ─────────────────────────────────
+
+    /// Basic lookup: symbol in a file with source lines, no substitution.
+    #[test]
+    fn resolve_symbol_info_basic_lookup() {
+        let file_uri = "file:///utils.kt";
+
+        let mut sym = make_sym("compute", SymbolKind::FUNCTION, 2, 5);
+        sym.detail = "fun compute(x: Int): String".to_owned();
+
+        let file_data = Arc::new(crate::types::FileData {
+            symbols: vec![sym],
+            lines: std::sync::Arc::new(vec![
+                "package com.example".to_owned(),
+                String::new(),
+                "fun compute(x: Int): String = x.toString()".to_owned(),
+            ]),
+            ..Default::default()
+        });
+
+        let mut files = HashMap::new();
+        files.insert(file_uri.to_owned(), file_data);
+
+        let mut definitions = HashMap::new();
+        definitions.insert("compute".to_owned(), vec![make_location(file_uri, 2)]);
+
+        let idx = RealTestIndex { files, definitions };
+
+        let result = resolve_symbol_info(
+            &idx, "compute", None,
+            &Url::parse("file:///caller.kt").unwrap(),
+            SubstitutionContext::None,
+            &ResolveOptions::goto_def(),
+        );
+
+        assert!(result.is_some());
+        let r = result.unwrap();
+        assert_eq!(r.location.uri.as_str(), file_uri);
+        // collect_signature reads from source lines and should prefer those
+        assert!(r.raw_signature.contains("compute"), "raw_signature: {}", r.raw_signature);
+    }
+
+    /// With substitution context: `{T→String}` applied to the signature.
+    #[test]
+    fn resolve_symbol_info_applies_precomputed_subst() {
+        let file_uri = "file:///base.kt";
+
+        let mut sym = make_sym("process", SymbolKind::FUNCTION, 3, 5);
+        sym.detail = "fun process(item: T): T".to_owned();
+
+        let file_data = Arc::new(crate::types::FileData {
+            symbols: vec![sym],
+            lines: std::sync::Arc::new(vec![
+                "package com.example".to_owned(),
+                String::new(),
+                String::new(),
+                "fun process(item: T): T {".to_owned(),
+            ]),
+            ..Default::default()
+        });
+
+        let mut files = HashMap::new();
+        files.insert(file_uri.to_owned(), file_data);
+
+        let mut definitions = HashMap::new();
+        definitions.insert("process".to_owned(), vec![make_location(file_uri, 3)]);
+
+        let idx = RealTestIndex { files, definitions };
+
+        let mut subst = HashMap::new();
+        subst.insert("T".to_owned(), "String".to_owned());
+
+        let result = resolve_symbol_info(
+            &idx, "process", None,
+            &Url::parse("file:///caller.kt").unwrap(),
+            SubstitutionContext::Precomputed(&subst),
+            &ResolveOptions::hover(),
+        );
+
+        assert!(result.is_some());
+        let r = result.unwrap();
+        assert!(r.signature.contains("String"), "signature should have substituted T→String: {}", r.signature);
+        assert!(!r.signature.contains(": T"), "raw T should be replaced: {}", r.signature);
     }
 }

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -1,11 +1,15 @@
 // Unified resolution service for symbol lookup, substitution, and extraction.
-// Phase 1: types, traits and stubs. Will be filled in incrementally.
+// Phase 2: Core `resolve_symbol_info` pipeline implementation.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 use tower_lsp::lsp_types::{Url, SymbolKind};
 
 use crate::indexer::Location;
 use crate::resolver::ReceiverType;
+use crate::types::{FileData, SymbolEntry};
+use crate::LinesExt;
+use crate::indexer::doc::extract_doc_comment;
 
 /// Domain-level resolution result. Small, owned data suitable for LSP adapters.
 pub struct ResolvedSymbol {
@@ -28,6 +32,7 @@ impl ResolveOptions {
     pub fn hover() -> Self { Self { allow_rg: true, include_doc: true, apply_subst: true } }
     pub fn inlay() -> Self { Self { allow_rg: false, include_doc: false, apply_subst: true } }
     pub fn completion() -> Self { Self { allow_rg: false, include_doc: true, apply_subst: true } }
+    pub fn goto_def() -> Self { Self { allow_rg: true, include_doc: false, apply_subst: false } }
 }
 
 /// Substitution context used by the pipeline.
@@ -42,47 +47,287 @@ pub enum SubstitutionContext<'a> {
 pub trait IndexRead {
     fn get_file_lines(&self, uri: &str) -> Option<Vec<String>>;
     fn get_definitions(&self, name: &str) -> Option<Vec<Location>>;
+    fn get_file_data(&self, uri: &str) -> Option<Arc<FileData>>;
 }
 
-/// Resolve a named symbol from a cursor position. Returns None when not found.
+// ─── Pipeline Entry Point (thin coordinator) ───────────────────────────────
+
+/// Core resolution pipeline: locate → load → enrich → substitute → extract.
+/// Thin coordinator that delegates to pure functions and trait methods.
 pub fn resolve_symbol_info<I: IndexRead>(
-    _index: &I,
+    index: &I,
     name: &str,
     _qualifier: Option<&str>,
     _from_uri: &Url,
-    _subst_ctx: SubstitutionContext<'_>,
-    _options: &ResolveOptions,
+    subst_ctx: SubstitutionContext<'_>,
+    options: &ResolveOptions,
 ) -> Option<ResolvedSymbol> {
-    // Stub: implementation will be added in next phases.
-    // Phase 2 will implement the full pipeline:
-    // 1. locate via resolve_symbol or definitions.get
-    // 2. load FileData for resolved location
-    // 3. find SymbolEntry at location
-    // 4. extract canonical signature (detail || collect_signature)
-    // 5. build substitution map (based on SubstitutionContext)
-    // 6. apply substitution to get display signature
-    // 7. extract doc (if options.include_doc)
-    // 8. return ResolvedSymbol
-    
-    // TODO: For now, just show that we're not returning error
-    eprintln!("resolve_symbol_info stub for: {}", name);
-    None
+    let location = locate_symbol(index, name)?;
+    let data = index.get_file_data(location.uri.as_str())?;
+    enrich_symbol(index, &data, &location, name, subst_ctx, options)
 }
 
 /// Resolve contextual receiver information (it/this).
 pub fn resolve_contextual_info<I: IndexRead>(
-    _index: &I,
-    _rt: &ReceiverType,
-    _from_uri: &Url,
-    _cursor_line: u32,
-    _options: &ResolveOptions,
+    index: &I,
+    rt: &ReceiverType,
+    from_uri: &Url,
+    cursor_line: u32,
+    options: &ResolveOptions,
 ) -> Option<ResolvedSymbol> {
-    None
+    resolve_symbol_info(
+        index,
+        &rt.leaf,
+        None,
+        from_uri,
+        SubstitutionContext::EnclosingClass {
+            uri: from_uri.as_str(),
+            cursor_line,
+        },
+        options,
+    )
 }
 
-/// Build substitution map for enclosing class (wrapper stub).
-pub fn build_subst_map<I: IndexRead>(_index: &I, _uri: &str, _cursor_line: u32) -> HashMap<String, String> {
+/// Build substitution map for enclosing class at cursor position.
+pub fn build_subst_map<I: IndexRead>(index: &I, uri: &str, cursor_line: u32) -> HashMap<String, String> {
+    build_enclosing_class_subst_impl(index, uri, cursor_line)
+}
+
+// ─── Pure Data Transformation Functions ──────────────────────────────────
+
+/// Extract canonical signature (prefer cached detail, fall back to source).
+fn extract_canonical_signature(sym: &SymbolEntry, data: &FileData) -> String {
+    if !sym.detail.is_empty() {
+        sym.detail.clone()
+    } else {
+        data.lines.collect_signature(sym.selection_range.start.line as usize)
+    }
+}
+
+/// Parse type parameters from a declaration string (e.g., "class Foo<T, U>").
+fn parse_type_params(decl: &str) -> Vec<String> {
+    // Type params appear before first '(' (constructor/function params).
+    let search_region = decl.split('(').next().unwrap_or(decl);
+    let Some(start) = search_region.find('<') else { return Vec::new() };
+    let Some(end) = search_region.rfind('>') else { return Vec::new() };
+    if end <= start + 1 {
+        return Vec::new();
+    }
+
+    let inner = &decl[start + 1..end];
+    let mut raw_params = Vec::new();
+    let mut depth = 0usize;
+    let mut seg_start = 0;
+
+    for (i, ch) in inner.char_indices() {
+        match ch {
+            '<' => depth += 1,
+            '>' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                let seg = inner[seg_start..i].trim();
+                if !seg.is_empty() {
+                    raw_params.push(seg);
+                }
+                seg_start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    let last = inner[seg_start..].trim();
+    if !last.is_empty() {
+        raw_params.push(last);
+    }
+
+    raw_params
+        .into_iter()
+        .map(|s| {
+            let s = s.strip_prefix("in ").unwrap_or(s);
+            let s = s.strip_prefix("out ").unwrap_or(s).trim();
+            let end_pos = s.find(|c: char| c == ':' || c.is_whitespace()).unwrap_or(s.len());
+            s[..end_pos].trim().to_owned()
+        })
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+/// Apply type-parameter substitution to a signature string.
+fn apply_subst(sig: &str, subst: &HashMap<String, String>) -> String {
+    if subst.is_empty() {
+        return sig.to_owned();
+    }
+
+    let mut result = String::with_capacity(sig.len() + 16);
+    let chars: Vec<char> = sig.chars().collect();
+    let mut i = 0;
+
+    while i < chars.len() {
+        let ch = chars[i];
+        if ch.is_alphabetic() || ch == '_' {
+            let start = i;
+            while i < chars.len() && (chars[i].is_alphanumeric() || chars[i] == '_') {
+                i += 1;
+            }
+            let ident: String = chars[start..i].iter().collect();
+            result.push_str(subst.get(&ident).map(|s| s.as_str()).unwrap_or(&ident));
+        } else {
+            result.push(ch);
+            i += 1;
+        }
+    }
+    result
+}
+
+// ─── Glue Functions (coordinate I/O + data transformation) ──────────────────
+
+/// Locate first definition of a symbol.
+fn locate_symbol<I: IndexRead>(index: &I, name: &str) -> Option<Location> {
+    index.get_definitions(name)?.into_iter().next()
+}
+
+/// Find SymbolEntry in FileData by range or name.
+fn find_symbol_entry<'a>(data: &'a FileData, location: &Location, name: &str) -> Option<&'a SymbolEntry> {
+    data.symbols
+        .iter()
+        .find(|s| s.selection_range == location.range)
+        .or_else(|| data.symbols.iter().find(|s| s.name == name))
+}
+
+/// Enrich symbol with signature, substitution, and docs.
+fn enrich_symbol<I: IndexRead>(
+    index: &I,
+    data: &FileData,
+    location: &Location,
+    name: &str,
+    subst_ctx: SubstitutionContext<'_>,
+    options: &ResolveOptions,
+) -> Option<ResolvedSymbol> {
+    let sym = find_symbol_entry(data, location, name)?;
+
+    let raw_signature = extract_canonical_signature(sym, data);
+    let subst = build_subst_if_needed(index, location, sym, &raw_signature, subst_ctx, options);
+    let signature = apply_subst(&raw_signature, &subst);
+    let doc = if options.include_doc {
+        extract_doc_comment(&data.lines, sym.selection_range.start.line as usize).unwrap_or_default()
+    } else {
+        String::new()
+    };
+
+    Some(ResolvedSymbol {
+        location: location.clone(),
+        kind: sym.kind,
+        raw_signature,
+        signature,
+        subst,
+        doc,
+    })
+}
+
+/// Build substitution map if requested by options and context.
+fn build_subst_if_needed<I: IndexRead>(
+    index: &I,
+    location: &Location,
+    _sym: &SymbolEntry,
+    _raw_sig: &str,
+    subst_ctx: SubstitutionContext<'_>,
+    options: &ResolveOptions,
+) -> HashMap<String, String> {
+    if !options.apply_subst {
+        return HashMap::new();
+    }
+
+    match subst_ctx {
+        SubstitutionContext::None => HashMap::new(),
+        SubstitutionContext::CrossFile { calling_uri } => {
+            build_type_param_subst_impl(index, location.uri.as_str(), location.range.start.line, calling_uri)
+        }
+        SubstitutionContext::EnclosingClass { uri, cursor_line } => {
+            build_enclosing_class_subst_impl(index, uri, cursor_line)
+        }
+        SubstitutionContext::Precomputed(m) => m.clone(),
+    }
+}
+
+// ─── Substitution Builders (coordinate I/O + pure logic) ────────────────────
+
+/// Build type-parameter substitution for cross-file lookup.
+fn build_type_param_subst_impl<I: IndexRead>(
+    index: &I,
+    sym_uri: &str,
+    sym_line: u32,
+    calling_uri: &str,
+) -> HashMap<String, String> {
+    if sym_uri == calling_uri {
+        return HashMap::new();
+    }
+
+    let sym_data = match index.get_file_data(sym_uri) {
+        Some(d) => d,
+        None => return HashMap::new(),
+    };
+
+    let container_name = match find_containing_class_name(&sym_data, sym_line) {
+        Some(n) => n,
+        None => return HashMap::new(),
+    };
+
+    let _container_sym = match sym_data.symbols.iter().find(|s| s.name == container_name) {
+        Some(s) => s,
+        None => return HashMap::new(),
+    };
+
+    // TODO: Implement full cross-file substitution logic (phases 2a)
+    // For now, stub to ensure compilation
+    let _ = index.get_file_data(calling_uri);
     HashMap::new()
+}
+
+/// Build substitution for enclosing class's type parameters.
+fn build_enclosing_class_subst_impl<I: IndexRead>(
+    index: &I,
+    uri: &str,
+    cursor_line: u32,
+) -> HashMap<String, String> {
+    let data = match index.get_file_data(uri) {
+        Some(d) => d,
+        None => return HashMap::new(),
+    };
+
+    let class_name = match find_containing_class_name(&data, cursor_line) {
+        Some(n) => n,
+        None => return HashMap::new(),
+    };
+
+    let class_sym = match data.symbols.iter().find(|s| s.name == class_name) {
+        Some(s) => s,
+        None => return HashMap::new(),
+    };
+
+    let class_line = class_sym.selection_range.start.line;
+    let mut result = HashMap::new();
+
+    for (line, _base_name, type_args) in data.supers.iter() {
+        if *line != class_line || type_args.is_empty() {
+            continue;
+        }
+
+        // TODO: Implement full enclosing class substitution (phases 2b)
+        // For now, stub to ensure compilation
+        let _ = (type_args, index);
+    }
+
+    result
+}
+
+// ─── Helper: Find Enclosing Class ────────────────────────────────────────────
+
+/// Find the name of the class that contains a symbol at the given line.
+fn find_containing_class_name(data: &FileData, sym_line: u32) -> Option<String> {
+    data.symbols
+        .iter()
+        .filter(|s| s.range.start.line <= sym_line && sym_line <= s.range.end.line)
+        .filter(|s| matches!(s.kind, SymbolKind::CLASS | SymbolKind::INTERFACE | SymbolKind::STRUCT))
+        .max_by_key(|s| s.range.end.line - s.range.start.line)
+        .map(|s| s.name.clone())
 }
 
 // ─── Indexer impl (production) ───────────────────────────────────────────────
@@ -99,6 +344,10 @@ impl IndexRead for super::Indexer {
     fn get_definitions(&self, name: &str) -> Option<Vec<Location>> {
         self.definitions.get(name).map(|rf| rf.clone())
     }
+
+    fn get_file_data(&self, uri: &str) -> Option<Arc<FileData>> {
+        self.files.get(uri).map(|rf| rf.clone())
+    }
 }
 
 #[cfg(test)]
@@ -110,6 +359,7 @@ mod tests {
     impl IndexRead for TestIndex {
         fn get_file_lines(&self, _uri: &str) -> Option<Vec<String>> { None }
         fn get_definitions(&self, _name: &str) -> Option<Vec<Location>> { None }
+        fn get_file_data(&self, _uri: &str) -> Option<Arc<FileData>> { None }
     }
 
     #[test]
@@ -117,5 +367,29 @@ mod tests {
         let idx = TestIndex;
         let res = resolve_symbol_info(&idx, "Foo", None, &Url::parse("file:///x").unwrap(), SubstitutionContext::None, &ResolveOptions::hover());
         assert!(res.is_none());
+    }
+
+    #[test]
+    fn parse_type_params_handles_simple_case() {
+        let decl = "class Foo<T, U>";
+        let params = parse_type_params(decl);
+        assert_eq!(params, vec!["T", "U"]);
+    }
+
+    #[test]
+    fn parse_type_params_handles_constraints() {
+        let decl = "class Foo<T: Any, U>";
+        let params = parse_type_params(decl);
+        assert_eq!(params, vec!["T", "U"]);
+    }
+
+    #[test]
+    fn apply_subst_replaces_identifiers() {
+        let mut subst = HashMap::new();
+        subst.insert("T".to_string(), "String".to_string());
+        subst.insert("U".to_string(), "Int".to_string());
+        let sig = "fun foo(x: T, y: U): T";
+        let result = apply_subst(sig, &subst);
+        assert_eq!(result, "fun foo(x: String, y: Int): String");
     }
 }

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -285,6 +285,7 @@ fn build_enclosing_class_subst_impl<I: IndexRead>(
     };
 
     let class_line = class_sym.selection_range.start.line;
+    let class_end_line = class_sym.range.end.line;
 
     // For each supertype with concrete type args, look up the BASE class's own
     // type parameters (e.g., `[T, U]` from `class Base<T, U>`), then zip with
@@ -323,6 +324,7 @@ fn build_enclosing_class_subst_impl<I: IndexRead>(
     // `{Event→…, State→…}` mappings from FlowReducer's type params.
     for sym in data.symbols.iter() {
         if sym.selection_range.start.line <= class_line { continue; }
+        if sym.selection_range.start.line > class_end_line { continue; }
         if !matches!(sym.kind, SymbolKind::FIELD | SymbolKind::PROPERTY) { continue; }
         let type_name = super::lookup::extract_property_type_name(&sym.detail);
         if type_name.is_empty() { continue; }

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -119,11 +119,6 @@ fn extract_canonical_signature(sym: &SymbolEntry, data: &FileData) -> String {
     }
 }
 
-/// Parse type parameters from a declaration string (e.g., "class Foo<T, U>").
-fn parse_type_params(decl: &str) -> Vec<String> {
-    super::parse_type_params_from_decl(decl)
-}
-
 /// Apply type-parameter substitution to a signature string.
 fn apply_subst(sig: &str, subst: &HashMap<String, String>) -> String {
     super::apply_type_subst(sig, subst)
@@ -228,15 +223,28 @@ fn build_type_param_subst_impl<I: IndexRead>(
         None => return HashMap::new(),
     };
 
-    let _container_sym = match sym_data.symbols.iter().find(|s| s.name == container_name) {
+    let container_sym = match sym_data.symbols.iter().find(|s| s.name == container_name) {
         Some(s) => s,
         None => return HashMap::new(),
     };
 
-    // TODO: Implement full cross-file substitution logic (phases 2a)
-    // For now, stub to ensure compilation
-    let _ = index.get_file_data(calling_uri);
-    HashMap::new()
+    let type_params = &container_sym.type_params;
+    if type_params.is_empty() { return HashMap::new(); }
+
+    let calling_data = match index.get_file_data(calling_uri) {
+        Some(d) => d,
+        None => return HashMap::new(),
+    };
+    let type_args = calling_data.supers.iter()
+        .find(|(_, base, _)| base == &container_name)
+        .map(|(_, _, args)| args.clone())
+        .unwrap_or_default();
+
+    if type_args.is_empty() { return HashMap::new(); }
+
+    type_params.iter().zip(type_args.iter())
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect()
 }
 
 /// Build substitution for enclosing class's type parameters.
@@ -260,19 +268,21 @@ fn build_enclosing_class_subst_impl<I: IndexRead>(
         None => return HashMap::new(),
     };
 
-    let class_line = class_sym.selection_range.start.line;
-    let mut result = HashMap::new();
+    let type_params = &class_sym.type_params;
+    if type_params.is_empty() { return HashMap::new(); }
 
+    let class_line = class_sym.selection_range.start.line;
+
+    // Collect all supers of this class, zipping their type args against the class's type params.
+    let mut result = HashMap::new();
     for (line, _base_name, type_args) in data.supers.iter() {
         if *line != class_line || type_args.is_empty() {
             continue;
         }
-
-        // TODO: Implement full enclosing class substitution (phases 2b)
-        // For now, stub to ensure compilation
-        let _ = (type_args, index);
+        for (param, arg) in type_params.iter().zip(type_args.iter()) {
+            result.entry(param.clone()).or_insert_with(|| arg.clone());
+        }
     }
-
     result
 }
 
@@ -344,14 +354,14 @@ mod tests {
     #[test]
     fn parse_type_params_handles_simple_case() {
         let decl = "class Foo<T, U>";
-        let params = parse_type_params(decl);
+        let params = super::super::parse_type_params_from_decl(decl);
         assert_eq!(params, vec!["T", "U"]);
     }
 
     #[test]
     fn parse_type_params_handles_constraints() {
         let decl = "class Foo<T: Any, U>";
-        let params = parse_type_params(decl);
+        let params = super::super::parse_type_params_from_decl(decl);
         assert_eq!(params, vec!["T", "U"]);
     }
 
@@ -382,6 +392,7 @@ mod tests {
             range:           make_range(start_line, end_line),
             selection_range: make_range(start_line, start_line),
             detail:          String::new(),
+            type_params:     Vec::new(),
         }
     }
 

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -352,20 +352,6 @@ mod tests {
     }
 
     #[test]
-    fn parse_type_params_handles_simple_case() {
-        let decl = "class Foo<T, U>";
-        let params = super::super::parse_type_params_from_decl(decl);
-        assert_eq!(params, vec!["T", "U"]);
-    }
-
-    #[test]
-    fn parse_type_params_handles_constraints() {
-        let decl = "class Foo<T: Any, U>";
-        let params = super::super::parse_type_params_from_decl(decl);
-        assert_eq!(params, vec!["T", "U"]);
-    }
-
-    #[test]
     fn apply_subst_replaces_identifiers() {
         let mut subst = HashMap::new();
         subst.insert("T".to_string(), "String".to_string());

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -1,0 +1,92 @@
+// Unified resolution service for symbol lookup, substitution, and extraction.
+// Phase 1: types, traits and stubs. Will be filled in incrementally.
+
+use std::collections::HashMap;
+use url::Url;
+
+use crate::types::{Location, SymbolKind, ReceiverType};
+
+/// Domain-level resolution result. Small, owned data suitable for LSP adapters.
+pub struct ResolvedSymbol {
+    pub location: Location,
+    pub kind: SymbolKind,
+    pub raw_signature: String,
+    pub signature: String,
+    pub subst: HashMap<String, String>,
+    pub doc: String,
+}
+
+/// Options controlling resolution behaviour and allowed fallbacks.
+pub struct ResolveOptions {
+    pub allow_rg: bool,
+    pub include_doc: bool,
+    pub apply_subst: bool,
+}
+
+impl ResolveOptions {
+    pub fn hover() -> Self { Self { allow_rg: true, include_doc: true, apply_subst: true } }
+    pub fn inlay() -> Self { Self { allow_rg: false, include_doc: false, apply_subst: true } }
+    pub fn completion() -> Self { Self { allow_rg: false, include_doc: true, apply_subst: true } }
+}
+
+/// Substitution context used by the pipeline.
+pub enum SubstitutionContext<'a> {
+    None,
+    CrossFile { calling_uri: &'a str },
+    EnclosingClass { uri: &'a str, cursor_line: u32 },
+    Precomputed(&'a HashMap<String, String>),
+}
+
+/// Test seam trait: read-only view into index state. Keep this lightweight for tests.
+pub trait IndexRead {
+    fn get_file_lines(&self, uri: &str) -> Option<Vec<String>>;
+    fn get_definitions(&self, name: &str) -> Option<Vec<Location>>;
+}
+
+/// Resolve a named symbol from a cursor position. Returns None when not found.
+pub fn resolve_symbol_info<I: IndexRead>(
+    _index: &I,
+    _name: &str,
+    _qualifier: Option<&str>,
+    _from_uri: &Url,
+    _subst_ctx: SubstitutionContext<'_>,
+    _options: &ResolveOptions,
+) -> Option<ResolvedSymbol> {
+    // Stub: implementation will be added in next phases.
+    None
+}
+
+/// Resolve contextual receiver information (it/this).
+pub fn resolve_contextual_info<I: IndexRead>(
+    _index: &I,
+    _rt: &ReceiverType,
+    _from_uri: &Url,
+    _cursor_line: u32,
+    _options: &ResolveOptions,
+) -> Option<ResolvedSymbol> {
+    None
+}
+
+/// Build substitution map for enclosing class (wrapper stub).
+pub fn build_subst_map<I: IndexRead>(_index: &I, _uri: &str, _cursor_line: u32) -> HashMap<String, String> {
+    HashMap::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use url::Url;
+
+    struct TestIndex;
+    impl IndexRead for TestIndex {
+        fn get_file_lines(&self, _uri: &str) -> Option<Vec<String>> { None }
+        fn get_definitions(&self, _name: &str) -> Option<Vec<Location>> { None }
+    }
+
+    #[test]
+    fn stub_resolve_returns_none() {
+        let idx = TestIndex;
+        let res = resolve_symbol_info(&idx, "Foo", None, &Url::parse("file:///x").unwrap(), SubstitutionContext::None, &ResolveOptions::hover());
+        assert!(res.is_none());
+    }
+}

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -47,13 +47,25 @@ pub trait IndexRead {
 /// Resolve a named symbol from a cursor position. Returns None when not found.
 pub fn resolve_symbol_info<I: IndexRead>(
     _index: &I,
-    _name: &str,
+    name: &str,
     _qualifier: Option<&str>,
     _from_uri: &Url,
     _subst_ctx: SubstitutionContext<'_>,
     _options: &ResolveOptions,
 ) -> Option<ResolvedSymbol> {
     // Stub: implementation will be added in next phases.
+    // Phase 2 will implement the full pipeline:
+    // 1. locate via resolve_symbol or definitions.get
+    // 2. load FileData for resolved location
+    // 3. find SymbolEntry at location
+    // 4. extract canonical signature (detail || collect_signature)
+    // 5. build substitution map (based on SubstitutionContext)
+    // 6. apply substitution to get display signature
+    // 7. extract doc (if options.include_doc)
+    // 8. return ResolvedSymbol
+    
+    // TODO: For now, just show that we're not returning error
+    eprintln!("resolve_symbol_info stub for: {}", name);
     None
 }
 

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -2,9 +2,10 @@
 // Phase 1: types, traits and stubs. Will be filled in incrementally.
 
 use std::collections::HashMap;
-use url::Url;
+use tower_lsp::lsp_types::{Url, SymbolKind};
 
-use crate::types::{Location, SymbolKind, ReceiverType};
+use crate::indexer::Location;
+use crate::resolver::ReceiverType;
 
 /// Domain-level resolution result. Small, owned data suitable for LSP adapters.
 pub struct ResolvedSymbol {
@@ -72,10 +73,26 @@ pub fn build_subst_map<I: IndexRead>(_index: &I, _uri: &str, _cursor_line: u32) 
     HashMap::new()
 }
 
+// ─── Indexer impl (production) ───────────────────────────────────────────────
+
+// Implement IndexRead for Indexer: production code doesn't use the trait,
+// but this enables unit tests to use a TestIndex stub.
+impl IndexRead for super::Indexer {
+    fn get_file_lines(&self, uri: &str) -> Option<Vec<String>> {
+        self.files
+            .get(uri)
+            .map(|rf| rf.lines.as_ref().as_slice().to_vec())
+    }
+
+    fn get_definitions(&self, name: &str) -> Option<Vec<Location>> {
+        self.definitions.get(name).map(|rf| rf.clone())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use url::Url;
+    use tower_lsp::lsp_types::Url;
 
     struct TestIndex;
     impl IndexRead for TestIndex {

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -106,75 +106,12 @@ fn extract_canonical_signature(sym: &SymbolEntry, data: &FileData) -> String {
 
 /// Parse type parameters from a declaration string (e.g., "class Foo<T, U>").
 fn parse_type_params(decl: &str) -> Vec<String> {
-    // Type params appear before first '(' (constructor/function params).
-    let search_region = decl.split('(').next().unwrap_or(decl);
-    let Some(start) = search_region.find('<') else { return Vec::new() };
-    let Some(end) = search_region.rfind('>') else { return Vec::new() };
-    if end <= start + 1 {
-        return Vec::new();
-    }
-
-    let inner = &decl[start + 1..end];
-    let mut raw_params = Vec::new();
-    let mut depth = 0usize;
-    let mut seg_start = 0;
-
-    for (i, ch) in inner.char_indices() {
-        match ch {
-            '<' => depth += 1,
-            '>' => depth = depth.saturating_sub(1),
-            ',' if depth == 0 => {
-                let seg = inner[seg_start..i].trim();
-                if !seg.is_empty() {
-                    raw_params.push(seg);
-                }
-                seg_start = i + 1;
-            }
-            _ => {}
-        }
-    }
-    let last = inner[seg_start..].trim();
-    if !last.is_empty() {
-        raw_params.push(last);
-    }
-
-    raw_params
-        .into_iter()
-        .map(|s| {
-            let s = s.strip_prefix("in ").unwrap_or(s);
-            let s = s.strip_prefix("out ").unwrap_or(s).trim();
-            let end_pos = s.find(|c: char| c == ':' || c.is_whitespace()).unwrap_or(s.len());
-            s[..end_pos].trim().to_owned()
-        })
-        .filter(|s| !s.is_empty())
-        .collect()
+    super::parse_type_params_from_decl(decl)
 }
 
 /// Apply type-parameter substitution to a signature string.
 fn apply_subst(sig: &str, subst: &HashMap<String, String>) -> String {
-    if subst.is_empty() {
-        return sig.to_owned();
-    }
-
-    let mut result = String::with_capacity(sig.len() + 16);
-    let chars: Vec<char> = sig.chars().collect();
-    let mut i = 0;
-
-    while i < chars.len() {
-        let ch = chars[i];
-        if ch.is_alphabetic() || ch == '_' {
-            let start = i;
-            while i < chars.len() && (chars[i].is_alphanumeric() || chars[i] == '_') {
-                i += 1;
-            }
-            let ident: String = chars[start..i].iter().collect();
-            result.push_str(subst.get(&ident).map(|s| s.as_str()).unwrap_or(&ident));
-        } else {
-            result.push(ch);
-            i += 1;
-        }
-    }
-    result
+    super::apply_type_subst(sig, subst)
 }
 
 // ─── Glue Functions (coordinate I/O + data transformation) ──────────────────
@@ -320,13 +257,13 @@ fn build_enclosing_class_subst_impl<I: IndexRead>(
 
 // ─── Helper: Find Enclosing Class ────────────────────────────────────────────
 
-/// Find the name of the class that contains a symbol at the given line.
+/// Find the name of the innermost class that contains a symbol at the given line.
 fn find_containing_class_name(data: &FileData, sym_line: u32) -> Option<String> {
     data.symbols
         .iter()
         .filter(|s| s.range.start.line <= sym_line && sym_line <= s.range.end.line)
-        .filter(|s| matches!(s.kind, SymbolKind::CLASS | SymbolKind::INTERFACE | SymbolKind::STRUCT))
-        .max_by_key(|s| s.range.end.line - s.range.start.line)
+        .filter(|s| matches!(s.kind, SymbolKind::CLASS | SymbolKind::INTERFACE | SymbolKind::STRUCT | SymbolKind::ENUM | SymbolKind::OBJECT))
+        .min_by_key(|s| s.range.end.line.saturating_sub(s.range.start.line))
         .map(|s| s.name.clone())
 }
 

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -48,6 +48,21 @@ pub trait IndexRead {
     fn get_file_lines(&self, uri: &str) -> Option<Vec<String>>;
     fn get_definitions(&self, name: &str) -> Option<Vec<Location>>;
     fn get_file_data(&self, uri: &str) -> Option<Arc<FileData>>;
+
+    /// Resolve definition locations for `name` with qualifier and import context.
+    /// Default implementation uses the global definitions map (no import awareness).
+    /// Production `Indexer` overrides this with the full resolver.
+    fn resolve_locations(
+        &self,
+        name: &str,
+        qualifier: Option<&str>,
+        from_uri: &Url,
+        allow_rg: bool,
+    ) -> Vec<Location> {
+        let _ = (qualifier, from_uri, allow_rg);
+        self.get_definitions(name)
+            .unwrap_or_default()
+    }
 }
 
 // ─── Pipeline Entry Point (thin coordinator) ───────────────────────────────
@@ -57,12 +72,12 @@ pub trait IndexRead {
 pub fn resolve_symbol_info<I: IndexRead>(
     index: &I,
     name: &str,
-    _qualifier: Option<&str>,
-    _from_uri: &Url,
+    qualifier: Option<&str>,
+    from_uri: &Url,
     subst_ctx: SubstitutionContext<'_>,
     options: &ResolveOptions,
 ) -> Option<ResolvedSymbol> {
-    let location = locate_symbol(index, name)?;
+    let location = locate_symbol(index, name, qualifier, from_uri, options.allow_rg)?;
     let data = index.get_file_data(location.uri.as_str())?;
     enrich_symbol(index, &data, &location, name, subst_ctx, options)
 }
@@ -116,9 +131,15 @@ fn apply_subst(sig: &str, subst: &HashMap<String, String>) -> String {
 
 // ─── Glue Functions (coordinate I/O + data transformation) ──────────────────
 
-/// Locate first definition of a symbol.
-fn locate_symbol<I: IndexRead>(index: &I, name: &str) -> Option<Location> {
-    index.get_definitions(name)?.into_iter().next()
+/// Locate first definition of a symbol using import-aware resolution.
+fn locate_symbol<I: IndexRead>(
+    index: &I,
+    name: &str,
+    qualifier: Option<&str>,
+    from_uri: &Url,
+    allow_rg: bool,
+) -> Option<Location> {
+    index.resolve_locations(name, qualifier, from_uri, allow_rg).into_iter().next()
 }
 
 /// Find SymbolEntry in FileData by range or name.
@@ -285,6 +306,20 @@ impl IndexRead for super::Indexer {
     fn get_file_data(&self, uri: &str) -> Option<Arc<FileData>> {
         self.files.get(uri).map(|rf| rf.clone())
     }
+
+    fn resolve_locations(
+        &self,
+        name: &str,
+        qualifier: Option<&str>,
+        from_uri: &Url,
+        allow_rg: bool,
+    ) -> Vec<Location> {
+        if allow_rg {
+            self.resolve_symbol(name, qualifier, from_uri)
+        } else {
+            self.resolve_symbol_no_rg(name, from_uri)
+        }
+    }
 }
 
 #[cfg(test)]
@@ -328,5 +363,66 @@ mod tests {
         let sig = "fun foo(x: T, y: U): T";
         let result = apply_subst(sig, &subst);
         assert_eq!(result, "fun foo(x: String, y: Int): String");
+    }
+
+    fn make_range(start_line: u32, end_line: u32) -> tower_lsp::lsp_types::Range {
+        use tower_lsp::lsp_types::Position;
+        tower_lsp::lsp_types::Range {
+            start: Position { line: start_line, character: 0 },
+            end:   Position { line: end_line,   character: 0 },
+        }
+    }
+
+    fn make_sym(name: &str, kind: SymbolKind, start_line: u32, end_line: u32) -> SymbolEntry {
+        use crate::types::Visibility;
+        SymbolEntry {
+            name:            name.to_owned(),
+            kind,
+            visibility:      Visibility::Public,
+            range:           make_range(start_line, end_line),
+            selection_range: make_range(start_line, start_line),
+            detail:          String::new(),
+        }
+    }
+
+    #[test]
+    fn find_containing_class_returns_innermost() {
+        use crate::types::FileData;
+        let data = FileData {
+            symbols: vec![
+                make_sym("Outer", SymbolKind::CLASS, 0, 20),
+                make_sym("Inner", SymbolKind::CLASS, 5, 15),
+            ],
+            ..Default::default()
+        };
+        // Line 7 is inside both Outer (0-20) and Inner (5-15); should return Inner.
+        let result = find_containing_class_name(&data, 7);
+        assert_eq!(result.as_deref(), Some("Inner"));
+    }
+
+    #[test]
+    fn find_containing_class_returns_none_for_top_level() {
+        use crate::types::FileData;
+        let data = FileData {
+            symbols: vec![make_sym("Outer", SymbolKind::CLASS, 5, 15)],
+            ..Default::default()
+        };
+        // Line 1 is outside any class.
+        let result = find_containing_class_name(&data, 1);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn find_containing_class_includes_enum_and_object() {
+        use crate::types::FileData;
+        let data = FileData {
+            symbols: vec![
+                make_sym("MyEnum", SymbolKind::ENUM, 0, 10),
+                make_sym("MyObject", SymbolKind::OBJECT, 12, 20),
+            ],
+            ..Default::default()
+        };
+        assert_eq!(find_containing_class_name(&data, 5).as_deref(), Some("MyEnum"));
+        assert_eq!(find_containing_class_name(&data, 15).as_deref(), Some("MyObject"));
     }
 }

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -13,6 +13,7 @@ use super::{
     find_named_lambda_param_type_in_lines,
     line_has_lambda_param,
     lambda_brace_pos_for_param,
+    is_inside_receiver_lambda,
 };
 use crate::indexer::NodeExt;
 use crate::queries::KIND_LAMBDA_LIT;
@@ -208,7 +209,15 @@ impl Indexer {
             }
             // Fallback for `this` in a regular class method body (not a lambda):
             // scan backward for the enclosing class/object declaration.
+            // Guard: if cursor is inside a receiver-lambda (apply/run/with) that just
+            // failed to resolve its receiver type, `this` refers to that lambda's
+            // receiver — not the enclosing class.  Returning enclosing_class_at here
+            // would silently return the wrong type.
             if name == "this" {
+                let pos2 = CursorPos { line: line_no, utf16_col: position.character as usize };
+                if is_inside_receiver_lambda(&lines, pos2, self, uri) {
+                    return None;
+                }
                 return self.enclosing_class_at(uri, position.line);
             }
             None

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -1305,6 +1305,7 @@ fn stale_keys_includes_both_qualified_aliases() {
         selection_range: Default::default(),
         detail: String::new(),
         type_params: Vec::new(),
+        extension_receiver: String::new(),
     };
     data.symbols.push(sym);
     let stale = super::stale_keys_for(&uri, &data);
@@ -1326,6 +1327,7 @@ fn stale_keys_stem_equals_sym_no_alias() {
         selection_range: Default::default(),
         detail: String::new(),
         type_params: Vec::new(),
+        extension_receiver: String::new(),
     };
     data.symbols.push(sym);
     let stale = super::stale_keys_for(&uri, &data);

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -1304,6 +1304,7 @@ fn stale_keys_includes_both_qualified_aliases() {
         range: Default::default(),
         selection_range: Default::default(),
         detail: String::new(),
+        type_params: Vec::new(),
     };
     data.symbols.push(sym);
     let stale = super::stale_keys_for(&uri, &data);
@@ -1324,6 +1325,7 @@ fn stale_keys_stem_equals_sym_no_alias() {
         range: Default::default(),
         selection_range: Default::default(),
         detail: String::new(),
+        type_params: Vec::new(),
     };
     data.symbols.push(sym);
     let stale = super::stale_keys_for(&uri, &data);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -8,7 +8,13 @@ use crate::indexer::NodeExt;
 use crate::StrExt;
 use crate::queries::{self, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
     KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_IDENTIFIER,
-    KIND_USER_TYPE, KIND_FUN_DECL};
+    KIND_USER_TYPE, KIND_FUN_DECL,
+    KIND_CLASS_DECL, KIND_ENUM_DECL, KIND_INTERFACE_DECL,
+    KIND_OBJECT_DECL, KIND_DELEGATION_SPEC,
+    KIND_RECORD_DECL, KIND_METHOD_DECL, KIND_CTOR_DECL, KIND_FIELD_DECL,
+    KIND_IMPORT_DECL, KIND_PACKAGE_DECL,
+    KIND_SUPERCLASS, KIND_SUPER_INTERFACES, KIND_EXTENDS_INTERFACES, KIND_TYPE_LIST,
+    KIND_PROTOCOL_DECL, KIND_INHERITANCE_SPEC};
 use crate::types::{FileData, ImportEntry, SymbolEntry, SyntaxError, Visibility};
 
 type MatchEntry = (usize, [Option<(String, Range, Range, Vec<String>)>; 2]);
@@ -287,7 +293,7 @@ fn push_def_symbols(
 
 fn extract_java(node: &Node, bytes: &[u8], data: &mut FileData) {
     match node.kind() {
-        "package_declaration" => {
+        KIND_PACKAGE_DECL => {
             // (package_declaration "package" (scoped_identifier | identifier) ";")
             let mut cur = node.walk();
             for child in node.children(&mut cur) {
@@ -299,16 +305,16 @@ fn extract_java(node: &Node, bytes: &[u8], data: &mut FileData) {
                 }
             }
         }
-        "class_declaration"     => push_named(node, bytes, SymbolKind::CLASS,     data),
-        "record_declaration"    => push_named(node, bytes, SymbolKind::STRUCT,    data),
-        "interface_declaration" => push_named(node, bytes, SymbolKind::INTERFACE, data),
+        KIND_CLASS_DECL     => push_named(node, bytes, SymbolKind::CLASS,     data),
+        KIND_RECORD_DECL    => push_named(node, bytes, SymbolKind::STRUCT,    data),
+        KIND_INTERFACE_DECL => push_named(node, bytes, SymbolKind::INTERFACE, data),
         "annotation_type_declaration" => push_named(node, bytes, SymbolKind::INTERFACE, data),
-        "enum_declaration"      => push_named(node, bytes, SymbolKind::ENUM,      data),
-        "method_declaration"    => push_named(node, bytes, SymbolKind::METHOD,    data),
-        "constructor_declaration" => push_named(node, bytes, SymbolKind::CONSTRUCTOR, data),
-        "enum_constant" => push_named(node, bytes, SymbolKind::ENUM_MEMBER, data),
-        "field_declaration"     => push_field_declaration(node, bytes, data),
-        "import_declaration" => push_java_import(node, bytes, data),
+        KIND_ENUM_DECL      => push_named(node, bytes, SymbolKind::ENUM,      data),
+        KIND_METHOD_DECL    => push_named(node, bytes, SymbolKind::METHOD,    data),
+        KIND_CTOR_DECL      => push_named(node, bytes, SymbolKind::CONSTRUCTOR, data),
+        "enum_constant"     => push_named(node, bytes, SymbolKind::ENUM_MEMBER, data),
+        KIND_FIELD_DECL     => push_field_declaration(node, bytes, data),
+        KIND_IMPORT_DECL    => push_java_import(node, bytes, data),
         _ => {}
     }
 }
@@ -888,16 +894,13 @@ pub(crate) fn extract_declared_names(lines: &[String]) -> Vec<String> {
 fn extract_supers_kotlin(root: Node, bytes: &[u8], data: &mut FileData) {
     let mut stack = vec![root];
     while let Some(node) = stack.pop() {
-        match node.kind() {
-            "class_declaration" | "object_declaration" => {
-                let name_line = node.name_line();
-                for child in node.children_of_kind("delegation_specifier") {
-                    if let Some((name, type_args)) = super_name_from_delegation(&child, bytes) {
-                        data.supers.push((name_line, name, type_args));
-                    }
+        if node.kind() == KIND_CLASS_DECL || node.kind() == KIND_OBJECT_DECL {
+            let name_line = node.name_line();
+            for child in node.children_of_kind(KIND_DELEGATION_SPEC) {
+                if let Some((name, type_args)) = super_name_from_delegation(&child, bytes) {
+                    data.supers.push((name_line, name, type_args));
                 }
             }
-            _ => {}
         }
         let mut cur = node.walk();
         for child in node.children(&mut cur) { stack.push(child); }
@@ -907,35 +910,28 @@ fn extract_supers_kotlin(root: Node, bytes: &[u8], data: &mut FileData) {
 /// Walk the Java CST and populate `data.supers` for class/interface/enum/record
 /// declarations that extend or implement other types.
 fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
-    match node.kind() {
-        "class_declaration" | "record_declaration" | "enum_declaration" => {
-            let name_line = node.name_line();
-            let mut cur = node.walk();
-            for child in node.children(&mut cur) {
-                match child.kind() {
-                    "superclass" => {
-                        // (superclass "extends" _type)
-                        if let Some(name) = child.java_first_type_name(bytes) {
-                            let type_args = child.type_arg_strings(bytes);
-                            data.supers.push((name_line, name, type_args));
-                        }
-                    }
-                    "super_interfaces" => {
-                        // (super_interfaces "implements" (type_list _type, ...))
-                        java_collect_type_list(&child, bytes, name_line, data);
-                    }
-                    _ => {}
+    let kind = node.kind();
+    if kind == KIND_CLASS_DECL || kind == KIND_RECORD_DECL || kind == KIND_ENUM_DECL {
+        let name_line = node.name_line();
+        let mut cur = node.walk();
+        for child in node.children(&mut cur) {
+            if child.kind() == KIND_SUPERCLASS {
+                // (superclass "extends" _type)
+                if let Some(name) = child.java_first_type_name(bytes) {
+                    let type_args = child.type_arg_strings(bytes);
+                    data.supers.push((name_line, name, type_args));
                 }
+            } else if child.kind() == KIND_SUPER_INTERFACES {
+                // (super_interfaces "implements" (type_list _type, ...))
+                java_collect_type_list(&child, bytes, name_line, data);
             }
         }
-        "interface_declaration" => {
-            let name_line = node.name_line();
-            if let Some(ext) = node.first_child_of_kind("extends_interfaces") {
-                // (extends_interfaces "extends" (type_list ...))
-                java_collect_type_list(&ext, bytes, name_line, data);
-            }
+    } else if kind == KIND_INTERFACE_DECL {
+        let name_line = node.name_line();
+        if let Some(ext) = node.first_child_of_kind(KIND_EXTENDS_INTERFACES) {
+            // (extends_interfaces "extends" (type_list ...))
+            java_collect_type_list(&ext, bytes, name_line, data);
         }
-        _ => {}
     }
 }
 
@@ -943,16 +939,13 @@ fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
 fn super_name_from_delegation(node: &Node, bytes: &[u8]) -> Option<(String, Vec<String>)> {
     let mut cur = node.walk();
     for child in node.children(&mut cur) {
-        match child.kind() {
-            "constructor_invocation" | "explicit_delegation" => {
-                if let Some(ut) = child.first_child_of_kind(KIND_USER_TYPE) {
-                    return ut.user_type_name(bytes).map(|n| (n, ut.type_arg_strings(bytes)));
-                }
+        let kind = child.kind();
+        if kind == "constructor_invocation" || kind == "explicit_delegation" {
+            if let Some(ut) = child.first_child_of_kind(KIND_USER_TYPE) {
+                return ut.user_type_name(bytes).map(|n| (n, ut.type_arg_strings(bytes)));
             }
-            "user_type" => {
-                return child.user_type_name(bytes).map(|n| (n, child.type_arg_strings(bytes)));
-            }
-            _ => {}
+        } else if kind == KIND_USER_TYPE {
+            return child.user_type_name(bytes).map(|n| (n, child.type_arg_strings(bytes)));
         }
     }
     None
@@ -961,7 +954,7 @@ fn super_name_from_delegation(node: &Node, bytes: &[u8]) -> Option<(String, Vec<
 /// Walk a `super_interfaces` or `extends_interfaces` node, collecting all type names
 /// from its `type_list` child into `data.supers`.
 fn java_collect_type_list(node: &Node, bytes: &[u8], name_line: u32, data: &mut FileData) {
-    let Some(type_list) = node.first_child_of_kind("type_list") else { return };
+    let Some(type_list) = node.first_child_of_kind(KIND_TYPE_LIST) else { return };
     let mut cc = type_list.walk();
     for type_node in type_list.children(&mut cc) {
         // type_list children may be leaf type_identifier nodes directly,
@@ -981,20 +974,17 @@ fn java_collect_type_list(node: &Node, bytes: &[u8], name_line: u32, data: &mut 
 fn extract_supers_swift(root: Node, bytes: &[u8], data: &mut FileData) {
     let mut stack = vec![root];
     while let Some(node) = stack.pop() {
-        match node.kind() {
-            "class_declaration" | "protocol_declaration" => {
-                let name_line = node.name_line();
-                for spec in node.children_of_kind("inheritance_specifier") {
-                    if let Some(ut) = spec.first_child_of_kind("user_type") {
-                        if let Some(name) = ut.user_type_name(bytes) {
-                            // Swift generics are structurally nested inside user_type,
-                            // not via type_arguments, so type_args are empty here.
-                            data.supers.push((name_line, name, Vec::new()));
-                        }
+        if node.kind() == KIND_CLASS_DECL || node.kind() == KIND_PROTOCOL_DECL {
+            let name_line = node.name_line();
+            for spec in node.children_of_kind(KIND_INHERITANCE_SPEC) {
+                if let Some(ut) = spec.first_child_of_kind(KIND_USER_TYPE) {
+                    if let Some(name) = ut.user_type_name(bytes) {
+                        // Swift generics are structurally nested inside user_type,
+                        // not via type_arguments, so type_args are empty here.
+                        data.supers.push((name_line, name, Vec::new()));
                     }
                 }
             }
-            _ => {}
         }
         let mut cur = node.walk();
         for child in node.children(&mut cur) { stack.push(child); }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,7 +7,7 @@ use tower_lsp::lsp_types::{Position, Range, SymbolKind};
 use crate::indexer::NodeExt;
 use crate::StrExt;
 use crate::queries::{self, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
-    KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_IDENTIFIER,
+    KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_IDENTIFIER, KIND_SCOPED_IDENT,
     KIND_USER_TYPE, KIND_FUN_DECL,
     KIND_CLASS_DECL, KIND_ENUM_DECL, KIND_INTERFACE_DECL,
     KIND_OBJECT_DECL, KIND_DELEGATION_SPEC,
@@ -947,7 +947,7 @@ impl crate::types::FileData {
     fn push_java_import(&mut self, node: &Node, bytes: &[u8]) {
         let mut cur = node.walk();
         for child in node.children(&mut cur) {
-            if matches!(child.kind(), "scoped_identifier" | "identifier") {
+            if matches!(child.kind(), KIND_SCOPED_IDENT | KIND_IDENTIFIER) {
                 if let Ok(txt) = child.utf8_text(bytes) {
                     let full_path  = txt.to_owned();
                     let local_name = full_path.last_segment().to_owned();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -11,7 +11,7 @@ use crate::queries::{self, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
     KIND_USER_TYPE, KIND_FUN_DECL};
 use crate::types::{FileData, ImportEntry, SymbolEntry, SyntaxError, Visibility};
 
-type MatchEntry = (usize, [Option<(String, Range, Range)>; 2]);
+type MatchEntry = (usize, [Option<(String, Range, Range, Vec<String>)>; 2]);
 
 // ─── cached query objects ────────────────────────────────────────────────────
 //
@@ -160,16 +160,16 @@ pub fn parse_swift(content: &str) -> FileData {
         .map(|m| {
             let (pidx, slot) = map_def_captures(&m, def_idx, name_idx, bytes);
             if pidx == queries::SWIFT_INIT_PATTERN_IDX && slot[0].is_none() {
-                // init_declaration — no @name, synthesize "init"
-                let def_range = m.captures.iter()
-                    .find(|cap| cap.index == def_idx)
-                    .map(|cap| ts_to_lsp(cap.node.range()));
-                if let Some(dr) = def_range {
+                // init_declaration — no @name, synthesize "init"; type_params from @def node.
+                let def_cap = m.captures.iter().find(|cap| cap.index == def_idx);
+                if let Some(cap) = def_cap {
+                    let dr = ts_to_lsp(cap.node.range());
                     let sel = Range::new(
                         Position::new(dr.start.line, dr.start.character),
                         Position::new(dr.start.line, dr.start.character + queries::SWIFT_INIT_NAME.len() as u32),
                     );
-                    return (pidx, [Some((queries::SWIFT_INIT_NAME.to_owned(), dr, sel)), None]);
+                    let type_params = cap.node.extract_type_params(bytes);
+                    return (pidx, [Some((queries::SWIFT_INIT_NAME.to_owned(), dr, sel, type_params)), None]);
                 }
             }
             (pidx, slot)
@@ -220,19 +220,22 @@ fn map_def_captures<'c, 't>(
     bytes: &[u8],
 ) -> MatchEntry {
     let pidx = m.pattern_index;
+    let mut def_node:   Option<tree_sitter::Node> = None;
     let mut def_range:  Option<Range> = None;
     let mut name_text:  Option<String> = None;
     let mut name_range: Option<Range> = None;
     for cap in m.captures.iter() {
         if cap.index == def_idx {
+            def_node  = Some(cap.node);
             def_range = Some(ts_to_lsp(cap.node.range()));
         } else if cap.index == name_idx {
             name_text  = cap.node.utf8_text_owned(bytes);
             name_range = Some(ts_to_lsp(cap.node.range()));
         }
     }
-    let slot = if let (Some(dr), Some(nt), Some(nr)) = (def_range, name_text, name_range) {
-        [Some((nt, dr, nr)), None]
+    let slot = if let (Some(dn), Some(dr), Some(nt), Some(nr)) = (def_node, def_range, name_text, name_range) {
+        let type_params = dn.extract_type_params(bytes);
+        [Some((nt, dr, nr, type_params)), None]
     } else {
         [None, None]
     };
@@ -246,14 +249,14 @@ fn map_def_captures<'c, 't>(
 /// with the **lowest** pattern index — lower index = more specific pattern.
 fn dedup_matches(
     matches: &[MatchEntry],
-) -> std::collections::BTreeMap<(u32, u32), (usize, String, Range, Range)> {
+) -> std::collections::BTreeMap<(u32, u32), (usize, String, Range, Range, Vec<String>)> {
     let mut best = std::collections::BTreeMap::new();
     for (pidx, slot) in matches {
-        if let Some((name, range, sel)) = slot[0].clone() {
+        if let Some((name, range, sel, type_params)) = slot[0].clone() {
             let key = (sel.start.line, sel.start.character);
-            let is_better = best.get(&key).map(|(ep, _, _, _)| pidx < ep).unwrap_or(true);
+            let is_better = best.get(&key).map(|(ep, _, _, _, _)| pidx < ep).unwrap_or(true);
             if is_better {
-                best.insert(key, (*pidx, name, range, sel));
+                best.insert(key, (*pidx, name, range, sel, type_params));
             }
         }
     }
@@ -264,18 +267,18 @@ fn dedup_matches(
 /// to `symbols`.  `pattern_meta` maps a pattern index to `(SymbolKind, label)`;
 /// `vis_fn` detects the visibility modifier from source lines.
 fn push_def_symbols(
-    best: std::collections::BTreeMap<(u32, u32), (usize, String, Range, Range)>,
+    best: std::collections::BTreeMap<(u32, u32), (usize, String, Range, Range, Vec<String>)>,
     pattern_meta: fn(usize) -> (SymbolKind, Option<&'static str>),
     vis_fn: fn(&[String], usize) -> Visibility,
     lines: &[String],
     symbols: &mut Vec<SymbolEntry>,
 ) {
-    for (_, (pidx, name, range, sel)) in best {
+    for (_, (pidx, name, range, sel, type_params)) in best {
         let (kind, _) = pattern_meta(pidx);
         if kind != SymbolKind::NULL {
             let visibility = vis_fn(lines, sel.start.line as usize);
             let detail = extract_detail(lines, range.start.line, range.end.line);
-            symbols.push(SymbolEntry { name, kind, visibility, range, selection_range: sel, detail });
+            symbols.push(SymbolEntry { name, kind, visibility, range, selection_range: sel, detail, type_params });
         }
     }
 }
@@ -335,6 +338,7 @@ fn push_field_declaration(node: &Node, bytes: &[u8], data: &mut FileData) {
                 range: nr,
                 selection_range: sel,
                 detail: detail.clone(),
+                type_params: Vec::new(), // fields are never generic
             });
         }
     }
@@ -356,10 +360,11 @@ fn push_java_import(node: &Node, bytes: &[u8], data: &mut FileData) {
 
 fn push_named(node: &Node, bytes: &[u8], kind: SymbolKind, data: &mut FileData) {
     if let Some((name, sel)) = first_identifier(node, bytes) {
-        let visibility = visibility_at_line(&data.lines, node.range().start_point.row);
-        let range = ts_to_lsp(node.range());
-        let detail = extract_detail(&data.lines, range.start.line, range.end.line);
-        data.symbols.push(SymbolEntry { name, kind, visibility, range, selection_range: sel, detail });
+        let visibility  = visibility_at_line(&data.lines, node.range().start_point.row);
+        let range       = ts_to_lsp(node.range());
+        let detail      = extract_detail(&data.lines, range.start.line, range.end.line);
+        let type_params = node.extract_type_params(bytes);
+        data.symbols.push(SymbolEntry { name, kind, visibility, range, selection_range: sel, detail, type_params });
     }
 }
 
@@ -462,12 +467,22 @@ fn fun_interface_name_from_fn_decl(node: &Node, bytes: &[u8]) -> Option<(usize, 
     None
 }
 
-fn push_interface_symbol(name: &str, node: &Node, sel_node_range: tree_sitter::Range, data: &mut FileData) {
-    let visibility = visibility_at_line(&data.lines, node.range().start_point.row);
-    let range      = ts_to_lsp(node.range());
-    let sel        = ts_to_lsp(sel_node_range);
-    let detail     = extract_detail(&data.lines, range.start.line, range.end.line);
-    data.symbols.push(SymbolEntry { name: name.to_owned(), kind: SymbolKind::INTERFACE, visibility, range, selection_range: sel, detail });
+fn push_interface_symbol(name: &str, node: &Node, sel_node_range: tree_sitter::Range, bytes: &[u8], data: &mut FileData) {
+    let visibility  = visibility_at_line(&data.lines, node.range().start_point.row);
+    let range       = ts_to_lsp(node.range());
+    let sel         = ts_to_lsp(sel_node_range);
+    let detail      = extract_detail(&data.lines, range.start.line, range.end.line);
+    // fun interface nodes are mis-parsed (ERROR or function_declaration), so the
+    // type_parameters CST child may not be present; fall back to string parsing.
+    let type_params = {
+        let cst_params = node.extract_type_params(bytes);
+        if cst_params.is_empty() {
+            crate::indexer::parse_type_params_from_decl(&detail)
+        } else {
+            cst_params
+        }
+    };
+    data.symbols.push(SymbolEntry { name: name.to_owned(), kind: SymbolKind::INTERFACE, visibility, range, selection_range: sel, detail, type_params });
 }
 
 /// Walk the parse tree and emit INTERFACE symbols for every `fun interface Foo` declaration.
@@ -484,7 +499,7 @@ fn extract_fun_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
         if node.is_error() && is_fun_interface_error(&node, bytes) {
             if let Some(child) = node.first_child_of_kind(KIND_SIMPLE_IDENT) {
                 if let Ok(name) = child.utf8_text(bytes) {
-                    push_interface_symbol(name, &node, child.range(), data);
+                    push_interface_symbol(name, &node, child.range(), bytes, data);
                 }
             }
             // Don't recurse further into ERROR children.
@@ -499,7 +514,7 @@ fn extract_fun_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
                     !(s.name == name && s.selection_range.start.line == sel.start.line
                       && matches!(s.kind, SymbolKind::FUNCTION | SymbolKind::METHOD))
                 });
-                push_interface_symbol(name, &node, name_ts_range, data);
+                push_interface_symbol(name, &node, name_ts_range, bytes, data);
             }
             // Still recurse into children to find nested fun interfaces.
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -898,9 +898,8 @@ impl crate::types::FileData {
                 for spec in node.children_of_kind(KIND_INHERITANCE_SPEC) {
                     if let Some(ut) = spec.first_child_of_kind(KIND_USER_TYPE) {
                         if let Some(name) = ut.user_type_name(bytes) {
-                            // Swift generics are structurally nested inside user_type,
-                            // not via type_arguments, so type_args are empty here.
-                            self.supers.push((name_line, name, Vec::new()));
+                            let type_args = ut.type_arg_strings(bytes);
+                            self.supers.push((name_line, name, type_args));
                         }
                     }
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -343,7 +343,27 @@ fn is_fun_interface_error(node: &Node, bytes: &[u8]) -> bool {
                 }
             }
             "simple_identifier" => has_name = true,
-            _ => {}
+            _ => {
+                // Variance case: `fun interface Foo<in A, out B>` produces a nested
+                // ERROR child that swallows `fun`, `interface`, and the name together:
+                //   ERROR { ERROR(user_type("interface"), simple_identifier("Foo")),
+                //           type_parameters(...) }
+                if child.is_error() {
+                    let mut ec = child.walk();
+                    for gc in child.children(&mut ec) {
+                        match gc.kind() {
+                            "fun" => has_fun = true,
+                            "user_type" => {
+                                if gc.utf8_text(bytes).unwrap_or("") == "interface" {
+                                    has_interface = true;
+                                }
+                            }
+                            "simple_identifier" => has_name = true,
+                            _ => {}
+                        }
+                    }
+                }
+            }
         }
     }
     has_fun && has_interface && has_name
@@ -411,7 +431,16 @@ fn extract_fun_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
     while let Some(node) = stack.pop() {
         // Case 1: no-modifier `fun interface` → ERROR node
         if node.is_error() && is_fun_interface_error(&node, bytes) {
-            if let Some(child) = node.first_child_of_kind(KIND_SIMPLE_IDENT) {
+            // Simple case: simple_identifier is a direct child.
+            let name_node = node.first_child_of_kind(KIND_SIMPLE_IDENT)
+                // Variance case: name is inside a nested ERROR child.
+                .or_else(|| {
+                    let mut cur = node.walk();
+                    let inner_error = node.children(&mut cur).find(|c| c.is_error());
+                    drop(cur);
+                    inner_error.and_then(|inner| inner.first_child_of_kind(KIND_SIMPLE_IDENT))
+                });
+            if let Some(child) = name_node {
                 if let Ok(name) = child.utf8_text(bytes) {
                     push_interface_symbol(name, &node, child.range(), bytes, data);
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -291,89 +291,6 @@ fn push_def_symbols(
 
 // ─── Java extraction (manual traversal — Java grammar has named fields) ──────
 
-fn extract_java(node: &Node, bytes: &[u8], data: &mut FileData) {
-    match node.kind() {
-        KIND_PACKAGE_DECL => {
-            // (package_declaration "package" (scoped_identifier | identifier) ";")
-            let mut cur = node.walk();
-            for child in node.children(&mut cur) {
-                if matches!(child.kind(), "scoped_identifier" | "identifier") {
-                    if let Ok(txt) = child.utf8_text(bytes) {
-                        data.package = Some(txt.to_owned());
-                    }
-                    break;
-                }
-            }
-        }
-        KIND_CLASS_DECL     => push_named(node, bytes, SymbolKind::CLASS,     data),
-        KIND_RECORD_DECL    => push_named(node, bytes, SymbolKind::STRUCT,    data),
-        KIND_INTERFACE_DECL => push_named(node, bytes, SymbolKind::INTERFACE, data),
-        "annotation_type_declaration" => push_named(node, bytes, SymbolKind::INTERFACE, data),
-        KIND_ENUM_DECL      => push_named(node, bytes, SymbolKind::ENUM,      data),
-        KIND_METHOD_DECL    => push_named(node, bytes, SymbolKind::METHOD,    data),
-        KIND_CTOR_DECL      => push_named(node, bytes, SymbolKind::CONSTRUCTOR, data),
-        "enum_constant"     => push_named(node, bytes, SymbolKind::ENUM_MEMBER, data),
-        KIND_FIELD_DECL     => push_field_declaration(node, bytes, data),
-        KIND_IMPORT_DECL    => push_java_import(node, bytes, data),
-        _ => {}
-    }
-}
-
-fn push_field_declaration(node: &Node, bytes: &[u8], data: &mut FileData) {
-    // Detect `static final` → CONSTANT, anything else → FIELD.
-    let kind = if node.first_child_of_kind("modifiers").is_some_and(|mods| {
-        let found_kinds: Vec<&str> = (0..mods.child_count())
-            .filter_map(|i| mods.child(i))
-            .map(|c| c.kind())
-            .collect();
-        ["static", "final"].iter().all(|&req| found_kinds.contains(&req))
-    }) {
-        SymbolKind::CONSTANT
-    } else {
-        SymbolKind::FIELD
-    };
-    let nr = ts_to_lsp(node.range());
-    let vis = visibility_at_line(&data.lines, node.range().start_point.row);
-    let detail = extract_detail(&data.lines, nr.start.line, nr.end.line);
-    for child in node.children_of_kind("variable_declarator") {
-        if let Some((name, sel)) = first_identifier(&child, bytes) {
-            data.symbols.push(SymbolEntry {
-                name,
-                kind,
-                visibility: vis,
-                range: nr,
-                selection_range: sel,
-                detail: detail.clone(),
-                type_params: Vec::new(), // fields are never generic
-            });
-        }
-    }
-}
-
-fn push_java_import(node: &Node, bytes: &[u8], data: &mut FileData) {
-    let mut cur = node.walk();
-    for child in node.children(&mut cur) {
-        if matches!(child.kind(), "scoped_identifier" | "identifier") {
-            if let Ok(txt) = child.utf8_text(bytes) {
-                let full_path  = txt.to_owned();
-                let local_name = full_path.last_segment().to_owned();
-                data.imports.push(ImportEntry { full_path, local_name, is_star: false });
-            }
-            return;
-        }
-    }
-}
-
-fn push_named(node: &Node, bytes: &[u8], kind: SymbolKind, data: &mut FileData) {
-    if let Some((name, sel)) = first_identifier(node, bytes) {
-        let visibility  = visibility_at_line(&data.lines, node.range().start_point.row);
-        let range       = ts_to_lsp(node.range());
-        let detail      = extract_detail(&data.lines, range.start.line, range.end.line);
-        let type_params = node.extract_type_params(bytes);
-        data.symbols.push(SymbolEntry { name, kind, visibility, range, selection_range: sel, detail, type_params });
-    }
-}
-
 fn first_identifier(node: &Node, bytes: &[u8]) -> Option<(String, Range)> {
     if let Some(n) = node.child_by_field_name("name") {
         if let Ok(t) = n.utf8_text(bytes) { return Some((t.to_owned(), ts_to_lsp(n.range()))); }
@@ -889,109 +806,7 @@ pub(crate) fn extract_declared_names(lines: &[String]) -> Vec<String> {
 
 // ─── supertype CST extraction ────────────────────────────────────────────────
 
-/// Walk the Kotlin CST and populate `data.supers` with `(class_name_line, supertype_name)`
-/// for every `class_declaration` and `object_declaration` that has delegation specifiers.
-fn extract_supers_kotlin(root: Node, bytes: &[u8], data: &mut FileData) {
-    let mut stack = vec![root];
-    while let Some(node) = stack.pop() {
-        if node.kind() == KIND_CLASS_DECL || node.kind() == KIND_OBJECT_DECL {
-            let name_line = node.name_line();
-            for child in node.children_of_kind(KIND_DELEGATION_SPEC) {
-                if let Some((name, type_args)) = super_name_from_delegation(&child, bytes) {
-                    data.supers.push((name_line, name, type_args));
-                }
-            }
-        }
-        let mut cur = node.walk();
-        for child in node.children(&mut cur) { stack.push(child); }
-    }
-}
-
-/// Walk the Java CST and populate `data.supers` for class/interface/enum/record
-/// declarations that extend or implement other types.
-fn extract_supers_java(node: &Node, bytes: &[u8], data: &mut FileData) {
-    let kind = node.kind();
-    if kind == KIND_CLASS_DECL || kind == KIND_RECORD_DECL || kind == KIND_ENUM_DECL {
-        let name_line = node.name_line();
-        let mut cur = node.walk();
-        for child in node.children(&mut cur) {
-            if child.kind() == KIND_SUPERCLASS {
-                // (superclass "extends" _type)
-                if let Some(name) = child.java_first_type_name(bytes) {
-                    let type_args = child.type_arg_strings(bytes);
-                    data.supers.push((name_line, name, type_args));
-                }
-            } else if child.kind() == KIND_SUPER_INTERFACES {
-                // (super_interfaces "implements" (type_list _type, ...))
-                java_collect_type_list(&child, bytes, name_line, data);
-            }
-        }
-    } else if kind == KIND_INTERFACE_DECL {
-        let name_line = node.name_line();
-        if let Some(ext) = node.first_child_of_kind(KIND_EXTENDS_INTERFACES) {
-            // (extends_interfaces "extends" (type_list ...))
-            java_collect_type_list(&ext, bytes, name_line, data);
-        }
-    }
-}
-
-/// Extract the supertype name from a `delegation_specifier` node.
-fn super_name_from_delegation(node: &Node, bytes: &[u8]) -> Option<(String, Vec<String>)> {
-    let mut cur = node.walk();
-    for child in node.children(&mut cur) {
-        let kind = child.kind();
-        if kind == "constructor_invocation" || kind == "explicit_delegation" {
-            if let Some(ut) = child.first_child_of_kind(KIND_USER_TYPE) {
-                return ut.user_type_name(bytes).map(|n| (n, ut.type_arg_strings(bytes)));
-            }
-        } else if kind == KIND_USER_TYPE {
-            return child.user_type_name(bytes).map(|n| (n, child.type_arg_strings(bytes)));
-        }
-    }
-    None
-}
-
-/// Walk a `super_interfaces` or `extends_interfaces` node, collecting all type names
-/// from its `type_list` child into `data.supers`.
-fn java_collect_type_list(node: &Node, bytes: &[u8], name_line: u32, data: &mut FileData) {
-    let Some(type_list) = node.first_child_of_kind(KIND_TYPE_LIST) else { return };
-    let mut cc = type_list.walk();
-    for type_node in type_list.children(&mut cc) {
-        // type_list children may be leaf type_identifier nodes directly,
-        // or wrapper nodes (generic_type, scoped_type_identifier) containing one.
-        let (name, type_args) = if type_node.kind() == KIND_TYPE_IDENT {
-            (type_node.utf8_text_owned(bytes), Vec::new())
-        } else {
-            (type_node.java_first_type_name(bytes), type_node.type_arg_strings(bytes))
-        };
-        if let Some(n) = name { data.supers.push((name_line, n, type_args)); }
-    }
-}
-
-/// Walk the Swift CST and populate `data.supers` with `(class_name_line, supertype_name, type_args)`
-/// for every `class_declaration` (class/struct/enum/extension) and `protocol_declaration`
-/// that has inheritance specifiers.
-fn extract_supers_swift(root: Node, bytes: &[u8], data: &mut FileData) {
-    let mut stack = vec![root];
-    while let Some(node) = stack.pop() {
-        if node.kind() == KIND_CLASS_DECL || node.kind() == KIND_PROTOCOL_DECL {
-            let name_line = node.name_line();
-            for spec in node.children_of_kind(KIND_INHERITANCE_SPEC) {
-                if let Some(ut) = spec.first_child_of_kind(KIND_USER_TYPE) {
-                    if let Some(name) = ut.user_type_name(bytes) {
-                        // Swift generics are structurally nested inside user_type,
-                        // not via type_arguments, so type_args are empty here.
-                        data.supers.push((name_line, name, Vec::new()));
-                    }
-                }
-            }
-        }
-        let mut cur = node.walk();
-        for child in node.children(&mut cur) { stack.push(child); }
-    }
-}
-
-// ─── FileData methods (thin wrappers around the free functions above) ────────
+// ─── FileData methods ────────────────────────────────────────────────────────
 
 impl crate::types::FileData {
     fn extract_package_and_imports(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
@@ -1000,20 +815,147 @@ impl crate::types::FileData {
     fn extract_fun_interfaces(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
         extract_fun_interfaces(root, bytes, self)
     }
-    fn extract_supers_kotlin(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
-        extract_supers_kotlin(root, bytes, self)
-    }
-    fn extract_java(&mut self, node: &Node, bytes: &[u8]) {
-        extract_java(node, bytes, self)
-    }
-    fn extract_supers_java(&mut self, node: &Node, bytes: &[u8]) {
-        extract_supers_java(node, bytes, self)
-    }
     fn extract_swift_imports(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
         extract_swift_imports(root, bytes, self)
     }
-    fn extract_supers_swift(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
-        extract_supers_swift(root, bytes, self)
+
+    fn extract_supers_kotlin(&mut self, root: Node, bytes: &[u8]) {
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            if node.kind() == KIND_CLASS_DECL || node.kind() == KIND_OBJECT_DECL {
+                let name_line = node.name_line();
+                for child in node.children_of_kind(KIND_DELEGATION_SPEC) {
+                    if let Some((name, type_args)) = child.super_from_delegation(bytes) {
+                        self.supers.push((name_line, name, type_args));
+                    }
+                }
+            }
+            let mut cur = node.walk();
+            for child in node.children(&mut cur) { stack.push(child); }
+        }
+    }
+
+    fn extract_supers_java(&mut self, node: &Node, bytes: &[u8]) {
+        let kind = node.kind();
+        if kind == KIND_CLASS_DECL || kind == KIND_RECORD_DECL || kind == KIND_ENUM_DECL {
+            let name_line = node.name_line();
+            let mut cur = node.walk();
+            for child in node.children(&mut cur) {
+                if child.kind() == KIND_SUPERCLASS {
+                    if let Some(name) = child.java_first_type_name(bytes) {
+                        self.supers.push((name_line, name, child.type_arg_strings(bytes)));
+                    }
+                } else if child.kind() == KIND_SUPER_INTERFACES {
+                    for (name, type_args) in child.java_type_list(bytes) {
+                        self.supers.push((name_line, name, type_args));
+                    }
+                }
+            }
+        } else if kind == KIND_INTERFACE_DECL {
+            let name_line = node.name_line();
+            if let Some(ext) = node.first_child_of_kind(KIND_EXTENDS_INTERFACES) {
+                for (name, type_args) in ext.java_type_list(bytes) {
+                    self.supers.push((name_line, name, type_args));
+                }
+            }
+        }
+    }
+
+    fn extract_supers_swift(&mut self, root: Node, bytes: &[u8]) {
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            if node.kind() == KIND_CLASS_DECL || node.kind() == KIND_PROTOCOL_DECL {
+                let name_line = node.name_line();
+                for spec in node.children_of_kind(KIND_INHERITANCE_SPEC) {
+                    if let Some(ut) = spec.first_child_of_kind(KIND_USER_TYPE) {
+                        if let Some(name) = ut.user_type_name(bytes) {
+                            // Swift generics are structurally nested inside user_type,
+                            // not via type_arguments, so type_args are empty here.
+                            self.supers.push((name_line, name, Vec::new()));
+                        }
+                    }
+                }
+            }
+            let mut cur = node.walk();
+            for child in node.children(&mut cur) { stack.push(child); }
+        }
+    }
+
+    fn extract_java(&mut self, node: &Node, bytes: &[u8]) {
+        match node.kind() {
+            KIND_PACKAGE_DECL => {
+                let mut cur = node.walk();
+                for child in node.children(&mut cur) {
+                    if matches!(child.kind(), "scoped_identifier" | "identifier") {
+                        if let Ok(txt) = child.utf8_text(bytes) {
+                            self.package = Some(txt.to_owned());
+                        }
+                        break;
+                    }
+                }
+            }
+            KIND_CLASS_DECL     => self.push_named(node, bytes, SymbolKind::CLASS),
+            KIND_RECORD_DECL    => self.push_named(node, bytes, SymbolKind::STRUCT),
+            KIND_INTERFACE_DECL => self.push_named(node, bytes, SymbolKind::INTERFACE),
+            "annotation_type_declaration" => self.push_named(node, bytes, SymbolKind::INTERFACE),
+            KIND_ENUM_DECL      => self.push_named(node, bytes, SymbolKind::ENUM),
+            KIND_METHOD_DECL    => self.push_named(node, bytes, SymbolKind::METHOD),
+            KIND_CTOR_DECL      => self.push_named(node, bytes, SymbolKind::CONSTRUCTOR),
+            "enum_constant"     => self.push_named(node, bytes, SymbolKind::ENUM_MEMBER),
+            KIND_FIELD_DECL     => self.push_field_declaration(node, bytes),
+            KIND_IMPORT_DECL    => self.push_java_import(node, bytes),
+            _ => {}
+        }
+    }
+
+    fn push_named(&mut self, node: &Node, bytes: &[u8], kind: SymbolKind) {
+        if let Some((name, sel)) = first_identifier(node, bytes) {
+            let visibility  = visibility_at_line(&self.lines, node.range().start_point.row);
+            let range       = ts_to_lsp(node.range());
+            let detail      = extract_detail(&self.lines, range.start.line, range.end.line);
+            let type_params = node.extract_type_params(bytes);
+            self.symbols.push(SymbolEntry { name, kind, visibility, range, selection_range: sel, detail, type_params });
+        }
+    }
+
+    fn push_field_declaration(&mut self, node: &Node, bytes: &[u8]) {
+        let kind = if node.first_child_of_kind("modifiers").is_some_and(|mods| {
+            let found_kinds: Vec<&str> = (0..mods.child_count())
+                .filter_map(|i| mods.child(i))
+                .map(|c| c.kind())
+                .collect();
+            ["static", "final"].iter().all(|&req| found_kinds.contains(&req))
+        }) {
+            SymbolKind::CONSTANT
+        } else {
+            SymbolKind::FIELD
+        };
+        let nr     = ts_to_lsp(node.range());
+        let vis    = visibility_at_line(&self.lines, node.range().start_point.row);
+        let detail = extract_detail(&self.lines, nr.start.line, nr.end.line);
+        for child in node.children_of_kind("variable_declarator") {
+            if let Some((name, sel)) = first_identifier(&child, bytes) {
+                self.symbols.push(SymbolEntry {
+                    name, kind, visibility: vis, range: nr,
+                    selection_range: sel, detail: detail.clone(),
+                    type_params: Vec::new(),
+                });
+            }
+        }
+    }
+
+    fn push_java_import(&mut self, node: &Node, bytes: &[u8]) {
+        let mut cur = node.walk();
+        for child in node.children(&mut cur) {
+            if matches!(child.kind(), "scoped_identifier" | "identifier") {
+                if let Ok(txt) = child.utf8_text(bytes) {
+                    let full_path  = txt.to_owned();
+                    let local_name = full_path.last_segment().to_owned();
+                    self.imports.push(ImportEntry { full_path, local_name, is_star: false });
+                }
+                return;
+            }
+        }
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -395,8 +395,49 @@ fn push_interface_symbol(name: &str, node: &Node, sel_node_range: tree_sitter::R
     let range       = ts_to_lsp(node.range());
     let sel         = ts_to_lsp(sel_node_range);
     let detail      = extract_detail(&data.lines, range.start.line, range.end.line);
-    let type_params = node.extract_type_params_or_error_child(bytes);
+    // CST primary extraction; fall back to text scan of the declaration line for
+    // `fun interface Foo<T>` when tree-sitter-kotlin 0.3 fails to recover
+    // type_parameters from its ERROR node.
+    let type_params = {
+        let cst = node.extract_type_params_or_error_child(bytes);
+        if cst.is_empty() { type_params_from_angle_brackets(&detail) } else { cst }
+    };
     data.symbols.push(SymbolEntry { name: name.to_owned(), kind: SymbolKind::INTERFACE, visibility, range, selection_range: sel, detail, type_params });
+}
+
+/// Extract simple type parameter names from the first `<…>` block in `text`.
+/// Returns empty when no well-formed `<…>` is found.
+/// E.g. `"fun interface Router<Effect>"` → `["Effect"]`
+/// E.g. `"fun interface Pair<A, B>"` → `["A", "B"]`
+fn type_params_from_angle_brackets(text: &str) -> Vec<String> {
+    let open = match text.find('<') {
+        Some(i) => i,
+        None => return Vec::new(),
+    };
+    let rest = &text[open + 1..];
+    let mut depth: usize = 1;
+    let mut close = None;
+    for (i, c) in rest.char_indices() {
+        match c {
+            '<' => depth += 1,
+            '>' => {
+                depth -= 1;
+                if depth == 0 { close = Some(i); break; }
+            }
+            _ => {}
+        }
+    }
+    let close = match close {
+        Some(i) => i,
+        None => return Vec::new(),
+    };
+    // Only accept simple identifier names (no bounds, variance annotations, etc.)
+    rest[..close]
+        .split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty() && s.chars().all(|c| c.is_alphanumeric() || c == '_'))
+        .map(|s| s.to_owned())
+        .collect()
 }
 
 /// Walk the parse tree and emit INTERFACE symbols for every `fun interface Foo` declaration.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -472,16 +472,7 @@ fn push_interface_symbol(name: &str, node: &Node, sel_node_range: tree_sitter::R
     let range       = ts_to_lsp(node.range());
     let sel         = ts_to_lsp(sel_node_range);
     let detail      = extract_detail(&data.lines, range.start.line, range.end.line);
-    // fun interface nodes are mis-parsed (ERROR or function_declaration), so the
-    // type_parameters CST child may not be present; fall back to string parsing.
-    let type_params = {
-        let cst_params = node.extract_type_params(bytes);
-        if cst_params.is_empty() {
-            crate::indexer::parse_type_params_from_decl(&detail)
-        } else {
-            cst_params
-        }
-    };
+    let type_params = node.extract_type_params_or_error_child(bytes);
     data.symbols.push(SymbolEntry { name: name.to_owned(), kind: SymbolKind::INTERFACE, visibility, range, selection_range: sel, detail, type_params });
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -284,7 +284,12 @@ fn push_def_symbols(
         if kind != SymbolKind::NULL {
             let visibility = vis_fn(lines, sel.start.line as usize);
             let detail = extract_detail(lines, range.start.line, range.end.line);
-            symbols.push(SymbolEntry { name, kind, visibility, range, selection_range: sel, detail, type_params });
+            let extension_receiver = if kind == SymbolKind::FUNCTION {
+                extract_extension_receiver(&detail).to_owned()
+            } else {
+                String::new()
+            };
+            symbols.push(SymbolEntry { name, kind, visibility, range, selection_range: sel, detail, type_params, extension_receiver });
         }
     }
 }
@@ -416,7 +421,7 @@ fn push_interface_symbol(name: &str, node: &Node, sel_node_range: tree_sitter::R
     let sel         = ts_to_lsp(sel_node_range);
     let detail      = extract_detail(&data.lines, range.start.line, range.end.line);
     let type_params = node.extract_type_params_or_error_child(bytes);
-    data.symbols.push(SymbolEntry { name: name.to_owned(), kind: SymbolKind::INTERFACE, visibility, range, selection_range: sel, detail, type_params });
+    data.symbols.push(SymbolEntry { name: name.to_owned(), kind: SymbolKind::INTERFACE, visibility, range, selection_range: sel, detail, type_params, extension_receiver: String::new() });
 }
 
 /// Walk the parse tree and emit INTERFACE symbols for every `fun interface Foo` declaration.
@@ -562,6 +567,65 @@ fn collect_syntax_errors(root: Node, bytes: &[u8]) -> Vec<SyntaxError> {
 ///   `val isChecked: Boolean`
 /// Maximum number of characters in an extracted detail string before truncation.
 const MAX_DETAIL_CHARS: usize = 120;
+
+/// Extract the bare receiver type name from a `fun` declaration detail string.
+///
+/// Handles:
+/// - `fun Foo.bar()` → `"Foo"`
+/// - `fun <T> List<T>.bar()` → `"List"`
+/// - `fun Foo.Bar.baz()` → `"Bar"` (last qualified segment)
+/// - `fun bar()` (no receiver) → `""`
+/// - Non-`fun` details → `""`
+pub(crate) fn extract_extension_receiver(detail: &str) -> &str {
+    let s = detail.trim_start();
+    // Must start with `fun` (possibly after annotations/visibility modifiers).
+    let after_fun = if let Some(rest) = s.strip_prefix("fun") {
+        if rest.starts_with(|c: char| c.is_alphanumeric() || c == '_') { return ""; }
+        rest
+    } else {
+        // Try stripping a leading keyword before `fun` (e.g. `private fun`, `inline fun`).
+        let word_end = s.find(|c: char| !c.is_alphanumeric() && c != '_').unwrap_or(s.len());
+        let rest = s[word_end..].trim_start();
+        if let Some(r) = rest.strip_prefix("fun") {
+            if r.starts_with(|c: char| c.is_alphanumeric() || c == '_') { return ""; }
+            r
+        } else {
+            return "";
+        }
+    };
+    let after_fun = after_fun.trim_start();
+    // Skip optional type params `<T, R>`.
+    let after_type_params = if after_fun.starts_with('<') {
+        let end = skip_balanced(after_fun, '<', '>');
+        after_fun[end..].trim_start()
+    } else {
+        after_fun
+    };
+    // What follows must be `ReceiverType.funcName`.  Find the last `.` before `(`.
+    let paren_pos = after_type_params.find('(').unwrap_or(after_type_params.len());
+    let before_paren = &after_type_params[..paren_pos];
+    let dot_pos = match before_paren.rfind('.') {
+        Some(p) => p,
+        None    => return "",
+    };
+    // Receiver portion is everything before that dot; strip generics for the base name.
+    let receiver_with_generics = before_paren[..dot_pos].trim();
+    let base_end = receiver_with_generics.find('<').unwrap_or(receiver_with_generics.len());
+    let base = receiver_with_generics[..base_end].trim_end();
+    // Return only the last qualified segment (e.g. `Outer.Inner` → `Inner`).
+    base.rsplit('.').next().unwrap_or(base)
+}
+
+/// Skip over balanced delimiters starting at index 0 of `s`.
+/// Returns the index *after* the closing delimiter.
+fn skip_balanced(s: &str, open: char, close: char) -> usize {
+    let mut depth = 0usize;
+    for (i, c) in s.char_indices() {
+        if c == open  { depth += 1; }
+        if c == close { depth = depth.saturating_sub(1); if depth == 0 { return i + c.len_utf8(); } }
+    }
+    s.len()
+}
 
 pub(crate) fn extract_detail(lines: &[String], start_line: u32, end_line: u32) -> String {
     let start = start_line as usize;
@@ -942,7 +1006,9 @@ impl crate::types::FileData {
             let range       = ts_to_lsp(node.range());
             let detail      = extract_detail(&self.lines, range.start.line, range.end.line);
             let type_params = node.extract_type_params(bytes);
-            self.symbols.push(SymbolEntry { name, kind, visibility, range, selection_range: sel, detail, type_params });
+            // Java extension methods (static methods in a class annotated with @JvmName etc.)
+            // are not real Kotlin extensions; leave extension_receiver empty for Java.
+            self.symbols.push(SymbolEntry { name, kind, visibility, range, selection_range: sel, detail, type_params, extension_receiver: String::new() });
         }
     }
 
@@ -966,7 +1032,7 @@ impl crate::types::FileData {
                 self.symbols.push(SymbolEntry {
                     name, kind, visibility: vis, range: nr,
                     selection_range: sel, detail: detail.clone(),
-                    type_params: Vec::new(),
+                    type_params: Vec::new(), extension_receiver: String::new(),
                 });
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -395,49 +395,8 @@ fn push_interface_symbol(name: &str, node: &Node, sel_node_range: tree_sitter::R
     let range       = ts_to_lsp(node.range());
     let sel         = ts_to_lsp(sel_node_range);
     let detail      = extract_detail(&data.lines, range.start.line, range.end.line);
-    // CST primary extraction; fall back to text scan of the declaration line for
-    // `fun interface Foo<T>` when tree-sitter-kotlin 0.3 fails to recover
-    // type_parameters from its ERROR node.
-    let type_params = {
-        let cst = node.extract_type_params_or_error_child(bytes);
-        if cst.is_empty() { type_params_from_angle_brackets(&detail) } else { cst }
-    };
+    let type_params = node.extract_type_params_or_error_child(bytes);
     data.symbols.push(SymbolEntry { name: name.to_owned(), kind: SymbolKind::INTERFACE, visibility, range, selection_range: sel, detail, type_params });
-}
-
-/// Extract simple type parameter names from the first `<…>` block in `text`.
-/// Returns empty when no well-formed `<…>` is found.
-/// E.g. `"fun interface Router<Effect>"` → `["Effect"]`
-/// E.g. `"fun interface Pair<A, B>"` → `["A", "B"]`
-fn type_params_from_angle_brackets(text: &str) -> Vec<String> {
-    let open = match text.find('<') {
-        Some(i) => i,
-        None => return Vec::new(),
-    };
-    let rest = &text[open + 1..];
-    let mut depth: usize = 1;
-    let mut close = None;
-    for (i, c) in rest.char_indices() {
-        match c {
-            '<' => depth += 1,
-            '>' => {
-                depth -= 1;
-                if depth == 0 { close = Some(i); break; }
-            }
-            _ => {}
-        }
-    }
-    let close = match close {
-        Some(i) => i,
-        None => return Vec::new(),
-    };
-    // Only accept simple identifier names (no bounds, variance annotations, etc.)
-    rest[..close]
-        .split(',')
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty() && s.chars().all(|c| c.is_alphanumeric() || c == '_'))
-        .map(|s| s.to_owned())
-        .collect()
 }
 
 /// Walk the parse tree and emit INTERFACE symbols for every `fun interface Foo` declaration.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -183,6 +183,9 @@ pub fn parse_swift(content: &str) -> FileData {
     // ── imports (manual tree walk — Swift imports are simpler) ────────────────
     data.extract_swift_imports(root, bytes);
 
+    // ── supertype relationships (inheritance specifiers) ──────────────────────
+    data.extract_supers_swift(root, bytes);
+
     // ── declared_names ───────────────────────────────────────────────────────
     data.declared_names = extract_declared_names(&data.lines);
 
@@ -783,19 +786,12 @@ fn extract_swift_imports(root: tree_sitter::Node, bytes: &[u8], data: &mut FileD
 ///
 /// Multi-line modifier blocks (rare) are NOT handled; they default to Public.
 pub(crate) fn visibility_at_line(lines: &[String], line_no: usize) -> Visibility {
-    let line = match lines.get(line_no) {
-        Some(l) => l,
-        None    => return Visibility::Public,
-    };
-    // Work only on the part before any `=`, `{`, or `(` to avoid false positives
-    // from string literals / bodies.
-    let decl = line.decl_prefix();
-
-    // Check whole-word tokens.
-    if contains_word(decl, "private")   { return Visibility::Private; }
-    if contains_word(decl, "protected") { return Visibility::Protected; }
-    if contains_word(decl, "internal")  { return Visibility::Internal; }
-    Visibility::Public
+    const KOTLIN_JAVA_MODS: &[(&str, Visibility)] = &[
+        ("private",   Visibility::Private),
+        ("protected", Visibility::Protected),
+        ("internal",  Visibility::Internal),
+    ];
+    visibility_at_line_impl(lines, line_no, Visibility::Public, KOTLIN_JAVA_MODS)
 }
 
 /// Swift visibility detection.
@@ -803,17 +799,29 @@ pub(crate) fn visibility_at_line(lines: &[String], line_no: usize) -> Visibility
 /// Swift modifiers: `private`, `fileprivate`, `internal`, `public`, `open`.
 /// Default is `internal` (unlike Kotlin which defaults to `public`).
 pub(crate) fn swift_visibility_at_line(lines: &[String], line_no: usize) -> Visibility {
-    let line = match lines.get(line_no) {
-        Some(l) => l,
-        None    => return Visibility::Internal,
-    };
-    let decl = line.decl_prefix();
+    const SWIFT_MODS: &[(&str, Visibility)] = &[
+        ("private",     Visibility::Private),
+        ("fileprivate", Visibility::Private),
+        ("public",      Visibility::Public),
+        ("open",        Visibility::Public),
+    ];
+    visibility_at_line_impl(lines, line_no, Visibility::Internal, SWIFT_MODS)
+}
 
-    if contains_word(decl, "private")     { return Visibility::Private; }
-    if contains_word(decl, "fileprivate") { return Visibility::Private; }
-    if contains_word(decl, "public")      { return Visibility::Public; }
-    if contains_word(decl, "open")        { return Visibility::Public; }
-    Visibility::Internal // Swift default
+fn visibility_at_line_impl(
+    lines:     &[String],
+    line_no:   usize,
+    default:   Visibility,
+    modifiers: &[(&str, Visibility)],
+) -> Visibility {
+    let Some(line) = lines.get(line_no) else { return default };
+    // Work only on the part before any `=`, `{`, or `(` to avoid false positives
+    // from string literals / bodies.
+    let decl = line.decl_prefix();
+    for &(kw, vis) in modifiers {
+        if contains_word(decl, kw) { return vis; }
+    }
+    default
 }
 
 fn contains_word(text: &str, word: &str) -> bool {
@@ -961,6 +969,32 @@ fn java_collect_type_list(node: &Node, bytes: &[u8], name_line: u32, data: &mut 
     }
 }
 
+/// Walk the Swift CST and populate `data.supers` with `(class_name_line, supertype_name, type_args)`
+/// for every `class_declaration` (class/struct/enum/extension) and `protocol_declaration`
+/// that has inheritance specifiers.
+fn extract_supers_swift(root: Node, bytes: &[u8], data: &mut FileData) {
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        match node.kind() {
+            "class_declaration" | "protocol_declaration" => {
+                let name_line = node.name_line();
+                for spec in node.children_of_kind("inheritance_specifier") {
+                    if let Some(ut) = spec.first_child_of_kind("user_type") {
+                        if let Some(name) = ut.user_type_name(bytes) {
+                            // Swift generics are structurally nested inside user_type,
+                            // not via type_arguments, so type_args are empty here.
+                            data.supers.push((name_line, name, Vec::new()));
+                        }
+                    }
+                }
+            }
+            _ => {}
+        }
+        let mut cur = node.walk();
+        for child in node.children(&mut cur) { stack.push(child); }
+    }
+}
+
 // ─── FileData methods (thin wrappers around the free functions above) ────────
 
 impl crate::types::FileData {
@@ -981,6 +1015,9 @@ impl crate::types::FileData {
     }
     fn extract_swift_imports(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
         extract_swift_imports(root, bytes, self)
+    }
+    fn extract_supers_swift(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
+        extract_supers_swift(root, bytes, self)
     }
 }
 

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -650,9 +650,17 @@ class LoanReducer {
     #[test]
     fn swift_supers_with_generic_base() {
         let data = parse_swift("class Foo: Bar<Baz> {}");
-        let names = supers_names(&data);
-        // Base name "Bar" is captured; generic param stripped by user_type_name
-        assert!(names.contains(&"Bar".to_owned()), "missing Bar; got: {names:?}");
+        let entry = data.supers.iter().find(|(_, name, _)| name == "Bar")
+            .expect("missing Bar super");
+        assert_eq!(entry.2, vec!["Baz"], "type_args for Bar<Baz> should be [Baz]");
+    }
+
+    #[test]
+    fn swift_supers_multi_generic_args() {
+        let data = parse_swift("class Foo: Base<Int, String> {}");
+        let entry = data.supers.iter().find(|(_, name, _)| name == "Base")
+            .expect("missing Base super");
+        assert_eq!(entry.2, vec!["Int", "String"], "type_args for Base<Int, String> should be [Int, String]");
     }
 
     // ── visibility ───────────────────────────────────────────────────────────
@@ -807,15 +815,16 @@ class LoanReducer {
         }
     }
 
-    // ── Moneta real-file fixture tests ───────────────────────────────────────
-    // These tests parse actual source files from the Moneta/android workspace
-    // to verify CST extraction against production code.
-    // Skipped automatically if the path doesn't exist (not present in CI).
+    // ── fun interface CST fixture tests ──────────────────────────────────────
+    // Fixture files live in tests/fixtures/kotlin/ — they replicate the package
+    // structure of the original production sources so the package declaration
+    // and naming context are preserved.
 
     #[test]
-    fn moneta_router_fun_interface_has_type_param() {
-        let path = "/home/ocel/Work/Moneta/android/core/common/src/main/java/cz/moneta/smartbanka/common/mvi/Router.kt";
-        let Ok(src) = std::fs::read_to_string(path) else { return; };
+    fn fun_interface_single_type_param_indexed() {
+        let src = std::fs::read_to_string(
+            concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/kotlin/mvi/Router.kt")
+        ).expect("fixture Router.kt missing");
         let data = parse_kotlin(&src);
         let sym = data.symbols.iter().find(|s| s.name == "Router" && s.kind == SymbolKind::INTERFACE)
             .expect("Router interface not indexed");
@@ -823,9 +832,10 @@ class LoanReducer {
     }
 
     #[test]
-    fn moneta_iinputvalidator_variance_stripped() {
-        let path = "/home/ocel/Work/Moneta/android/core/commonui/src/main/java/cz/moneta/smartbanka/mobile/commonui/component/input/validator/IInputValidator.kt";
-        let Ok(src) = std::fs::read_to_string(path) else { return; };
+    fn fun_interface_variance_stripped() {
+        let src = std::fs::read_to_string(
+            concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/kotlin/input/validator/IInputValidator.kt")
+        ).expect("fixture IInputValidator.kt missing");
         let data = parse_kotlin(&src);
         let sym = data.symbols.iter().find(|s| s.name == "IInputValidator" && s.kind == SymbolKind::INTERFACE)
             .expect("IInputValidator should be indexed");

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -811,3 +811,32 @@ class LoanReducer {
         }
     }
 
+    // ── Moneta real-file fixture tests ───────────────────────────────────────
+    // These tests parse actual source files from the Moneta/android workspace
+    // to verify CST extraction against production code.
+    // Skipped automatically if the path doesn't exist (not present in CI).
+
+    #[test]
+    fn moneta_router_fun_interface_has_type_param() {
+        let path = "/home/ocel/Work/Moneta/android/core/common/src/main/java/cz/moneta/smartbanka/common/mvi/Router.kt";
+        let Ok(src) = std::fs::read_to_string(path) else { return; };
+        let data = parse_kotlin(&src);
+        let sym = data.symbols.iter().find(|s| s.name == "Router" && s.kind == SymbolKind::INTERFACE)
+            .expect("Router interface not indexed");
+        assert_eq!(sym.type_params, vec!["Effect"], "Router<Effect> type_params wrong");
+    }
+
+    #[test]
+    fn moneta_iinputvalidator_variance_stripped() {
+        let path = "/home/ocel/Work/Moneta/android/core/commonui/src/main/java/cz/moneta/smartbanka/mobile/commonui/component/input/validator/IInputValidator.kt";
+        let Ok(src) = std::fs::read_to_string(path) else { return; };
+        let data = parse_kotlin(&src);
+        if let Some(sym) = data.symbols.iter().find(|s| s.name == "IInputValidator" && s.kind == SymbolKind::INTERFACE) {
+            // When indexed, variance must be stripped: `in In` → "In", `out Out` → "Out"
+            assert_eq!(sym.type_params, vec!["In", "Out"], "IInputValidator<in In, out Out> type_params wrong");
+        }
+        // If not indexed: known limitation — tree-sitter-kotlin 0.3 wraps the name
+        // differently when variance annotations appear before type params, hiding
+        // the simple_identifier the detection logic relies on.
+    }
+

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -843,3 +843,50 @@ class LoanReducer {
             "variance 'in'/'out' must be stripped from type_params");
     }
 
+    // ── extract_extension_receiver ────────────────────────────────────────────
+
+    #[test]
+    fn extension_receiver_simple() {
+        assert_eq!(super::extract_extension_receiver("fun Foo.bar()"), "Foo");
+    }
+
+    #[test]
+    fn extension_receiver_with_type_params() {
+        assert_eq!(super::extract_extension_receiver("fun <T> List<T>.bar()"), "List");
+    }
+
+    #[test]
+    fn extension_receiver_qualified() {
+        // `fun Outer.Inner.baz()` — last segment is Inner
+        assert_eq!(super::extract_extension_receiver("fun Outer.Inner.baz()"), "Inner");
+    }
+
+    #[test]
+    fn extension_receiver_no_receiver() {
+        assert_eq!(super::extract_extension_receiver("fun bar()"), "");
+    }
+
+    #[test]
+    fn extension_receiver_non_fun() {
+        assert_eq!(super::extract_extension_receiver("val x: Int"), "");
+        assert_eq!(super::extract_extension_receiver("class Foo"), "");
+    }
+
+    #[test]
+    fn extension_receiver_indexed_in_symbol_entry() {
+        // A top-level extension function should have extension_receiver populated.
+        let src = "fun String.shout(): String = this.uppercase()";
+        let data = super::parse_kotlin(src);
+        let sym = data.symbols.iter().find(|s| s.name == "shout")
+            .expect("shout should be indexed");
+        assert_eq!(sym.extension_receiver, "String");
+    }
+
+    #[test]
+    fn non_extension_fun_has_empty_receiver() {
+        let src = "fun greet(name: String): String = \"Hello $name\"";
+        let data = super::parse_kotlin(src);
+        let sym = data.symbols.iter().find(|s| s.name == "greet")
+            .expect("greet should be indexed");
+        assert_eq!(sym.extension_receiver, "");
+    }

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -761,3 +761,53 @@ class LoanReducer {
             "method param leaked into interface type_params: {:?}", s.type_params);
     }
 
+    /// Multi-type-param `fun interface` declarations (e.g. `<A, B>`) are currently
+    /// not indexed — tree-sitter-kotlin 0.3 parses `<A, B>` as a comparison chain
+    /// and produces an ERROR structure that doesn't match the single-param path.
+    /// This test documents the known limitation so a future fix is visible.
+    #[test]
+    fn fun_interface_multi_type_params_known_limitation() {
+        let src = "fun interface Pair<A, B> { fun get(): A }";
+        let data = parse_kotlin(src);
+        // Known limitation: multi-param fun interfaces are not indexed under their name.
+        // When this is fixed, this test should be updated to assert sym(&data, "Pair") is Some.
+        assert!(sym(&data, "Pair").is_none(),
+            "if Pair is now indexed, update this test to assert type_params = [A, B]");
+    }
+
+    /// type_params_from_angle_brackets must not produce entries containing `:` or spaces.
+    /// For `fun interface Sortable<T: Comparable>`, like multi-param, the whole
+    /// declaration is not indexed (same tree-sitter-kotlin 0.3 limitation).
+    #[test]
+    fn angle_brackets_strips_variance_and_bounds() {
+        // When a fun interface with variance/bounds IS indexed, type_params must strip them.
+        // Not all forms are detectable by is_fun_interface_error (tree-sitter may wrap the
+        // name in user_type when generics follow), so we use `if let Some`.
+        let cases: &[(&str, &[&str])] = &[
+            ("fun interface Producer<out T>",  &["T"]),
+            ("fun interface Consumer<in T>",   &["T"]),
+            ("fun interface Box<T : Any>",     &["T"]),
+            ("fun interface Pair<out A, in B>", &["A", "B"]),
+        ];
+        for (src, expected) in cases {
+            let data = parse_kotlin(src);
+            if let Some(sym) = data.symbols.iter().find(|s| s.kind == SymbolKind::INTERFACE) {
+                assert_eq!(&sym.type_params.iter().map(String::as_str).collect::<Vec<_>>(),
+                    expected, "type_params wrong for: {src}");
+            }
+            // If not indexed: known limitation — tree-sitter-kotlin 0.3 wraps the
+            // name in user_type when variance appears, hiding the simple_identifier.
+        }
+    }
+
+    #[test]
+    fn angle_brackets_ignores_complex_declarations() {
+        let src = "fun interface Sortable<T: Comparable> { fun sort() }";
+        let data = parse_kotlin(src);
+        // `T: Comparable` bound stripped → no `:` in type_params
+        for s in &data.symbols {
+            assert!(!s.type_params.iter().any(|p| p.contains(':')),
+                "bound leaked into type_params for {}: {:?}", s.name, s.type_params);
+        }
+    }
+

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -761,18 +761,14 @@ class LoanReducer {
             "method param leaked into interface type_params: {:?}", s.type_params);
     }
 
-    /// Multi-type-param `fun interface` declarations (e.g. `<A, B>`) are currently
-    /// not indexed — tree-sitter-kotlin 0.3 parses `<A, B>` as a comparison chain
-    /// and produces an ERROR structure that doesn't match the single-param path.
-    /// This test documents the known limitation so a future fix is visible.
+    /// Multi-type-param `fun interface` declarations (e.g. `<A, B>`) are now indexed
+    /// via the nested-ERROR detection path added for variance support.
     #[test]
-    fn fun_interface_multi_type_params_known_limitation() {
+    fn fun_interface_multi_type_params_indexed() {
         let src = "fun interface Pair<A, B> { fun get(): A }";
         let data = parse_kotlin(src);
-        // Known limitation: multi-param fun interfaces are not indexed under their name.
-        // When this is fixed, this test should be updated to assert sym(&data, "Pair") is Some.
-        assert!(sym(&data, "Pair").is_none(),
-            "if Pair is now indexed, update this test to assert type_params = [A, B]");
+        let s = sym(&data, "Pair").expect("Pair should now be indexed");
+        assert_eq!(s.type_params, vec!["A", "B"]);
     }
 
     /// type_params_from_angle_brackets must not produce entries containing `:` or spaces.
@@ -831,12 +827,9 @@ class LoanReducer {
         let path = "/home/ocel/Work/Moneta/android/core/commonui/src/main/java/cz/moneta/smartbanka/mobile/commonui/component/input/validator/IInputValidator.kt";
         let Ok(src) = std::fs::read_to_string(path) else { return; };
         let data = parse_kotlin(&src);
-        if let Some(sym) = data.symbols.iter().find(|s| s.name == "IInputValidator" && s.kind == SymbolKind::INTERFACE) {
-            // When indexed, variance must be stripped: `in In` → "In", `out Out` → "Out"
-            assert_eq!(sym.type_params, vec!["In", "Out"], "IInputValidator<in In, out Out> type_params wrong");
-        }
-        // If not indexed: known limitation — tree-sitter-kotlin 0.3 wraps the name
-        // differently when variance annotations appear before type params, hiding
-        // the simple_identifier the detection logic relies on.
+        let sym = data.symbols.iter().find(|s| s.name == "IInputValidator" && s.kind == SymbolKind::INTERFACE)
+            .expect("IInputValidator should be indexed");
+        assert_eq!(sym.type_params, vec!["In", "Out"],
+            "variance 'in'/'out' must be stripped from type_params");
     }
 

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -714,3 +714,51 @@ class LoanReducer {
         let s = sym(&data, "Pair").expect("Pair not found");
         assert_eq!(s.type_params, vec!["A", "B"]);
     }
+
+    // ── fun interface type_params ──────────────────────────────────────────────
+
+    #[test]
+    fn fun_interface_no_modifier_is_indexed() {
+        let src = "fun interface Action {}";
+        let data = parse_kotlin(src);
+        let s = sym(&data, "Action").expect("Action not found");
+        assert_eq!(s.kind, tower_lsp::lsp_types::SymbolKind::INTERFACE);
+        assert!(s.type_params.is_empty());
+    }
+
+    #[test]
+    fn fun_interface_with_modifier_is_indexed() {
+        let src = "public fun interface Runnable {}";
+        let data = parse_kotlin(src);
+        let s = sym(&data, "Runnable").expect("Runnable not found");
+        assert_eq!(s.kind, tower_lsp::lsp_types::SymbolKind::INTERFACE);
+        assert!(s.type_params.is_empty());
+    }
+
+    #[test]
+    fn fun_interface_body_generic_method_not_harvested() {
+        // Non-generic fun interface whose body has a generic method must not
+        // pick up the method's type param as the interface's own type param.
+        let src = "fun interface Transformer { fun <T> transform(x: Any): T }";
+        let data = parse_kotlin(src);
+        let s = sym(&data, "Transformer").expect("Transformer not found");
+        assert_eq!(s.kind, tower_lsp::lsp_types::SymbolKind::INTERFACE);
+        assert!(s.type_params.is_empty(),
+            "body method type param leaked: {:?}", s.type_params);
+    }
+
+    #[test]
+    fn fun_interface_generic_type_params() {
+        // tree-sitter-kotlin may or may not create a type_parameters node inside
+        // the ERROR recovery for `fun interface Router<Effect>`.  Assert the known
+        // behaviour so regressions are visible.
+        let src = "fun interface Router<Effect> { fun route(effect: Effect) }";
+        let data = parse_kotlin(src);
+        let s = sym(&data, "Router").expect("Router not found");
+        assert_eq!(s.kind, tower_lsp::lsp_types::SymbolKind::INTERFACE);
+        // If CST error recovery produces a type_parameters node, type_params will be
+        // populated. If not, empty is acceptable (known tree-sitter-kotlin 0.3 limitation).
+        // The important thing is that the method's type params are NOT included.
+        assert!(!s.type_params.contains(&"effect".to_string()),
+            "method param leaked into interface type_params: {:?}", s.type_params);
+    }

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -602,8 +602,8 @@ class LoanReducer {
         let sel   = Range::new(Position::new(1, 0), Position::new(1, 3));
         let range = sel;
         let matches: Vec<MatchEntry> = vec![
-            (2, [Some(("Foo".into(), range, sel)), None]),
-            (0, [Some(("Foo".into(), range, sel)), None]),
+            (2, [Some(("Foo".into(), range, sel, vec![])), None]),
+            (0, [Some(("Foo".into(), range, sel, vec![])), None]),
         ];
         let best = dedup_matches(&matches);
         assert_eq!(best.len(), 1);
@@ -679,4 +679,38 @@ class LoanReducer {
     fn visibility_swift_open_is_public() {
         let lines: Vec<String> = vec!["open class Foo {}".into()];
         assert_eq!(swift_visibility_at_line(&lines, 0), crate::types::Visibility::Public);
+    }
+
+    // ── type_params extraction ──────────────────────────────────────────────
+
+    #[test]
+    fn kotlin_generic_class_has_type_params() {
+        let src = "class Box<T, U>(val value: T) {}";
+        let data = parse_kotlin(src);
+        let s = sym(&data, "Box").expect("Box not found");
+        assert_eq!(s.type_params, vec!["T", "U"]);
+    }
+
+    #[test]
+    fn kotlin_generic_interface_has_type_params() {
+        let src = "interface FlowReducer<in Event, out Effect, State> {}";
+        let data = parse_kotlin(src);
+        let s = sym(&data, "FlowReducer").expect("FlowReducer not found");
+        assert_eq!(s.type_params, vec!["Event", "Effect", "State"]);
+    }
+
+    #[test]
+    fn kotlin_non_generic_class_has_empty_type_params() {
+        let src = "class Plain {}";
+        let data = parse_kotlin(src);
+        let s = sym(&data, "Plain").expect("Plain not found");
+        assert!(s.type_params.is_empty(), "expected empty type_params, got {:?}", s.type_params);
+    }
+
+    #[test]
+    fn java_generic_class_has_type_params() {
+        let src = "public class Pair<A, B> { public A first; public B second; }";
+        let data = parse_java(src);
+        let s = sym(&data, "Pair").expect("Pair not found");
+        assert_eq!(s.type_params, vec!["A", "B"]);
     }

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -609,3 +609,74 @@ class LoanReducer {
         assert_eq!(best.len(), 1);
         assert_eq!(best.values().next().unwrap().0, 0, "pidx 0 should win over pidx 2");
     }
+
+    // ── Swift supers extraction ──────────────────────────────────────────────
+
+    fn supers_names(data: &FileData) -> Vec<String> {
+        data.supers.iter().map(|(_, name, _)| name.clone()).collect()
+    }
+
+    #[test]
+    fn swift_supers_class() {
+        let data = parse_swift("class Foo: UIViewController, Sendable {}");
+        let names = supers_names(&data);
+        assert!(names.contains(&"UIViewController".to_owned()), "missing UIViewController; got: {names:?}");
+        assert!(names.contains(&"Sendable".to_owned()), "missing Sendable; got: {names:?}");
+    }
+
+    #[test]
+    fn swift_supers_protocol() {
+        let data = parse_swift("protocol P: Q, R {}");
+        let names = supers_names(&data);
+        assert!(names.contains(&"Q".to_owned()), "missing Q; got: {names:?}");
+        assert!(names.contains(&"R".to_owned()), "missing R; got: {names:?}");
+    }
+
+    #[test]
+    fn swift_supers_struct() {
+        let data = parse_swift("struct Point: Drawable {}");
+        let names = supers_names(&data);
+        assert!(names.contains(&"Drawable".to_owned()), "missing Drawable; got: {names:?}");
+    }
+
+    #[test]
+    fn swift_supers_extension() {
+        let data = parse_swift("extension Point: Hashable, Equatable {}");
+        let names = supers_names(&data);
+        assert!(names.contains(&"Hashable".to_owned()), "missing Hashable; got: {names:?}");
+        assert!(names.contains(&"Equatable".to_owned()), "missing Equatable; got: {names:?}");
+    }
+
+    #[test]
+    fn swift_supers_with_generic_base() {
+        let data = parse_swift("class Foo: Bar<Baz> {}");
+        let names = supers_names(&data);
+        // Base name "Bar" is captured; generic param stripped by user_type_name
+        assert!(names.contains(&"Bar".to_owned()), "missing Bar; got: {names:?}");
+    }
+
+    // ── visibility ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn visibility_kotlin_defaults_public() {
+        let lines: Vec<String> = vec!["fun foo() {}".into()];
+        assert_eq!(visibility_at_line(&lines, 0), crate::types::Visibility::Public);
+    }
+
+    #[test]
+    fn visibility_kotlin_private() {
+        let lines: Vec<String> = vec!["private fun foo() {}".into()];
+        assert_eq!(visibility_at_line(&lines, 0), crate::types::Visibility::Private);
+    }
+
+    #[test]
+    fn visibility_swift_defaults_internal() {
+        let lines: Vec<String> = vec!["func foo() {}".into()];
+        assert_eq!(swift_visibility_at_line(&lines, 0), crate::types::Visibility::Internal);
+    }
+
+    #[test]
+    fn visibility_swift_open_is_public() {
+        let lines: Vec<String> = vec!["open class Foo {}".into()];
+        assert_eq!(swift_visibility_at_line(&lines, 0), crate::types::Visibility::Public);
+    }

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -749,16 +749,15 @@ class LoanReducer {
 
     #[test]
     fn fun_interface_generic_type_params() {
-        // tree-sitter-kotlin may or may not create a type_parameters node inside
-        // the ERROR recovery for `fun interface Router<Effect>`.  Assert the known
-        // behaviour so regressions are visible.
         let src = "fun interface Router<Effect> { fun route(effect: Effect) }";
         let data = parse_kotlin(src);
         let s = sym(&data, "Router").expect("Router not found");
         assert_eq!(s.kind, tower_lsp::lsp_types::SymbolKind::INTERFACE);
-        // If CST error recovery produces a type_parameters node, type_params will be
-        // populated. If not, empty is acceptable (known tree-sitter-kotlin 0.3 limitation).
-        // The important thing is that the method's type params are NOT included.
+        // Text fallback extracts type params from the declaration line when CST
+        // error recovery doesn't produce a type_parameters node.
+        assert_eq!(s.type_params, vec!["Effect".to_string()],
+            "type_params should be extracted via text fallback: {:?}", s.type_params);
         assert!(!s.type_params.contains(&"effect".to_string()),
             "method param leaked into interface type_params: {:?}", s.type_params);
     }
+

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -347,6 +347,7 @@ pub const SWIFT_INIT_NAME: &str = "init";
 pub(crate) const KIND_SIMPLE_IDENT:      &str = "simple_identifier";
 pub(crate) const KIND_TYPE_IDENT:        &str = "type_identifier";
 pub(crate) const KIND_IDENTIFIER:        &str = "identifier";
+pub(crate) const KIND_SCOPED_IDENT:      &str = "scoped_identifier";
 pub(crate) const KIND_CALL_EXPR:         &str = "call_expression";
 pub(crate) const KIND_LAMBDA_LIT:        &str = "lambda_literal";
 pub(crate) const KIND_LAMBDA_PARAMS:     &str = "lambda_parameters";

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -379,3 +379,8 @@ pub(crate) const KIND_TYPE_LIST:         &str = "type_list";
 // Swift-specific
 pub(crate) const KIND_PROTOCOL_DECL:     &str = "protocol_declaration";
 pub(crate) const KIND_INHERITANCE_SPEC:  &str = "inheritance_specifier";
+
+// ─── Generic / type parameter node kinds (shared across Kotlin, Java, Swift) ─
+pub(crate) const KIND_TYPE_PARAMS:       &str = "type_parameters";
+pub(crate) const KIND_TYPE_PARAM:        &str = "type_parameter";
+pub(crate) const KIND_TYPE_ARGS:         &str = "type_arguments";

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -344,13 +344,38 @@ pub const SWIFT_INIT_NAME: &str = "init";
 // These match the `node.kind()` strings produced by tree-sitter-kotlin,
 // tree-sitter-java, and tree-sitter-swift grammars.
 
-pub(crate) const KIND_SIMPLE_IDENT:  &str = "simple_identifier";
-pub(crate) const KIND_TYPE_IDENT:    &str = "type_identifier";
-pub(crate) const KIND_IDENTIFIER:    &str = "identifier";
-pub(crate) const KIND_CALL_EXPR:     &str = "call_expression";
-pub(crate) const KIND_LAMBDA_LIT:    &str = "lambda_literal";
-pub(crate) const KIND_LAMBDA_PARAMS: &str = "lambda_parameters";
-pub(crate) const KIND_VALUE_ARG:     &str = "value_argument";
-pub(crate) const KIND_VALUE_ARGS:    &str = "value_arguments";
-pub(crate) const KIND_USER_TYPE:     &str = "user_type";
-pub(crate) const KIND_FUN_DECL:      &str = "function_declaration";
+pub(crate) const KIND_SIMPLE_IDENT:      &str = "simple_identifier";
+pub(crate) const KIND_TYPE_IDENT:        &str = "type_identifier";
+pub(crate) const KIND_IDENTIFIER:        &str = "identifier";
+pub(crate) const KIND_CALL_EXPR:         &str = "call_expression";
+pub(crate) const KIND_LAMBDA_LIT:        &str = "lambda_literal";
+pub(crate) const KIND_LAMBDA_PARAMS:     &str = "lambda_parameters";
+pub(crate) const KIND_VALUE_ARG:         &str = "value_argument";
+pub(crate) const KIND_VALUE_ARGS:        &str = "value_arguments";
+pub(crate) const KIND_USER_TYPE:         &str = "user_type";
+pub(crate) const KIND_FUN_DECL:          &str = "function_declaration";
+
+// ─── Declaration node kinds (shared or language-specific) ──────────────────
+pub(crate) const KIND_CLASS_DECL:        &str = "class_declaration";
+pub(crate) const KIND_ENUM_DECL:         &str = "enum_declaration";
+pub(crate) const KIND_INTERFACE_DECL:    &str = "interface_declaration";
+
+// Kotlin-specific
+pub(crate) const KIND_OBJECT_DECL:       &str = "object_declaration";
+pub(crate) const KIND_DELEGATION_SPEC:   &str = "delegation_specifier";
+
+// Java-specific
+pub(crate) const KIND_RECORD_DECL:       &str = "record_declaration";
+pub(crate) const KIND_METHOD_DECL:       &str = "method_declaration";
+pub(crate) const KIND_CTOR_DECL:         &str = "constructor_declaration";
+pub(crate) const KIND_FIELD_DECL:        &str = "field_declaration";
+pub(crate) const KIND_IMPORT_DECL:       &str = "import_declaration";
+pub(crate) const KIND_PACKAGE_DECL:      &str = "package_declaration";
+pub(crate) const KIND_SUPERCLASS:        &str = "superclass";
+pub(crate) const KIND_SUPER_INTERFACES:  &str = "super_interfaces";
+pub(crate) const KIND_EXTENDS_INTERFACES:&str = "extends_interfaces";
+pub(crate) const KIND_TYPE_LIST:         &str = "type_list";
+
+// Swift-specific
+pub(crate) const KIND_PROTOCOL_DECL:     &str = "protocol_declaration";
+pub(crate) const KIND_INHERITANCE_SPEC:  &str = "inheritance_specifier";

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -140,6 +140,89 @@ pub(crate) fn is_annotation_context(line: &str, prefix: &str) -> bool {
 }
 
 /// Completion for `super.` — gather all members from the parent hierarchy.
+/// Scan the index for extension functions whose `extension_receiver` matches `receiver_type`
+/// and return them as `CompletionItem`s with auto-import `additionalTextEdits` when needed.
+///
+/// Only called for Kotlin files; Java files don't consume Kotlin extension functions.
+fn extension_fn_completions(
+    idx:           &Indexer,
+    receiver_type: &str,
+    from_uri:      &Url,
+    snippets:      bool,
+) -> Vec<CompletionItem> {
+    if receiver_type.is_empty() { return vec![]; }
+
+    // Gather current imports + package once (to avoid repeating per symbol).
+    let is_java = false;
+    let live = idx.live_lines.get(from_uri.as_str()).map(|ll| ll.clone());
+    let (cur_imports, cur_pkg, cur_lines) = idx.files.get(from_uri.as_str())
+        .map(|f| {
+            let lines = live.clone().unwrap_or_else(|| f.lines.clone());
+            let imports = if live.is_some() { lines.parse_imports() } else { f.imports.clone() };
+            (imports, f.package.clone().unwrap_or_default(), lines)
+        })
+        .unwrap_or_else(|| {
+            let lines = live.clone().unwrap_or_default();
+            let imports = lines.parse_imports();
+            (imports, String::new(), lines)
+        });
+
+    let mut items = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    for file_entry in idx.files.iter() {
+        let file_uri_str = file_entry.key().clone();
+        let file = file_entry.value();
+        // Skip the current file — its top-level extensions are already in scope.
+        if file_uri_str == from_uri.as_str() { continue; }
+        // Only look at Kotlin files.
+        if !file_uri_str.ends_with(".kt") && !file_uri_str.ends_with(".kts") { continue; }
+
+        for sym in &file.symbols {
+            if sym.extension_receiver != receiver_type { continue; }
+            // Skip private/protected — not accessible from other files.
+            if matches!(sym.visibility, Visibility::Private | Visibility::Protected) { continue; }
+
+            let dedup_key = format!("{}:{}", sym.name, file_uri_str);
+            if !seen.insert(dedup_key) { continue; }
+
+            // Build FQN for auto-import: package.funcName
+            let pkg = file.package.as_deref().unwrap_or("");
+            let fqn = if pkg.is_empty() { sym.name.clone() } else { format!("{pkg}.{}", sym.name) };
+
+            let pkg_of_fqn = match fqn.rfind('.') { Some(i) => &fqn[..i], None => "" };
+            let needs_import = !already_imported(&fqn, &cur_imports)
+                && !cur_imports.iter().any(|imp| imp.is_star && imp.full_path == pkg_of_fqn)
+                && pkg_of_fqn != cur_pkg;
+
+            let import_edit = if needs_import {
+                Some(vec![cur_lines.make_import_edit(&fqn, is_java)])
+            } else {
+                None
+            };
+
+            let insert_text = if snippets { Some(format!("{}($1)", sym.name)) } else { None };
+            let detail = if !sym.detail.is_empty() { Some(sym.detail.clone()) }
+                         else if needs_import { Some(pkg_of_fqn.to_string()) }
+                         else { None };
+
+            items.push(CompletionItem {
+                label:                sym.name.clone(),
+                kind:                 Some(CompletionItemKind::FUNCTION),
+                insert_text,
+                insert_text_format:   if snippets { Some(InsertTextFormat::SNIPPET) } else { None },
+                sort_text:            Some(format!("01:ext:{}", sym.name)),
+                detail,
+                command:              if snippets { Some(trigger_parameter_hints()) } else { None },
+                additional_text_edits: import_edit,
+                ..Default::default()
+            });
+        }
+    }
+
+    items
+}
+
 fn complete_super(idx: &Indexer, from_uri: &Url, snippets: bool) -> Vec<CompletionItem> {
     if idx.files.get(from_uri.as_str()).is_none() { return vec![]; }
     let mut items: Vec<CompletionItem> = Vec::new();
@@ -233,6 +316,13 @@ pub(crate) fn complete_dot(idx: &Indexer, receiver: &str, from_uri: &Url, snippe
     // when the current file is a Kotlin file; add Swift-specific snippets for Swift.
     let from_path = from_uri.path();
     items.extend(dot_completions_for_lang(from_path, &rt.qualified, snippets));
+
+    // Append indexed extension functions whose receiver matches `rt.outer`.
+    // These may be defined in other files and need an auto-import.
+    if from_path.ends_with(".kt") || from_path.ends_with(".kts") {
+        items.extend(extension_fn_completions(idx, &rt.outer, from_uri, snippets));
+    }
+
     items
 }
 

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -250,6 +250,9 @@ pub(crate) fn infer_type_in_lines(lines: &[String], var_name: &str) -> Option<St
 ///
 /// `val items: List<Product>` → `"List<Product>"`
 /// `val state: StateFlow<UiState>` → `"StateFlow<UiState>"`
+///
+/// Also handles delegate-inferred types:
+/// `val foo by lazy { SomeType() }` → `"SomeType"` (single-line only)
 pub(crate) fn infer_type_in_lines_raw(lines: &[String], var_name: &str) -> Option<String> {
     let pattern = format!("{var_name}:");
 
@@ -272,6 +275,27 @@ pub(crate) fn infer_type_in_lines_raw(lines: &[String], var_name: &str) -> Optio
             }
         }
     }
+
+    // Secondary scan: `val varName by lazy { ConstructorCall() }`
+    // Works only for single-line declarations without an explicit type annotation.
+    let lazy_pattern = format!("{var_name} by lazy");
+    for line in lines {
+        if !line.contains(&lazy_pattern) { continue; }
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") || trimmed.starts_with('*') || trimmed.starts_with("/*") {
+            continue;
+        }
+        if let Some(brace_pos) = line.find('{') {
+            let after_brace = line[brace_pos + 1..].trim_start();
+            // Extract the first identifier (stops at `<`, `(`, whitespace, etc.)
+            let ident = after_brace.dotted_ident_prefix();
+            let base = ident.split('.').last().unwrap_or(&ident);
+            if !base.is_empty() && base.starts_with_uppercase() {
+                return Some(base.to_owned());
+            }
+        }
+    }
+
     None
 }
 

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -1225,3 +1225,11 @@ data class State(
         assert_eq!(rt.leaf,      "OneYearOlderInteractor");
     }
 
+
+    #[test]
+    fn supers_swift_multiple_conformances() {
+        let src = "class Foo: UIViewController, Sendable {}";
+        let s: Vec<String> = crate::parser::parse_swift(src).supers.into_iter().map(|(_, n, _)| n).collect();
+        assert!(s.contains(&"UIViewController".to_string()), "missing UIViewController, got {s:?}");
+        assert!(s.contains(&"Sendable".to_string()), "missing Sendable, got {s:?}");
+    }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -690,6 +690,24 @@ data class State(
     }
 
     #[test]
+    fn infer_type_in_lines_raw_by_lazy_single_line() {
+        // `val repo by lazy { UserRepository() }` — no explicit annotation
+        let lines: Vec<String> = vec![
+            "    private val repo by lazy { UserRepository() }".into(),
+        ];
+        assert_eq!(infer_type_in_lines_raw(&lines, "repo"), Some("UserRepository".into()));
+    }
+
+    #[test]
+    fn infer_type_in_lines_raw_explicit_annotation_takes_priority() {
+        // `val repo: UserRepository by lazy { ... }` — annotation wins (first scan)
+        let lines: Vec<String> = vec![
+            "    private val repo: UserRepository by lazy { UserRepository() }".into(),
+        ];
+        assert_eq!(infer_type_in_lines_raw(&lines, "repo"), Some("UserRepository".into()));
+    }
+
+    #[test]
     fn goto_def_on_named_lambda_param_resolves_to_declaration_line() {
         // items.forEach { product ->
         //     product.name   ← gd on `product` here

--- a/src/types.rs
+++ b/src/types.rs
@@ -43,7 +43,12 @@ pub struct SymbolEntry {
     /// e.g. `class Foo<T, U>` → `["T", "U"]`.
     /// Empty for non-generic symbols.
     #[serde(default)]
-    pub type_params:      Vec<String>,
+    pub type_params:          Vec<String>,
+    /// For extension functions: the receiver type name (without generics).
+    /// e.g. `fun MyType.foo()` → `"MyType"`, `fun <T> List<T>.bar()` → `"List"`.
+    /// Empty string for non-extension symbols.
+    #[serde(default)]
+    pub extension_receiver:   String,
 }
 
 /// One import statement parsed from a Kotlin file.

--- a/src/types.rs
+++ b/src/types.rs
@@ -39,6 +39,11 @@ pub struct SymbolEntry {
     /// Empty string when not computed.
     #[serde(default)]
     pub detail:           String,
+    /// Generic type parameter names extracted from the CST at parse time.
+    /// e.g. `class Foo<T, U>` → `["T", "U"]`.
+    /// Empty for non-generic symbols.
+    #[serde(default)]
+    pub type_params:      Vec<String>,
 }
 
 /// One import statement parsed from a Kotlin file.

--- a/tests/fixtures/kotlin/input/validator/IInputValidator.kt
+++ b/tests/fixtures/kotlin/input/validator/IInputValidator.kt
@@ -1,0 +1,6 @@
+package cz.moneta.smartbanka.mobile.commonui.component.input.validator
+
+
+fun interface IInputValidator<in In, out Out> {
+  fun validate(value: In): Out?
+}

--- a/tests/fixtures/kotlin/mvi/Router.kt
+++ b/tests/fixtures/kotlin/mvi/Router.kt
@@ -1,0 +1,6 @@
+package cz.moneta.smartbanka.common.mvi
+
+
+fun interface Router<Effect> {
+  fun handle(effect: Effect)
+}

--- a/tests/swift_grammar.rs
+++ b/tests/swift_grammar.rs
@@ -205,3 +205,4 @@ import class CoreData.NSManagedObject
         }
     }
 }
+

--- a/tests/swift_grammar.rs
+++ b/tests/swift_grammar.rs
@@ -206,3 +206,4 @@ import class CoreData.NSManagedObject
     }
 }
 
+


### PR DESCRIPTION
## Summary

Extends type inference and completion in 4 areas:

### 1. RHS assignment type inference (`4160a65`)
`val x = SomeType()` / `val api = retrofit.create(DashboardApi::class.java)` / `val repo = inject<T>()` now infer the type without an explicit annotation.

### 2. Method return type inference + fix declared_names rejection (`9f4a2ba`)
- Removed `declared_names` fast-reject that blocked unannotated vars from reaching the assignment scan when using the indexed snapshot (not live_lines).
- `val response = service.getDetail(args)` now resolves the type by:  looking up `service`'s type → finding `getDetail` in the symbol index → extracting the return type from `SymbolEntry.detail`.
- DashMap guards are dropped before the recursive call to prevent deadlocks.

### 3. Hover shows inferred type for unannotated vars (`6f20627`)
- `hover_info_at_location` now shows `val response: AccountDetailResponseBody` instead of the raw RHS expression when no explicit type annotation is present.
- Also fixes a potential DashMap deadlock by dropping the guard before calling inference.
- Same method inference added to `infer_variable_type_raw` (used by the completion path).

### 4. Inherited members in dot-completion (`15b8d36`)
- `complete_dot` now walks the supertype hierarchy (via `FileData.supers`) up to 4 levels deep.
- New `collect_inherited_members` recursive helper: resolves each supertype, fetches its members via `symbols_from_nested_type`, recurses.
- Direct members deduplicated first so overridden methods don't appear twice.
- Fixes: `AccountDetailResponseBody : Account` — fields from the Java parent class now appear in completion.

## Tests
- 638 tests total (up from 630), all passing.