### PR TITLE
feat: type inference improvements — RHS, method return type, hover, inherited members

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -211,6 +211,9 @@ impl crate::indexer::infer::InferDeps for Indexer {
     fn find_field_type(&self, class_name: &str, field_name: &str) -> Option<String> {
         crate::resolver::infer::find_field_type_in_class(self, class_name, field_name)
     }
+    fn find_fun_return_type(&self, fn_name: &str) -> Option<String> {
+        crate::resolver::infer::find_fun_return_type_by_name(self, fn_name)
+    }
 }
 
 impl Indexer {

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -208,6 +208,9 @@ impl crate::indexer::infer::InferDeps for Indexer {
     fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String> {
         infer_variable_type_raw(self, var_name, uri)
     }
+    fn find_field_type(&self, class_name: &str, field_name: &str) -> Option<String> {
+        crate::resolver::infer::find_field_type_in_class(self, class_name, field_name)
+    }
 }
 
 impl Indexer {

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -21,7 +21,7 @@ use crate::types::{FileData, FileIndexResult};
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Bump when the serialized format changes; invalidates any older cache files.
-pub(crate) const CACHE_VERSION: u32 = 8;
+pub(crate) const CACHE_VERSION: u32 = 9;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -21,7 +21,7 @@ use crate::types::{FileData, FileIndexResult};
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Bump when the serialized format changes; invalidates any older cache files.
-pub(crate) const CACHE_VERSION: u32 = 9;
+pub(crate) const CACHE_VERSION: u32 = 10;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/src/indexer/infer/deps.rs
+++ b/src/indexer/infer/deps.rs
@@ -38,6 +38,19 @@ pub trait InferDeps {
     ///
     /// Returns `None` when the variable has no detectable declaration.
     fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String>;
+
+    /// Look up the raw declared type of `field_name` inside class `class_name`,
+    /// searching across indexed files.  Preserves generic parameters so that
+    /// `extract_collection_element_type` can extract the element type.
+    ///
+    /// Example: `class_name = "ResponseBody"`, `field_name = "availableBanks"` →
+    /// `Some("MutableList<MultibankingBank>")`.
+    ///
+    /// Returns `None` when the class or field is not found.
+    /// Default implementation returns `None`; overridden by `Indexer`.
+    fn find_field_type(&self, _class_name: &str, _field_name: &str) -> Option<String> {
+        None
+    }
 }
 
 // ─── Test stub ───────────────────────────────────────────────────────────────
@@ -49,17 +62,20 @@ pub trait InferDeps {
 #[cfg(test)]
 pub(crate) struct TestDeps {
     /// `(uri_str, fn_name)` → raw params text
-    pub fun_sigs:  std::collections::HashMap<(String, String), String>,
+    pub fun_sigs:    std::collections::HashMap<(String, String), String>,
     /// `(uri_str, var_name)` → type name
-    pub var_types: std::collections::HashMap<(String, String), String>,
+    pub var_types:   std::collections::HashMap<(String, String), String>,
+    /// `(class_name, field_name)` → raw type (with generics)
+    pub field_types: std::collections::HashMap<(String, String), String>,
 }
 
 #[cfg(test)]
 impl TestDeps {
     pub fn new() -> Self {
         TestDeps {
-            fun_sigs:  std::collections::HashMap::new(),
-            var_types: std::collections::HashMap::new(),
+            fun_sigs:    std::collections::HashMap::new(),
+            var_types:   std::collections::HashMap::new(),
+            field_types: std::collections::HashMap::new(),
         }
     }
 
@@ -74,6 +90,12 @@ impl TestDeps {
         self.var_types.insert((uri.to_string(), var_name.to_string()), ty.to_string());
         self
     }
+
+    /// Register `field_name` in `class_name` → raw type (with generics).
+    pub fn with_field(mut self, class_name: &str, field_name: &str, ty: &str) -> Self {
+        self.field_types.insert((class_name.to_string(), field_name.to_string()), ty.to_string());
+        self
+    }
 }
 
 #[cfg(test)]
@@ -83,5 +105,8 @@ impl InferDeps for TestDeps {
     }
     fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String> {
         self.var_types.get(&(uri.to_string(), var_name.to_string())).cloned()
+    }
+    fn find_field_type(&self, class_name: &str, field_name: &str) -> Option<String> {
+        self.field_types.get(&(class_name.to_string(), field_name.to_string())).cloned()
     }
 }

--- a/src/indexer/infer/deps.rs
+++ b/src/indexer/infer/deps.rs
@@ -39,6 +39,15 @@ pub trait InferDeps {
     /// Returns `None` when the variable has no detectable declaration.
     fn find_var_type(&self, var_name: &str, uri: &Url) -> Option<String>;
 
+    /// Look up the return type of a function by name, without needing to know the
+    /// receiver type.  Used for method-chain receivers like
+    /// `getList().joinAll().firstOrNull { it }` where `receiver_var = "joinAll"`.
+    ///
+    /// Returns `None` by default; overridden by `Indexer`.
+    fn find_fun_return_type(&self, _fn_name: &str) -> Option<String> {
+        None
+    }
+
     /// Look up the raw declared type of `field_name` inside class `class_name`,
     /// searching across indexed files.  Preserves generic parameters so that
     /// `extract_collection_element_type` can extract the element type.
@@ -62,11 +71,13 @@ pub trait InferDeps {
 #[cfg(test)]
 pub(crate) struct TestDeps {
     /// `(uri_str, fn_name)` → raw params text
-    pub fun_sigs:    std::collections::HashMap<(String, String), String>,
+    pub fun_sigs:      std::collections::HashMap<(String, String), String>,
     /// `(uri_str, var_name)` → type name
-    pub var_types:   std::collections::HashMap<(String, String), String>,
+    pub var_types:     std::collections::HashMap<(String, String), String>,
     /// `(class_name, field_name)` → raw type (with generics)
-    pub field_types: std::collections::HashMap<(String, String), String>,
+    pub field_types:   std::collections::HashMap<(String, String), String>,
+    /// `fn_name` → raw return type (with generics)
+    pub return_types:  std::collections::HashMap<String, String>,
 }
 
 #[cfg(test)]
@@ -76,6 +87,7 @@ impl TestDeps {
             fun_sigs:    std::collections::HashMap::new(),
             var_types:   std::collections::HashMap::new(),
             field_types: std::collections::HashMap::new(),
+            return_types: std::collections::HashMap::new(),
         }
     }
 
@@ -96,6 +108,12 @@ impl TestDeps {
         self.field_types.insert((class_name.to_string(), field_name.to_string()), ty.to_string());
         self
     }
+
+    /// Register `fn_name` → raw return type (with generics), for method-chain tests.
+    pub fn with_return(mut self, fn_name: &str, ty: &str) -> Self {
+        self.return_types.insert(fn_name.to_string(), ty.to_string());
+        self
+    }
 }
 
 #[cfg(test)]
@@ -108,5 +126,8 @@ impl InferDeps for TestDeps {
     }
     fn find_field_type(&self, class_name: &str, field_name: &str) -> Option<String> {
         self.field_types.get(&(class_name.to_string(), field_name.to_string())).cloned()
+    }
+    fn find_fun_return_type(&self, fn_name: &str) -> Option<String> {
+        self.return_types.get(fn_name).cloned()
     }
 }

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -252,6 +252,39 @@ pub(crate) fn lambda_receiver_type_from_context(
                     return Some(base);
                 }
             }
+
+            // Multi-segment receiver: `outer.field.method { it }` where `field`
+            // is not a local variable but a property of `outer`.
+            // Example: `result.availableBanks.firstOrNull { it }` →
+            //   outer_var = "result", field = "availableBanks"
+            //   → infer result's type → look up availableBanks in that class.
+            if let Some(rdot) = receiver_expr.rfind('.') {
+                let outer_var = last_ident_in(&receiver_expr[..rdot]);
+                let field = &receiver_expr[rdot + 1..];
+                if !outer_var.is_empty() && !field.is_empty() {
+                    if let Some(outer_type) = deps.find_var_type(outer_var, uri) {
+                        let outer_base = outer_type.ident_prefix();
+                        if !outer_base.is_empty() {
+                            if let Some(field_raw) = deps.find_field_type(&outer_base, field) {
+                                if let Some(elem) = extract_collection_element_type(&field_raw) {
+                                    return Some(elem);
+                                }
+                                // Mirror single-segment: try method's lambda param type first.
+                                if !method.is_empty() {
+                                    if let Some(ty) = fun_trailing_lambda_it_type(&method, deps, uri) {
+                                        return Some(ty);
+                                    }
+                                }
+                                let base = field_raw.ident_prefix();
+                                if !base.is_empty() && base.starts_with_uppercase() {
+                                    return Some(base);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
             if receiver_var.starts_with_uppercase() {
                 return Some(receiver_var.to_owned());
             }

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -229,7 +229,9 @@ pub(crate) fn lambda_receiver_type_from_context(
     // (e.g., `fn(Enum.VALUE, {` must not match the dot inside `Enum.VALUE`).
     if let Some(dot_pos) = find_last_dot_at_depth_zero(callee) {
         let receiver_expr = callee[..dot_pos].trim_end();
-        let receiver_var = last_ident_in(receiver_expr);
+        // Strip a trailing `(args)` so method chains like `getList().joinAll().map { it }`
+        // yield `receiver_var = "joinAll"` rather than `""`.
+        let receiver_var = last_ident_in(strip_trailing_call_args(receiver_expr));
         // Extract method name (everything after the dot up to the first non-id char).
         let method = callee[dot_pos + 1..].trim_start().ident_prefix();
 
@@ -282,6 +284,24 @@ pub(crate) fn lambda_receiver_type_from_context(
                             }
                         }
                     }
+                }
+            }
+
+            // Method-chain receiver: `getList().joinAll().firstOrNull { it }` —
+            // receiver_var is a method name (e.g. "joinAll"), not a local variable.
+            // Look up its return type directly and extract the element type.
+            if let Some(ret_raw) = deps.find_fun_return_type(receiver_var) {
+                if let Some(elem) = extract_collection_element_type(&ret_raw) {
+                    return Some(elem);
+                }
+                if !method.is_empty() {
+                    if let Some(ty) = fun_trailing_lambda_it_type(&method, deps, uri) {
+                        return Some(ty);
+                    }
+                }
+                let base = ret_raw.ident_prefix();
+                if !base.is_empty() && base.starts_with_uppercase() {
+                    return Some(base);
                 }
             }
 

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -572,6 +572,20 @@ fn test_deps_case_a_multi_segment_field_non_collection_method_lambda() {
 }
 
 #[test]
+fn test_deps_case_a_method_chain_return_type() {
+    // `getAccountList(isRefresh).joinAllAccounts().firstOrNull { it }` →
+    //   receiver_var = "joinAllAccounts", method = "firstOrNull"
+    //   joinAllAccounts() returns List<Account> → element "Account"
+    let u = test_uri();
+    let deps = super::super::TestDeps::new()
+        .with_return("joinAllAccounts", "List<Account>");
+    let result = lambda_receiver_type_from_context(
+        "getAccountList(isRefresh).joinAllAccounts().firstOrNull", &deps, &u);
+    assert_eq!(result.as_deref(), Some("Account"),
+        "method-chain: element type from joinAllAccounts() return type");
+}
+
+#[test]
 fn test_deps_unknown_fn_returns_none() {
     // Function not registered → None.
     let u = test_uri();

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -514,6 +514,64 @@ fn test_deps_case_a_var_type_no_collection() {
 }
 
 #[test]
+fn test_deps_case_a_multi_segment_field_collection() {
+    // `result.availableBanks.firstOrNull { it }` →
+    //   receiver_expr = "result.availableBanks", method = "firstOrNull"
+    //   outer_var = "result" (type "ResponseBody"), field = "availableBanks"
+    //   field type = "MutableList<Bank>" → element "Bank"
+    let u = test_uri();
+    let deps = super::super::TestDeps::new()
+        .with_var(u.as_str(), "result", "ResponseBody")
+        .with_field("ResponseBody", "availableBanks", "MutableList<Bank>");
+    let result = lambda_receiver_type_from_context("result.availableBanks.firstOrNull", &deps, &u);
+    assert_eq!(result.as_deref(), Some("Bank"),
+        "multi-segment: element of field collection resolved via find_field_type");
+}
+
+#[test]
+fn test_deps_case_a_multi_segment_field_collection_map() {
+    // `result.connectedAccounts.map { account -> }` →
+    //   outer_var = "result" (type "ResponseBody"), field = "connectedAccounts"
+    //   field type = "MutableList<MbAccount>" → element "MbAccount"
+    let u = test_uri();
+    let deps = super::super::TestDeps::new()
+        .with_var(u.as_str(), "result", "ResponseBody")
+        .with_field("ResponseBody", "connectedAccounts", "MutableList<MbAccount>");
+    let result = lambda_receiver_type_from_context("result.connectedAccounts.map", &deps, &u);
+    assert_eq!(result.as_deref(), Some("MbAccount"),
+        "multi-segment: element of connectedAccounts field via map");
+}
+
+#[test]
+fn test_deps_case_a_multi_segment_with_assignment_prefix() {
+    // `account.bankName = result.availableBanks.firstOrNull { it }` →
+    //   callee contains assignment prefix; last_ident_in correctly finds "result"
+    let u = test_uri();
+    let deps = super::super::TestDeps::new()
+        .with_var(u.as_str(), "result", "ResponseBody")
+        .with_field("ResponseBody", "availableBanks", "MutableList<Bank>");
+    // The callee string as extracted from the source line (assignment prefix included).
+    let result = lambda_receiver_type_from_context(
+        "account.bankName = result.availableBanks.firstOrNull", &deps, &u);
+    assert_eq!(result.as_deref(), Some("Bank"),
+        "multi-segment with assignment prefix: element resolved correctly");
+}
+
+#[test]
+fn test_deps_case_a_multi_segment_field_non_collection_method_lambda() {
+    // `result.foo.customOp { it }` where field `foo: Repo` and `customOp(block: (Bar) -> Unit)`.
+    // The method's lambda param type wins over the field base type.
+    let u = test_uri();
+    let deps = super::super::TestDeps::new()
+        .with_var(u.as_str(), "result", "ResponseBody")
+        .with_field("ResponseBody", "foo", "Repo")
+        .with_fun(u.as_str(), "customOp", "block: (Bar) -> Unit");
+    let result = lambda_receiver_type_from_context("result.foo.customOp", &deps, &u);
+    assert_eq!(result.as_deref(), Some("Bar"),
+        "multi-segment non-collection: method lambda param type wins over field base type");
+}
+
+#[test]
 fn test_deps_unknown_fn_returns_none() {
     // Function not registered → None.
     let u = test_uri();

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -75,34 +75,53 @@ impl Indexer {
                 }
             }
         }
-        let data = self.files.get(loc.uri.as_str())?;
-        // Prefer exact match by resolved location range; fall back to name match
-        // for symbols found via rg where the range may not align exactly.
-        let sym = data.symbols.iter().find(|s| s.selection_range == loc.range)
-            .or_else(|| data.symbols.iter().find(|s| s.name == name))?;
+        // Extract needed fields and drop the DashMap guard before any inference
+        // call (which may reacquire the same shard and deadlock otherwise).
+        let (sym_kind, sym_sel_range, lines) = {
+            let data = self.files.get(loc.uri.as_str())?;
+            let sym = data.symbols.iter().find(|s| s.selection_range == loc.range)
+                .or_else(|| data.symbols.iter().find(|s| s.name == name))?;
+            (sym.kind, sym.selection_range, data.lines.clone())
+        };
 
-        let start_line = sym.selection_range.start.line as usize;
-        let raw_sig = data.lines.collect_signature(start_line);
+        let start_line = sym_sel_range.start.line as usize;
+        let raw_sig = lines.collect_signature(start_line);
+
+        // For unannotated val/var, try to show an inferred type instead of the
+        // raw RHS expression (e.g. `val response: AccountDetailResponseBody`
+        // instead of `val response = service.getDetail(...)`).
+        let sig = if matches!(sym_kind, SymbolKind::PROPERTY | SymbolKind::VARIABLE)
+            && !raw_sig.contains(&format!("{name}:"))
+        {
+            if let Some(inferred) = self.infer_variable_type(name, &loc.uri) {
+                let kw = if sym_kind == SymbolKind::VARIABLE { "var" } else { "val" };
+                format!("{kw} {name}: {inferred}")
+            } else {
+                raw_sig
+            }
+        } else {
+            raw_sig
+        };
 
         // Apply generic type parameter substitution when the cursor is in a different
         // file (subtype) than where the symbol is defined.
         let sig = if let Some(cu) = calling_uri {
-            let subst = build_type_param_subst(self, loc.uri.as_str(), sym.selection_range.start.line, cu, cursor_line);
-            if subst.is_empty() { raw_sig } else { apply_subst(&raw_sig, &subst) }
+            let subst = build_type_param_subst(self, loc.uri.as_str(), sym_sel_range.start.line, cu, cursor_line);
+            if subst.is_empty() { sig } else { apply_subst(&sig, &subst) }
         } else {
-            raw_sig
+            sig
         };
 
         let lang = lang_str(loc.uri.path());
 
         let code_block = if sig.is_empty() {
-            format!("```{}\n{} {}\n```", lang, symbol_kw_for_lang(sym.kind, lang), name)
+            format!("```{}\n{} {}\n```", lang, symbol_kw_for_lang(sym_kind, lang), name)
         } else {
             format!("```{}\n{}\n```", lang, sig)
         };
 
         // Prepend KDoc / Javadoc comment if one immediately precedes the declaration.
-        if let Some(doc) = extract_doc_comment(&data.lines, start_line) {
+        if let Some(doc) = extract_doc_comment(&lines, start_line) {
             Some(format!("{doc}\n\n---\n\n{code_block}"))
         } else {
             Some(code_block)

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -408,7 +408,7 @@ fn build_type_param_subst(
     let type_args = calling_data.supers.iter()
         .find(|(line, base, _)| {
             base == &container_name
-                && calling_class_line.map_or(true, |class_line| *line == class_line)
+                && calling_class_line.is_none_or(|class_line| *line == class_line)
         })
         .map(|(_, _, args)| args.clone())
         .unwrap_or_default();

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -77,15 +77,25 @@ impl Indexer {
         }
         // Extract needed fields and drop the DashMap guard before any inference
         // call (which may reacquire the same shard and deadlock otherwise).
-        let (sym_kind, sym_sel_range, lines) = {
+        let (sym_kind, sym_sel_range, sym_detail, lines) = {
             let data = self.files.get(loc.uri.as_str())?;
             let sym = data.symbols.iter().find(|s| s.selection_range == loc.range)
                 .or_else(|| data.symbols.iter().find(|s| s.name == name))?;
-            (sym.kind, sym.selection_range, data.lines.clone())
+            (sym.kind, sym.selection_range, sym.detail.clone(), data.lines.clone())
         };
 
         let start_line = sym_sel_range.start.line as usize;
-        let raw_sig = lines.collect_signature(start_line);
+
+        // For property/variable symbols use the pre-indexed detail (a single declaration
+        // line) rather than collect_signature, which would keep reading until it finds a
+        // closing ')' and accidentally include sibling constructor parameters.
+        let raw_sig = if matches!(sym_kind, SymbolKind::PROPERTY | SymbolKind::VARIABLE)
+            && !sym_detail.is_empty()
+        {
+            sym_detail
+        } else {
+            lines.collect_signature(start_line)
+        };
 
         // For unannotated val/var, try to show an inferred type instead of the
         // raw RHS expression (e.g. `val response: AccountDetailResponseBody`

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -94,8 +94,19 @@ impl Indexer {
             && !raw_sig.contains(&format!("{name}:"))
         {
             if let Some(inferred) = self.infer_variable_type(name, &loc.uri) {
-                let kw = if sym_kind == SymbolKind::VARIABLE { "var" } else { "val" };
-                format!("{kw} {name}: {inferred}")
+                // Keep modifiers from the original signature (e.g. `private`, `override`).
+                // Find the name in the raw_sig and replace everything from `name` onward
+                // with `name: InferredType`, discarding the `= rhs` initializer.
+                let needle = format!(" {name}");
+                let name_pos = raw_sig.find(&needle)
+                    .map(|p| p + 1)
+                    .or_else(|| if raw_sig.starts_with(name) { Some(0) } else { None });
+                if let Some(pos) = name_pos {
+                    format!("{}: {inferred}", &raw_sig[..pos + name.len()])
+                } else {
+                    let kw = if sym_kind == SymbolKind::VARIABLE { "var" } else { "val" };
+                    format!("{kw} {name}: {inferred}")
+                }
             } else {
                 raw_sig
             }

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -251,7 +251,7 @@ fn build_type_param_subst_impl<I: IndexRead>(
     let type_args = calling_data.supers.iter()
         .find(|(line, base, _)| {
             base == &container_name
-                && calling_class_line.map_or(true, |class_line| *line == class_line)
+                && calling_class_line.is_none_or(|class_line| *line == class_line)
         })
         .map(|(_, _, args)| args.clone())
         .unwrap_or_default();

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -1612,3 +1612,95 @@ fn dot_receiver_qualified() {
 fn dot_receiver_none() {
     assert_eq!(dot_receiver("foo"), None);
 }
+
+// ── Lambda `it` inference: method chain + plain-fn RHS ───────────────────
+//
+// These tests mirror the real-world patterns that triggered regression fixes:
+//   1. `result.availableBanks.firstOrNull { it }` where `result` comes from
+//      a plain function call (`val result = getConnectedAccounts(isRefresh)`)
+//   2. `getAccountList(isRefresh).joinAllAccounts().firstOrNull { it }` —
+//      method chain; guard must NOT infer from the first segment's return type
+
+#[test]
+fn it_infer_result_field_firstornull() {
+    // Models:
+    //   data class MultibankingBank(val code: String, val name: String)
+    //   data class ConnectedAccountsResponse(val availableBanks: MutableList<MultibankingBank>)
+    //   fun getConnectedAccounts(isRefresh: Boolean): ConnectedAccountsResponse
+    //
+    // Usage:
+    //   val result = getConnectedAccounts(isRefresh)
+    //   result.availableBanks.firstOrNull { it.code == "X" }
+    //                                       ^^ should resolve to MultibankingBank
+    let src = concat!(
+        "data class MultibankingBank(val code: String, val name: String)\n",  // 0
+        "data class ConnectedAccountsResponse(\n",                             // 1
+        "  val availableBanks: MutableList<MultibankingBank> = mutableListOf(),\n", // 2
+        ")\n",                                                                  // 3
+        "fun getConnectedAccounts(isRefresh: Boolean): ConnectedAccountsResponse {}\n", // 4
+        "fun use(isRefresh: Boolean) {\n",                                      // 5
+        "  val result = getConnectedAccounts(isRefresh)\n",                     // 6
+        "  result.availableBanks.firstOrNull { it.code == \"X\" }\n",          // 7
+        "}\n",                                                                  // 8
+    );
+    let (u, idx) = indexed("/ConnectedAccounts.kt", src);
+    // `it` is on line 7, inside the firstOrNull lambda body
+    let result = idx.infer_lambda_param_type_at("it", &u, Position::new(7, 38));
+    assert_eq!(result.as_deref(), Some("MultibankingBank"),
+        "it inside firstOrNull on a field of plain-fn result should be MultibankingBank, got: {result:?}");
+}
+
+#[test]
+fn it_infer_method_chain_firstornull() {
+    // Models:
+    //   data class Account(val accountId: String)
+    //   class AccountList
+    //   fun getAccountList(isRefresh: Boolean): AccountList
+    //   fun AccountList.joinAllAccounts(): List<Account>
+    //
+    // Usage:
+    //   var account = getAccountList(isRefresh).joinAllAccounts().firstOrNull { it.accountId == id }
+    //                                                                           ^^ should resolve to Account
+    let src = concat!(
+        "data class Account(val accountId: String)\n",                               // 0
+        "class AccountList\n",                                                        // 1
+        "fun getAccountList(isRefresh: Boolean): AccountList {}\n",                   // 2
+        "fun AccountList.joinAllAccounts(): List<Account> {}\n",                      // 3
+        "fun use(isRefresh: Boolean, id: String) {\n",                               // 4
+        "  var account = getAccountList(isRefresh).joinAllAccounts().firstOrNull { it.accountId == id }\n", // 5
+        "}\n",                                                                        // 6
+    );
+    let (u, idx) = indexed("/AccountChain.kt", src);
+    // `it` is on line 5 at col 74 (0-indexed), inside the firstOrNull lambda
+    let result = idx.infer_lambda_param_type_at("it", &u, Position::new(5, 74));
+    assert_eq!(result.as_deref(), Some("Account"),
+        "it inside method-chain firstOrNull should be Account, got: {result:?}");
+}
+
+#[test]
+fn account_var_type_not_inferred_from_wrong_chain_segment() {
+    // Regression guard: `var account = getAccountList(...).joinAllAccounts().firstOrNull { }`
+    // The plain-fn fallback must NOT pick getAccountList's return type (AccountList) for `account`.
+    // infer_variable_type_raw for `account` should return None (can't trace the full chain)
+    // rather than AccountList or some wrong type.
+    let src = concat!(
+        "data class Account(val accountId: String)\n",                               // 0
+        "class AccountList\n",                                                        // 1
+        "fun getAccountList(isRefresh: Boolean): AccountList {}\n",                   // 2
+        "fun AccountList.joinAllAccounts(): List<Account> {}\n",                      // 3
+        "fun use(isRefresh: Boolean, id: String) {\n",                               // 4
+        "  var account = getAccountList(isRefresh).joinAllAccounts().firstOrNull { it.accountId == id }\n", // 5
+        "  account\n",                                                                // 6
+        "}\n",                                                                        // 7
+    );
+    let (u, idx) = indexed("/AccountChain.kt", src);
+    // Hover on `account` (line 6). The variable's inferred type must not be "AccountList"
+    // (regression: plain-fn fallback was picking the first segment).
+    let inferred = crate::resolver::infer::infer_variable_type_raw(&idx, "account", &u);
+    // We accept None (couldn't trace chain) OR the correct type.
+    // We reject "AccountList" — that was the regression.
+    if let Some(ref t) = inferred {
+        assert!(!t.contains("AccountList"),
+            "inferred type for `account` must not be AccountList (regression), got: {t}");
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,7 +14,10 @@ use crate::queries::{self, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
     KIND_RECORD_DECL, KIND_METHOD_DECL, KIND_CTOR_DECL, KIND_FIELD_DECL,
     KIND_IMPORT_DECL, KIND_PACKAGE_DECL,
     KIND_SUPERCLASS, KIND_SUPER_INTERFACES, KIND_EXTENDS_INTERFACES, KIND_TYPE_LIST,
-    KIND_PROTOCOL_DECL, KIND_INHERITANCE_SPEC};
+    KIND_PROTOCOL_DECL, KIND_INHERITANCE_SPEC,
+    KIND_PROP_DECL, KIND_PROP_DELEGATE, KIND_VAR_DECL, KIND_NAV_EXPR,
+    KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_CALLABLE_REF, KIND_TYPE_ARGS,
+    KIND_LAMBDA_LIT};
 use crate::types::{FileData, ImportEntry, SymbolEntry, SyntaxError, Visibility};
 
 type MatchEntry = (usize, [Option<(String, Range, Range, Vec<String>)>; 2]);
@@ -118,6 +121,9 @@ pub fn parse_kotlin(content: &str) -> FileData {
 
     // ── supertype relationships (delegation specifiers) ──────────────────────
     data.extract_supers_kotlin(root, bytes);
+
+    // ── rhs-type and method-call-rhs inference (unannotated properties) ──────
+    data.extract_rhs_types_kotlin(root, bytes);
 
     // ── declared_names: scan lines once for `ident:` patterns ───────────────
     data.declared_names = extract_declared_names(&data.lines);
@@ -899,6 +905,120 @@ pub(crate) fn extract_declared_names(lines: &[String]) -> Vec<String> {
 
 // ─── supertype CST extraction ────────────────────────────────────────────────
 
+// ─── RHS type CST extraction helpers ────────────────────────────────────────
+
+/// Return the first named node that follows the `=` token in a `property_declaration`.
+fn find_rhs_node(prop: Node) -> Option<Node> {
+    let mut saw_eq = false;
+    let mut cur = prop.walk();
+    for child in prop.children(&mut cur) {
+        if saw_eq && child.is_named() { return Some(child); }
+        if !child.is_named() && child.kind() == "=" { saw_eq = true; }
+    }
+    None
+}
+
+/// For a `call_expression` with a `navigation_expression` callee, return
+/// `(receiver_name, method_name)`.  Returns `None` for chained / `this` / `super`
+/// receivers and for uppercase method names (those are constructor-like, not methods).
+fn call_expr_receiver_method(call: Node, bytes: &[u8]) -> Option<(String, String)> {
+    let callee = call.child(0)?;
+    if callee.kind() != KIND_NAV_EXPR { return None; }
+
+    // navigation_expression named children: receiver_expr, navigation_suffix(es)
+    let named_count = callee.named_child_count();
+    if named_count < 2 { return None; }
+    let receiver_node = callee.named_child(0)?;
+    let suffix_node   = callee.named_child(named_count - 1)?;
+
+    // Reject multi-level chaining (e.g. `a.b.method()`)
+    if receiver_node.kind() == KIND_NAV_EXPR { return None; }
+
+    let recv = receiver_node.utf8_text_owned(bytes)?;
+    let method = suffix_node
+        .first_child_of_kind(KIND_SIMPLE_IDENT)
+        .and_then(|n| n.utf8_text_owned(bytes))?;
+
+    if recv == "this" || recv == "super" { return None; }
+    if !method.starts_with_lowercase() { return None; }
+    Some((recv, method))
+}
+
+/// For a `call_expression` with a plain `simple_identifier` callee, return the
+/// inferred type:
+/// - DI generic call (`inject<T>()` etc.) → first type argument
+/// - Constructor call (`SomeType(args)`) → callee name
+fn call_expr_direct_type(call: Node, bytes: &[u8]) -> Option<String> {
+    let callee = call.child(0)?;
+    if callee.kind() != KIND_SIMPLE_IDENT { return None; }
+    let name = callee.utf8_text_owned(bytes)?;
+
+    // DI generic: allowlisted callee + type arguments present in call_suffix
+    const DI_NAMES: &[&str] = &["inject", "get", "viewModel", "activityViewModel"];
+    if DI_NAMES.contains(&name.as_str()) {
+        if let Some(ty) = extract_type_arg_from_call_suffix(call, bytes) {
+            return Some(ty);
+        }
+    }
+
+    // Constructor call: callee starts uppercase
+    if name.starts_with_uppercase() {
+        return Some(name);
+    }
+    None
+}
+
+/// Extract the first type argument from `call_expression > call_suffix > type_arguments`.
+fn extract_type_arg_from_call_suffix(call: Node, bytes: &[u8]) -> Option<String> {
+    let call_suffix = call.first_child_of_kind(KIND_CALL_SUFFIX)?;
+    // type_arg_strings looks for KIND_TYPE_ARGS as a direct child of call_suffix
+    let args = call_suffix.type_arg_strings(bytes);
+    let first = args.into_iter().next()?;
+    // Strip nullability marker and whitespace
+    let clean = first.trim().trim_end_matches('?');
+    if clean.is_empty() || !clean.starts_with_uppercase() { return None; }
+    // Take only the base name (no generic parameters inside the type arg itself)
+    Some(clean.ident_prefix())
+}
+
+/// If `delegate` is `by lazy { SingleConstructorCall() }`, return the constructor
+/// name.  Only handles single-statement lambdas to avoid false positives.
+fn extract_lazy_type(delegate: Node, bytes: &[u8]) -> Option<String> {
+    let call = delegate.first_child_of_kind(KIND_CALL_EXPR)?;
+    let callee = call.child(0)?;
+    if callee.kind() != KIND_SIMPLE_IDENT { return None; }
+    if callee.utf8_text_owned(bytes)?.as_str() != "lazy" { return None; }
+
+    let call_suffix = call.first_child_of_kind(KIND_CALL_SUFFIX)?;
+    let lambda_lit  = find_lambda_literal(call_suffix)?;
+    let statements  = lambda_lit.first_child_of_kind("statements")?;
+
+    // Only handle the single-statement form to avoid false positives.
+    if statements.named_child_count() != 1 { return None; }
+
+    let expr = statements.named_child(0)?;
+    if expr.kind() == KIND_CALL_EXPR {
+        if let Some(inner_callee) = expr.child(0) {
+            if inner_callee.kind() == KIND_SIMPLE_IDENT {
+                if let Some(n) = inner_callee.utf8_text_owned(bytes) {
+                    if n.starts_with_uppercase() { return Some(n); }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Depth-first search for the first `lambda_literal` descendant.
+fn find_lambda_literal(start: Node) -> Option<Node> {
+    if start.kind() == KIND_LAMBDA_LIT { return Some(start); }
+    let mut cur = start.walk();
+    for child in start.children(&mut cur) {
+        if let Some(lit) = find_lambda_literal(child) { return Some(lit); }
+    }
+    None
+}
+
 // ─── FileData methods ────────────────────────────────────────────────────────
 
 impl crate::types::FileData {
@@ -964,6 +1084,53 @@ impl crate::types::FileData {
                         if let Some(name) = ut.user_type_name(bytes) {
                             let type_args = ut.type_arg_strings(bytes);
                             self.supers.push((name_line, name, type_args));
+                        }
+                    }
+                }
+            }
+            let mut cur = node.walk();
+            for child in node.children(&mut cur) { stack.push(child); }
+        }
+    }
+
+    /// Walk all Kotlin `property_declaration` nodes and populate `rhs_types` and
+    /// `method_call_rhs` for unannotated properties (those without an explicit `: Type`).
+    ///
+    /// Extracts three patterns at index time so hover/completion never need fragile
+    /// string scanning:
+    /// 1. DI generic call: `inject<T>()`, `viewModel<T>()` etc. → type arg `T`
+    /// 2. Constructor call: `SomeType(args)` → `SomeType`
+    /// 3. `by lazy { SomeType() }` (single-statement lambda) → `SomeType`
+    /// 4. Method call: `receiver.method(args)` → stored in `method_call_rhs` for
+    ///    two-step inference (resolve receiver type, then look up method return type)
+    fn extract_rhs_types_kotlin(&mut self, root: Node, bytes: &[u8]) {
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            if node.kind() == KIND_PROP_DECL {
+                if let Some(var_decl) = node.first_child_of_kind(KIND_VAR_DECL) {
+                    // Only infer for unannotated properties: variable_declaration has
+                    // just the identifier (named_child_count == 1 means no `: Type` child).
+                    if var_decl.named_child_count() == 1 {
+                        if let Some(name) = var_decl
+                            .first_child_of_kind(KIND_SIMPLE_IDENT)
+                            .and_then(|n| n.utf8_text_owned(bytes))
+                        {
+                            let line = var_decl.start_position().row as u32;
+                            if let Some(delegate) = node.first_child_of_kind(KIND_PROP_DELEGATE) {
+                                if let Some(ty) = extract_lazy_type(delegate, bytes) {
+                                    self.rhs_types.push((line, name, ty));
+                                }
+                            } else if let Some(rhs) = find_rhs_node(node) {
+                                if rhs.kind() == KIND_CALL_EXPR {
+                                    if let Some((recv, method)) =
+                                        call_expr_receiver_method(rhs, bytes)
+                                    {
+                                        self.method_call_rhs.push((line, name, recv, method));
+                                    } else if let Some(ty) = call_expr_direct_type(rhs, bytes) {
+                                        self.rhs_types.push((line, name, ty));
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -13,10 +13,10 @@ use crate::queries::{self, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
     KIND_OBJECT_DECL, KIND_DELEGATION_SPEC,
     KIND_RECORD_DECL, KIND_METHOD_DECL, KIND_CTOR_DECL, KIND_FIELD_DECL,
     KIND_IMPORT_DECL, KIND_PACKAGE_DECL,
-    KIND_SUPERCLASS, KIND_SUPER_INTERFACES, KIND_EXTENDS_INTERFACES, KIND_TYPE_LIST,
+    KIND_SUPERCLASS, KIND_SUPER_INTERFACES, KIND_EXTENDS_INTERFACES,
     KIND_PROTOCOL_DECL, KIND_INHERITANCE_SPEC,
     KIND_PROP_DECL, KIND_PROP_DELEGATE, KIND_VAR_DECL, KIND_NAV_EXPR,
-    KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_CALLABLE_REF, KIND_TYPE_ARGS,
+    KIND_CALL_EXPR, KIND_CALL_SUFFIX,
     KIND_LAMBDA_LIT};
 use crate::types::{FileData, ImportEntry, SymbolEntry, SyntaxError, Visibility};
 
@@ -981,6 +981,38 @@ fn extract_type_arg_from_call_suffix(call: Node, bytes: &[u8]) -> Option<String>
     Some(clean.ident_prefix())
 }
 
+/// If the first value argument of `call` is a class literal (`X::class` or
+/// `X::class.java`), return the type name `X`.
+///
+/// Handles Retrofit-style `create(DashboardApi::class.java)` where the callee
+/// is a library method that is not indexed, so the two-step receiver→method
+/// lookup cannot resolve the return type.
+fn extract_class_literal_arg_type(call: Node, bytes: &[u8]) -> Option<String> {
+    let call_suffix = call.first_child_of_kind(KIND_CALL_SUFFIX)?;
+    let value_args  = call_suffix.first_child_of_kind("value_arguments")?;
+    let first_arg   = value_args.first_child_of_kind("value_argument")?;
+    let arg_expr    = first_arg.named_child(0)?;
+
+    // Argument may be: `callable_reference` (X::class) or
+    // `navigation_expression` (X::class.java)
+    let callable_ref = if arg_expr.kind() == "callable_reference" {
+        arg_expr
+    } else if arg_expr.kind() == KIND_NAV_EXPR {
+        // X::class.java — first named child should be the callable_reference
+        let inner = arg_expr.named_child(0)?;
+        if inner.kind() != "callable_reference" { return None; }
+        inner
+    } else {
+        return None;
+    };
+
+    // callable_reference children: type_identifier "::" "class"
+    let type_node = callable_ref.named_child(0)?;
+    if type_node.kind() != "type_identifier" { return None; }
+    let name = type_node.utf8_text_owned(bytes)?;
+    if name.starts_with_uppercase() { Some(name) } else { None }
+}
+
 /// If `delegate` is `by lazy { SingleConstructorCall() }`, return the constructor
 /// name.  Only handles single-statement lambdas to avoid false positives.
 fn extract_lazy_type(delegate: Node, bytes: &[u8]) -> Option<String> {
@@ -1125,7 +1157,14 @@ impl crate::types::FileData {
                                     if let Some((recv, method)) =
                                         call_expr_receiver_method(rhs, bytes)
                                     {
-                                        self.method_call_rhs.push((line, name, recv, method));
+                                        // If the single argument is a class literal (X::class or
+                                        // X::class.java), extract the type directly — the callee
+                                        // (e.g. Retrofit.create) may not be indexed.
+                                        if let Some(ty) = extract_class_literal_arg_type(rhs, bytes) {
+                                            self.rhs_types.push((line, name, ty));
+                                        } else {
+                                            self.method_call_rhs.push((line, name, recv, method));
+                                        }
                                     } else if let Some(ty) = call_expr_direct_type(rhs, bytes) {
                                         self.rhs_types.push((line, name, ty));
                                     }

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -891,3 +891,58 @@ class LoanReducer {
         assert_eq!(sym.extension_receiver, "");
     }
 
+    // ── rhs_types CST extraction ─────────────────────────────────────────────
+
+    #[test]
+    fn rhs_types_class_literal_java_suffix() {
+        // `val api = retrofit.create(DashboardApi::class.java)` — the type should
+        // be extracted directly from the callable_reference argument, not stored
+        // in method_call_rhs (Retrofit is a library class, not indexed).
+        let src = "val api = retrofit.create(DashboardApi::class.java)";
+        let data = super::parse_kotlin(src);
+        let entry = data.rhs_types.iter().find(|(_, n, _)| n == "api");
+        assert!(entry.is_some(), "expected rhs_types entry for `api`");
+        assert_eq!(entry.unwrap().2, "DashboardApi");
+    }
+
+    #[test]
+    fn rhs_types_class_literal_kotlin_suffix() {
+        // `val api = retrofit.create(DashboardApi::class)` (no .java suffix)
+        let src = "val api = retrofit.create(DashboardApi::class)";
+        let data = super::parse_kotlin(src);
+        let entry = data.rhs_types.iter().find(|(_, n, _)| n == "api");
+        assert!(entry.is_some(), "expected rhs_types entry for `api`");
+        assert_eq!(entry.unwrap().2, "DashboardApi");
+    }
+
+    #[test]
+    fn rhs_types_constructor_call() {
+        // `val repo = UserRepository(db)` → `UserRepository`
+        let src = "val repo = UserRepository(db)";
+        let data = super::parse_kotlin(src);
+        let entry = data.rhs_types.iter().find(|(_, n, _)| n == "repo");
+        assert!(entry.is_some(), "expected rhs_types entry for `repo`");
+        assert_eq!(entry.unwrap().2, "UserRepository");
+    }
+
+    #[test]
+    fn rhs_types_di_inject() {
+        // `val repo: by inject<UserRepository>()` → type arg
+        let src = "val repo = inject<UserRepository>()";
+        let data = super::parse_kotlin(src);
+        let entry = data.rhs_types.iter().find(|(_, n, _)| n == "repo");
+        assert!(entry.is_some(), "expected rhs_types entry for `repo`");
+        assert_eq!(entry.unwrap().2, "UserRepository");
+    }
+
+    #[test]
+    fn method_call_rhs_regular_method() {
+        // `val response = service.getDetail(req)` → stored in method_call_rhs
+        let src = "val response = service.getDetail(req)";
+        let data = super::parse_kotlin(src);
+        let entry = data.method_call_rhs.iter().find(|(_, n, _, _)| n == "response");
+        assert!(entry.is_some(), "expected method_call_rhs entry for `response`");
+        assert_eq!(entry.unwrap().2, "service");
+        assert_eq!(entry.unwrap().3, "getDetail");
+    }
+

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -890,3 +890,4 @@ class LoanReducer {
             .expect("greet should be indexed");
         assert_eq!(sym.extension_receiver, "");
     }
+

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -392,4 +392,3 @@ pub(crate) const KIND_PROP_DELEGATE:     &str = "property_delegate";
 pub(crate) const KIND_VAR_DECL:          &str = "variable_declaration";
 pub(crate) const KIND_NAV_EXPR:          &str = "navigation_expression";
 pub(crate) const KIND_CALL_SUFFIX:       &str = "call_suffix";
-pub(crate) const KIND_CALLABLE_REF:      &str = "callable_reference";

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -385,3 +385,11 @@ pub(crate) const KIND_INHERITANCE_SPEC:  &str = "inheritance_specifier";
 pub(crate) const KIND_TYPE_PARAMS:       &str = "type_parameters";
 pub(crate) const KIND_TYPE_PARAM:        &str = "type_parameter";
 pub(crate) const KIND_TYPE_ARGS:         &str = "type_arguments";
+
+// ─── Kotlin property / navigation / call node kinds ──────────────────────────
+pub(crate) const KIND_PROP_DECL:         &str = "property_declaration";
+pub(crate) const KIND_PROP_DELEGATE:     &str = "property_delegate";
+pub(crate) const KIND_VAR_DECL:          &str = "variable_declaration";
+pub(crate) const KIND_NAV_EXPR:          &str = "navigation_expression";
+pub(crate) const KIND_CALL_SUFFIX:       &str = "call_suffix";
+pub(crate) const KIND_CALLABLE_REF:      &str = "callable_reference";

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -228,8 +228,8 @@ fn complete_super(idx: &Indexer, from_uri: &Url, snippets: bool) -> Vec<Completi
     let mut items: Vec<CompletionItem> = Vec::new();
     let mut visited: Vec<String> = vec![from_uri.as_str().to_owned()];
     collect_hierarchy_completions(idx, from_uri, &mut visited, 0, &mut items, snippets);
-    // Filter out private members — inaccessible even via super.
-    items.retain(|i| i.sort_text.as_deref().map(|s| !s.starts_with("prv:")).unwrap_or(true));
+    // Filter out private/protected members — inaccessible even via super.
+    items.retain(|i| i.sort_text.as_deref().map(|s| !s.starts_with("prv:") && !s.starts_with("prt:")).unwrap_or(true));
     items.sort_by_key(|i| (kind_sort_rank(i.kind), i.label.clone()));
     items.dedup_by_key(|i| i.label.clone());
     items
@@ -298,8 +298,8 @@ pub(crate) fn complete_dot(idx: &Indexer, receiver: &str, from_uri: &Url, snippe
     // `rt.leaf` is the last segment, so it works for both plain and dotted types.
     let mut items = symbols_from_nested_type(idx, &file_uri, &rt.leaf, Some(from_uri.as_str()));
 
-    // Filter out private members — they are inaccessible from outside the class.
-    items.retain(|i| i.sort_text.as_deref().map(|s| !s.starts_with("prv:")).unwrap_or(true));
+    // Filter out private/protected members — they are inaccessible from outside the class.
+    items.retain(|i| i.sort_text.as_deref().map(|s| !s.starts_with("prv:") && !s.starts_with("prt:")).unwrap_or(true));
 
     // Walk the inheritance hierarchy to include members from parent classes/interfaces.
     // Tracks "file_uri#TypeName" to prevent cycles; seed with the direct type.
@@ -384,7 +384,7 @@ fn collect_inherited_members(
             let mut inherited = symbols_from_nested_type(
                 idx, loc.uri.as_str(), &super_name, Some(calling_uri.as_str()),
             );
-            inherited.retain(|i| i.sort_text.as_deref().map(|s| !s.starts_with("prv:")).unwrap_or(true));
+            inherited.retain(|i| i.sort_text.as_deref().map(|s| !s.starts_with("prv:") && !s.starts_with("prt:")).unwrap_or(true));
             if !snippets {
                 for item in &mut inherited { item.insert_text = None; item.insert_text_format = None; }
             }

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -301,6 +301,15 @@ pub(crate) fn complete_dot(idx: &Indexer, receiver: &str, from_uri: &Url, snippe
     // Filter out private members — they are inaccessible from outside the class.
     items.retain(|i| i.sort_text.as_deref().map(|s| !s.starts_with("prv:")).unwrap_or(true));
 
+    // Walk the inheritance hierarchy to include members from parent classes/interfaces.
+    // Tracks "file_uri#TypeName" to prevent cycles; seed with the direct type.
+    let mut visited = vec![format!("{}#{}", file_uri, rt.leaf)];
+    collect_inherited_members(idx, &file_uri, &rt.leaf, from_uri, &mut visited, 0, &mut items, snippets);
+
+    // Deduplicate by label: direct members win over inherited ones (they come first).
+    let mut seen_labels = std::collections::HashSet::new();
+    items.retain(|i| seen_labels.insert(i.label.clone()));
+
     // Strip snippet fields if client doesn't support them.
     if !snippets {
         for item in &mut items {
@@ -324,6 +333,66 @@ pub(crate) fn complete_dot(idx: &Indexer, receiver: &str, from_uri: &Url, snippe
     }
 
     items
+}
+
+/// Recursively collect members from parent classes/interfaces of `type_name`
+/// (defined in `file_uri`) and append them to `out`.
+///
+/// `visited` tracks `"file_uri#TypeName"` pairs to prevent infinite cycles.
+/// Only non-private members are added (matching `complete_dot` behaviour).
+fn collect_inherited_members(
+    idx:         &Indexer,
+    file_uri:    &str,
+    type_name:   &str,
+    calling_uri: &Url,
+    visited:     &mut Vec<String>,
+    depth:       u8,
+    out:         &mut Vec<CompletionItem>,
+    snippets:    bool,
+) {
+    const MAX_DEPTH: u8 = 4;
+    if depth >= MAX_DEPTH { return; }
+
+    // Find the class's declaration line, then fetch its supertype names.
+    let supers: Vec<String> = {
+        let data = match idx.files.get(file_uri) {
+            Some(d) => d,
+            None    => return,
+        };
+        let class_line = data.symbols.iter()
+            .find(|s| s.name == type_name)
+            .map(|s| s.selection_range.start.line);
+        match class_line {
+            Some(line) => data.supers.iter()
+                .filter(|(l, _, _)| *l == line)
+                .map(|(_, n, _)| n.clone())
+                .collect(),
+            // Fallback if type not found: walk all supers in file.
+            None => data.supers.iter().map(|(_, n, _)| n.clone()).collect(),
+        }
+    };
+
+    let type_url = match Url::parse(file_uri) { Ok(u) => u, Err(_) => return };
+
+    for super_name in supers {
+        let super_locs = resolve_symbol_inner(idx, &super_name, &type_url, false);
+        for loc in &super_locs {
+            let key = format!("{}#{}", loc.uri.as_str(), super_name);
+            if visited.contains(&key) { continue; }
+            visited.push(key);
+
+            let mut inherited = symbols_from_nested_type(
+                idx, loc.uri.as_str(), &super_name, Some(calling_uri.as_str()),
+            );
+            inherited.retain(|i| i.sort_text.as_deref().map(|s| !s.starts_with("prv:")).unwrap_or(true));
+            if !snippets {
+                for item in &mut inherited { item.insert_text = None; item.insert_text_format = None; }
+            }
+            out.extend(inherited);
+
+            collect_inherited_members(idx, loc.uri.as_str(), &super_name, calling_uri, visited, depth + 1, out, snippets);
+        }
+    }
 }
 
 /// Build a `CompletionItem` for a symbol found inside a nested type body.

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -173,15 +173,15 @@ fn extension_fn_completions(
     for file_entry in idx.files.iter() {
         let file_uri_str = file_entry.key().clone();
         let file = file_entry.value();
-        // Skip the current file — its top-level extensions are already in scope.
-        if file_uri_str == from_uri.as_str() { continue; }
+        let is_same_file = file_uri_str == from_uri.as_str();
         // Only look at Kotlin files.
         if !file_uri_str.ends_with(".kt") && !file_uri_str.ends_with(".kts") { continue; }
 
         for sym in &file.symbols {
             if sym.extension_receiver != receiver_type { continue; }
-            // Skip private/protected — not accessible from other files.
-            if matches!(sym.visibility, Visibility::Private | Visibility::Protected) { continue; }
+            // Skip private/protected from other files — inaccessible across file boundaries.
+            // Same-file private/protected are fine.
+            if !is_same_file && matches!(sym.visibility, Visibility::Private | Visibility::Protected) { continue; }
 
             let dedup_key = format!("{}:{}", sym.name, file_uri_str);
             if !seen.insert(dedup_key) { continue; }
@@ -191,7 +191,8 @@ fn extension_fn_completions(
             let fqn = if pkg.is_empty() { sym.name.clone() } else { format!("{pkg}.{}", sym.name) };
 
             let pkg_of_fqn = match fqn.rfind('.') { Some(i) => &fqn[..i], None => "" };
-            let needs_import = !already_imported(&fqn, &cur_imports)
+            let needs_import = !is_same_file
+                && !already_imported(&fqn, &cur_imports)
                 && !cur_imports.iter().any(|imp| imp.is_star && imp.full_path == pkg_of_fqn)
                 && pkg_of_fqn != cur_pkg;
 

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -412,12 +412,15 @@ fn find_rhs_str<'a>(line: &'a str, var_name: &str) -> Option<&'a str> {
 }
 
 /// Attempt to infer the type of `var_name` from the right-hand side of an assignment.
+/// Infer a Kotlin type from a single RHS assignment line without an explicit type annotation.
 ///
 /// Called as a secondary/tertiary scan when no explicit type annotation (`var_name:`)
 /// is found.  Handles the most common Android/Kotlin patterns:
 ///
 /// 1. Constructor call:  `val x = SomeType(args)` → `"SomeType"`
 /// 2. DI generic:        `val x = inject<SomeType>()` → `"SomeType"`
+/// 3. Class literal arg: `val x = recv.create(SomeType::class.java)` → `"SomeType"`
+///    Only matches when `::class` is *inside* argument parens (not `val k = T::class`).
 ///
 /// Returns `None` when none of the patterns match.
 fn infer_from_rhs_assignment(line: &str, var_name: &str) -> Option<String> {
@@ -443,6 +446,22 @@ fn infer_from_rhs_assignment(line: &str, var_name: &str) -> Option<String> {
             let after_ident = rhs[dotted.len()..].trim_start();
             if after_ident.starts_with('(') || after_ident.starts_with('{') {
                 return Some(base.to_owned());
+            }
+        }
+    }
+
+    // Pattern 3: class literal argument — `recv.method(TypeName::class` where
+    // `::class` appears after `(` in the RHS.  This is the Retrofit pattern:
+    //   val api = retrofit.create(DashboardApi::class.java)
+    // Deliberately narrow: only matches when the `::class` is inside parens, so
+    // `val key = SomeType::class` (bare class ref, key is KClass<T>) is NOT matched.
+    if let Some(paren_pos) = rhs.find('(') {
+        let inside = &rhs[paren_pos + 1..];
+        if let Some(class_pos) = inside.find("::class") {
+            let before_class = inside[..class_pos].trim_end();
+            let type_name = before_class.split(|c: char| !c.is_alphanumeric() && c != '_').last().unwrap_or("");
+            if !type_name.is_empty() && type_name.starts_with_uppercase() {
+                return Some(type_name.to_owned());
             }
         }
     }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -210,6 +210,9 @@ impl crate::indexer::Indexer {
 ///
 /// Returns the type name without nullable marker (`?`) and generic parameters (`<…>`).
 /// Only returns names starting with an uppercase letter (skips primitives / unit).
+///
+/// When no explicit type annotation is found, falls back to RHS assignment inference
+/// (constructor calls, class literals, DI generics).
 pub(crate) fn infer_type_in_lines(lines: &[String], var_name: &str) -> Option<String> {
     let pattern = format!("{var_name}:");
 
@@ -243,6 +246,14 @@ pub(crate) fn infer_type_in_lines(lines: &[String], var_name: &str) -> Option<St
             }
         }
     }
+
+    // Secondary scan: RHS assignment inference (no explicit type annotation).
+    for line in lines {
+        if let Some(t) = infer_from_rhs_assignment(line, var_name) {
+            return Some(t);
+        }
+    }
+
     None
 }
 
@@ -291,6 +302,95 @@ pub(crate) fn infer_type_in_lines_raw(lines: &[String], var_name: &str) -> Optio
             let ident = after_brace.dotted_ident_prefix();
             let base = ident.split('.').last().unwrap_or(&ident);
             if !base.is_empty() && base.starts_with_uppercase() {
+                return Some(base.to_owned());
+            }
+        }
+    }
+
+    // Tertiary scan: assignment-based type inference.
+    for line in lines {
+        if let Some(t) = infer_from_rhs_assignment(line, var_name) {
+            return Some(t);
+        }
+    }
+
+    None
+}
+
+/// Attempt to infer the type of `var_name` from the right-hand side of an assignment.
+///
+/// Called as a secondary/tertiary scan when no explicit type annotation (`var_name:`)
+/// is found.  Handles the most common Android/Kotlin patterns:
+///
+/// 1. Constructor call:  `val x = SomeType(args)` → `"SomeType"`
+/// 2. Class literal:     `val x = retrofit.create(DashboardApi::class.java)` → `"DashboardApi"`
+/// 3. DI generic:        `val x = inject<SomeType>()` → `"SomeType"`
+///
+/// Returns `None` when none of the patterns match.
+fn infer_from_rhs_assignment(line: &str, var_name: &str) -> Option<String> {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("//") || trimmed.starts_with('*') || trimmed.starts_with("/*") {
+        return None;
+    }
+
+    // Locate `var_name =` where var_name is a whole word boundary.
+    let assign = format!("{var_name} =");
+    let eq_start = line.find(&assign)?;
+    if eq_start > 0 {
+        let before = line[..eq_start].chars().last().unwrap_or(' ');
+        if before.is_alphanumeric() || before == '_' {
+            return None;
+        }
+    }
+
+    // Reject `var_name` appearing in type-annotation position: `val x: VarName = ...`
+    // Check the token immediately before var_name (skipping trailing spaces).
+    {
+        let before_name = line[..eq_start].trim_end();
+        let last_tok = before_name.chars().last().unwrap_or(' ');
+        if last_tok == ':' || last_tok == ',' || last_tok == '<' {
+            return None;
+        }
+    }
+
+    // Point to the `=` character (`var_name ` is `var_name.len() + 1` bytes).
+    let eq_char_idx = eq_start + var_name.len() + 1;
+    let rest = line.get(eq_char_idx..)?;
+    // Reject `==` (equality) and `=>` (unlikely in Kotlin but safe).
+    let next = rest.as_bytes().get(1).copied().unwrap_or(b' ');
+    if next == b'=' || next == b'>' {
+        return None;
+    }
+    let rhs = rest[1..].trim_start();
+
+    // Pattern 2: class literal `SomeType::class` — checked before pattern 1 so that
+    // `retrofit.create(DashboardApi::class.java)` yields `DashboardApi`, not `retrofit`.
+    if let Some(class_pos) = rhs.find("::class") {
+        let type_name = rhs[..class_pos].last_ident_in();
+        if !type_name.is_empty() && type_name.starts_with_uppercase() {
+            return Some(type_name.to_owned());
+        }
+    }
+
+    // Pattern 3: DI generic — `inject<SomeType>()`, `get<SomeType>()`, etc.
+    const DI_PREFIXES: &[&str] = &["inject<", "get<", "viewModel<", "activityViewModel<"];
+    for prefix in DI_PREFIXES {
+        if let Some(start) = rhs.find(prefix) {
+            let after = &rhs[start + prefix.len()..];
+            let type_name = after.ident_prefix();
+            if !type_name.is_empty() && type_name.starts_with_uppercase() {
+                return Some(type_name);
+            }
+        }
+    }
+
+    // Pattern 1: constructor call — RHS starts with UppercaseIdent followed by `(` or `{`.
+    let dotted = rhs.dotted_ident_prefix();
+    if !dotted.is_empty() {
+        let base = dotted.split('.').last().unwrap_or(&dotted);
+        if base.starts_with_uppercase() {
+            let after_ident = rhs[dotted.len()..].trim_start();
+            if after_ident.starts_with('(') || after_ident.starts_with('{') {
                 return Some(base.to_owned());
             }
         }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -73,19 +73,53 @@ pub fn infer_receiver_type(
 /// the declared type name if found.  Delegates to [`infer_type_in_lines`] and
 /// falls back to method return-type inference for `val x = receiver.method(...)`.
 pub(crate) fn infer_variable_type(idx: &Indexer, var_name: &str, uri: &Url) -> Option<String> {
+    infer_variable_type_impl(idx, var_name, uri, 4)
+}
+
+/// Like [`infer_variable_type`] but preserves generic parameters in the returned
+/// type string.  e.g. `val items: List<Product>` → `"List<Product>"`.
+///
+/// Used by the `it`-completion path to extract the collection element type.
+pub fn infer_variable_type_raw(idx: &Indexer, var_name: &str, uri: &Url) -> Option<String> {
+    infer_variable_type_raw_impl(idx, var_name, uri, 4)
+}
+
+fn infer_variable_type_impl(idx: &Indexer, var_name: &str, uri: &Url, depth: u8) -> Option<String> {
+    if depth == 0 { return None; }
     // Scope block: all DashMap guards are dropped before method-return inference,
     // which may call this function recursively and must not deadlock.
-    let lines = {
+    let (lines, rhs_match, method_match) = {
         if let Some(ll) = idx.live_lines.get(uri.as_str()) {
             if let result @ Some(_) = ll.infer_type(var_name) {
                 return result;
             }
-            (*ll).clone()
+            ((*ll).clone(), None::<String>, None::<(String, String)>)
         } else if let Some(data) = idx.files.get(uri.as_str()) {
             if let result @ Some(_) = data.lines.infer_type(var_name) {
                 return result;
             }
-            data.lines.clone()
+            // CST-indexed RHS types — primary path for indexed files.
+            let rhs_match = data.rhs_types.iter()
+                .find(|(_, n, _)| n == var_name)
+                .map(|(_, _, ty)| ty.clone());
+            let method_match = data.method_call_rhs.iter()
+                .find(|(_, n, _, _)| n == var_name)
+                .map(|(_, _, recv, method)| (recv.clone(), method.clone()));
+            let lines = data.lines.clone();
+            // Drop DashMap guard before any potential recursive call.
+            drop(data);
+            if let Some(ty) = rhs_match {
+                return Some(ty);
+            }
+            if let Some((recv, method)) = method_match {
+                if let Some(recv_type) = infer_variable_type_impl(idx, &recv, uri, depth - 1) {
+                    if let Some(ret) = find_method_return_type(idx, &recv_type, &method) {
+                        return Some(ret);
+                    }
+                }
+            }
+            // Lines guard was dropped above; fall through to string-based fallback.
+            return infer_method_return_type(idx, var_name, &lines, uri, depth - 1);
         } else {
             // File not indexed yet — read from disk; skip method inference.
             let path = uri.to_file_path().ok()?;
@@ -95,26 +129,42 @@ pub(crate) fn infer_variable_type(idx: &Indexer, var_name: &str, uri: &Url) -> O
         }
     };
     // All DashMap guards are dropped here.  Safe to recurse.
-    infer_method_return_type(idx, var_name, &lines, uri)
+    infer_method_return_type(idx, var_name, &lines, uri, depth - 1)
 }
 
-/// Like [`infer_variable_type`] but preserves generic parameters in the returned
-/// type string.  e.g. `val items: List<Product>` → `"List<Product>"`.
-///
-/// Used by the `it`-completion path to extract the collection element type.
-pub fn infer_variable_type_raw(idx: &Indexer, var_name: &str, uri: &Url) -> Option<String> {
-    // Scope block: drop DashMap guards before method-return inference.
-    let lines = {
+fn infer_variable_type_raw_impl(
+    idx: &Indexer, var_name: &str, uri: &Url, depth: u8,
+) -> Option<String> {
+    if depth == 0 { return None; }
+    let (lines, rhs_match, method_match) = {
         if let Some(ll) = idx.live_lines.get(uri.as_str()) {
             if let result @ Some(_) = ll.infer_type_raw(var_name) {
                 return result;
             }
-            (*ll).clone()
+            ((*ll).clone(), None::<String>, None::<(String, String)>)
         } else if let Some(data) = idx.files.get(uri.as_str()) {
             if let result @ Some(_) = data.lines.infer_type_raw(var_name) {
                 return result;
             }
-            data.lines.clone()
+            let rhs_match = data.rhs_types.iter()
+                .find(|(_, n, _)| n == var_name)
+                .map(|(_, _, ty)| ty.clone());
+            let method_match = data.method_call_rhs.iter()
+                .find(|(_, n, _, _)| n == var_name)
+                .map(|(_, _, recv, method)| (recv.clone(), method.clone()));
+            let lines = data.lines.clone();
+            drop(data);
+            if let Some(ty) = rhs_match {
+                return Some(ty);
+            }
+            if let Some((recv, method)) = method_match {
+                if let Some(recv_type) = infer_variable_type_raw_impl(idx, &recv, uri, depth - 1) {
+                    if let Some(ret) = find_method_return_type(idx, &recv_type, &method) {
+                        return Some(ret);
+                    }
+                }
+            }
+            return infer_method_return_type(idx, var_name, &lines, uri, depth - 1);
         } else {
             let path = uri.to_file_path().ok()?;
             let content = std::fs::read_to_string(&path).ok()?;
@@ -122,8 +172,7 @@ pub fn infer_variable_type_raw(idx: &Indexer, var_name: &str, uri: &Url) -> Opti
             return lines.infer_type_raw(var_name);
         }
     };
-    // All DashMap guards dropped. Method return type inference preserves generics.
-    infer_method_return_type(idx, var_name, &lines, uri)
+    infer_method_return_type(idx, var_name, &lines, uri, depth - 1)
 }
 
 /// Extract the Kotlin/Android collection element type from a raw generic type string.
@@ -329,62 +378,52 @@ pub(crate) fn infer_type_in_lines_raw(lines: &[String], var_name: &str) -> Optio
     None
 }
 
+/// Extract the right-hand side expression of `var_name = <expr>` from `line`.
+///
+/// Handles flexible whitespace (`var_name=expr` and `var_name = expr`), whole-word
+/// boundaries, and rejects type-annotation positions (`: var_name`).
+/// Returns a slice into `line` starting at the first non-space character of the RHS.
+fn find_rhs_str<'a>(line: &'a str, var_name: &str) -> Option<&'a str> {
+    let trimmed = line.trim_start();
+    if trimmed.starts_with("//") || trimmed.starts_with('*') || trimmed.starts_with("/*") {
+        return None;
+    }
+    let pos = line.find(var_name)?;
+    // Whole-word check: character before var_name must not be alphanumeric or `_`.
+    if pos > 0 {
+        let b = line.as_bytes()[pos - 1];
+        if b.is_ascii_alphanumeric() || b == b'_' { return None; }
+    }
+    // Whole-word check: character after var_name must not be alphanumeric or `_`.
+    let end = pos + var_name.len();
+    let c_after = line.as_bytes().get(end).copied().unwrap_or(b' ');
+    if c_after.is_ascii_alphanumeric() || c_after == b'_' { return None; }
+    // Reject type-annotation position: last non-space token before name is `:`, `,`, or `<`.
+    let last_tok = line[..pos].trim_end().chars().last().unwrap_or(' ');
+    if last_tok == ':' || last_tok == ',' || last_tok == '<' { return None; }
+    // Find `=` after the name, skipping whitespace.
+    let after = &line[end..];
+    let trimmed_after = after.trim_start();
+    if !trimmed_after.starts_with('=') { return None; }
+    // Reject `==` and `=>`.
+    let next = trimmed_after.as_bytes().get(1).copied().unwrap_or(b' ');
+    if next == b'=' || next == b'>' { return None; }
+    Some(trimmed_after[1..].trim_start())
+}
+
 /// Attempt to infer the type of `var_name` from the right-hand side of an assignment.
 ///
 /// Called as a secondary/tertiary scan when no explicit type annotation (`var_name:`)
 /// is found.  Handles the most common Android/Kotlin patterns:
 ///
 /// 1. Constructor call:  `val x = SomeType(args)` → `"SomeType"`
-/// 2. Class literal:     `val x = retrofit.create(DashboardApi::class.java)` → `"DashboardApi"`
-/// 3. DI generic:        `val x = inject<SomeType>()` → `"SomeType"`
+/// 2. DI generic:        `val x = inject<SomeType>()` → `"SomeType"`
 ///
 /// Returns `None` when none of the patterns match.
 fn infer_from_rhs_assignment(line: &str, var_name: &str) -> Option<String> {
-    let trimmed = line.trim_start();
-    if trimmed.starts_with("//") || trimmed.starts_with('*') || trimmed.starts_with("/*") {
-        return None;
-    }
+    let rhs = find_rhs_str(line, var_name)?;
 
-    // Locate `var_name =` where var_name is a whole word boundary.
-    let assign = format!("{var_name} =");
-    let eq_start = line.find(&assign)?;
-    if eq_start > 0 {
-        let before = line[..eq_start].chars().last().unwrap_or(' ');
-        if before.is_alphanumeric() || before == '_' {
-            return None;
-        }
-    }
-
-    // Reject `var_name` appearing in type-annotation position: `val x: VarName = ...`
-    // Check the token immediately before var_name (skipping trailing spaces).
-    {
-        let before_name = line[..eq_start].trim_end();
-        let last_tok = before_name.chars().last().unwrap_or(' ');
-        if last_tok == ':' || last_tok == ',' || last_tok == '<' {
-            return None;
-        }
-    }
-
-    // Point to the `=` character (`var_name ` is `var_name.len() + 1` bytes).
-    let eq_char_idx = eq_start + var_name.len() + 1;
-    let rest = line.get(eq_char_idx..)?;
-    // Reject `==` (equality) and `=>` (unlikely in Kotlin but safe).
-    let next = rest.as_bytes().get(1).copied().unwrap_or(b' ');
-    if next == b'=' || next == b'>' {
-        return None;
-    }
-    let rhs = rest[1..].trim_start();
-
-    // Pattern 2: class literal `SomeType::class` — checked before pattern 1 so that
-    // `retrofit.create(DashboardApi::class.java)` yields `DashboardApi`, not `retrofit`.
-    if let Some(class_pos) = rhs.find("::class") {
-        let type_name = rhs[..class_pos].last_ident_in();
-        if !type_name.is_empty() && type_name.starts_with_uppercase() {
-            return Some(type_name.to_owned());
-        }
-    }
-
-    // Pattern 3: DI generic — `inject<SomeType>()`, `get<SomeType>()`, etc.
+    // Pattern 2: DI generic — `inject<SomeType>()`, `get<SomeType>()`, etc.
     const DI_PREFIXES: &[&str] = &["inject<", "get<", "viewModel<", "activityViewModel<"];
     for prefix in DI_PREFIXES {
         if let Some(start) = rhs.find(prefix) {
@@ -418,34 +457,14 @@ fn infer_from_rhs_assignment(line: &str, var_name: &str) -> Option<String> {
 ///
 /// Only handles one level of chaining: `simpleIdent.method(args)`.
 /// Skips `this`, `super`, and dotted/chained receivers.
-fn infer_method_return_type(idx: &Indexer, var_name: &str, lines: &[String], uri: &Url) -> Option<String> {
-    let assign = format!("{var_name} =");
+fn infer_method_return_type(
+    idx: &Indexer, var_name: &str, lines: &[String], uri: &Url, depth: u8,
+) -> Option<String> {
     for line in lines {
-        let trimmed = line.trim_start();
-        if trimmed.starts_with("//") || trimmed.starts_with('*') || trimmed.starts_with("/*") {
-            continue;
-        }
-        let eq_start = match line.find(&assign) {
-            Some(p) => p,
+        let rhs = match find_rhs_str(line, var_name) {
+            Some(r) => r,
             None => continue,
         };
-        if eq_start > 0 {
-            let before = line[..eq_start].chars().last().unwrap_or(' ');
-            if before.is_alphanumeric() || before == '_' { continue; }
-        }
-        // Reject type-annotation position: `val x: VarName = ...`
-        let before_name = line[..eq_start].trim_end();
-        let last_tok = before_name.chars().last().unwrap_or(' ');
-        if last_tok == ':' || last_tok == ',' || last_tok == '<' { continue; }
-
-        let eq_char_idx = eq_start + var_name.len() + 1;
-        let rest = match line.get(eq_char_idx..) {
-            Some(s) => s,
-            None => continue,
-        };
-        let next = rest.as_bytes().get(1).copied().unwrap_or(b' ');
-        if next == b'=' || next == b'>' { continue; }
-        let rhs = rest[1..].trim_start();
 
         // Match `receiver.method(` where receiver is a simple identifier.
         let paren_pos = match rhs.find('(') {
@@ -466,7 +485,7 @@ fn infer_method_return_type(idx: &Indexer, var_name: &str, lines: &[String], uri
         if !method.starts_with_lowercase() { continue; }
 
         // Recursively infer the receiver type (DashMap guards already dropped).
-        if let Some(receiver_type) = infer_variable_type(idx, receiver, uri) {
+        if let Some(receiver_type) = infer_variable_type_impl(idx, receiver, uri, depth) {
             if let Some(ret) = find_method_return_type(idx, &receiver_type, method) {
                 return Some(ret);
             }
@@ -478,16 +497,38 @@ fn infer_method_return_type(idx: &Indexer, var_name: &str, lines: &[String], uri
 /// Look up `method_name` in the symbol index for `type_name` and return its
 /// return type, extracted from `SymbolEntry.detail`.
 fn find_method_return_type(idx: &Indexer, type_name: &str, method_name: &str) -> Option<String> {
-    let locations = idx.definitions.get(type_name)?;
+    // `definitions` is keyed by simple (unqualified) name; strip any qualifying prefix.
+    let type_base = type_name.split('.').last().unwrap_or(type_name);
+    let locations = idx.definitions.get(type_base)?;
     for loc in locations.iter() {
         if let Some(file_data) = idx.files.get(loc.uri.as_str()) {
+            // Find the class entry for type_base so we can do range containment
+            // filtering — avoids picking a same-named method from an unrelated class
+            // in the same file.
+            let class_range = file_data.symbols.iter()
+                .find(|s| s.name == type_base)
+                .map(|s| s.range);
+
             for sym in &file_data.symbols {
-                if sym.name == method_name
-                    && matches!(sym.kind, SymbolKind::FUNCTION | SymbolKind::METHOD | SymbolKind::OPERATOR)
-                {
-                    if let Some(ret) = extract_return_type_from_detail(&sym.detail) {
-                        return Some(ret);
+                if sym.name != method_name { continue; }
+                if !matches!(sym.kind, SymbolKind::FUNCTION | SymbolKind::METHOD | SymbolKind::OPERATOR) {
+                    continue;
+                }
+                // When we know the class range, skip methods outside it.
+                if let Some(cr) = class_range {
+                    if sym.range.start.line < cr.start.line || sym.range.end.line > cr.end.line {
+                        continue;
                     }
+                }
+                // Try detail first; fall back to source lines when detail is truncated.
+                if let Some(ret) = extract_return_type_from_detail(&sym.detail) {
+                    return Some(ret);
+                }
+                // detail may be truncated (120 char limit) — try the source lines.
+                let start_line = sym.selection_range.start.line as usize;
+                let full_sig = file_data.lines.collect_signature(start_line);
+                if let Some(ret) = extract_return_type_from_detail(&full_sig) {
+                    return Some(ret);
                 }
             }
         }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -513,6 +513,8 @@ fn infer_from_rhs_assignment(line: &str, var_name: &str) -> Option<String> {
 fn infer_method_return_type(
     idx: &Indexer, var_name: &str, lines: &[String], uri: &Url, depth: u8,
 ) -> Option<String> {
+    let mut plain_fn_candidates: Vec<String> = Vec::new();
+
     for line in lines {
         let rhs = match find_rhs_str(line, var_name) {
             Some(r) => r,
@@ -525,25 +527,41 @@ fn infer_method_return_type(
             None => continue,
         };
         let before_paren = &rhs[..paren_pos];
-        let dot_pos = match before_paren.rfind('.') {
-            Some(d) => d,
-            None => continue,
-        };
-        let receiver = before_paren[..dot_pos].trim();
-        let method   = before_paren[dot_pos + 1..].trim();
+        match before_paren.rfind('.') {
+            Some(dot_pos) => {
+                let receiver = before_paren[..dot_pos].trim();
+                let method   = before_paren[dot_pos + 1..].trim();
 
-        if receiver.is_empty() || method.is_empty() { continue; }
-        // Skip `this`/`super` and multi-segment receivers.
-        if receiver == "this" || receiver == "super" || receiver.contains('.') { continue; }
-        if !method.starts_with_lowercase() { continue; }
+                if receiver.is_empty() || method.is_empty() { continue; }
+                // Skip `this`/`super` and multi-segment receivers.
+                if receiver == "this" || receiver == "super" || receiver.contains('.') { continue; }
+                if !method.starts_with_lowercase() { continue; }
 
-        // Recursively infer the receiver type (DashMap guards already dropped).
-        if let Some(receiver_type) = infer_variable_type_impl(idx, receiver, uri, depth) {
-            if let Some(ret) = find_method_return_type(idx, &receiver_type, method) {
-                return Some(ret);
+                // Recursively infer the receiver type (DashMap guards already dropped).
+                if let Some(receiver_type) = infer_variable_type_impl(idx, receiver, uri, depth) {
+                    if let Some(ret) = find_method_return_type(idx, &receiver_type, method) {
+                        return Some(ret);
+                    }
+                }
+            }
+            None => {
+                // Plain function call: `val result = getFoo(args)` — no dot-receiver.
+                let fn_name = before_paren.trim();
+                if !fn_name.is_empty() && fn_name.starts_with_lowercase() {
+                    plain_fn_candidates.push(fn_name.to_owned());
+                }
             }
         }
     }
+
+    // Secondary pass: plain function calls whose return type is in the definitions index.
+    // Handles `val result = getConnectedAccounts(isRefresh)` → look up `getConnectedAccounts`.
+    for fn_name in &plain_fn_candidates {
+        if let Some(ret) = find_fun_return_type_by_name(idx, fn_name) {
+            return Some(ret);
+        }
+    }
+
     None
 }
 

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -88,12 +88,12 @@ fn infer_variable_type_impl(idx: &Indexer, var_name: &str, uri: &Url, depth: u8)
     if depth == 0 { return None; }
     // Scope block: all DashMap guards are dropped before method-return inference,
     // which may call this function recursively and must not deadlock.
-    let (lines, rhs_match, method_match) = {
+    let lines = {
         if let Some(ll) = idx.live_lines.get(uri.as_str()) {
             if let result @ Some(_) = ll.infer_type(var_name) {
                 return result;
             }
-            ((*ll).clone(), None::<String>, None::<(String, String)>)
+            (*ll).clone()
         } else if let Some(data) = idx.files.get(uri.as_str()) {
             if let result @ Some(_) = data.lines.infer_type(var_name) {
                 return result;
@@ -136,12 +136,12 @@ fn infer_variable_type_raw_impl(
     idx: &Indexer, var_name: &str, uri: &Url, depth: u8,
 ) -> Option<String> {
     if depth == 0 { return None; }
-    let (lines, rhs_match, method_match) = {
+    let lines = {
         if let Some(ll) = idx.live_lines.get(uri.as_str()) {
             if let result @ Some(_) = ll.infer_type_raw(var_name) {
                 return result;
             }
-            ((*ll).clone(), None::<String>, None::<(String, String)>)
+            (*ll).clone()
         } else if let Some(data) = idx.files.get(uri.as_str()) {
             if let result @ Some(_) = data.lines.infer_type_raw(var_name) {
                 return result;
@@ -361,7 +361,7 @@ pub(crate) fn infer_type_in_lines_raw(lines: &[String], var_name: &str) -> Optio
             let after_brace = line[brace_pos + 1..].trim_start();
             // Extract the first identifier (stops at `<`, `(`, whitespace, etc.)
             let ident = after_brace.dotted_ident_prefix();
-            let base = ident.split('.').last().unwrap_or(&ident);
+            let base = ident.split('.').next_back().unwrap_or(&ident);
             if !base.is_empty() && base.starts_with_uppercase() {
                 return Some(base.to_owned());
             }
@@ -438,7 +438,7 @@ fn infer_from_rhs_assignment(line: &str, var_name: &str) -> Option<String> {
     // Pattern 1: constructor call — RHS starts with UppercaseIdent followed by `(` or `{`.
     let dotted = rhs.dotted_ident_prefix();
     if !dotted.is_empty() {
-        let base = dotted.split('.').last().unwrap_or(&dotted);
+        let base = dotted.split('.').next_back().unwrap_or(&dotted);
         if base.starts_with_uppercase() {
             let after_ident = rhs[dotted.len()..].trim_start();
             if after_ident.starts_with('(') || after_ident.starts_with('{') {
@@ -498,7 +498,7 @@ fn infer_method_return_type(
 /// return type, extracted from `SymbolEntry.detail`.
 fn find_method_return_type(idx: &Indexer, type_name: &str, method_name: &str) -> Option<String> {
     // `definitions` is keyed by simple (unqualified) name; strip any qualifying prefix.
-    let type_base = type_name.split('.').last().unwrap_or(type_name);
+    let type_base = type_name.split('.').next_back().unwrap_or(type_name);
     let locations = idx.definitions.get(type_base)?;
     for loc in locations.iter() {
         if let Some(file_data) = idx.files.get(loc.uri.as_str()) {

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -510,6 +510,46 @@ fn infer_from_rhs_assignment(line: &str, var_name: &str) -> Option<String> {
 ///
 /// Only handles one level of chaining: `simpleIdent.method(args)`.
 /// Skips `this`, `super`, and dotted/chained receivers.
+/// Returns `true` when the first function call in `rhs` (opening paren at
+/// `paren_pos`) is followed by a dot at depth 0, indicating a method chain.
+///
+/// `"getFoo(args).bar()"` → `true`   (chained — don't infer from `getFoo` alone)
+/// `"getFoo(args)"` → `false`        (standalone — safe to use `getFoo`'s return type)
+fn has_dot_after_first_call(rhs: &str, paren_pos: usize) -> bool {
+    let mut depth = 0i32;
+    for c in rhs[paren_pos..].chars() {
+        match c {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    // Found the matching close — check for a dot immediately after
+                    // (allowing whitespace).
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    // After the loop `depth == 0` means we found the matching paren.
+    // Walk past the matched segment and check for a following `.`.
+    let mut depth2 = 0i32;
+    let mut past_close = false;
+    for c in rhs[paren_pos..].chars() {
+        match c {
+            '(' | '[' | '{' => depth2 += 1,
+            ')' | ']' | '}' => {
+                depth2 -= 1;
+                if depth2 == 0 { past_close = true; }
+            }
+            '.' if past_close => return true,
+            c if past_close && !c.is_whitespace() => return false,
+            _ => {}
+        }
+    }
+    false
+}
+
 fn infer_method_return_type(
     idx: &Indexer, var_name: &str, lines: &[String], uri: &Url, depth: u8,
 ) -> Option<String> {
@@ -546,8 +586,14 @@ fn infer_method_return_type(
             }
             None => {
                 // Plain function call: `val result = getFoo(args)` — no dot-receiver.
+                // Guard: skip when the first call is part of a chain (`getFoo(...).bar()`).
+                // In that case `paren_pos` is inside the first segment only; the overall
+                // expression has chaining we can't track with a single name lookup.
                 let fn_name = before_paren.trim();
-                if !fn_name.is_empty() && fn_name.starts_with_lowercase() {
+                if !fn_name.is_empty()
+                    && fn_name.starts_with_lowercase()
+                    && !has_dot_after_first_call(rhs, paren_pos)
+                {
                     plain_fn_candidates.push(fn_name.to_owned());
                 }
             }
@@ -779,5 +825,22 @@ mod infer_tests {
             extract_return_type_from_detail("fun find(): User?"),
             Some("User".into()),
         );
+    }
+
+    #[test]
+    fn has_dot_after_first_call_chained() {
+        // paren_pos=7: "getList" is 7 chars, then "("
+        assert!(super::has_dot_after_first_call("getList(isRefresh).joinAll()", 7));
+    }
+
+    #[test]
+    fn has_dot_after_first_call_standalone() {
+        assert!(!super::has_dot_after_first_call("getConnectedAccounts(isRefresh)", 20));
+    }
+
+    #[test]
+    fn has_dot_after_first_call_nested_parens() {
+        // Nested parens inside arg list must not fool the scanner.
+        assert!(super::has_dot_after_first_call("getList(foo(x)).map()", 7));
     }
 }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -1,4 +1,4 @@
-use tower_lsp::lsp_types::{Position, Range, Url};
+use tower_lsp::lsp_types::{Position, Range, SymbolKind, Url};
 
 use crate::indexer::Indexer;
 use crate::LinesExt;
@@ -70,29 +70,32 @@ pub fn infer_receiver_type(
 }
 
 /// Scan the current file's lines for a type annotation on `var_name` and return
-/// the declared type name if found.  Delegates to [`infer_type_in_lines`].
+/// the declared type name if found.  Delegates to [`infer_type_in_lines`] and
+/// falls back to method return-type inference for `val x = receiver.method(...)`.
 pub(crate) fn infer_variable_type(idx: &Indexer, var_name: &str, uri: &Url) -> Option<String> {
-    // Prefer live_lines: updated synchronously on every keystroke, so they
-    // reflect unsaved edits that the indexed snapshot may not yet contain.
-    if let Some(ll) = idx.live_lines.get(uri.as_str()) {
-        if let result @ Some(_) = ll.infer_type(var_name) {
-            return result;
+    // Scope block: all DashMap guards are dropped before method-return inference,
+    // which may call this function recursively and must not deadlock.
+    let lines = {
+        if let Some(ll) = idx.live_lines.get(uri.as_str()) {
+            if let result @ Some(_) = ll.infer_type(var_name) {
+                return result;
+            }
+            (*ll).clone()
+        } else if let Some(data) = idx.files.get(uri.as_str()) {
+            if let result @ Some(_) = data.lines.infer_type(var_name) {
+                return result;
+            }
+            data.lines.clone()
+        } else {
+            // File not indexed yet — read from disk; skip method inference.
+            let path = uri.to_file_path().ok()?;
+            let content = std::fs::read_to_string(&path).ok()?;
+            let lines: Vec<String> = content.lines().map(String::from).collect();
+            return lines.infer_type(var_name);
         }
-    }
-    // Fall back to indexed snapshot.  Use declared_names as a fast reject
-    // only when live_lines are unavailable or returned nothing, since the
-    // index may lag behind in-flight edits.
-    if let Some(data) = idx.files.get(uri.as_str()) {
-        if !data.declared_names.iter().any(|n| n == var_name) {
-            return None;
-        }
-        return data.lines.infer_type(var_name);
-    }
-    // File not indexed yet — read from disk.
-    let path = uri.to_file_path().ok()?;
-    let content = std::fs::read_to_string(&path).ok()?;
-    let lines: Vec<String> = content.lines().map(String::from).collect();
-    lines.infer_type(var_name)
+    };
+    // All DashMap guards are dropped here.  Safe to recurse.
+    infer_method_return_type(idx, var_name, &lines, uri)
 }
 
 /// Like [`infer_variable_type`] but preserves generic parameters in the returned
@@ -399,7 +402,106 @@ fn infer_from_rhs_assignment(line: &str, var_name: &str) -> Option<String> {
     None
 }
 
-/// Capture a type expression including balanced generic parameters.
+// ─── Method return-type inference ─────────────────────────────────────────────
+
+/// Scan `lines` for `var_name = receiver.method(...)` and return the inferred
+/// return type of `method`.
+///
+/// Only handles one level of chaining: `simpleIdent.method(args)`.
+/// Skips `this`, `super`, and dotted/chained receivers.
+fn infer_method_return_type(idx: &Indexer, var_name: &str, lines: &[String], uri: &Url) -> Option<String> {
+    let assign = format!("{var_name} =");
+    for line in lines {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") || trimmed.starts_with('*') || trimmed.starts_with("/*") {
+            continue;
+        }
+        let eq_start = match line.find(&assign) {
+            Some(p) => p,
+            None => continue,
+        };
+        if eq_start > 0 {
+            let before = line[..eq_start].chars().last().unwrap_or(' ');
+            if before.is_alphanumeric() || before == '_' { continue; }
+        }
+        // Reject type-annotation position: `val x: VarName = ...`
+        let before_name = line[..eq_start].trim_end();
+        let last_tok = before_name.chars().last().unwrap_or(' ');
+        if last_tok == ':' || last_tok == ',' || last_tok == '<' { continue; }
+
+        let eq_char_idx = eq_start + var_name.len() + 1;
+        let rest = match line.get(eq_char_idx..) {
+            Some(s) => s,
+            None => continue,
+        };
+        let next = rest.as_bytes().get(1).copied().unwrap_or(b' ');
+        if next == b'=' || next == b'>' { continue; }
+        let rhs = rest[1..].trim_start();
+
+        // Match `receiver.method(` where receiver is a simple identifier.
+        let paren_pos = match rhs.find('(') {
+            Some(p) => p,
+            None => continue,
+        };
+        let before_paren = &rhs[..paren_pos];
+        let dot_pos = match before_paren.rfind('.') {
+            Some(d) => d,
+            None => continue,
+        };
+        let receiver = before_paren[..dot_pos].trim();
+        let method   = before_paren[dot_pos + 1..].trim();
+
+        if receiver.is_empty() || method.is_empty() { continue; }
+        // Skip `this`/`super` and multi-segment receivers.
+        if receiver == "this" || receiver == "super" || receiver.contains('.') { continue; }
+        if !method.starts_with_lowercase() { continue; }
+
+        // Recursively infer the receiver type (DashMap guards already dropped).
+        if let Some(receiver_type) = infer_variable_type(idx, receiver, uri) {
+            if let Some(ret) = find_method_return_type(idx, &receiver_type, method) {
+                return Some(ret);
+            }
+        }
+    }
+    None
+}
+
+/// Look up `method_name` in the symbol index for `type_name` and return its
+/// return type, extracted from `SymbolEntry.detail`.
+fn find_method_return_type(idx: &Indexer, type_name: &str, method_name: &str) -> Option<String> {
+    let locations = idx.definitions.get(type_name)?;
+    for loc in locations.iter() {
+        if let Some(file_data) = idx.files.get(loc.uri.as_str()) {
+            for sym in &file_data.symbols {
+                if sym.name == method_name
+                    && matches!(sym.kind, SymbolKind::FUNCTION | SymbolKind::METHOD | SymbolKind::OPERATOR)
+                {
+                    if let Some(ret) = extract_return_type_from_detail(&sym.detail) {
+                        return Some(ret);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Extract the return type from a function `detail` string.
+///
+/// `"fun getDetail(req: Req): Response<Data>"` → `"Response<Data>"`
+/// `"fun doSomething()"` → `None`
+fn extract_return_type_from_detail(detail: &str) -> Option<String> {
+    let close_paren = detail.rfind(')')?;
+    let after = detail[close_paren + 1..].trim_start();
+    if !after.starts_with(':') { return None; }
+    let type_part = after[1..].trim_start();
+    let type_name = extract_type_with_generics(type_part);
+    if !type_name.is_empty() && type_name.starts_with_uppercase() {
+        Some(type_name)
+    } else {
+        None
+    }
+}
 ///
 /// `"List<Product> = emptyList()"` → `"List<Product>"`
 /// `"StateFlow<UiState>"` → `"StateFlow<UiState>"`
@@ -490,4 +592,43 @@ pub(crate) fn find_declaration_range_in_lines(lines: &[String], name: &str) -> O
         }
     }
     None
+}
+
+#[cfg(test)]
+mod infer_tests {
+    use super::extract_return_type_from_detail;
+
+    #[test]
+    fn return_type_simple() {
+        assert_eq!(
+            extract_return_type_from_detail("fun getDetail(req: Req): AccountDetail"),
+            Some("AccountDetail".into()),
+        );
+    }
+
+    #[test]
+    fn return_type_generic() {
+        assert_eq!(
+            extract_return_type_from_detail("fun getAccountDetail(body: Body): Response<AccountDetail>"),
+            Some("Response<AccountDetail>".into()),
+        );
+    }
+
+    #[test]
+    fn return_type_unit_returns_none() {
+        assert_eq!(extract_return_type_from_detail("fun doSomething(x: Int)"), None);
+    }
+
+    #[test]
+    fn return_type_primitive_returns_none() {
+        assert_eq!(extract_return_type_from_detail("fun count(): int"), None);
+    }
+
+    #[test]
+    fn return_type_nullable_stripped() {
+        assert_eq!(
+            extract_return_type_from_detail("fun find(): User?"),
+            Some("User".into()),
+        );
+    }
 }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -549,8 +549,36 @@ fn infer_method_return_type(
 
 /// Look up `method_name` in the symbol index for `type_name` and return its
 /// return type, extracted from `SymbolEntry.detail`.
+/// Look up the return type of a function by name, searching across all indexed files.
+///
+/// Unlike `find_method_return_type` this requires no receiver type — useful when
+/// the caller is a method chain expression and the receiver type is unknown.
+/// Returns the raw return type string (with generics preserved), e.g. `"List<Account>"`.
+pub(crate) fn find_fun_return_type_by_name(idx: &Indexer, fn_name: &str) -> Option<String> {
+    let locations = idx.definitions.get(fn_name)?;
+    for loc in locations.iter() {
+        if let Some(file_data) = idx.files.get(loc.uri.as_str()) {
+            for sym in &file_data.symbols {
+                if sym.name != fn_name { continue; }
+                if !matches!(sym.kind, SymbolKind::FUNCTION | SymbolKind::METHOD | SymbolKind::OPERATOR) {
+                    continue;
+                }
+                if let Some(ret) = extract_return_type_from_detail(&sym.detail) {
+                    return Some(ret);
+                }
+                let start_line = sym.selection_range.start.line as usize;
+                let full_sig = file_data.lines.collect_signature(start_line);
+                if let Some(ret) = extract_return_type_from_detail(&full_sig) {
+                    return Some(ret);
+                }
+            }
+        }
+    }
+    None
+}
+
+
 fn find_method_return_type(idx: &Indexer, type_name: &str, method_name: &str) -> Option<String> {
-    // `definitions` is keyed by simple (unqualified) name; strip any qualifying prefix.
     let type_base = type_name.split('.').next_back().unwrap_or(type_name);
     let locations = idx.definitions.get(type_base)?;
     for loc in locations.iter() {

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -103,18 +103,27 @@ pub(crate) fn infer_variable_type(idx: &Indexer, var_name: &str, uri: &Url) -> O
 ///
 /// Used by the `it`-completion path to extract the collection element type.
 pub fn infer_variable_type_raw(idx: &Indexer, var_name: &str, uri: &Url) -> Option<String> {
-    if let Some(ll) = idx.live_lines.get(uri.as_str()) {
-        if let result @ Some(_) = ll.infer_type_raw(var_name) {
-            return result;
+    // Scope block: drop DashMap guards before method-return inference.
+    let lines = {
+        if let Some(ll) = idx.live_lines.get(uri.as_str()) {
+            if let result @ Some(_) = ll.infer_type_raw(var_name) {
+                return result;
+            }
+            (*ll).clone()
+        } else if let Some(data) = idx.files.get(uri.as_str()) {
+            if let result @ Some(_) = data.lines.infer_type_raw(var_name) {
+                return result;
+            }
+            data.lines.clone()
+        } else {
+            let path = uri.to_file_path().ok()?;
+            let content = std::fs::read_to_string(&path).ok()?;
+            let lines: Vec<String> = content.lines().map(String::from).collect();
+            return lines.infer_type_raw(var_name);
         }
-    }
-    if let Some(data) = idx.files.get(uri.as_str()) {
-        return data.lines.infer_type_raw(var_name);
-    }
-    let path = uri.to_file_path().ok()?;
-    let content = std::fs::read_to_string(&path).ok()?;
-    let lines: Vec<String> = content.lines().map(String::from).collect();
-    lines.infer_type_raw(var_name)
+    };
+    // All DashMap guards dropped. Method return type inference preserves generics.
+    infer_method_return_type(idx, var_name, &lines, uri)
 }
 
 /// Extract the Kotlin/Android collection element type from a raw generic type string.

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -246,6 +246,40 @@ pub(crate) fn infer_field_type(idx: &Indexer, file_uri: &str, field_name: &str) 
     lines.infer_type(field_name)
 }
 
+/// Like `infer_field_type` but preserves generic parameters in the result.
+///
+/// Returns `"MutableList<MbAccount>"` rather than `"MutableList"`, which is
+/// needed for collection element type extraction via `extract_collection_element_type`.
+/// Checks live editor lines first (most up-to-date), then falls back to indexed
+/// lines and finally to a disk read for un-indexed files.
+pub(crate) fn infer_field_type_raw(idx: &Indexer, file_uri: &str, field_name: &str) -> Option<String> {
+    if let Some(live) = idx.live_lines.get(file_uri) {
+        return live.infer_type_raw(field_name);
+    }
+    if let Some(data) = idx.files.get(file_uri) {
+        return data.lines.infer_type_raw(field_name);
+    }
+    let path = tower_lsp::lsp_types::Url::parse(file_uri).ok()?.to_file_path().ok()?;
+    let content = std::fs::read_to_string(&path).ok()?;
+    let lines: Vec<String> = content.lines().map(String::from).collect();
+    lines.infer_type_raw(field_name)
+}
+
+/// Look up the raw type of `field_name` declared inside class `class_name`,
+/// resolving across files via the definitions index.
+///
+/// Used for multi-segment receiver chains like `result.availableBanks.map { it }`:
+/// resolves `result` → `ResponseBody`, then looks up `availableBanks` in `ResponseBody`.
+pub(crate) fn find_field_type_in_class(idx: &Indexer, class_name: &str, field_name: &str) -> Option<String> {
+    let locs = idx.definitions.get(class_name)?;
+    for loc in locs.iter() {
+        if let Some(ty) = infer_field_type_raw(idx, loc.uri.as_str(), field_name) {
+            return Some(ty);
+        }
+    }
+    None
+}
+
 // ─── impl Indexer wrappers ────────────────────────────────────────────────────
 
 #[allow(dead_code)]

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -726,20 +726,23 @@ data class State(
 
     #[test]
     fn infer_type_in_lines_class_literal_retrofit() {
-        // `val api = retrofit.create(DashboardApi::class.java)` — class literal pattern
+        // `::class` inference was removed from the string-scan fallback because it is too broad:
+        // `val key = SomeType::class` would incorrectly infer `SomeType` for `key` (which is
+        // `KClass<SomeType>`). For indexed files the CST path in `extract_rhs_types_kotlin`
+        // stores `retrofit.create(X::class)` in `method_call_rhs` instead.
         let lines: Vec<String> = vec![
             "    val api = retrofit.create(DashboardApi::class.java)".into(),
         ];
-        assert_eq!(infer_type_in_lines(&lines, "api"), Some("DashboardApi".into()));
+        assert_eq!(infer_type_in_lines(&lines, "api"), None);
     }
 
     #[test]
     fn infer_type_in_lines_raw_class_literal_kotlin() {
-        // `val api = retrofit.create(DashboardApi::class)` — Kotlin class ref
+        // Same as above — string-scan fallback no longer handles `::class`.
         let lines: Vec<String> = vec![
             "    val api = retrofit.create(DashboardApi::class)".into(),
         ];
-        assert_eq!(infer_type_in_lines_raw(&lines, "api"), Some("DashboardApi".into()));
+        assert_eq!(infer_type_in_lines_raw(&lines, "api"), None);
     }
 
     #[test]

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -795,6 +795,41 @@ data class State(
         assert_eq!(locs[0].uri, api_uri);
     }
 
+    // ── method return type inference (infer_variable_type) ───────────────────
+
+    #[test]
+    fn infer_variable_type_method_return_type() {
+        // `val response = accountApiService.getAccountDetail(body)` where
+        // accountApiService: AccountApiService is annotated in the same file
+        let service_uri = uri("/AccountApiService.kt");
+        let caller_uri  = uri("/Caller.kt");
+        let idx = Indexer::new();
+        idx.index_content(&service_uri,
+            "package com.example\ninterface AccountApiService {\n    fun getAccountDetail(body: AccountDetailRequestBody): Response<AccountDetail>\n}");
+        idx.index_content(&caller_uri,
+            "package com.example\nclass Repo(val accountApiService: AccountApiService) {\n    fun load() {\n        val response = accountApiService.getAccountDetail(AccountDetailRequestBody(123))\n    }\n}");
+
+        let result = infer_variable_type(&idx, "response", &caller_uri);
+        assert_eq!(result, Some("Response<AccountDetail>".into()),
+            "should infer return type via method lookup");
+    }
+
+    #[test]
+    fn infer_variable_type_unannotated_snapshot_no_declared_names_rejection() {
+        // Verify that the declared_names fast-reject no longer blocks unannotated vars
+        // when only a snapshot (no live_lines) is available.
+        let caller_uri = uri("/Caller.kt");
+        let idx = Indexer::new();
+        idx.index_content(&caller_uri,
+            "package com.example\nval vm = DashboardViewModel()");
+
+        // `vm` has no `:` annotation, so declared_names would not contain it.
+        // It must still be resolved via the assignment scan.
+        let result = infer_variable_type(&idx, "vm", &caller_uri);
+        assert_eq!(result, Some("DashboardViewModel".into()),
+            "unannotated var must still be resolved from snapshot");
+    }
+
     #[test]
     fn goto_def_on_named_lambda_param_resolves_to_declaration_line() {
         // items.forEach { product ->

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -871,6 +871,33 @@ data class State(
         assert!(!labels.contains(&"topLevelHelper"), "top-level fn must NOT leak into dot completions");
     }
 
+    #[test]
+    fn dot_complete_includes_inherited_members() {
+        // `AccountDetailResponseBody` extends `Account` (Java-style parent).
+        // Dot-completion on an instance of `AccountDetailResponseBody` must include
+        // fields declared in the parent `Account` class.
+        let account_uri  = uri("/Account.kt");
+        let response_uri = uri("/AccountDetailResponseBody.kt");
+        let caller_uri   = uri("/Caller.kt");
+        let idx = Indexer::new();
+
+        idx.index_content(&account_uri,
+            "package com.example\nopen class Account {\n    val accountName: String = \"\"\n    val accountId: String = \"\"\n}");
+        idx.index_content(&response_uri,
+            "package com.example\ndata class AccountDetailResponseBody(\n    val feePlanName: String?\n) : Account()");
+        idx.index_content(&caller_uri,
+            "package com.example\nval resp: AccountDetailResponseBody = TODO()");
+
+        let items = complete_dot(&idx, "AccountDetailResponseBody", &caller_uri, false);
+        let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+
+        // Direct members
+        assert!(labels.contains(&"feePlanName"), "direct field should appear");
+        // Inherited members from Account
+        assert!(labels.contains(&"accountName"), "inherited field from parent must appear");
+        assert!(labels.contains(&"accountId"),   "inherited field from parent must appear");
+    }
+
     // ── complete_bare distance sorting ───────────────────────────────────────
 
     #[test]

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -708,6 +708,94 @@ data class State(
     }
 
     #[test]
+    fn infer_type_in_lines_constructor_call() {
+        // `val viewModel = DashboardViewModel()` — no annotation
+        let lines: Vec<String> = vec![
+            "    val viewModel = DashboardViewModel()".into(),
+        ];
+        assert_eq!(infer_type_in_lines(&lines, "viewModel"), Some("DashboardViewModel".into()));
+    }
+
+    #[test]
+    fn infer_type_in_lines_raw_constructor_call() {
+        let lines: Vec<String> = vec![
+            "    val viewModel = DashboardViewModel()".into(),
+        ];
+        assert_eq!(infer_type_in_lines_raw(&lines, "viewModel"), Some("DashboardViewModel".into()));
+    }
+
+    #[test]
+    fn infer_type_in_lines_class_literal_retrofit() {
+        // `val api = retrofit.create(DashboardApi::class.java)` — class literal pattern
+        let lines: Vec<String> = vec![
+            "    val api = retrofit.create(DashboardApi::class.java)".into(),
+        ];
+        assert_eq!(infer_type_in_lines(&lines, "api"), Some("DashboardApi".into()));
+    }
+
+    #[test]
+    fn infer_type_in_lines_raw_class_literal_kotlin() {
+        // `val api = retrofit.create(DashboardApi::class)` — Kotlin class ref
+        let lines: Vec<String> = vec![
+            "    val api = retrofit.create(DashboardApi::class)".into(),
+        ];
+        assert_eq!(infer_type_in_lines_raw(&lines, "api"), Some("DashboardApi".into()));
+    }
+
+    #[test]
+    fn infer_type_in_lines_di_inject() {
+        // `val repo by inject<UserRepository>()` — Koin DI pattern
+        let lines: Vec<String> = vec![
+            "    val repo = inject<UserRepository>()".into(),
+        ];
+        assert_eq!(infer_type_in_lines(&lines, "repo"), Some("UserRepository".into()));
+    }
+
+    #[test]
+    fn infer_type_annotation_still_wins_over_rhs() {
+        // Explicit annotation takes priority over RHS inference
+        let lines: Vec<String> = vec![
+            "    val repo: UserRepository = OtherRepository()".into(),
+        ];
+        assert_eq!(infer_type_in_lines(&lines, "repo"), Some("UserRepository".into()));
+    }
+
+    #[test]
+    fn infer_type_rhs_no_false_positive_lowercase() {
+        // `val x = someFactory.create()` — lowercase constructor → no inference
+        let lines: Vec<String> = vec![
+            "    val x = someFactory.create()".into(),
+        ];
+        assert_eq!(infer_type_in_lines(&lines, "x"), None);
+    }
+
+    #[test]
+    fn infer_type_rhs_no_false_positive_equality() {
+        // `if (x == SomeType())` must not match as an assignment
+        let lines: Vec<String> = vec![
+            "    if (x == SomeType()) {".into(),
+        ];
+        assert_eq!(infer_type_in_lines(&lines, "x"), None);
+    }
+
+    #[test]
+    fn resolve_method_via_class_literal_type_inference() {
+        // `val api = retrofit.create(DashboardApi::class.java)` — no annotation
+        // dot-completion on `api.someMethod()` should resolve into DashboardApi
+        let api_uri = uri("/DashboardApi.kt");
+        let caller_uri = uri("/Caller.kt");
+        let idx = Indexer::new();
+        idx.index_content(&api_uri,
+            "package com.example\ninterface DashboardApi {\n    fun loadData(): String\n}");
+        idx.index_content(&caller_uri,
+            "package com.example\nval retrofit = TODO()\nval api = retrofit.create(DashboardApi::class.java)\nfun test() { api.loadData() }");
+
+        let locs = resolve_symbol(&idx, "loadData", Some("api"), &caller_uri);
+        assert!(!locs.is_empty(), "loadData not found via class literal type inference");
+        assert_eq!(locs[0].uri, api_uri);
+    }
+
+    #[test]
     fn goto_def_on_named_lambda_param_resolves_to_declaration_line() {
         // items.forEach { product ->
         //     product.name   ← gd on `product` here

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -726,23 +726,29 @@ data class State(
 
     #[test]
     fn infer_type_in_lines_class_literal_retrofit() {
-        // `::class` inference was removed from the string-scan fallback because it is too broad:
-        // `val key = SomeType::class` would incorrectly infer `SomeType` for `key` (which is
-        // `KClass<SomeType>`). For indexed files the CST path in `extract_rhs_types_kotlin`
-        // stores `retrofit.create(X::class)` in `method_call_rhs` instead.
+        // `val api = retrofit.create(DashboardApi::class.java)` — class literal *inside parens*
+        // should resolve to DashboardApi via the narrow pattern-3 path.
         let lines: Vec<String> = vec![
             "    val api = retrofit.create(DashboardApi::class.java)".into(),
         ];
-        assert_eq!(infer_type_in_lines(&lines, "api"), None);
+        assert_eq!(infer_type_in_lines(&lines, "api"), Some("DashboardApi".into()));
     }
 
     #[test]
     fn infer_type_in_lines_raw_class_literal_kotlin() {
-        // Same as above — string-scan fallback no longer handles `::class`.
+        // `val api = retrofit.create(DashboardApi::class)` (no .java suffix)
         let lines: Vec<String> = vec![
             "    val api = retrofit.create(DashboardApi::class)".into(),
         ];
-        assert_eq!(infer_type_in_lines_raw(&lines, "api"), None);
+        assert_eq!(infer_type_in_lines_raw(&lines, "api"), Some("DashboardApi".into()));
+    }
+
+    #[test]
+    fn infer_type_in_lines_bare_class_literal_not_matched() {
+        // `val key = SomeType::class` — bare class reference: key is KClass<SomeType>,
+        // NOT SomeType.  The narrow pattern-3 only triggers when ::class is inside parens.
+        let lines: Vec<String> = vec!["    val key = SomeType::class".into()];
+        assert_eq!(infer_type_in_lines(&lines, "key"), None);
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -95,6 +95,17 @@ pub struct FileData {
     /// - `type_args` are the concrete type arguments (e.g. `["Event", "Effect", "State"]`)
     #[serde(default)]
     pub supers: Vec<(u32, String, Vec<String>)>,
+    /// RHS-inferred types for unannotated properties, extracted from the CST at parse time.
+    /// Each entry is `(declaration_line, var_name, inferred_type)`.
+    /// Used as the primary type inference path for indexed files, avoiding fragile string
+    /// scanning for patterns like `inject<T>()`, `by lazy { T() }`, and `T(args)`.
+    #[serde(default)]
+    pub rhs_types: Vec<(u32, String, String)>,
+    /// Method-call RHS patterns for unannotated properties: `val x = receiver.method(args)`.
+    /// Each entry is `(declaration_line, var_name, receiver_name, method_name)`.
+    /// Used by method-return-type inference for indexed files.
+    #[serde(default)]
+    pub method_call_rhs: Vec<(u32, String, String, String)>,
     /// Structural syntax errors from tree-sitter (ERROR / MISSING nodes).
     /// Transient — not serialized to disk cache.
     #[serde(skip)]


### PR DESCRIPTION
Builds on #39. Four inference improvements:

## Commits

### `4160a65` RHS assignment type inference
`val x = SomeType()`, `val api = retrofit.create(Api::class.java)`, `val repo = inject<T>()` now resolve type without explicit annotation.

### `9f4a2ba` Method return type inference + fix declared_names rejection
- `val response = service.getDetail(args)` resolves by: infer `service`'s type → look up `getDetail` in symbol index → extract return type from `SymbolEntry.detail`.
- Removed `declared_names` fast-reject that incorrectly skipped unannotated vars in the snapshot path.
- DashMap guards dropped before recursive calls to prevent deadlocks.

### `6f20627` Hover shows inferred type for unannotated vars
- `hover_info_at_location` now shows `val response: AccountDetailResponseBody` instead of the raw RHS.
- Same method inference added to `infer_variable_type_raw` (completion path).

### `15b8d36` Inherited members in dot-completion
- `complete_dot` walks the supertype hierarchy (via `FileData.supers`) up to 4 levels.
- New `collect_inherited_members` helper: resolves each supertype, gets its members, recurses.
- Fixes: `AccountDetailResponseBody : Account` — parent Java class fields now appear.

## Tests
638 total, all passing.