### PR TITLE
refactor: Language enum, FileData::containing_class_at, on-demand index fix

### DIFF
--- a/src/backend/actions.rs
+++ b/src/backend/actions.rs
@@ -232,7 +232,7 @@ impl Backend {
 
         // Case A: cursor on import line — append ` as <last_segment>`.
         // Only relevant for Kotlin/KTS files (Java/Swift don't use this syntax).
-        let is_kotlin = uri.path().ends_with(".kt") || uri.path().ends_with(".kts");
+        let is_kotlin = crate::Language::from_path(uri.path()).is_kotlin();
         if is_kotlin && trimmed.starts_with("import ") && !trimmed.contains(" as ") {
             let path  = trimmed.trim_start_matches("import ").trim().trim_end_matches(".*");
             let alias = path.rsplit('.').next().unwrap_or(path);

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -33,10 +33,12 @@ impl Backend {
                 } else {
                     crate::indexer::apply_type_subst(&rt.raw, &subst)
                 };
-                let lang = if uri.path().ends_with(".kt") { "kotlin" }
-                           else if uri.path().ends_with(".swift") { "swift" }
-                           else { "java" };
-                let kw = if uri.path().ends_with(".swift") { "let" } else { "val" };
+                let lang = match crate::Language::from_path(uri.path()) {
+                    crate::Language::Kotlin => "kotlin",
+                    crate::Language::Swift  => "swift",
+                    crate::Language::Java   => "java",
+                };
+                let kw = if crate::Language::from_path(uri.path()).is_swift() { "let" } else { "val" };
                 let sig_md = format!("```{lang}\n{kw} {}: {type_name}\n```", ctx.word);
                 // Resolve the type using the same path as go-to-definition (import-aware)
                 let leaf = type_name.rsplit('.').next().unwrap_or(type_name.as_str());

--- a/src/backend/rename.rs
+++ b/src/backend/rename.rs
@@ -2,6 +2,7 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use super::Backend;
 use super::actions::is_non_call_keyword;
+use super::helpers::resolve_references_scope;
 use crate::StrExt;
 
 /// Replace all whole-word occurrences of `word` in `lines` with `replacement`.
@@ -181,26 +182,9 @@ impl Backend {
             None    => return Ok(None),
         };
 
-        // ── Resolve scoping (same logic as `references`) ────────────────────
+        // ── Resolve scoping (delegates to the shared helper used by findReferences) ─
         let (parent_class, declared_pkg) = if name.starts_with_uppercase() {
-            let on_decl = self.indexer.is_declared_in(uri, &name)
-                && self.indexer.definitions.get(&name)
-                    .map(|locs| locs.iter().any(|l| l.uri == *uri && l.range.start.line == pos.line))
-                    .unwrap_or(false);
-            if on_decl {
-                let parent = self.indexer.enclosing_class_at(uri, pos.line);
-                let pkg    = self.indexer.package_of(uri);
-                (parent, pkg)
-            } else {
-                let (parent, pkg) = self.indexer.resolve_symbol_via_import(uri, &name);
-                if parent.is_some() || pkg.is_some() {
-                    (parent, pkg)
-                } else {
-                    let parent = self.indexer.declared_parent_class_of(&name, uri);
-                    let pkg    = self.indexer.declared_package_of(&name);
-                    (parent, pkg)
-                }
-            }
+            resolve_references_scope(&self.indexer, uri, pos.line, &name)
         } else {
             // Lowercase symbol — limit to enclosing scope in current file only.
             let lines = match self.indexer.lines_for(uri) {

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -342,28 +342,14 @@ fn symbol_kw_for_lang(kind: SymbolKind, lang: &str) -> &'static str {
 }
 
 fn lang_str(path: &str) -> &'static str {
-    if path.ends_with(".kt") || path.ends_with(".kts") { "kotlin" }
-    else if path.ends_with(".swift")                   { "swift" }
-    else                                               { "java" }
+    match crate::Language::from_path(path) {
+        crate::Language::Kotlin => "kotlin",
+        crate::Language::Swift  => "swift",
+        crate::Language::Java   => "java",
+    }
 }
 
 // ─── Generic type parameter substitution ─────────────────────────────────────
-
-/// Find the name of the innermost class/interface/object that contains `sym_line`
-/// in the given file's symbol list. Returns `None` if the symbol is top-level.
-fn find_containing_class_name(data: &crate::types::FileData, sym_line: u32) -> Option<String> {
-    use tower_lsp::lsp_types::SymbolKind;
-    const CLASS_KINDS: &[SymbolKind] = &[
-        SymbolKind::CLASS, SymbolKind::INTERFACE, SymbolKind::STRUCT,
-        SymbolKind::ENUM, SymbolKind::OBJECT,
-    ];
-    data.symbols.iter()
-        .filter(|s| CLASS_KINDS.contains(&s.kind))
-        .filter(|s| s.range.start.line <= sym_line && sym_line <= s.range.end.line)
-        // innermost = smallest range span
-        .min_by_key(|s| s.range.end.line.saturating_sub(s.range.start.line))
-        .map(|s| s.name.clone())
-}
 
 /// Build a type-parameter → concrete-type substitution map for a symbol declared
 /// inside a generic class/interface when viewed from a specialised subtype.
@@ -390,7 +376,7 @@ fn build_type_param_subst(
         None => return Default::default(),
     };
 
-    let container_name = match find_containing_class_name(&sym_data, sym_line) {
+    let container_name = match sym_data.containing_class_at(sym_line) {
         Some(n) => n,
         None    => return Default::default(),
     };
@@ -411,7 +397,7 @@ fn build_type_param_subst(
     // When multiple classes in the same file extend the same base, use cursor_line
     // to identify the specific calling class and scope the supers lookup.
     let calling_class_line = cursor_line
-        .and_then(|line| find_containing_class_name(&calling_data, line))
+        .and_then(|line| calling_data.containing_class_at(line))
         .and_then(|name| calling_data.symbols.iter().find(|s| s.name == name))
         .map(|s| s.selection_range.start.line);
 
@@ -445,7 +431,7 @@ fn build_enclosing_class_subst(
     }};
 
     // Find the enclosing class
-    let class_name = match find_containing_class_name(&data, cursor_line) {
+    let class_name = match data.containing_class_at(cursor_line) {
         Some(n) => n,
         None => {
             return Default::default();

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -223,7 +223,7 @@ fn build_type_param_subst_impl<I: IndexRead>(
         None => return HashMap::new(),
     };
 
-    let container_name = match find_containing_class_name(&sym_data, sym_line) {
+    let container_name = match sym_data.containing_class_at(sym_line) {
         Some(n) => n,
         None => return HashMap::new(),
     };
@@ -244,7 +244,7 @@ fn build_type_param_subst_impl<I: IndexRead>(
     // Use `caller_cursor_line` to identify the specific calling class — when multiple
     // classes in the same file extend the same base with different type args,
     // this ensures we pick the correct substitution for the caller.
-    let calling_class_line = find_containing_class_name(&calling_data, caller_cursor_line)
+    let calling_class_line = calling_data.containing_class_at(caller_cursor_line)
         .and_then(|name| calling_data.symbols.iter().find(|s| s.name == name))
         .map(|s| s.selection_range.start.line);
 
@@ -274,7 +274,7 @@ fn build_enclosing_class_subst_impl<I: IndexRead>(
         None => return HashMap::new(),
     };
 
-    let class_name = match find_containing_class_name(&data, cursor_line) {
+    let class_name = match data.containing_class_at(cursor_line) {
         Some(n) => n,
         None => return HashMap::new(),
     };
@@ -347,18 +347,6 @@ fn build_enclosing_class_subst_impl<I: IndexRead>(
     result
 }
 
-// ─── Helper: Find Enclosing Class ────────────────────────────────────────────
-
-/// Find the name of the innermost class that contains a symbol at the given line.
-fn find_containing_class_name(data: &FileData, sym_line: u32) -> Option<String> {
-    data.symbols
-        .iter()
-        .filter(|s| s.range.start.line <= sym_line && sym_line <= s.range.end.line)
-        .filter(|s| matches!(s.kind, SymbolKind::CLASS | SymbolKind::INTERFACE | SymbolKind::STRUCT | SymbolKind::ENUM | SymbolKind::OBJECT))
-        .min_by_key(|s| s.range.end.line.saturating_sub(s.range.start.line))
-        .map(|s| s.name.clone())
-}
-
 // ─── Indexer impl (production) ───────────────────────────────────────────────
 
 // Implement IndexRead for Indexer: production code doesn't use the trait,
@@ -386,7 +374,12 @@ impl IndexRead for super::Indexer {
         allow_rg: bool,
     ) -> Vec<Location> {
         if allow_rg {
-            self.resolve_symbol(name, qualifier, from_uri)
+            let locs = self.resolve_symbol(name, qualifier, from_uri);
+            // Ensure every rg-discovered file is indexed so get_file_data() succeeds.
+            for loc in &locs {
+                self.ensure_indexed(&loc.uri);
+            }
+            locs
         } else {
             if let Some(qual) = qualifier {
                 // Index-only qualified resolution: resolve the qualifier without rg,
@@ -512,7 +505,7 @@ mod tests {
             ],
             ..Default::default()
         };
-        assert_eq!(find_containing_class_name(&data, 7).as_deref(), Some("Inner"));
+        assert_eq!(data.containing_class_at(7).as_deref(), Some("Inner"));
     }
 
     #[test]
@@ -522,7 +515,7 @@ mod tests {
             symbols: vec![make_sym("Outer", SymbolKind::CLASS, 5, 15)],
             ..Default::default()
         };
-        assert!(find_containing_class_name(&data, 1).is_none());
+        assert!(data.containing_class_at(1).is_none());
     }
 
     #[test]
@@ -535,8 +528,8 @@ mod tests {
             ],
             ..Default::default()
         };
-        assert_eq!(find_containing_class_name(&data, 5).as_deref(), Some("MyEnum"));
-        assert_eq!(find_containing_class_name(&data, 15).as_deref(), Some("MyObject"));
+        assert_eq!(data.containing_class_at(5).as_deref(), Some("MyEnum"));
+        assert_eq!(data.containing_class_at(15).as_deref(), Some("MyObject"));
     }
 
     // ── build_subst_map end-to-end tests ─────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod types;
 
 pub(crate) use lines_ext::LinesExt;
 pub(crate) use str_ext::StrExt;
+pub(crate) use types::Language;
 
 use tower_lsp::{LspService, Server};
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -209,12 +209,10 @@ pub fn parse_swift(content: &str) -> FileData {
 
 /// Dispatch to the correct parser based on file extension.
 pub fn parse_by_extension(path: &str, content: &str) -> FileData {
-    if path.ends_with(".swift") {
-        parse_swift(content)
-    } else if path.ends_with(".java") {
-        parse_java(content)
-    } else {
-        parse_kotlin(content)
+    match crate::Language::from_path(path) {
+        crate::Language::Swift  => parse_swift(content),
+        crate::Language::Java   => parse_java(content),
+        crate::Language::Kotlin => parse_kotlin(content),
     }
 }
 

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -174,8 +174,8 @@ fn extension_fn_completions(
         let file_uri_str = file_entry.key().clone();
         let file = file_entry.value();
         let is_same_file = file_uri_str == from_uri.as_str();
-        // Only look at Kotlin files.
-        if !file_uri_str.ends_with(".kt") && !file_uri_str.ends_with(".kts") { continue; }
+        // Only look at Kotlin files — extension functions are a Kotlin feature.
+        if !crate::Language::from_path(&file_uri_str).is_kotlin() { continue; }
 
         for sym in &file.symbols {
             if sym.extension_receiver != receiver_type { continue; }
@@ -329,7 +329,7 @@ pub(crate) fn complete_dot(idx: &Indexer, receiver: &str, from_uri: &Url, snippe
 
     // Append indexed extension functions whose receiver matches `rt.outer`.
     // These may be defined in other files and need an auto-import.
-    if from_path.ends_with(".kt") || from_path.ends_with(".kts") {
+    if crate::Language::from_path(from_path).is_kotlin() {
         items.extend(extension_fn_completions(idx, &rt.outer, from_uri, snippets));
     }
 
@@ -622,7 +622,7 @@ pub(crate) fn complete_bare(idx: &Indexer, prefix: &str, from_uri: &Url, snippet
     //    prefix/acronym matches only (max_score=1) — no substring flood.
     // Emits one CompletionItem per distinct FQN, with additionalTextEdits for auto-import.
     if !lowercase_mode && prefix.len() >= MIN_CASE_INSENSITIVE_PREFIX {
-        let is_java = from_uri.as_str().ends_with(".java");
+        let is_java = crate::Language::from_path(from_uri.as_str()).is_java();
         // Prefer live_lines (updated on every keystroke) over the indexed snapshot so that
         // import deduplication and insertion position are based on the current buffer state.
         let live = idx.live_lines.get(from_uri.as_str()).map(|ll| ll.clone());

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -196,11 +196,11 @@ pub(crate) fn resolve_symbol_inner(idx: &Indexer, name: &str, from_uri: &Url, wi
     // Swift files have no package declarations, so same-package and star-import
     // steps return empty. Use the in-memory definitions index directly to avoid
     // expensive project-wide rg fallback at step 5.
-    if from_uri.path().ends_with(".swift") && name.starts_with_uppercase() {
+    if crate::Language::from_path(from_uri.path()).is_swift() && name.starts_with_uppercase() {
         if let Some(locs_ref) = idx.definitions.get(name) {
             let locs: Vec<Location> = locs_ref.clone();
             // Prefer definitions from .swift files when available.
-            let swift_locs: Vec<Location> = locs.iter().filter(|l| l.uri.path().ends_with(".swift")).cloned().collect();
+            let swift_locs: Vec<Location> = locs.iter().filter(|l| crate::Language::from_path(l.uri.path()).is_swift()).cloned().collect();
             if !swift_locs.is_empty() { return swift_locs; }
             if !locs.is_empty() { return locs; }
         }

--- a/src/stdlib_tail.rs
+++ b/src/stdlib_tail.rs
@@ -5,13 +5,10 @@ use crate::stdlib::dot_completions_for;
 /// add Swift-specific templates for .swift files. `from_path` should be the
 /// file path portion of the request URI (e.g., "/home/user/project/src/Foo.kt").
 pub fn dot_completions_for_lang(from_path: &str, receiver_type: &str, snippets: bool) -> Vec<tower_lsp::lsp_types::CompletionItem> {
-    if from_path.ends_with(".kt") {
-        dot_completions_for(receiver_type, snippets)
-    } else if from_path.ends_with(".swift") {
-        // Very small Swift snippet set: common patterns
-        swift_dot_completions(snippets)
-    } else {
-        Vec::new()
+    match crate::Language::from_path(from_path) {
+        crate::Language::Kotlin => dot_completions_for(receiver_type, snippets),
+        crate::Language::Swift  => swift_dot_completions(snippets),
+        crate::Language::Java   => Vec::new(),
     }
 }
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,6 +2,32 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 use tower_lsp::lsp_types::{Range, SymbolKind};
 
+/// Source language inferred from a file's path extension.
+///
+/// Used to centralise all `path.ends_with(".kt")` / `".swift"` / `".java"` dispatch.
+/// Obtain via [`Language::from_path`]; the default is `Kotlin` (most common case).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Language {
+    #[default]
+    Kotlin,
+    Java,
+    Swift,
+}
+
+impl Language {
+    /// Infer the language from a file path or URI string.
+    pub fn from_path(path: &str) -> Self {
+        if path.ends_with(".swift")                        { Language::Swift }
+        else if path.ends_with(".java")                    { Language::Java  }
+        else                                               { Language::Kotlin }
+    }
+
+    pub fn is_kotlin(self)  -> bool { matches!(self, Language::Kotlin) }
+    pub fn is_java(self)    -> bool { matches!(self, Language::Java)   }
+    pub fn is_swift(self)   -> bool { matches!(self, Language::Swift)  }
+    pub fn is_jvm(self)     -> bool { matches!(self, Language::Kotlin | Language::Java) }
+}
+
 /// A position within a document used by infer functions.
 ///
 /// `utf16_col` is a UTF-16 code unit offset, matching the LSP `Position.character` field.
@@ -112,9 +138,24 @@ pub struct FileData {
     pub syntax_errors: Vec<SyntaxError>,
 }
 
-// ────────────────────────────────────────────────────────────────────────────
-// Indexing Result Types (for SOLID refactoring)
-// ────────────────────────────────────────────────────────────────────────────
+impl FileData {
+    /// Find the name of the innermost class/interface/object/enum that contains
+    /// `line` in this file's symbol list. Returns `None` if the symbol is
+    /// top-level (not inside any class).
+    pub fn containing_class_at(&self, line: u32) -> Option<String> {
+        const CLASS_KINDS: &[SymbolKind] = &[
+            SymbolKind::CLASS, SymbolKind::INTERFACE, SymbolKind::STRUCT,
+            SymbolKind::ENUM,  SymbolKind::OBJECT,
+        ];
+        self.symbols.iter()
+            .filter(|s| CLASS_KINDS.contains(&s.kind))
+            .filter(|s| s.range.start.line <= line && line <= s.range.end.line)
+            .min_by_key(|s| s.range.end.line.saturating_sub(s.range.start.line))
+            .map(|s| s.name.clone())
+    }
+}
+
+
 
 /// Result of parsing a single file. Pure data, no side effects.
 /// This is what index_content will return instead of mutating DashMaps.


### PR DESCRIPTION
## Changes

### Language enum
Add `Language { Kotlin, Java, Swift }` to `types.rs` with `from_path()`, `is_kotlin/java/swift/jvm()` helpers. Replace all 18 `ends_with(".kt")`/`.java`/`.swift` dispatch sites across 7 files (`parser.rs`, `handlers.rs`, `actions.rs`, `complete.rs`, `resolver/mod.rs`, `lookup.rs`, `stdlib_tail.rs`).

### FileData::containing_class_at
Deduplicate the two private `find_containing_class_name()` functions in `lookup.rs` and `resolution.rs` into a single canonical method on `FileData` in `types.rs`.

### On-demand index fix
`IndexRead::resolve_locations()` now calls `ensure_indexed()` on all rg-discovered URIs before returning, so `get_file_data()` never returns `None` for files rg found but hadn't yet indexed.

### Extension fn same-file fix
Extension functions defined in the current file are now included in dot-completion (previously silently dropped).