### PR TITLE
refactor: migrate hover handler to resolution service (Phase 6)

### DIFF
--- a/src/backend/format.rs
+++ b/src/backend/format.rs
@@ -1,0 +1,82 @@
+//! Hover Markdown formatting helpers.
+//!
+//! These functions turn a [`ResolvedSymbol`] into the final Markdown string
+//! returned by the `textDocument/hover` handler.  They are presentation-only
+//! and contain no resolution logic.
+
+use tower_lsp::lsp_types::SymbolKind;
+use crate::indexer::lookup::{symbol_kw_for_lang, lang_str};
+use crate::indexer::resolution::ResolvedSymbol;
+
+/// Format a standard symbol hover: optional KDoc block + fenced code block.
+///
+/// ```text
+/// /** KDoc comment */
+///
+/// ---
+///
+/// ```kotlin
+/// fun foo(x: Int): String
+/// ```
+/// ```
+pub(super) fn format_symbol_hover(info: &ResolvedSymbol, uri_path: &str) -> String {
+    let lang = lang_str(uri_path);
+    let sig  = info.signature.as_str();
+    let name = symbol_name_from_sig(sig);
+
+    let code_block = if sig.is_empty() {
+        format!("```{lang}\n{} {name}\n```", symbol_kw_for_lang(info.kind, lang))
+    } else {
+        format!("```{lang}\n{sig}\n```")
+    };
+
+    if info.doc.is_empty() {
+        code_block
+    } else {
+        format!("{}\n\n---\n\n{code_block}", info.doc)
+    }
+}
+
+/// Format a contextual hover for an `it` / named lambda parameter:
+///
+/// ```text
+/// ```kotlin
+/// val it: AccountType
+/// ```
+///
+/// ---
+///
+/// <optional type-symbol hover>
+/// ```
+///
+/// `type_sig_md` — the synthesized declaration line, e.g. `"val it: AccountType"`.
+/// `type_detail` — optional hover markdown for the resolved type symbol itself.
+pub(super) fn format_contextual_hover(
+    type_sig_md:  &str,
+    uri_path:     &str,
+    type_detail:  Option<&str>,
+) -> String {
+    let lang = lang_str(uri_path);
+    let sig_block = format!("```{lang}\n{type_sig_md}\n```");
+    match type_detail {
+        Some(td) if !td.is_empty() => format!("{sig_block}\n\n---\n\n{td}"),
+        _ => sig_block,
+    }
+}
+
+/// Infer a display name from a signature string (last identifier before `(`/`:`/space).
+fn symbol_name_from_sig(sig: &str) -> &str {
+    // e.g. "fun foo(" → "foo", "class Bar" → "Bar"
+    // Walk backwards to find the name token.
+    let trimmed = sig.trim_end_matches(|c: char| !c.is_alphanumeric() && c != '_');
+    trimmed
+        .rsplit(|c: char| !c.is_alphanumeric() && c != '_')
+        .next()
+        .unwrap_or(trimmed)
+}
+
+/// Return the language keyword for a symbol kind (Swift-aware).
+#[allow(dead_code)]
+pub(super) fn kw_for_kind(kind: SymbolKind, uri_path: &str) -> &'static str {
+    symbol_kw_for_lang(kind, lang_str(uri_path))
+}

--- a/src/backend/format.rs
+++ b/src/backend/format.rs
@@ -22,10 +22,10 @@ use crate::indexer::resolution::ResolvedSymbol;
 pub(super) fn format_symbol_hover(info: &ResolvedSymbol, uri_path: &str) -> String {
     let lang = lang_str(uri_path);
     let sig  = info.signature.as_str();
-    let name = symbol_name_from_sig(sig);
 
     let code_block = if sig.is_empty() {
-        format!("```{lang}\n{} {name}\n```", symbol_kw_for_lang(info.kind, lang))
+        // Signature unavailable — fall back to keyword + known symbol name.
+        format!("```{lang}\n{} {}\n```", symbol_kw_for_lang(info.kind, lang), info.name)
     } else {
         format!("```{lang}\n{sig}\n```")
     };
@@ -62,17 +62,6 @@ pub(super) fn format_contextual_hover(
         Some(td) if !td.is_empty() => format!("{sig_block}\n\n---\n\n{td}"),
         _ => sig_block,
     }
-}
-
-/// Infer a display name from a signature string (last identifier before `(`/`:`/space).
-fn symbol_name_from_sig(sig: &str) -> &str {
-    // e.g. "fun foo(" → "foo", "class Bar" → "Bar"
-    // Walk backwards to find the name token.
-    let trimmed = sig.trim_end_matches(|c: char| !c.is_alphanumeric() && c != '_');
-    trimmed
-        .rsplit(|c: char| !c.is_alphanumeric() && c != '_')
-        .next()
-        .unwrap_or(trimmed)
 }
 
 /// Return the language keyword for a symbol kind (Swift-aware).

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -2,6 +2,11 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use crate::indexer::find_fun_signature_with_receiver;
 use crate::indexer::NodeExt;
+use crate::indexer::resolution::{
+    resolve_symbol_info, enrich_at_location, build_subst_map,
+    SubstitutionContext, ResolveOptions,
+};
+use crate::indexer::apply_type_subst;
 use crate::StrExt;
 use crate::queries::KIND_VALUE_ARG;
 use crate::inlay_hints::compute_inlay_hints;
@@ -9,6 +14,7 @@ use super::Backend;
 use super::cursor::CursorContext;
 use super::helpers::resolve_references_scope;
 use super::actions::is_non_call_keyword;
+use super::format::{format_symbol_hover, format_contextual_hover};
 
 /// Maximum number of workspace symbol results to return.
 const WORKSPACE_SYMBOL_CAP: usize = 512;
@@ -23,43 +29,35 @@ impl Backend {
             return Ok(None);
         };
 
-        // For `it` or a named lambda param, generate hover showing the inferred type.
+        let make_hover = |md: String| Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: md,
+            }),
+            range: None,
+        };
+
+        // Path 1: `it` / named lambda param — show inferred type + optional type detail.
         if ctx.qualifier.is_none() {
             if let Some(ref rt) = ctx.contextual {
-                // Apply type parameter substitution (same as inlay hints)
-                let subst = self.indexer.type_subst_for_enclosing_class(uri.as_str(), position.line);
+                let kw = if crate::Language::from_path(uri.path()).is_swift() { "let" } else { "val" };
+                let subst = build_subst_map(self.indexer.as_ref(), uri.as_str(), position.line);
                 let type_name = if subst.is_empty() {
                     rt.raw.clone()
                 } else {
-                    crate::indexer::apply_type_subst(&rt.raw, &subst)
+                    apply_type_subst(&rt.raw, &subst)
                 };
-                let lang = match crate::Language::from_path(uri.path()) {
-                    crate::Language::Kotlin => "kotlin",
-                    crate::Language::Swift  => "swift",
-                    crate::Language::Java   => "java",
-                };
-                let kw = if crate::Language::from_path(uri.path()).is_swift() { "let" } else { "val" };
-                let sig_md = format!("```{lang}\n{kw} {}: {type_name}\n```", ctx.word);
-                // Resolve the type using the same path as go-to-definition (import-aware)
                 let leaf = type_name.rsplit('.').next().unwrap_or(type_name.as_str());
-                let locs = self.indexer.find_definition_qualified(leaf, None, uri);
-                let type_hover = if let Some(loc) = locs.first() {
-                    self.indexer.hover_info_at_location(loc, leaf, Some(uri.as_str()), Some(position.line))
-                } else {
-                    self.indexer.hover_info(leaf, Some(uri.as_str()))
-                };
-                let full = if let Some(th) = type_hover {
-                    format!("{sig_md}\n\n---\n\n{th}")
-                } else {
-                    sig_md
-                };
-                return Ok(Some(Hover {
-                    contents: HoverContents::Markup(MarkupContent {
-                        kind:  MarkupKind::Markdown,
-                        value: full,
-                    }),
-                    range: None,
-                }));
+                let type_sig_md = format!("{kw} {}: {type_name}", ctx.word);
+                // Resolve the type's own hover: import-aware, rg fallback, then stdlib.
+                let type_detail = resolve_symbol_info(
+                        self.indexer.as_ref(), leaf, None, uri,
+                        SubstitutionContext::CrossFile { calling_uri: uri.as_str(), cursor_line: position.line },
+                        &ResolveOptions::hover())
+                    .map(|i| format_symbol_hover(&i, uri.path()))
+                    .or_else(|| crate::stdlib::hover(leaf));
+                let md = format_contextual_hover(&type_sig_md, uri.path(), type_detail.as_deref());
+                return Ok(Some(make_hover(md)));
             }
             // Lambda parameter with failed type inference — don't fall through to rg
             // lookup (would show confusing hover for unrelated symbols).
@@ -68,56 +66,35 @@ impl Backend {
             }
         }
 
-        // Use the same resolution chain as go-to-definition so hover always
-        // points at the same symbol (import-aware, not just first index match).
-
-        // `this.field` / `it.field` — use the already-resolved contextual receiver
+        // Path 2: `this.field` / `it.field` — use the already-resolved contextual receiver
         // so hover shows the member from the correct class.
         if ctx.qualifier.is_some() {
             if let Some(ref rt) = ctx.contextual {
                 let locs = self.resolve_with_receiver_fallback(&ctx.word, rt, uri);
                 if let Some(loc) = locs.first() {
-                    if let Some(md) = self.indexer.hover_info_at_location(loc, &ctx.word, Some(uri.as_str()), Some(position.line)) {
-                        return Ok(Some(Hover {
-                            contents: HoverContents::Markup(MarkupContent {
-                                kind:  MarkupKind::Markdown,
-                                value: md,
-                            }),
-                            range: None,
-                        }));
+                    let subst_ctx = SubstitutionContext::CrossFile {
+                        calling_uri: uri.as_str(),
+                        cursor_line: position.line,
+                    };
+                    if let Some(info) = enrich_at_location(self.indexer.as_ref(), loc, &ctx.word, subst_ctx, &ResolveOptions::hover()) {
+                        return Ok(Some(make_hover(format_symbol_hover(&info, uri.path()))));
                     }
                 }
             }
         }
 
-        let locs = self.indexer.find_definition_qualified(&ctx.word, ctx.qualifier.as_deref(), uri);
-        let hover_md = if let Some(loc) = locs.first() {
-            self.indexer.hover_info_at_location(loc, &ctx.word, Some(uri.as_str()), Some(position.line))
-        } else {
-            // Index lookup — works for already-indexed symbols + stdlib.
-            let from_index = self.indexer.hover_info(&ctx.word, Some(uri.as_str()));
-            if from_index.is_some() {
-                from_index
-            } else {
-                // rg fallback: find the declaration even when the index is empty.
-                let file_path = uri.to_file_path().ok();
-                let (rg_root, matcher) = {
-                    let wr = self.indexer.workspace_root.read().unwrap().clone();
-                    let m = self.indexer.ignore_matcher.read().unwrap().clone();
-                    (crate::rg::effective_rg_root(wr.as_deref(), file_path.as_deref()), m)
-                };
-                let rg_locs = crate::rg::rg_find_definition(&ctx.word, rg_root.as_deref(), matcher.as_deref());
-                rg_locs.first().and_then(|loc| self.indexer.hover_info_at_location(loc, &ctx.word, Some(uri.as_str()), Some(position.line)))
-            }
+        // Path 3: regular symbol — import-aware resolution, rg fallback, then stdlib.
+        let subst_ctx = SubstitutionContext::CrossFile {
+            calling_uri: uri.as_str(),
+            cursor_line: position.line,
         };
+        let hover_md = resolve_symbol_info(
+                self.indexer.as_ref(), &ctx.word, ctx.qualifier.as_deref(), uri,
+                subst_ctx, &ResolveOptions::hover())
+            .map(|i| format_symbol_hover(&i, uri.path()))
+            .or_else(|| crate::stdlib::hover(&ctx.word));
 
-        Ok(hover_md.map(|md| Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind:  MarkupKind::Markdown,
-                value: md,
-            }),
-            range: None,
-        }))
+        Ok(hover_md.map(make_hover))
     }
 
     pub(super) async fn references_impl(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -16,6 +16,7 @@ pub mod rename;
 pub mod actions;
 pub mod helpers;
 pub mod cursor;
+pub mod format;
 
 pub struct Backend {
     pub(super) client:  Client,

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -16,7 +16,7 @@ pub use crate::rg::SOURCE_EXTENSIONS;
 mod doc;
 
 mod infer;
-mod resolution;
+pub(crate) mod resolution;
 // Re-export pure helpers from submodules so existing callers within this file
 // and the inline test module (`use super::*`) continue to resolve them by name.
 #[allow(unused_imports)]
@@ -63,7 +63,7 @@ mod apply;
 #[allow(unused_imports)]
 pub(crate) use self::apply::{file_contributions, stale_keys_for, build_bare_names};
 
-mod lookup;
+pub(crate) mod lookup;
 pub(crate) use lookup::apply_type_subst;
 
 mod node_ext;

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -46,6 +46,10 @@ impl Indexer {
     }
 
     /// Build a Markdown hover snippet for a symbol name.
+    ///
+    /// **Note:** Production code uses `resolution::resolve_symbol_info` +
+    /// `backend::format::format_symbol_hover` instead. This method is retained
+    /// for lookup unit tests (Phase 10 will migrate tests and delete it).
     pub fn hover_info(&self, name: &str, calling_uri: Option<&str>) -> Option<String> {
         // Check stdlib first so well-known symbols (run, apply, map, …) get
         // proper signatures even when no project source contains them.
@@ -60,7 +64,10 @@ impl Indexer {
     }
 
     /// Build hover markdown for `name` at a specific resolved `Location`.
-    /// Used by the hover handler so it shows the same symbol as go-to-definition.
+    ///
+    /// **Note:** Production code uses `resolution::enrich_at_location` +
+    /// `backend::format::format_symbol_hover` instead. This method is retained
+    /// for lookup unit tests (Phase 10 will migrate tests and delete it).
     ///
     /// `calling_uri` — the file where the cursor is (used to substitute generic type
     /// parameters with concrete types when the symbol is from a base class).
@@ -315,11 +322,11 @@ impl Indexer {
     /// Used by inlay hints to convert inferred types like `EffectType` → `Effect`
     /// when the cursor is inside a class that specialises a generic base.
     pub(crate) fn type_subst_for_enclosing_class(&self, uri: &str, cursor_line: u32) -> std::collections::HashMap<String, String> {
-        build_enclosing_class_subst(self, uri, cursor_line)
+        super::resolution::build_subst_map(self, uri, cursor_line)
     }
 }
 
-fn symbol_kw(kind: SymbolKind) -> &'static str {
+pub(crate) fn symbol_kw(kind: SymbolKind) -> &'static str {
     match kind {
         SymbolKind::CLASS          => "class",
         SymbolKind::INTERFACE      => "interface",
@@ -335,13 +342,13 @@ fn symbol_kw(kind: SymbolKind) -> &'static str {
     }
 }
 
-fn symbol_kw_for_lang(kind: SymbolKind, lang: &str) -> &'static str {
+pub(crate) fn symbol_kw_for_lang(kind: SymbolKind, lang: &str) -> &'static str {
     let kw = symbol_kw(kind);
     // Swift uses `func`, not `fun`.
     if lang == "swift" && kw == "fun" { "func" } else { kw }
 }
 
-fn lang_str(path: &str) -> &'static str {
+pub(crate) fn lang_str(path: &str) -> &'static str {
     match crate::Language::from_path(path) {
         crate::Language::Kotlin => "kotlin",
         crate::Language::Swift  => "swift",
@@ -414,99 +421,6 @@ fn build_type_param_subst(
     type_params.iter().zip(type_args.iter())
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect()
-}
-
-/// Build a substitution map from ALL supertypes of the enclosing class at `cursor_line`.
-///
-/// For each super with type args (e.g., `FlowReducer<Event, Effect, State>`), looks up
-/// the super's type params (`EventType`, `EffectType`, `StateType`) and builds the mapping.
-/// This allows inlay hints to show concrete types instead of generic param names.
-fn build_enclosing_class_subst(
-    idx:         &Indexer,
-    uri:         &str,
-    cursor_line: u32,
-) -> std::collections::HashMap<String, String> {
-    let data = match idx.files.get(uri) { Some(d) => d, None => {
-        return Default::default();
-    }};
-
-    // Find the enclosing class
-    let class_name = match data.containing_class_at(cursor_line) {
-        Some(n) => n,
-        None => {
-            return Default::default();
-        }
-    };
-
-    // Get the class symbol's line to find its supers
-    let class_sym = match data.symbols.iter().find(|s| s.name == class_name) {
-        Some(s) => s,
-        None => return Default::default(),
-    };
-    let class_line = class_sym.selection_range.start.line;
-    let class_end_line = class_sym.range.end.line;
-    let mut result = std::collections::HashMap::new();
-
-    for (line, base_name, type_args) in data.supers.iter() {
-        if *line != class_line || type_args.is_empty() { continue; }
-
-        // Look up the super class's type parameters from its symbol detail
-        let super_sym = idx.definitions.get(base_name.as_str())
-            .and_then(|locs| locs.first().cloned());
-        if super_sym.is_none() {
-            continue;
-        }
-        let Some(super_loc) = super_sym else { continue };
-        let Some(super_data) = idx.files.get(super_loc.uri.as_str()) else {
-            continue;
-        };
-        let Some(sym) = super_data.symbols.iter().find(|s| s.name == *base_name) else {
-            continue;
-        };
-
-        let type_params = &sym.type_params;
-        // Zip params → args
-        for (param, arg) in type_params.iter().zip(type_args.iter()) {
-            result.insert(param.clone(), arg.clone());
-        }
-    }
-
-    // Also collect substitutions from member property types.
-    // If the enclosing class has a property like `val reducer: DashboardProductsReducer`
-    // and that type extends `FlowReducer<Event, Effect, State>`, include FlowReducer's
-    // type param → concrete arg mappings.
-    for sym in data.symbols.iter() {
-        if sym.selection_range.start.line <= class_line { continue; }
-        if sym.selection_range.start.line > class_end_line { continue; }
-        if !matches!(sym.kind, SymbolKind::FIELD | SymbolKind::PROPERTY) { continue; }
-        // Extract type name from detail (e.g., "private val foo: SomeType by lazy")
-        let type_name = extract_property_type_name(&sym.detail);
-        if type_name.is_empty() { continue; }
-        // Look up the property type's class definition
-        let Some(locs) = idx.definitions.get(type_name) else { continue };
-        let Some(loc) = locs.first() else { continue };
-        let Some(prop_type_data) = idx.files.get(loc.uri.as_str()) else { continue };
-        // Find this type's supers and resolve their type params
-        let prop_sym = match prop_type_data.symbols.iter().find(|s| s.name == type_name) {
-            Some(s) => s,
-            None => continue,
-        };
-        let prop_class_line = prop_sym.selection_range.start.line;
-        for (line, base_name, type_args) in prop_type_data.supers.iter() {
-            if *line != prop_class_line || type_args.is_empty() { continue; }
-            // Already have these params mapped? Skip.
-            let Some(super_locs) = idx.definitions.get(base_name.as_str()) else { continue };
-            let Some(super_loc) = super_locs.first() else { continue };
-            let Some(super_file) = idx.files.get(super_loc.uri.as_str()) else { continue };
-            let Some(super_sym) = super_file.symbols.iter().find(|s| s.name == *base_name) else { continue };
-            let type_params = &super_sym.type_params;
-            for (param, arg) in type_params.iter().zip(type_args.iter()) {
-                result.entry(param.clone()).or_insert_with(|| arg.clone());
-            }
-        }
-    }
-
-    result
 }
 
 /// Extract the simple type name from a property detail string.

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -14,6 +14,8 @@ use crate::indexer::doc::extract_doc_comment;
 /// Domain-level resolution result. Small, owned data suitable for LSP adapters.
 pub struct ResolvedSymbol {
     pub location: Location,
+    /// The original symbol name (from the index), independent of signature parsing.
+    pub name: String,
     pub kind: SymbolKind,
     pub raw_signature: String,
     pub signature: String,
@@ -217,6 +219,7 @@ fn enrich_symbol<I: IndexRead>(
 
     Some(ResolvedSymbol {
         location: location.clone(),
+        name: sym.name.clone(),
         kind: sym.kind,
         raw_signature,
         signature,

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -63,6 +63,15 @@ pub trait IndexRead {
         self.get_definitions(name)
             .unwrap_or_default()
     }
+
+    /// Infer the concrete type of an unannotated variable/property.
+    ///
+    /// Used to augment hover for `val foo = someCall()` with `val foo: ReturnType`
+    /// when no explicit `: Type` annotation is present.
+    /// Default impl returns `None`; production Indexer delegates to full type inference.
+    fn infer_variable_type_for(&self, _name: &str, _uri: &Url) -> Option<String> {
+        None
+    }
 }
 
 // ─── Pipeline Entry Point (thin coordinator) ───────────────────────────────
@@ -80,6 +89,21 @@ pub fn resolve_symbol_info<I: IndexRead>(
     let location = locate_symbol(index, name, qualifier, from_uri, options.allow_rg)?;
     let data = index.get_file_data(location.uri.as_str())?;
     enrich_symbol(index, &data, &location, name, subst_ctx, options)
+}
+
+/// Enrich a pre-resolved location without a locate step.
+///
+/// Used when the caller already holds a `Location` (e.g., from
+/// `resolve_with_receiver_fallback`) and only needs enrichment.
+pub fn enrich_at_location<I: IndexRead>(
+    index: &I,
+    location: &Location,
+    name: &str,
+    subst_ctx: SubstitutionContext<'_>,
+    options: &ResolveOptions,
+) -> Option<ResolvedSymbol> {
+    let data = index.get_file_data(location.uri.as_str())?;
+    enrich_symbol(index, &data, location, name, subst_ctx, options)
 }
 
 /// Resolve contextual receiver information (it/this).
@@ -115,10 +139,17 @@ pub fn build_subst_map<I: IndexRead>(index: &I, uri: &str, cursor_line: u32) -> 
 
 /// Extract canonical signature (prefer full source, fall back to cached detail).
 ///
-/// `detail` is truncated to ~120 chars at index time; `collect_signature` reads
-/// the original source lines and returns the complete declaration up to `{`/`=`.
-/// We prefer the full source version so callers see untruncated signatures.
+/// For properties/variables: use the pre-indexed `detail` string directly —
+/// `collect_signature` on a property line reads forward until it finds `{` or `=`
+/// and can accidentally collect sibling constructor parameters.
+/// For functions/classes: prefer `collect_signature` (full untruncated source),
+/// falling back to `detail` (truncated at ~120 chars at index time).
 fn extract_canonical_signature(sym: &SymbolEntry, data: &FileData) -> String {
+    if matches!(sym.kind, SymbolKind::PROPERTY | SymbolKind::VARIABLE)
+        && !sym.detail.is_empty()
+    {
+        return sym.detail.clone();
+    }
     let full = data.lines.collect_signature(sym.selection_range.start.line as usize);
     if !full.is_empty() { full } else { sym.detail.clone() }
 }
@@ -161,6 +192,21 @@ fn enrich_symbol<I: IndexRead>(
     let sym = find_symbol_entry(data, location, name)?;
 
     let raw_signature = extract_canonical_signature(sym, data);
+
+    // For unannotated val/var (no `: Type` in the signature), try to infer the
+    // concrete type so callers see `val foo: ReturnType` instead of `val foo = expr`.
+    let raw_signature = if matches!(sym.kind, SymbolKind::PROPERTY | SymbolKind::VARIABLE)
+        && !raw_signature.contains(&format!("{name}:"))
+    {
+        if let Some(inferred) = index.infer_variable_type_for(name, &location.uri) {
+            augment_property_sig(&raw_signature, name, sym.kind, &inferred)
+        } else {
+            raw_signature
+        }
+    } else {
+        raw_signature
+    };
+
     let subst = build_subst_if_needed(index, location, sym, &raw_signature, subst_ctx, options);
     let signature = apply_subst(&raw_signature, &subst);
     let doc = if options.include_doc {
@@ -177,6 +223,23 @@ fn enrich_symbol<I: IndexRead>(
         subst,
         doc,
     })
+}
+
+/// Rebuild a property signature with an inferred type annotation.
+///
+/// Replaces the `= rhs` initializer with `: InferredType`, preserving any
+/// leading modifiers (e.g. `private`, `override`).
+fn augment_property_sig(raw: &str, name: &str, kind: SymbolKind, inferred: &str) -> String {
+    let needle = format!(" {name}");
+    let name_pos = raw.find(&needle)
+        .map(|p| p + 1)
+        .or_else(|| if raw.starts_with(name) { Some(0) } else { None });
+    if let Some(pos) = name_pos {
+        format!("{}: {inferred}", &raw[..pos + name.len()])
+    } else {
+        let kw = if kind == SymbolKind::VARIABLE { "var" } else { "val" };
+        format!("{kw} {name}: {inferred}")
+    }
 }
 
 /// Build substitution map if requested by options and context.
@@ -395,6 +458,10 @@ impl IndexRead for super::Indexer {
             }
             self.resolve_symbol_no_rg(name, from_uri)
         }
+    }
+
+    fn infer_variable_type_for(&self, name: &str, uri: &Url) -> Option<String> {
+        self.infer_variable_type(name, uri)
     }
 }
 

--- a/src/stdlib_tail.rs
+++ b/src/stdlib_tail.rs
@@ -1,9 +1,10 @@
 
 use crate::stdlib::dot_completions_for;
 
-/// Language-aware dot completions: only return Kotlin stdlib for .kt files,
-/// add Swift-specific templates for .swift files. `from_path` should be the
-/// file path portion of the request URI (e.g., "/home/user/project/src/Foo.kt").
+/// Language-aware dot completions. Returns Kotlin stdlib completions for Kotlin
+/// and `.kts` files, Swift-specific templates for `.swift` files, and nothing
+/// for Java (handled by JVM tooling). `from_path` should be the file path
+/// portion of the request URI (e.g., "/home/user/project/src/Foo.kt").
 pub fn dot_completions_for_lang(from_path: &str, receiver_type: &str, snippets: bool) -> Vec<tower_lsp::lsp_types::CompletionItem> {
     match crate::Language::from_path(from_path) {
         crate::Language::Kotlin => dot_completions_for(receiver_type, snippets),

--- a/src/types.rs
+++ b/src/types.rs
@@ -16,6 +16,10 @@ pub enum Language {
 
 impl Language {
     /// Infer the language from a file path or URI string.
+    ///
+    /// Explicit matches: `.java` → Java, `.swift` → Swift.
+    /// Everything else (`.kt`, `.kts`, unknown extensions) → Kotlin, since this
+    /// server is Kotlin-primary and `.kts` files use the same language features.
     pub fn from_path(path: &str) -> Self {
         if path.ends_with(".swift")                        { Language::Swift }
         else if path.ends_with(".java")                    { Language::Java  }


### PR DESCRIPTION
## What

Migrates the hover handler from the old `lookup.rs` API to the new `resolution.rs` service, completing Phase 6 of the unified resolution architecture.

## Changes

### `src/indexer/resolution.rs`
- Added `infer_variable_type_for` to `IndexRead` trait + `Indexer` impl
- Fixed `extract_canonical_signature`: PROPERTY/VARIABLE now uses `sym.detail` first (avoids sibling constructor param bleed from `collect_signature`)
- Added `augment_property_sig` helper for unannotated val/var
- Added public `enrich_at_location` entry point for location-based enrichment

### `src/indexer/lookup.rs`
- Deleted `build_enclosing_class_subst` duplicate (~87 lines)
- `type_subst_for_enclosing_class` now delegates to `resolution::build_subst_map`
- Made `symbol_kw`, `symbol_kw_for_lang`, `lang_str` `pub(crate)`
- `hover_info`/`hover_info_at_location` retained for tests (deleted in Phase 10)

### `src/backend/format.rs` (new)
- `format_symbol_hover` — renders full symbol hover markdown
- `format_contextual_hover` — renders `val it: Type` + optional type detail

### `src/backend/handlers.rs`
- `hover_impl` rewritten to use `resolve_symbol_info`, `enrich_at_location`, `build_subst_map`
- Three paths: contextual (it/this), qualified receiver, regular symbol
- Passes `self.indexer.as_ref()` to satisfy `IndexRead` bound (Arc deref)

### `src/indexer.rs`
- `mod resolution` and `mod lookup` made `pub(crate)`

## Tests

655 tests pass, 0 failures.