### PR TITLE
feat(phase8): migrate completion_resolve to resolution service

### DIFF
--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -52,7 +52,7 @@ impl Backend {
                 // Resolve the type's own hover: import-aware, rg fallback, then stdlib.
                 let type_detail = resolve_symbol_info(
                         self.indexer.as_ref(), leaf, None, uri,
-                        SubstitutionContext::CrossFile { calling_uri: uri.as_str(), cursor_line: position.line },
+                        SubstitutionContext::CrossFile { calling_uri: uri.as_str(), cursor_line: Some(position.line) },
                         &ResolveOptions::hover())
                     .map(|i| format_symbol_hover(&i, uri.path()))
                     .or_else(|| crate::stdlib::hover(leaf));
@@ -74,7 +74,7 @@ impl Backend {
                 if let Some(loc) = locs.first() {
                     let subst_ctx = SubstitutionContext::CrossFile {
                         calling_uri: uri.as_str(),
-                        cursor_line: position.line,
+                        cursor_line: Some(position.line),
                     };
                     if let Some(info) = enrich_at_location(self.indexer.as_ref(), loc, &ctx.word, subst_ctx, &ResolveOptions::hover()) {
                         return Ok(Some(make_hover(format_symbol_hover(&info, uri.path()))));
@@ -86,7 +86,7 @@ impl Backend {
         // Path 3: regular symbol — import-aware resolution, rg fallback, then stdlib.
         let subst_ctx = SubstitutionContext::CrossFile {
             calling_uri: uri.as_str(),
-            cursor_line: position.line,
+            cursor_line: Some(position.line),
         };
         let hover_md = resolve_symbol_info(
                 self.indexer.as_ref(), &ctx.word, ctx.qualifier.as_deref(), uri,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -660,6 +660,8 @@ impl LanguageServer for Backend {
     // ── completionItem/resolve ────────────────────────────────────────────────
 
     async fn completion_resolve(&self, mut item: CompletionItem) -> Result<CompletionItem> {
+        use crate::indexer::resolution::{enrich_at_line, SubstitutionContext, ResolveOptions};
+
         if let Some(ref data) = item.data {
             if let (Some(uri), Some(line)) = (
                 data.get("u").and_then(|v| v.as_str()),
@@ -667,20 +669,32 @@ impl LanguageServer for Backend {
             ) {
                 let col         = data.get("c").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
                 let calling_uri = data.get("cu").and_then(|v| v.as_str());
-                // Always fill (or override) detail so type param substitution takes effect.
-                if let Some(d) = self.indexer.symbol_detail_at(uri, line as u32, col, calling_uri) {
-                    if !d.is_empty() {
-                        item.detail = Some(d);
+
+                let subst_ctx = match calling_uri {
+                    Some(cu) if cu != uri => SubstitutionContext::CrossFile {
+                        calling_uri: cu,
+                        cursor_line: None,
+                    },
+                    _ => SubstitutionContext::None,
+                };
+
+                if let Some(info) = enrich_at_line(
+                    self.indexer.as_ref(),
+                    uri,
+                    line as u32,
+                    col,
+                    subst_ctx,
+                    &ResolveOptions::completion(),
+                ) {
+                    if !info.signature.is_empty() {
+                        item.detail = Some(info.signature);
                     }
-                }
-                // Populate documentation only when KDoc/Javadoc is present.
-                if let Some((doc_md, _)) =
-                    self.indexer.completion_docs_for(uri, line as u32, col, calling_uri)
-                {
-                    item.documentation = Some(Documentation::MarkupContent(MarkupContent {
-                        kind:  MarkupKind::Markdown,
-                        value: doc_md,
-                    }));
+                    if !info.doc.is_empty() {
+                        item.documentation = Some(Documentation::MarkupContent(MarkupContent {
+                            kind:  MarkupKind::Markdown,
+                            value: info.doc,
+                        }));
+                    }
                 }
             }
         }

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -135,13 +135,13 @@ pub fn enrich_at_line<I: IndexRead>(
         .find(|s| {
             s.selection_range.start.line == line
                 && s.selection_range.start.character <= col
-                && col <= s.selection_range.end.character
+                && col < s.selection_range.end.character
         })
         .or_else(|| data.symbols.iter().find(|s| s.selection_range.start.line == line))?;
 
     let uri = Url::parse(uri_str).ok()?;
-    let location = Location { uri, range: sym.range };
-    enrich_symbol(index, &data, &location, &sym.name.clone(), subst_ctx, options)
+    let location = Location { uri, range: sym.selection_range };
+    enrich_symbol(index, &data, &location, &sym.name, subst_ctx, options)
 }
 
 /// Resolve contextual receiver information (it/this).
@@ -716,6 +716,85 @@ mod tests {
         let subst = build_subst_map(&idx, child_uri, 10);
         assert_eq!(subst.get("Event").map(|s| s.as_str()), Some("DashEvent"));
         assert_eq!(subst.get("State").map(|s| s.as_str()), Some("DashState"));
+    }
+
+    // ── enrich_at_line tests ──────────────────────────────────────────────────
+
+    fn make_sym_col(name: &str, kind: SymbolKind, line: u32, col_start: u32, col_end: u32) -> SymbolEntry {
+        use crate::types::Visibility;
+        use tower_lsp::lsp_types::{Position, Range};
+        SymbolEntry {
+            name: name.to_owned(),
+            kind,
+            visibility: Visibility::Public,
+            range: Range {
+                start: Position { line, character: col_start },
+                end:   Position { line, character: col_end },
+            },
+            selection_range: Range {
+                start: Position { line, character: col_start },
+                end:   Position { line, character: col_end },
+            },
+            detail: format!("fun {}()", name),
+            type_params: Vec::new(),
+            extension_receiver: String::new(),
+        }
+    }
+
+    /// Two overloads on different lines: enrich_at_line selects the right one by line.
+    #[test]
+    fn enrich_at_line_picks_by_line() {
+        let file_uri = "file:///overloads.kt";
+        let sym_a = make_sym_col("process", SymbolKind::FUNCTION, 0, 4, 11);
+        let sym_b = make_sym_col("process", SymbolKind::FUNCTION, 5, 4, 11);
+
+        let file_data = Arc::new(crate::types::FileData {
+            symbols: vec![sym_a, sym_b],
+            lines: std::sync::Arc::new(vec![
+                "fun process() {}".to_owned(),
+                String::new(), String::new(), String::new(), String::new(),
+                "fun process() {}".to_owned(),
+            ]),
+            ..Default::default()
+        });
+        let mut files = HashMap::new();
+        files.insert(file_uri.to_owned(), file_data);
+        let idx = RealTestIndex { files, definitions: HashMap::new() };
+
+        // Picking line 0 returns the first symbol; line 5 returns the second.
+        let res0 = enrich_at_line(&idx, file_uri, 0, 6, SubstitutionContext::None, &ResolveOptions::hover());
+        assert!(res0.is_some(), "should find symbol on line 0");
+
+        let res5 = enrich_at_line(&idx, file_uri, 5, 6, SubstitutionContext::None, &ResolveOptions::hover());
+        assert!(res5.is_some(), "should find symbol on line 5");
+
+        // Both have the same name but came from different symbol entries.
+        assert_eq!(res0.unwrap().location.range.start.line, 0);
+        assert_eq!(res5.unwrap().location.range.start.line, 5);
+    }
+
+    /// Column outside any symbol on the line → falls back to first sym on that line.
+    #[test]
+    fn enrich_at_line_col_fallback() {
+        let file_uri = "file:///fb.kt";
+        let sym = make_sym_col("fetch", SymbolKind::FUNCTION, 2, 4, 9);
+
+        let file_data = Arc::new(crate::types::FileData {
+            symbols: vec![sym],
+            lines: std::sync::Arc::new(vec![
+                String::new(), String::new(),
+                "fun fetch() {}".to_owned(),
+            ]),
+            ..Default::default()
+        });
+        let mut files = HashMap::new();
+        files.insert(file_uri.to_owned(), file_data);
+        let idx = RealTestIndex { files, definitions: HashMap::new() };
+
+        // col 99 is far outside [4,9) — should still resolve via fallback.
+        let res = enrich_at_line(&idx, file_uri, 2, 99, SubstitutionContext::None, &ResolveOptions::hover());
+        assert!(res.is_some(), "fallback should work when col misses");
+        assert_eq!(res.unwrap().name, "fetch");
     }
 
     // ── resolve_symbol_info end-to-end tests ─────────────────────────────────

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -28,19 +28,28 @@ pub struct ResolveOptions {
     pub allow_rg: bool,
     pub include_doc: bool,
     pub apply_subst: bool,
+    /// When true, prefer `SymbolEntry.detail` (cached, short) over the full
+    /// `collect_signature` source read.  Use for completion detail strings.
+    pub prefer_cached_detail: bool,
 }
 
 impl ResolveOptions {
-    pub fn hover() -> Self { Self { allow_rg: true, include_doc: true, apply_subst: true } }
-    pub fn inlay() -> Self { Self { allow_rg: false, include_doc: false, apply_subst: true } }
-    pub fn completion() -> Self { Self { allow_rg: false, include_doc: true, apply_subst: true } }
-    pub fn goto_def() -> Self { Self { allow_rg: true, include_doc: false, apply_subst: false } }
+    pub fn hover()      -> Self { Self { allow_rg: true,  include_doc: true,  apply_subst: true,  prefer_cached_detail: false } }
+    pub fn inlay()      -> Self { Self { allow_rg: false, include_doc: false, apply_subst: true,  prefer_cached_detail: false } }
+    pub fn completion() -> Self { Self { allow_rg: false, include_doc: true,  apply_subst: true,  prefer_cached_detail: true  } }
+    pub fn goto_def()   -> Self { Self { allow_rg: true,  include_doc: false, apply_subst: false, prefer_cached_detail: false } }
 }
 
 /// Substitution context used by the pipeline.
 pub enum SubstitutionContext<'a> {
     None,
-    CrossFile { calling_uri: &'a str, cursor_line: u32 },
+    /// Cross-file substitution: the symbol is from another file and we need to
+    /// substitute generic type params with the concrete args used by the caller.
+    ///
+    /// `cursor_line`: the cursor's line in `calling_uri`, used to identify which
+    /// class is calling (when a file has multiple classes extending the same base).
+    /// `None` = unknown / don't disambiguate → picks the first matching class.
+    CrossFile { calling_uri: &'a str, cursor_line: Option<u32> },
     EnclosingClass { uri: &'a str, cursor_line: u32 },
     Precomputed(&'a HashMap<String, String>),
 }
@@ -108,6 +117,33 @@ pub fn enrich_at_location<I: IndexRead>(
     enrich_symbol(index, &data, location, name, subst_ctx, options)
 }
 
+/// Find the symbol at `(line, col)` in `uri_str`, then enrich it.
+///
+/// Used by `completion_resolve` which stores line/col in the completion item
+/// data rather than a full `Location`.  If no symbol is at the exact position,
+/// falls back to first symbol whose selection range starts on `line`.
+pub fn enrich_at_line<I: IndexRead>(
+    index: &I,
+    uri_str: &str,
+    line: u32,
+    col: u32,
+    subst_ctx: SubstitutionContext<'_>,
+    options: &ResolveOptions,
+) -> Option<ResolvedSymbol> {
+    let data = index.get_file_data(uri_str)?;
+    let sym = data.symbols.iter()
+        .find(|s| {
+            s.selection_range.start.line == line
+                && s.selection_range.start.character <= col
+                && col <= s.selection_range.end.character
+        })
+        .or_else(|| data.symbols.iter().find(|s| s.selection_range.start.line == line))?;
+
+    let uri = Url::parse(uri_str).ok()?;
+    let location = Location { uri, range: sym.range };
+    enrich_symbol(index, &data, &location, &sym.name.clone(), subst_ctx, options)
+}
+
 /// Resolve contextual receiver information (it/this).
 pub fn resolve_contextual_info<I: IndexRead>(
     index: &I,
@@ -139,18 +175,19 @@ pub fn build_subst_map<I: IndexRead>(index: &I, uri: &str, cursor_line: u32) -> 
 
 // ─── Pure Data Transformation Functions ──────────────────────────────────
 
-/// Extract canonical signature (prefer full source, fall back to cached detail).
+/// Extract canonical signature respecting caller intent.
 ///
-/// For properties/variables: use the pre-indexed `detail` string directly —
-/// `collect_signature` on a property line reads forward until it finds `{` or `=`
-/// and can accidentally collect sibling constructor parameters.
-/// For functions/classes: prefer `collect_signature` (full untruncated source),
-/// falling back to `detail` (truncated at ~120 chars at index time).
-fn extract_canonical_signature(sym: &SymbolEntry, data: &FileData) -> String {
-    if matches!(sym.kind, SymbolKind::PROPERTY | SymbolKind::VARIABLE)
-        && !sym.detail.is_empty()
-    {
-        return sym.detail.clone();
+/// - `prefer_cached_detail = true` (completion): use `detail`-first — it's
+///   pre-computed, concise (~120 chars), and safe for single-line UI slots.
+/// - `prefer_cached_detail = false` (hover): prefer `collect_signature` for
+///   the full untruncated declaration; fall back to `detail`.
+///
+/// For properties/variables `collect_signature` reads forward until `{`/`=`
+/// and can accidentally collect sibling constructor params, so `detail` is
+/// always used for those kinds regardless of the `prefer_cached_detail` flag.
+fn extract_canonical_signature(sym: &SymbolEntry, data: &FileData, prefer_cached: bool) -> String {
+    if prefer_cached || matches!(sym.kind, SymbolKind::PROPERTY | SymbolKind::VARIABLE) {
+        if !sym.detail.is_empty() { return sym.detail.clone(); }
     }
     let full = data.lines.collect_signature(sym.selection_range.start.line as usize);
     if !full.is_empty() { full } else { sym.detail.clone() }
@@ -193,7 +230,7 @@ fn enrich_symbol<I: IndexRead>(
 ) -> Option<ResolvedSymbol> {
     let sym = find_symbol_entry(data, location, name)?;
 
-    let raw_signature = extract_canonical_signature(sym, data);
+    let raw_signature = extract_canonical_signature(sym, data, options.prefer_cached_detail);
 
     // For unannotated val/var (no `: Type` in the signature), try to infer the
     // concrete type so callers see `val foo: ReturnType` instead of `val foo = expr`.
@@ -278,7 +315,7 @@ fn build_type_param_subst_impl<I: IndexRead>(
     sym_uri: &str,
     sym_line: u32,
     calling_uri: &str,
-    caller_cursor_line: u32,
+    caller_cursor_line: Option<u32>,
 ) -> HashMap<String, String> {
     if sym_uri == calling_uri {
         return HashMap::new();
@@ -310,7 +347,9 @@ fn build_type_param_subst_impl<I: IndexRead>(
     // Use `caller_cursor_line` to identify the specific calling class — when multiple
     // classes in the same file extend the same base with different type args,
     // this ensures we pick the correct substitution for the caller.
-    let calling_class_line = calling_data.containing_class_at(caller_cursor_line)
+    // When `None`, the first class extending the base is used (e.g. for completion).
+    let calling_class_line = caller_cursor_line
+        .and_then(|line| calling_data.containing_class_at(line))
         .and_then(|name| calling_data.symbols.iter().find(|s| s.name == name))
         .map(|s| s.selection_range.start.line);
 
@@ -834,7 +873,7 @@ mod tests {
         let result_dash = resolve_symbol_info(
             &idx, "reduce", None,
             &Url::parse(caller_uri).unwrap(),
-            SubstitutionContext::CrossFile { calling_uri: caller_uri, cursor_line: 4 },
+            SubstitutionContext::CrossFile { calling_uri: caller_uri, cursor_line: Some(4) },
             &ResolveOptions::hover(),
         );
         let dash = result_dash.expect("should resolve reduce");
@@ -845,7 +884,7 @@ mod tests {
         let result_sett = resolve_symbol_info(
             &idx, "reduce", None,
             &Url::parse(caller_uri).unwrap(),
-            SubstitutionContext::CrossFile { calling_uri: caller_uri, cursor_line: 14 },
+            SubstitutionContext::CrossFile { calling_uri: caller_uri, cursor_line: Some(14) },
             &ResolveOptions::hover(),
         );
         let sett = result_sett.expect("should resolve reduce");


### PR DESCRIPTION
## Phase 8: Completion resolve migration

Migrates `completionItem/resolve` handler from two separate old-API calls to the unified resolution pipeline.

### Changes

**`resolution.rs`**
- Added `enrich_at_line`: enriches a symbol from file URI + line/col rather than a pre-resolved `Location` — the entry point completion_resolve needs
- `SubstitutionContext::CrossFile.cursor_line`: changed from `u32` to `Option<u32>`
  - `None` → first match in file (for completion, cursor position is in the calling file, not the symbol file)
  - `Some(line)` → disambiguate when multiple classes extend the same base
- Added `prefer_cached_detail: bool` to `ResolveOptions`:
  - `false` (hover): `collect_signature` first — full untruncated declaration  
  - `true` (completion): `sym.detail` first — pre-computed, short, safe for popup

**`backend/mod.rs`**
- `completion_resolve`: replaced two calls (`symbol_detail_at` + `completion_docs_for`) with single `enrich_at_line` using `ResolveOptions::completion()`

**`backend/handlers.rs`**
- Updated 3 `CrossFile` call sites: `cursor_line: position.line` → `cursor_line: Some(position.line)`

### Result
655 tests pass. Dead code (`symbol_detail_at`, `completion_docs_for`) targeted for removal in Phase 10.