### PR TITLE
refactor(phase10): remove dead code from lookup.rs

### DIFF
--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -5,8 +5,6 @@
 //! - [`Indexer::is_declared_in`]             — test if a name is declared in a file
 //! - [`Indexer::find_definition`]            — resolve definition locations by name
 //! - [`Indexer::find_definition_qualified`]  — resolve with optional dot-qualifier
-//! - [`Indexer::hover_info`]                 — build Markdown hover snippet by name
-//! - [`Indexer::hover_info_at_location`]     — build hover snippet for a specific location
 //! - [`Indexer::file_symbols`]               — all symbols declared in a file
 //! - [`Indexer::package_of`]                 — package declared in a file
 //! - [`Indexer::declared_package_of`]        — package in which a name is declared
@@ -16,9 +14,7 @@
 use tower_lsp::lsp_types::*;
 
 use crate::types::SymbolEntry;
-use crate::LinesExt;
 use crate::StrExt;
-use crate::stdlib::hover;
 use super::Indexer;
 use super::doc::extract_doc_comment;
 
@@ -43,185 +39,6 @@ impl Indexer {
         from_uri: &Url,
     ) -> Vec<Location> {
         self.resolve_symbol(name, qualifier, from_uri)
-    }
-
-    /// Build a Markdown hover snippet for a symbol name.
-    ///
-    /// **Note:** Production code uses `resolution::resolve_symbol_info` +
-    /// `backend::format::format_symbol_hover` instead. This method is retained
-    /// for lookup unit tests (Phase 10 will migrate tests and delete it).
-    pub fn hover_info(&self, name: &str, calling_uri: Option<&str>) -> Option<String> {
-        // Check stdlib first so well-known symbols (run, apply, map, …) get
-        // proper signatures even when no project source contains them.
-        if let Some(md) = hover(name) { return Some(md); }
-
-        // Drop the dashmap ref before taking the second one.
-        let loc: Location = {
-            let r = self.definitions.get(name)?;
-            r.first()?.clone()
-        };
-        self.hover_info_at_location(&loc, name, calling_uri, None)
-    }
-
-    /// Build hover markdown for `name` at a specific resolved `Location`.
-    ///
-    /// **Note:** Production code uses `resolution::enrich_at_location` +
-    /// `backend::format::format_symbol_hover` instead. This method is retained
-    /// for lookup unit tests (Phase 10 will migrate tests and delete it).
-    ///
-    /// `calling_uri` — the file where the cursor is (used to substitute generic type
-    /// parameters with concrete types when the symbol is from a base class).
-    /// `cursor_line` — the line of the cursor in `calling_uri`; used to disambiguate
-    /// when multiple classes in the same file extend the same generic base.
-    pub fn hover_info_at_location(&self, loc: &Location, name: &str, calling_uri: Option<&str>, cursor_line: Option<u32>) -> Option<String> {
-        // On-demand index: the file may have been found by rg but not yet indexed.
-        if !self.files.contains_key(loc.uri.as_str()) {
-            if let Ok(path) = loc.uri.to_file_path() {
-                if let Ok(content) = std::fs::read_to_string(&path) {
-                    self.index_content(&loc.uri, &content);
-                }
-            }
-        }
-        // Extract needed fields and drop the DashMap guard before any inference
-        // call (which may reacquire the same shard and deadlock otherwise).
-        let (sym_kind, sym_sel_range, sym_detail, lines) = {
-            let data = self.files.get(loc.uri.as_str())?;
-            let sym = data.symbols.iter().find(|s| s.selection_range == loc.range)
-                .or_else(|| data.symbols.iter().find(|s| s.name == name))?;
-            (sym.kind, sym.selection_range, sym.detail.clone(), data.lines.clone())
-        };
-
-        let start_line = sym_sel_range.start.line as usize;
-
-        // For property/variable symbols use the pre-indexed detail (a single declaration
-        // line) rather than collect_signature, which would keep reading until it finds a
-        // closing ')' and accidentally include sibling constructor parameters.
-        let raw_sig = if matches!(sym_kind, SymbolKind::PROPERTY | SymbolKind::VARIABLE)
-            && !sym_detail.is_empty()
-        {
-            sym_detail
-        } else {
-            lines.collect_signature(start_line)
-        };
-
-        // For unannotated val/var, try to show an inferred type instead of the
-        // raw RHS expression (e.g. `val response: AccountDetailResponseBody`
-        // instead of `val response = service.getDetail(...)`).
-        let sig = if matches!(sym_kind, SymbolKind::PROPERTY | SymbolKind::VARIABLE)
-            && !raw_sig.contains(&format!("{name}:"))
-        {
-            if let Some(inferred) = self.infer_variable_type(name, &loc.uri) {
-                // Keep modifiers from the original signature (e.g. `private`, `override`).
-                // Find the name in the raw_sig and replace everything from `name` onward
-                // with `name: InferredType`, discarding the `= rhs` initializer.
-                let needle = format!(" {name}");
-                let name_pos = raw_sig.find(&needle)
-                    .map(|p| p + 1)
-                    .or_else(|| if raw_sig.starts_with(name) { Some(0) } else { None });
-                if let Some(pos) = name_pos {
-                    format!("{}: {inferred}", &raw_sig[..pos + name.len()])
-                } else {
-                    let kw = if sym_kind == SymbolKind::VARIABLE { "var" } else { "val" };
-                    format!("{kw} {name}: {inferred}")
-                }
-            } else {
-                raw_sig
-            }
-        } else {
-            raw_sig
-        };
-
-        // Apply generic type parameter substitution when the cursor is in a different
-        // file (subtype) than where the symbol is defined.
-        let sig = if let Some(cu) = calling_uri {
-            let subst = build_type_param_subst(self, loc.uri.as_str(), sym_sel_range.start.line, cu, cursor_line);
-            if subst.is_empty() { sig } else { apply_subst(&sig, &subst) }
-        } else {
-            sig
-        };
-
-        let lang = lang_str(loc.uri.path());
-
-        let code_block = if sig.is_empty() {
-            format!("```{}\n{} {}\n```", lang, symbol_kw_for_lang(sym_kind, lang), name)
-        } else {
-            format!("```{}\n{}\n```", lang, sig)
-        };
-
-        // Prepend KDoc / Javadoc comment if one immediately precedes the declaration.
-        if let Some(doc) = extract_doc_comment(&lines, start_line) {
-            Some(format!("{doc}\n\n---\n\n{code_block}"))
-        } else {
-            Some(code_block)
-        }
-    }
-
-    /// Returns the pre-computed `detail` string (declaration signature) for the
-    /// symbol declared at the given line+character in `uri_str`. Used by
-    /// `completionItem/resolve` to populate `CompletionItem.detail`.
-    ///
-    /// `calling_uri` — the file where the cursor is; used for generic type substitution.
-    pub fn symbol_detail_at(&self, uri_str: &str, line: u32, col: u32, calling_uri: Option<&str>) -> Option<String> {
-        let data = self.files.get(uri_str)?;
-        let sym = data.symbols.iter()
-            .find(|s| s.selection_range.start.line == line
-                   && s.selection_range.start.character == col)
-            .or_else(|| data.symbols.iter().find(|s| s.selection_range.start.line == line))?;
-        let lang = lang_str(uri_str);
-        let raw = if sym.detail.is_empty() {
-            format!("{} {}", symbol_kw_for_lang(sym.kind, lang), sym.name)
-        } else {
-            sym.detail.clone()
-        };
-        if let Some(cu) = calling_uri {
-            let subst = build_type_param_subst(self, uri_str, sym.selection_range.start.line, cu, None);
-            if !subst.is_empty() { return Some(apply_subst(&raw, &subst)); }
-        }
-        Some(raw)
-    }
-
-    /// Build Markdown documentation for a completion item identified by its
-    /// source file URI and declaration line+character.
-    ///
-    /// Called by `completionItem/resolve` to lazily populate `documentation`
-    /// without bloating the initial completion response.
-    ///
-    /// Returns `(doc_markdown, detail)` where `doc_markdown` is the KDoc/Javadoc
-    /// comment only (no code block — the signature is already shown in `detail`)
-    /// and `detail` is the short signature string for `CompletionItem.detail`.
-    ///
-    /// `calling_uri` — the file where the cursor is; used for generic type substitution.
-    pub fn completion_docs_for(&self, uri_str: &str, line: u32, col: u32, calling_uri: Option<&str>) -> Option<(String, String)> {
-        let data = self.files.get(uri_str)?;
-        let start_line = line as usize;
-
-        let sym = data.symbols.iter()
-            .find(|s| s.selection_range.start.line == line
-                   && s.selection_range.start.character == col)
-            .or_else(|| data.symbols.iter().find(|s| s.selection_range.start.line == line))?;
-
-        let lang = lang_str(uri_str);
-
-        // detail: prefer the pre-computed SymbolEntry.detail; fall back to
-        // a minimal keyword + name string so the field is never empty.
-        let raw_detail = if sym.detail.is_empty() {
-            format!("{} {}", symbol_kw_for_lang(sym.kind, lang), sym.name)
-        } else {
-            sym.detail.clone()
-        };
-
-        // Apply generic type parameter substitution when requested.
-        let detail = if let Some(cu) = calling_uri {
-            let subst = build_type_param_subst(self, uri_str, sym.selection_range.start.line, cu, None);
-            if subst.is_empty() { raw_detail } else { apply_subst(&raw_detail, &subst) }
-        } else {
-            raw_detail
-        };
-
-        // documentation: KDoc/Javadoc only — the signature is already in detail.
-        let doc_md = extract_doc_comment(&data.lines, start_line)?;
-
-        Some((doc_md, detail))
     }
 
     /// All symbols declared in the given file (for `documentSymbol`).
@@ -307,14 +124,6 @@ impl Indexer {
         (None, None)
     }
 
-    /// Apply generic type parameter substitution to `sig` for a symbol at `sym_uri:sym_line`
-    /// when viewed from `calling_uri`.  Returns the substituted string, or the original if
-    /// no substitution is applicable.
-    pub(crate) fn type_subst_sig(&self, sym_uri: &str, sym_line: u32, calling_uri: &str, sig: &str) -> String {
-        let subst = build_type_param_subst(self, sym_uri, sym_line, calling_uri, None);
-        if subst.is_empty() { sig.to_owned() } else { apply_subst(sig, &subst) }
-    }
-
 }
 
 pub(crate) fn symbol_kw(kind: SymbolKind) -> &'static str {
@@ -349,100 +158,14 @@ pub(crate) fn lang_str(path: &str) -> &'static str {
 
 // ─── Generic type parameter substitution ─────────────────────────────────────
 
-/// Build a type-parameter → concrete-type substitution map for a symbol declared
-/// inside a generic class/interface when viewed from a specialised subtype.
+/// Apply a type-parameter substitution map to a type string.
 ///
-/// For example: `FlowReducer<EventType, out EffectType, StateType>` specialised by
-/// `DashboardProductsReducer : FlowReducer<Event, Effect, State>` gives
-/// `{"EventType" → "Event", "EffectType" → "Effect", "StateType" → "State"}`.
+/// Only replaces whole-word occurrences (character boundaries), so `EventType`
+/// is not partially replaced when substituting `Event`.
 ///
-/// Returns an empty map when substitution is not applicable (same file, no generics,
-/// or the calling file doesn't implement the container class).
-fn build_type_param_subst(
-    idx:         &Indexer,
-    sym_uri:     &str,
-    sym_line:    u32,
-    calling_uri: &str,
-    cursor_line: Option<u32>,
-) -> std::collections::HashMap<String, String> {
-    if sym_uri == calling_uri {
-        return Default::default();
-    }
-
-    let sym_data = match idx.files.get(sym_uri) {
-        Some(d) => d,
-        None => return Default::default(),
-    };
-
-    let container_name = match sym_data.containing_class_at(sym_line) {
-        Some(n) => n,
-        None    => return Default::default(),
-    };
-
-    let container_sym = match sym_data.symbols.iter().find(|s| s.name == container_name) {
-        Some(s) => s,
-        None    => return Default::default(),
-    };
-
-    let type_params = &container_sym.type_params;
-    if type_params.is_empty() { return Default::default(); }
-
-    let calling_data = match idx.files.get(calling_uri) {
-        Some(d) => d,
-        None    => return Default::default(),
-    };
-
-    // When multiple classes in the same file extend the same base, use cursor_line
-    // to identify the specific calling class and scope the supers lookup.
-    let calling_class_line = cursor_line
-        .and_then(|line| calling_data.containing_class_at(line))
-        .and_then(|name| calling_data.symbols.iter().find(|s| s.name == name))
-        .map(|s| s.selection_range.start.line);
-
-    let type_args = calling_data.supers.iter()
-        .find(|(line, base, _)| {
-            base == &container_name
-                && calling_class_line.is_none_or(|class_line| *line == class_line)
-        })
-        .map(|(_, _, args)| args.clone())
-        .unwrap_or_default();
-
-    if type_args.is_empty() { return Default::default(); }
-
-    type_params.iter().zip(type_args.iter())
-        .map(|(k, v)| (k.clone(), v.clone()))
-        .collect()
-}
-
-/// Extract the simple type name from a property detail string.
-/// E.g. "private val foo: DashboardProductsReducer by lazy" → "DashboardProductsReducer"
-/// E.g. "val x: List<String>" → "List"
-pub(crate) fn extract_property_type_name(detail: &str) -> &str {
-    // Find ": Type" pattern
-    let colon_pos = match detail.find(':') {
-        Some(p) => p,
-        None => return "",
-    };
-    let after_colon = detail[colon_pos + 1..].trim_start();
-    // Take the first identifier (uppercase start = type name)
-    let end = after_colon.find(|c: char| !c.is_alphanumeric() && c != '_').unwrap_or(after_colon.len());
-    let name = &after_colon[..end];
-    if name.is_empty() || !name.chars().next().unwrap_or(' ').is_uppercase() {
-        return "";
-    }
-    name
-}
-
-/// Apply a type-parameter substitution map to a type string (public for inlay_hints).
+/// Re-exported as `crate::indexer::apply_type_subst` for use by inlay_hints,
+/// backend handlers, and the resolution module.
 pub(crate) fn apply_type_subst(sig: &str, subst: &std::collections::HashMap<String, String>) -> String {
-    apply_subst(sig, subst)
-}
-
-/// Apply a type-parameter substitution map to a signature string.
-///
-/// Only replaces whole-word occurrences (character boundaries), so `EventType` is
-/// not partially replaced when looking up `Event`.
-fn apply_subst(sig: &str, subst: &std::collections::HashMap<String, String>) -> String {
     if subst.is_empty() { return sig.to_owned(); }
     let mut result = String::with_capacity(sig.len() + 16);
     let chars: Vec<char> = sig.chars().collect();
@@ -450,7 +173,6 @@ fn apply_subst(sig: &str, subst: &std::collections::HashMap<String, String>) -> 
     while i < chars.len() {
         let ch = chars[i];
         if ch.is_alphabetic() || ch == '_' {
-            // Collect the full identifier starting at i.
             let start = i;
             while i < chars.len() && (chars[i].is_alphanumeric() || chars[i] == '_') {
                 i += 1;

--- a/src/indexer/lookup_tests.rs
+++ b/src/indexer/lookup_tests.rs
@@ -20,47 +20,27 @@ fn indexed(path: &str, src: &str) -> (Url, Indexer) {
     (u, idx)
 }
 
-// ── Swift hover uses "func" not "fun" ────────────────────────────────────────
+// ── keyword helpers ───────────────────────────────────────────────────────────
 
 #[test]
-fn swift_hover_uses_func_keyword() {
-    // Swift function with no signature detail should show "func", not "fun".
-    let src = "func greet() {}";
-    let (u, idx) = indexed("/Greeting.swift", src);
-    let hover = idx.hover_info_at_location(
-        &Location { uri: u.clone(), range: Default::default() },
-        "greet",
-        None,
-        None,
-    ).unwrap_or_default();
-    assert!(
-        hover.contains("func"),
-        "Swift hover should say 'func', got: {hover}"
-    );
-    assert!(
-        !hover.contains("```kotlin\nfun ") && !hover.contains("```swift\nfun "),
-        "Swift hover must not emit 'fun', got: {hover}"
-    );
+fn swift_uses_func_keyword() {
+    // Swift functions must render as `func`, not `fun`.
+    assert_eq!(super::symbol_kw_for_lang(SymbolKind::FUNCTION, "swift"), "func");
+    assert_eq!(super::symbol_kw_for_lang(SymbolKind::METHOD,   "swift"), "func");
 }
 
 #[test]
-fn kotlin_hover_still_uses_fun_keyword() {
-    let src = "fun greet() {}";
-    let (u, idx) = indexed("/Greeting.kt", src);
-    let hover = idx.hover_info_at_location(
-        &Location { uri: u.clone(), range: Default::default() },
-        "greet",
-        None,
-        None,
-    ).unwrap_or_default();
-    assert!(
-        hover.contains("fun"),
-        "Kotlin hover should say 'fun', got: {hover}"
-    );
+fn kotlin_uses_fun_keyword() {
+    assert_eq!(super::symbol_kw_for_lang(SymbolKind::FUNCTION, "kotlin"), "fun");
+    assert_eq!(super::symbol_kw_for_lang(SymbolKind::METHOD,   "kotlin"), "fun");
 }
 
+// ── resolve_symbol_info: KDoc inclusion ──────────────────────────────────────
+
 #[test]
-fn hover_includes_kdoc() {
+fn resolve_includes_kdoc() {
+    use crate::indexer::resolution::{resolve_symbol_info, ResolveOptions, SubstitutionContext};
+
     let src = r#"package com.example
 
 /**
@@ -68,50 +48,52 @@ fn hover_includes_kdoc() {
  */
 class Account(val name: String)"#;
     let (u, idx) = indexed("/Account.kt", src);
-    let hover = idx.hover_info("Account", None).unwrap();
-    assert!(hover.contains("Represents a user account"), "got: {hover}");
-    assert!(hover.contains("```kotlin"), "got: {hover}");
-    assert!(hover.contains("---"), "separator missing: {hover}");
+
+    let info = resolve_symbol_info(
+        &idx, "Account", None, &u,
+        SubstitutionContext::None,
+        &ResolveOptions { allow_rg: false, include_doc: true, apply_subst: false, prefer_cached_detail: false },
+    ).expect("Account should resolve");
+
+    assert!(
+        info.doc.contains("Represents a user account"),
+        "KDoc should appear in doc field, got: {:?}", info.doc
+    );
 }
 
-// ── hover on val bindings ────────────────────────────────────────────────────
+// ── val binding: find_definition_qualified + signature ───────────────────────
 
 #[test]
-fn hover_val_binding_constructor_param() {
-    // Constructor parameter: `private val repo: IGoldConversionRepository`
-    let idx = Indexer::new();
-    let u = uri("/Foo.kt");
-    idx.index_content(&u, "\
+fn val_binding_found_and_has_type() {
+    use crate::indexer::resolution::{resolve_symbol_info, ResolveOptions, SubstitutionContext};
+
+    let (u, idx) = indexed("/Foo.kt", "\
 class Foo(
     private val repo: IGoldConversionRepository
 ) {
     fun doStuff() {}
 }");
-    // 1. repo should be captured as a symbol
-    let data = idx.files.get(u.as_str()).unwrap();
-    let repo_sym = data.symbols.iter().find(|s| s.name == "repo");
-    assert!(repo_sym.is_some(), "repo should be in symbols; got: {:?}",
-        data.symbols.iter().map(|s| &s.name).collect::<Vec<_>>());
-
-    // 2. find_definition_qualified should find it
+    // 1. find_definition_qualified must find repo
     let locs = idx.find_definition_qualified("repo", None, &u);
     assert!(!locs.is_empty(), "repo should be found via find_definition_qualified");
 
-    // 3. hover_info_at_location should return something
-    let hover = idx.hover_info_at_location(locs.first().unwrap(), "repo", None, None);
-    assert!(hover.is_some(), "hover on val repo should produce result");
-    let md = hover.unwrap();
-    assert!(md.contains("repo"), "hover should mention 'repo', got: {md}");
+    // 2. resolve_symbol_info should return a signature mentioning the type
+    let info = resolve_symbol_info(
+        &idx, "repo", None, &u,
+        SubstitutionContext::None,
+        &ResolveOptions { allow_rg: false, include_doc: false, apply_subst: false, prefer_cached_detail: false },
+    );
+    assert!(info.is_some(), "resolve should find repo");
+    let sig = info.unwrap().signature;
+    assert!(sig.contains("repo"), "signature should mention 'repo', got: {sig}");
+    assert!(sig.contains("IGoldConversionRepository"), "signature should show type, got: {sig}");
 }
 
-// ── real-world patterns ──────────────────────────────────────────────────────
-
 #[test]
-fn real_hover_constructor_val_binding() {
-    // From report: hover on `repo` in constructor param returns nothing
-    let idx = Indexer::new();
-    let u = uri("/ContactAddressInteractor.kt");
-    idx.index_content(&u, "\
+fn real_val_binding_constructor_param() {
+    use crate::indexer::resolution::{resolve_symbol_info, ResolveOptions, SubstitutionContext};
+
+    let (u, idx) = indexed("/ContactAddressInteractor.kt", "\
 package cz.moneta.smartbanka.feature.gold_conversion.model.goldcard
 internal class ContactAddressInteractor @Inject constructor(
   private val repo: IGoldConversionRepository,
@@ -119,149 +101,25 @@ internal class ContactAddressInteractor @Inject constructor(
   override suspend fun loadData(): PersonalAddress =
     requireNotNull(repo.contactAddressSetup().contactAddress)
 }");
-    // hover on `repo` (line 2, col ~14)
     let locs = idx.find_definition_qualified("repo", None, &u);
     assert!(!locs.is_empty(), "repo should be found");
-    let hover = idx.hover_info_at_location(locs.first().unwrap(), "repo", None, None);
-    assert!(hover.is_some(), "hover on val repo should work");
-    let md = hover.unwrap();
-    assert!(md.contains("repo"), "hover should mention repo: {md}");
-    assert!(md.contains("IGoldConversionRepository"), "hover should show type: {md}");
-}
 
-// ── completion_docs_for ──────────────────────────────────────────────────────
-
-#[test]
-fn completion_docs_for_returns_kdoc_and_detail() {
-    let idx = Indexer::new();
-    let u = uri("/Foo.kt");
-    idx.index_content(&u, "\
-package com.example
-
-/**
- * Adds two numbers together.
- * @param a first number
- */
-fun add(a: Int, b: Int): Int = a + b
-");
-    // `add` is declared at line 6 (0-based)
-    let sym = {
-        let f = idx.files.get(u.as_str()).unwrap();
-        f.symbols.iter().find(|s| s.name == "add").cloned().unwrap()
-    };
-    let line = sym.selection_range.start.line;
-    let col  = sym.selection_range.start.character;
-
-    let result = idx.completion_docs_for(u.as_str(), line, col, None);
-    assert!(result.is_some(), "completion_docs_for should return Some for documented function");
-    let (doc_md, detail) = result.unwrap();
-    assert!(doc_md.contains("Adds two numbers"), "doc should contain KDoc text, got: {doc_md}");
-    assert!(!doc_md.contains("```"), "doc should NOT include a code block (detail carries the sig), got: {doc_md}");
-    assert!(!detail.is_empty(), "detail should be non-empty");
-}
-
-#[test]
-fn completion_docs_for_returns_none_without_kdoc() {
-    let idx = Indexer::new();
-    let u = uri("/Bar.kt");
-    idx.index_content(&u, "fun multiply(x: Int, y: Int): Int = x * y\n");
-    let sym = {
-        let f = idx.files.get(u.as_str()).unwrap();
-        f.symbols.iter().find(|s| s.name == "multiply").cloned().unwrap()
-    };
-    let line = sym.selection_range.start.line;
-    let col  = sym.selection_range.start.character;
-    // No KDoc → None (caller skips setting documentation)
-    assert!(idx.completion_docs_for(u.as_str(), line, col, None).is_none());
-}
-
-#[test]
-fn completion_docs_for_kts_uses_kotlin_lang() {
-    let idx = Indexer::new();
-    let u = uri("/build.gradle.kts");
-    idx.index_content(&u, "\
-/** Configure something. */
-fun configure() {}\n");
-    let sym = {
-        let f = idx.files.get(u.as_str()).unwrap();
-        f.symbols.iter().find(|s| s.name == "configure").cloned().unwrap()
-    };
-    let line = sym.selection_range.start.line;
-    let col  = sym.selection_range.start.character;
-    let (doc_md, _detail) = idx.completion_docs_for(u.as_str(), line, col, None).unwrap();
-    assert!(doc_md.contains("Configure something"));
-}
-
-// ── generic type parameter substitution ─────────────────────────────────────
-
-#[test]
-fn hover_generic_type_params_substituted_in_subclass() {
-    // FlowReducer is a generic interface in one file.
-    // DashboardProductsReducer specialises it in another.
-    // Hovering `reduce` from the subclass file should show concrete types.
-    let idx = Indexer::new();
-
-    let base_u = uri("/FlowReducer.kt");
-    idx.index_content(&base_u, "\
-interface FlowReducer<EventType, out EffectType, StateType> {
-    fun reduce(state: StateType, event: EventType): StateType
-    fun effects(event: EventType): List<EffectType>
-}
-");
-
-    let sub_u = uri("/DashboardProductsReducer.kt");
-    idx.index_content(&sub_u, "\
-class DashboardProductsReducer : FlowReducer<Event, Effect, State> {
-    override fun reduce(state: State, event: Event): State = state
-    override fun effects(event: Event): List<Effect> = emptyList()
-}
-");
-
-    // `reduce` is declared in FlowReducer — hover from the subclass file
-    let base_data = idx.files.get(base_u.as_str()).unwrap();
-    let reduce_sym = base_data.symbols.iter().find(|s| s.name == "reduce").cloned()
-        .expect("reduce should be indexed in FlowReducer.kt");
-    let loc = tower_lsp::lsp_types::Location {
-        uri:   base_u.clone(),
-        range: reduce_sym.selection_range,
-    };
-
-    let hover = idx.hover_info_at_location(&loc, "reduce", Some(sub_u.as_str()), None)
-        .expect("hover should return Some");
-
-    // Type params should be substituted: StateType→State, EventType→Event
-    assert!(hover.contains("State"), "hover should show 'State', got: {hover}");
-    assert!(hover.contains("Event"), "hover should show 'Event', got: {hover}");
-    assert!(!hover.contains("StateType"), "hover must NOT show 'StateType', got: {hover}");
-    assert!(!hover.contains("EventType"), "hover must NOT show 'EventType', got: {hover}");
-}
-
-#[test]
-fn hover_generic_no_subst_when_same_file() {
-    // Hovering from the same file should NOT substitute (raw type params shown).
-    let idx = Indexer::new();
-    let u = uri("/FlowReducer.kt");
-    idx.index_content(&u, "\
-interface FlowReducer<EventType, out EffectType, StateType> {
-    fun reduce(state: StateType, event: EventType): StateType
-}
-");
-    let data = idx.files.get(u.as_str()).unwrap();
-    let reduce_sym = data.symbols.iter().find(|s| s.name == "reduce").cloned().unwrap();
-    let loc = tower_lsp::lsp_types::Location { uri: u.clone(), range: reduce_sym.selection_range };
-
-    // calling_uri == sym_uri → no substitution
-    let hover = idx.hover_info_at_location(&loc, "reduce", Some(u.as_str()), None).unwrap();
-    assert!(hover.contains("StateType"), "same-file hover should keep raw type params, got: {hover}");
+    let info = resolve_symbol_info(
+        &idx, "repo", None, &u,
+        SubstitutionContext::None,
+        &ResolveOptions { allow_rg: false, include_doc: false, apply_subst: false, prefer_cached_detail: false },
+    ).expect("hover on val repo should work");
+    assert!(info.signature.contains("IGoldConversionRepository"),
+        "hover should show type: {}", info.signature);
 }
 
 // ── Port-regression: property-type harvesting ─────────────────────────────────
 
 /// When the enclosing class's supers contain generic type args, the inlay-hint
-/// substitution path (`type_subst_for_enclosing_class`) must return the correct
-/// mapping. This tests the "UncC" scenario: build_enclosing_class_subst must
-/// perform phase 2 (member property harvesting) so that a property whose type
-/// extends a generic base contributes its type-param mappings to the enclosing class.
+/// substitution path (`build_subst_map`) must return the correct mapping.
+/// This tests the "UncC" scenario: build_enclosing_class_subst must perform
+/// phase 2 (member property harvesting) so that a property whose type extends
+/// a generic base contributes its type-param mappings to the enclosing class.
 #[test]
 fn inlay_hints_generic_subst_via_property_type_harvesting() {
     let idx = Indexer::new();
@@ -288,9 +146,6 @@ class DashViewModel {
 }
 ");
 
-    // Inlay hint substitution from inside DashViewModel (line 2 = inside the class):
-    // Phase 2 of build_enclosing_class_subst should trace:
-    //   property `reducer: DashReducer` → DashReducer supers → FlowReducer<E=DashEvent, S=DashState>
     let subst = crate::indexer::resolution::build_subst_map(&idx, owner_u.as_str(), 2);
     assert!(subst.contains_key("E") || subst.contains_key("S"),
         "property harvesting should produce substitution for FlowReducer params, got: {subst:?}");
@@ -302,53 +157,3 @@ class DashViewModel {
     }
 }
 
-// ── Port-regression: two callers in same file ─────────────────────────────────
-
-/// When two classes in the same file extend the same generic base with different
-/// type args, hovering inside each class must use the correct substitution.
-/// This is the "Unb5/TRjS" regression — fixed by adding cursor_line to
-/// build_type_param_subst / hover_info_at_location.
-#[test]
-fn hover_generic_subst_disambiguates_two_callers_in_same_file() {
-    let idx = Indexer::new();
-
-    let base_u = uri("/Processor.kt");
-    idx.index_content(&base_u, "\
-interface Processor<IN, OUT> {
-    fun process(input: IN): OUT
-}
-");
-
-    let caller_u = uri("/Callers.kt");
-    idx.index_content(&caller_u, "\
-class StringProcessor : Processor<String, Int> {
-    override fun process(input: String): Int = input.length
-}
-
-class BoolProcessor : Processor<Boolean, String> {
-    override fun process(input: Boolean): String = input.toString()
-}
-");
-
-    let base_data = idx.files.get(base_u.as_str()).unwrap();
-    let process_sym = base_data.symbols.iter().find(|s| s.name == "process").cloned()
-        .expect("process not found");
-    let loc = tower_lsp::lsp_types::Location {
-        uri: base_u.clone(),
-        range: process_sym.selection_range,
-    };
-
-    // Cursor on line 1 (inside StringProcessor): should use String/Int
-    let hover_string = idx.hover_info_at_location(&loc, "process", Some(caller_u.as_str()), Some(1))
-        .expect("hover should resolve for StringProcessor");
-    assert!(!hover_string.contains("Boolean"),
-        "StringProcessor hover (line 1) must not show Boolean, got: {hover_string}");
-
-    // Cursor on line 6 (inside BoolProcessor): should use Boolean/String
-    let hover_bool = idx.hover_info_at_location(&loc, "process", Some(caller_u.as_str()), Some(6))
-        .expect("hover should resolve for BoolProcessor");
-    assert!(hover_bool.contains("Boolean"),
-        "BoolProcessor hover (line 6) should show Boolean, got: {hover_bool}");
-    assert!(!hover_bool.contains("Int"),
-        "BoolProcessor hover (line 6) must not show Int, got: {hover_bool}");
-}

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -1004,4 +1004,98 @@ mod tests {
         assert!(sett.signature.contains("SettEvent"), "sett: {}", sett.signature);
         assert!(sett.signature.contains("SettState"), "sett: {}", sett.signature);
     }
+
+    // ── enrich_at_line (completion resolve) ──────────────────────────────────
+
+    #[test]
+    fn enrich_at_line_returns_detail_for_completion_resolve() {
+        let uri = "file:///Foo.kt";
+        let mut sym = make_sym("add", SymbolKind::FUNCTION, 0, 0);
+        sym.detail = "fun add(a: Int, b: Int): Int".to_owned();
+
+        let data = Arc::new(crate::types::FileData {
+            symbols: vec![sym],
+            ..Default::default()
+        });
+        let mut files = HashMap::new();
+        files.insert(uri.to_owned(), data);
+        let idx = RealTestIndex {
+            files,
+            definitions: HashMap::new(),
+        };
+
+        let result = enrich_at_line(
+            &idx,
+            uri,
+            0,    // line
+            0,    // col
+            SubstitutionContext::None,
+            &ResolveOptions::completion(),
+        );
+        assert!(result.is_some(), "enrich_at_line should return Some for documented function");
+        let info = result.unwrap();
+        assert!(!info.signature.is_empty(), "signature should not be empty");
+        assert_eq!(info.signature, "fun add(a: Int, b: Int): Int");
+        // doc should be empty by default for completion() options
+        assert_eq!(info.doc, "");
+    }
+
+    #[test]
+    fn enrich_at_line_falls_back_to_line_only_match_for_completion() {
+        let uri = "file:///Bar.kt";
+        let sym = make_sym("multiply", SymbolKind::FUNCTION, 0, 0);
+        let data = Arc::new(crate::types::FileData {
+            symbols: vec![sym],
+            ..Default::default()
+        });
+        let mut files = HashMap::new();
+        files.insert(uri.to_owned(), data);
+        let idx = RealTestIndex {
+            files,
+            definitions: HashMap::new(),
+        };
+
+        // Query with col=5, but symbol is at col=0: should fall back to line-only match
+        let result = enrich_at_line(
+            &idx,
+            uri,
+            0,    // line (matches)
+            5,    // col (doesn't match, but fallback should find it)
+            SubstitutionContext::None,
+            &ResolveOptions::completion(),
+        );
+        assert!(result.is_some(), "enrich_at_line should fall back to line-only match");
+        assert_eq!(result.unwrap().kind, SymbolKind::FUNCTION);
+    }
+
+    #[test]
+    fn enrich_at_line_exact_position_match_preferred() {
+        // Verify that exact col match takes precedence over line-only match
+        let uri = "file:///Baz.kt";
+        let sym1 = make_sym_col("first", SymbolKind::FUNCTION, 0, 0, 5);
+        let sym2 = make_sym_col("second", SymbolKind::FUNCTION, 0, 7, 13);
+
+        let data = Arc::new(crate::types::FileData {
+            symbols: vec![sym1, sym2],
+            ..Default::default()
+        });
+        let mut files = HashMap::new();
+        files.insert(uri.to_owned(), data);
+        let idx = RealTestIndex {
+            files,
+            definitions: HashMap::new(),
+        };
+
+        // Query at col=8 (within "second"): should match second, not first
+        let result = enrich_at_line(
+            &idx,
+            uri,
+            0,
+            8,
+            SubstitutionContext::None,
+            &ResolveOptions::completion(),
+        );
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().name, "second", "should prefer exact position match");
+    }
 }

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -173,6 +173,40 @@ pub fn build_subst_map<I: IndexRead>(index: &I, uri: &str, cursor_line: u32) -> 
     build_enclosing_class_subst_impl(index, uri, cursor_line)
 }
 
+/// Apply cross-file type-parameter substitution to a signature string.
+///
+/// Equivalent to the old `Indexer::type_subst_sig` but works over `IndexRead`
+/// so it can be used from `resolver/complete.rs` without depending on `Indexer`.
+pub(crate) fn cross_file_type_subst<I: IndexRead>(
+    index: &I,
+    sym_uri: &str,
+    sym_line: u32,
+    calling_uri: &str,
+    sig: &str,
+) -> String {
+    let subst = build_type_param_subst_impl(index, sym_uri, sym_line, calling_uri, None);
+    if subst.is_empty() { sig.to_owned() } else { super::apply_type_subst(sig, &subst) }
+}
+
+/// Extract the simple type name from a property detail string.
+/// E.g. `"private val foo: DashboardProductsReducer by lazy"` → `"DashboardProductsReducer"`
+/// E.g. `"val x: List<String>"` → `"List"`
+pub(crate) fn extract_property_type_name(detail: &str) -> &str {
+    let colon_pos = match detail.find(':') {
+        Some(p) => p,
+        None => return "",
+    };
+    let after_colon = detail[colon_pos + 1..].trim_start();
+    let end = after_colon
+        .find(|c: char| !c.is_alphanumeric() && c != '_')
+        .unwrap_or(after_colon.len());
+    let name = &after_colon[..end];
+    if name.is_empty() || !name.chars().next().unwrap_or(' ').is_uppercase() {
+        return "";
+    }
+    name
+}
+
 // ─── Pure Data Transformation Functions ──────────────────────────────────
 
 /// Extract canonical signature respecting caller intent.
@@ -431,7 +465,7 @@ fn build_enclosing_class_subst_impl<I: IndexRead>(
         if sym.selection_range.start.line <= class_line { continue; }
         if sym.selection_range.start.line > class_end_line { continue; }
         if !matches!(sym.kind, SymbolKind::FIELD | SymbolKind::PROPERTY) { continue; }
-        let type_name = super::lookup::extract_property_type_name(&sym.detail);
+        let type_name = extract_property_type_name(&sym.detail);
         if type_name.is_empty() { continue; }
         let Some(locs) = index.get_definitions(type_name) else { continue };
         let Some(loc) = locs.into_iter().next() else { continue };

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -413,7 +413,7 @@ fn completion_item_for_nested_symbol(
     let detail_raw = if s.detail.is_empty() { None } else { Some(s.detail.clone()) };
     let detail = detail_raw.map(|d| {
         if let Some(cu) = calling_uri {
-            idx.type_subst_sig(uri_str, s.selection_range.start.line, cu, &d)
+            crate::indexer::resolution::cross_file_type_subst(idx, uri_str, s.selection_range.start.line, cu, &d)
         } else {
             d
         }


### PR DESCRIPTION
## Phase 10: Dead Code Removal

Completes the unified resolution architecture refactor by stripping the old API surface from `lookup.rs`.

### What was deleted

| Function | Replacement |
|---|---|
| `Indexer::hover_info` | `resolution::resolve_symbol_info` + formatter |
| `Indexer::hover_info_at_location` | `resolution::resolve_symbol_info` + formatter |
| `Indexer::symbol_detail_at` | `resolution::resolve_symbol_info` |
| `Indexer::completion_docs_for` | `resolution::resolve_symbol_info` |
| `build_type_param_subst` (private) | `resolution::build_subst_map` |
| `apply_subst` (private) | `resolution::cross_file_type_subst` |
| `type_subst_sig` | `resolution::cross_file_type_subst` |
| `extract_property_type_name` (private) | moved to `resolution.rs` |

`apply_type_subst` is kept — 3 live callers (`inlay_hints.rs`, `handlers.rs`, `resolution.rs`).

### Test migration

Tests for deleted APIs were rewritten to use `resolve_symbol_info` directly:
- Swift `func` vs Kotlin `fun` → tests `symbol_kw_for_lang` directly  
- KDoc inclusion → `resolve_symbol_info` with `include_doc: true`
- val binding signature → `resolve_symbol_info` checking `.signature`
- Generic subst disambiguation regression → already covered by `resolution_tests`; lookup test removed

Net change: 651 tests (657 → 651; 11 old deleted, 5 new added, 1 unchanged).