### PR TITLE
refactor(phase12): replace bool/tuple returns with named structs

### DIFF
--- a/src/backend/cursor.rs
+++ b/src/backend/cursor.rs
@@ -17,7 +17,7 @@ use crate::resolver::{infer_receiver_type, ReceiverKind, ReceiverType};
 /// Cursor context for identifier-based LSP features (hover, goto-def, completion).
 ///
 /// Built once per request; individual fields are `None` when not applicable.
-pub struct CursorContext {
+pub(crate) struct CursorContext {
     /// The identifier token under the cursor.
     pub word: String,
     /// The dot-qualifier to the left of the cursor (e.g. `"it"`, `"viewModel"`).
@@ -38,7 +38,7 @@ impl CursorContext {
     ///
     /// Returns `None` only when there is no identifier under the cursor
     /// (e.g. cursor is in whitespace or on a non-identifier token).
-    pub fn build(idx: &Indexer, uri: &Url, position: Position) -> Option<Self> {
+    pub(crate) fn build(idx: &Indexer, uri: &Url, position: Position) -> Option<Self> {
         let (word, qualifier) = idx.word_and_qualifier_at(uri, position)?;
 
         let line = position.line as usize;

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -411,20 +411,18 @@ impl Backend {
         let col = crate::indexer::live_tree::utf16_col_to_byte(line_text, pos.character as usize);
         let before = &line_text[..col];
 
-        // Extract (fn_name, qualifier, active_param) — CST first, text fallback.
-        let Some((name, qualifier, active_param)) =
-            extract_call_info(pos, &self.indexer, uri, lines, before, line_idx)
-        else {
+        // Extract CallInfo — CST first, text fallback.
+        let Some(ci) = extract_call_info(pos, &self.indexer, uri, lines, before, line_idx) else {
             return Ok(None);
         };
 
         let params_text =
-            find_fun_signature_with_receiver(&self.indexer, uri, &name, qualifier.as_deref());
+            find_fun_signature_with_receiver(&self.indexer, uri, &ci.fn_name, ci.qualifier.as_deref());
         if params_text.is_empty() {
             return Ok(None);
         }
 
-        Ok(build_signature_help(&name, &params_text, active_param))
+        Ok(build_signature_help(&ci.fn_name, &params_text, ci.active_param))
     }
 
     pub(super) async fn folding_range_impl(
@@ -595,7 +593,17 @@ fn build_signature_help(
     })
 }
 
-/// Extract `(fn_name, qualifier, active_param)` for the call under the cursor.
+/// Resolved call-site information needed for `textDocument/signatureHelp`.
+struct CallInfo {
+    /// Name of the function being called.
+    fn_name: String,
+    /// Optional receiver before the dot (e.g. `"builder"` in `builder.build()`).
+    qualifier: Option<String>,
+    /// Zero-based index of the parameter the cursor is currently inside.
+    active_param: u32,
+}
+
+/// Extract [`CallInfo`] for the call under the cursor.
 ///
 /// Tries the CST (live tree) first — O(depth), accurate qualifier extraction.
 /// Falls back to a text scan when no live tree is available, when the cursor
@@ -607,7 +615,7 @@ fn extract_call_info(
     lines: &[String],
     before: &str,
     line_idx: usize,
-) -> Option<(String, Option<String>, u32)> {
+) -> Option<CallInfo> {
     // ── CST path ─────────────────────────────────────────────────────────────
     if let Some(result) = cst_call_info(pos, indexer, uri) {
         return Some(result);
@@ -627,7 +635,7 @@ fn cst_call_info(
     pos: Position,
     indexer: &crate::indexer::Indexer,
     uri: &Url,
-) -> Option<(String, Option<String>, u32)> {
+) -> Option<CallInfo> {
     use crate::indexer::live_tree::utf16_col_to_byte;
     use tree_sitter::Point;
 
@@ -688,7 +696,7 @@ fn cst_call_info(
         count
     };
 
-    Some((fn_name, qualifier, active_param))
+    Some(CallInfo { fn_name, qualifier, active_param })
 }
 
 /// Scans a single source line for an unclosed call-site opening.
@@ -791,7 +799,7 @@ fn text_call_info(
     lines: &[String],
     before: &str,
     line_idx: usize,
-) -> Option<(String, Option<String>, u32)> {
+) -> Option<CallInfo> {
     let mut depth: i32 = 0;
     let mut active_param: u32 = 0;
     let mut call_name: Option<String> = None;
@@ -842,8 +850,8 @@ fn text_call_info(
         }
     }
 
-    let name = call_name.filter(|n| !n.is_empty())?;
-    Some((name, call_qualifier, active_param))
+    let fn_name = call_name.filter(|n| !n.is_empty())?;
+    Some(CallInfo { fn_name, qualifier: call_qualifier, active_param })
 }
 
 /// Iterator over the byte offsets in `line` where `word` occurs as a whole

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -10,15 +10,15 @@ use tower_lsp::{async_trait, Client, LanguageServer};
 use self::helpers::syntax_diagnostics;
 use crate::indexer::{workspace_cache_path, IgnoreMatcher, Indexer};
 
-pub mod actions;
-pub mod cursor;
-pub mod format;
-pub mod handlers;
-pub mod helpers;
-pub mod nav;
-pub mod rename;
+pub(crate) mod actions;
+pub(crate) mod cursor;
+pub(crate) mod format;
+pub(crate) mod handlers;
+pub(crate) mod helpers;
+pub(crate) mod nav;
+pub(crate) mod rename;
 
-pub struct Backend {
+pub(crate) struct Backend {
     pub(super) client: Client,
     pub(super) indexer: Arc<Indexer>,
     /// Per-URI abort handle for the pending debounced reindex task.
@@ -31,7 +31,7 @@ pub struct Backend {
 }
 
 impl Backend {
-    pub fn new(client: Client) -> Self {
+    pub(crate) fn new(client: Client) -> Self {
         Self {
             client,
             indexer: Arc::new(Indexer::new()),

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -657,7 +657,7 @@ impl LanguageServer for Backend {
         let sem = idx.parse_sem();
         tokio::task::spawn(async move {
             if let Ok(path) = uri.to_file_path() {
-                if let Ok(content) = std::fs::read_to_string(&path) {
+                if let Ok(content) = tokio::fs::read_to_string(&path).await {
                     if let Ok(permit) = sem.acquire_owned().await {
                         tokio::task::spawn_blocking(move || {
                             let _permit = permit;
@@ -686,7 +686,7 @@ impl LanguageServer for Backend {
             let sem = idx.parse_sem();
             tokio::task::spawn(async move {
                 if let Ok(path) = uri.to_file_path() {
-                    if let Ok(content) = std::fs::read_to_string(&path) {
+                    if let Ok(content) = tokio::fs::read_to_string(&path).await {
                         if let Ok(permit) = sem.acquire_owned().await {
                             tokio::task::spawn_blocking(move || {
                                 let _permit = permit;

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -8,7 +8,7 @@ use tower_lsp::lsp_types::*;
 use tower_lsp::{async_trait, Client, LanguageServer};
 
 use self::helpers::syntax_diagnostics;
-use crate::indexer::{workspace_cache_path, IgnoreMatcher, Indexer};
+use crate::indexer::{workspace_cache_path, IgnoreMatcher, Indexer, ProgressReporter};
 
 pub(crate) mod actions;
 pub(crate) mod cursor;
@@ -17,6 +17,81 @@ pub(crate) mod handlers;
 pub(crate) mod helpers;
 pub(crate) mod nav;
 pub(crate) mod rename;
+
+// ─── LSP progress reporter (outbound adapter) ────────────────────────────────
+
+mod progress {
+    use tower_lsp::lsp_types::ProgressParams;
+
+    /// `$/progress` notification — reports workspace indexing status to the editor.
+    pub(super) enum KotlinProgress {}
+    impl tower_lsp::lsp_types::notification::Notification for KotlinProgress {
+        type Params = ProgressParams;
+        const METHOD: &'static str = "$/progress";
+    }
+}
+
+/// Sends LSP `$/progress` notifications via `tower_lsp::Client`.
+struct LspProgressReporter(Client);
+
+impl ProgressReporter for LspProgressReporter {
+    async fn begin(&self, token: &NumberOrString, message: &str) {
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            self.0
+                .send_request::<tower_lsp::lsp_types::request::WorkDoneProgressCreate>(
+                    WorkDoneProgressCreateParams {
+                        token: token.clone(),
+                    },
+                ),
+        )
+        .await;
+        self.0
+            .send_notification::<progress::KotlinProgress>(ProgressParams {
+                token: token.clone(),
+                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(
+                    WorkDoneProgressBegin {
+                        title: "kotlin-lsp".into(),
+                        cancellable: Some(false),
+                        message: Some(message.to_owned()),
+                        percentage: Some(0),
+                    },
+                )),
+            })
+            .await;
+    }
+
+    async fn report(&self, token: &NumberOrString, done: usize, total: usize) {
+        let pct = if total > 0 {
+            ((done * 100) / total) as u32
+        } else {
+            0
+        };
+        self.0
+            .send_notification::<progress::KotlinProgress>(ProgressParams {
+                token: token.clone(),
+                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Report(
+                    WorkDoneProgressReport {
+                        cancellable: Some(false),
+                        message: Some(format!("{done}/{total} files…")),
+                        percentage: Some(pct),
+                    },
+                )),
+            })
+            .await;
+    }
+
+    async fn end(&self, token: &NumberOrString, message: &str) {
+        self.0
+            .send_notification::<progress::KotlinProgress>(ProgressParams {
+                token: token.clone(),
+                value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(WorkDoneProgressEnd {
+                    message: Some(message.to_owned()),
+                })),
+            })
+            .await;
+    }
+}
 
 pub(crate) struct Backend {
     pub(super) client: Client,
@@ -237,7 +312,11 @@ impl LanguageServer for Backend {
             tokio::spawn(async move {
                 // No specific open-file priorities at initialize.
                 indexer
-                    .index_workspace_prioritized(&path, Vec::new(), Some(client))
+                    .index_workspace_prioritized(
+                        &path,
+                        Vec::new(),
+                        Arc::new(LspProgressReporter(client)),
+                    )
                     .await;
             });
         }
@@ -303,7 +382,7 @@ impl LanguageServer for Backend {
             let client = self.client.clone();
             idx.reset_index_state();
             tokio::spawn(async move {
-                idx.index_workspace(&root, Some(client)).await;
+                idx.index_workspace(&root, Arc::new(LspProgressReporter(client))).await;
             });
             self.client
                 .show_message(MessageType::INFO, "kotlin-lsp: reindexing workspace…")
@@ -475,11 +554,12 @@ impl LanguageServer for Backend {
             let root2 = root.clone();
             let opened = opened_path_opt.clone();
             tokio::spawn(async move {
+                let reporter = Arc::new(LspProgressReporter(client));
                 if let Some(op) = opened {
-                    idx.index_workspace_prioritized(&root2, vec![op], Some(client))
+                    idx.index_workspace_prioritized(&root2, vec![op], reporter)
                         .await;
                 } else {
-                    idx.index_workspace_prioritized(&root2, Vec::new(), Some(client))
+                    idx.index_workspace_prioritized(&root2, Vec::new(), reporter)
                         .await;
                 }
             });

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -6,8 +6,21 @@ use tower_lsp::lsp_types::*;
 
 fn locs_to_response(locs: Vec<Location>) -> GotoDefinitionResponse {
     match locs.len() {
-        1 => GotoDefinitionResponse::Scalar(locs.into_iter().next().unwrap()),
+        1 => GotoDefinitionResponse::Scalar(
+            locs.into_iter().next().expect("len == 1 by match arm"),
+        ),
         _ => GotoDefinitionResponse::Array(locs),
+    }
+}
+
+/// Converts a possibly-empty location list into an optional LSP response.
+fn locs_to_opt_response(locs: Vec<Location>) -> Option<GotoDefinitionResponse> {
+    match locs.len() {
+        0 => None,
+        1 => Some(GotoDefinitionResponse::Scalar(
+            locs.into_iter().next().expect("len == 1 by match arm"),
+        )),
+        _ => Some(GotoDefinitionResponse::Array(locs)),
     }
 }
 
@@ -83,12 +96,7 @@ impl Backend {
             .indexer
             .find_definition_qualified(&ctx.word, ctx.qualifier.as_deref(), uri);
         if !locs.is_empty() {
-            return Ok(match locs.len() {
-                1 => Some(GotoDefinitionResponse::Scalar(
-                    locs.into_iter().next().unwrap(),
-                )),
-                _ => Some(GotoDefinitionResponse::Array(locs)),
-            });
+            return Ok(locs_to_opt_response(locs));
         }
 
         // Index miss (symbol not indexed or indexing in progress) → rg fallback.
@@ -109,13 +117,7 @@ impl Backend {
         })
         .await
         .unwrap_or_default();
-        Ok(match rg_locs.len() {
-            0 => None,
-            1 => Some(GotoDefinitionResponse::Scalar(
-                rg_locs.into_iter().next().unwrap(),
-            )),
-            _ => Some(GotoDefinitionResponse::Array(rg_locs)),
-        })
+        Ok(locs_to_opt_response(rg_locs))
     }
 
     pub(super) async fn goto_implementation_impl(
@@ -162,12 +164,7 @@ impl Backend {
             .unwrap_or_default();
             if !rg_impls.is_empty() {
                 // Return early with rg results.
-                return Ok(match rg_impls.len() {
-                    1 => Some(GotoDefinitionResponse::Scalar(
-                        rg_impls.into_iter().next().unwrap(),
-                    )),
-                    _ => Some(GotoDefinitionResponse::Array(rg_impls)),
-                });
+                return Ok(locs_to_opt_response(rg_impls));
             }
         }
 
@@ -207,13 +204,7 @@ impl Backend {
             }
         }
 
-        Ok(match locs.len() {
-            0 => None,
-            1 => Some(GotoDefinitionResponse::Scalar(
-                locs.into_iter().next().unwrap(),
-            )),
-            _ => Some(GotoDefinitionResponse::Array(locs)),
-        })
+        Ok(locs_to_opt_response(locs))
     }
 
     /// Collect the parent class names for the class enclosing `row` in `uri`.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -12,6 +12,7 @@ use crate::StrExt;
 // Re-export rg-module items that existing callers reach via `crate::indexer::`.
 pub(crate) use crate::rg::IgnoreMatcher;
 pub(crate) use crate::rg::SOURCE_EXTENSIONS;
+pub(crate) use self::scan::{NoopReporter, ProgressReporter};
 
 mod doc;
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -11,7 +11,7 @@ use crate::StrExt;
 
 // Re-export rg-module items that existing callers reach via `crate::indexer::`.
 pub(crate) use crate::rg::IgnoreMatcher;
-pub use crate::rg::SOURCE_EXTENSIONS;
+pub(crate) use crate::rg::SOURCE_EXTENSIONS;
 
 mod doc;
 
@@ -57,7 +57,7 @@ pub(crate) use self::cache::workspace_cache_path;
 mod discover;
 
 mod scan;
-pub const MAX_FILES_UNLIMITED: usize = usize::MAX;
+pub(crate) const MAX_FILES_UNLIMITED: usize = usize::MAX;
 
 mod apply;
 #[allow(unused_imports)]
@@ -116,7 +116,7 @@ pub(crate) struct StaleKeys {
     pub package: Option<String>,
 }
 
-pub struct Indexer {
+pub(crate) struct Indexer {
     /// URI string → parsed file data.
     pub(crate) files: DashMap<String, Arc<FileData>>,
     /// Short name → definition locations  (fast first-pass lookup).
@@ -219,11 +219,11 @@ impl crate::indexer::infer::InferDeps for Indexer {
 }
 
 impl Indexer {
-    pub fn parse_sem(&self) -> Arc<tokio::sync::Semaphore> {
+    pub(crate) fn parse_sem(&self) -> Arc<tokio::sync::Semaphore> {
         Arc::clone(&self.parse_sem)
     }
 
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             files: DashMap::new(),
             definitions: DashMap::new(),
@@ -273,7 +273,7 @@ impl Indexer {
     /// Clears everything: files, definitions, qualified, packages, subtypes, content_hashes,
     /// completion_cache, bare_name_cache. Does NOT touch orchestration fields
     /// (workspace_root, parse_sem, generation counters, live_lines).
-    pub fn reset_index_state(&self) {
+    pub(crate) fn reset_index_state(&self) {
         self.files.clear();
         self.definitions.clear();
         self.qualified.clear();
@@ -296,7 +296,7 @@ impl Indexer {
     /// Update the live-lines cache for `uri` without any debounce.
     /// Called from `did_change` before the debounced re-index so that
     /// `completions()` always sees the current document text.
-    pub fn set_live_lines(&self, uri: &Url, content: &str) {
+    pub(crate) fn set_live_lines(&self, uri: &Url, content: &str) {
         let lines: Arc<Vec<String>> = Arc::new(content.lines().map(String::from).collect());
         self.live_lines.insert(uri.to_string(), lines);
     }
@@ -401,7 +401,7 @@ impl Indexer {
     ///
     /// Uses `live_lines` (updated synchronously on every keystroke) for the
     /// current file's line text, falling back to indexed lines or disk.
-    pub fn completions(
+    pub(crate) fn completions(
         &self,
         uri: &Url,
         position: Position,

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -144,7 +144,7 @@ pub(crate) fn build_bare_names(definitions: &DashMap<String, Vec<Location>>) -> 
 impl Indexer {
     /// Parse a single file via tree-sitter and extract symbols, supertypes, and a
     /// content hash.  Pure — no writes to any `Indexer` field.
-    pub fn parse_file(uri: &Url, content: &str) -> FileIndexResult {
+    pub(crate) fn parse_file(uri: &Url, content: &str) -> FileIndexResult {
         let data = parse_by_extension(uri.path(), content);
         let hash = hash_str(content);
 
@@ -185,7 +185,7 @@ impl Indexer {
     ///
     /// Uses pure [`stale_keys_for`] to compute removals and [`file_contributions`]
     /// to compute insertions. This is the per-file delta path (live edits, on_open).
-    pub fn apply_file_result(&self, result: &FileIndexResult) {
+    pub(crate) fn apply_file_result(&self, result: &FileIndexResult) {
         let uri_str = result.uri.to_string();
 
         // ── Remove stale entries ──────────────────────────────────────────────
@@ -221,7 +221,7 @@ impl Indexer {
     /// Full-replace path: resets all index maps first, then inserts all file
     /// contributions. Cache hits are already converted to `FileIndexResult` by
     /// `cache_entry_to_file_result` (supertypes included).
-    pub fn apply_workspace_result(&self, result: &WorkspaceIndexResult) {
+    pub(crate) fn apply_workspace_result(&self, result: &WorkspaceIndexResult) {
         log::info!(
             "Applying workspace results: {} files parsed, {} cache hits",
             result.stats.files_parsed,
@@ -255,7 +255,7 @@ impl Indexer {
     ///
     /// Generation-safe: captures `root_generation` at the start and discards results
     /// if it changes during async I/O (root switch / explicit reindex).
-    pub async fn index_source_paths(self: Arc<Self>, workspace_root: PathBuf) {
+    pub(crate) async fn index_source_paths(self: Arc<Self>, workspace_root: PathBuf) {
         let raw_paths = self.source_paths_raw.read().unwrap().clone();
         if raw_paths.is_empty() {
             return;
@@ -398,7 +398,7 @@ impl Indexer {
     }
 
     /// Coordinator: rebuild bare-name cache from current definitions map.
-    pub fn rebuild_bare_name_cache(&self) {
+    pub(crate) fn rebuild_bare_name_cache(&self) {
         if let Ok(mut cache) = self.bare_name_cache.write() {
             *cache = build_bare_names(&self.definitions);
         }
@@ -447,7 +447,7 @@ impl Indexer {
     /// when the content-hash matched the previous parse (no work done).
     /// Callers that need to publish diagnostics should read `data.syntax_errors`
     /// from the returned value.
-    pub fn index_content(&self, uri: &Url, content: &str) -> Option<Arc<FileData>> {
+    pub(crate) fn index_content(&self, uri: &Url, content: &str) -> Option<Arc<FileData>> {
         // Fast-path: skip re-parse if content hasn't changed since last index.
         let hash = hash_str(content);
         let uri_str = uri.to_string();
@@ -480,7 +480,7 @@ impl Indexer {
     ///
     /// This runs after `index_content` so that when the user types `repo.` the
     /// cache is already populated and the response is instant.
-    pub fn prewarm_completion_cache(self: Arc<Self>, uri: &Url) {
+    pub(crate) fn prewarm_completion_cache(self: Arc<Self>, uri: &Url) {
         let Some(data) = self.files.get(uri.as_str()) else {
             return;
         };

--- a/src/indexer/infer/deps.rs
+++ b/src/indexer/infer/deps.rs
@@ -25,7 +25,7 @@ use tower_lsp::lsp_types::Url;
 /// Two concrete implementations:
 /// - `Indexer` — production, full resolution with rg fallback
 /// - `TestDeps` — test stub, drives leaf-helper unit tests from plain `HashMap`s
-pub trait InferDeps {
+pub(crate) trait InferDeps {
     /// Return the raw parameter text inside a function's outer `()`, e.g.
     /// `"key: K, flow: Flow<T>, map: (T) -> Model"` (no surrounding parens).
     ///

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -52,6 +52,18 @@ const LAMBDA_PARAM_SCAN_BACK_LINES: usize = 40;
 
 /// Lines to scan backward for `{ param_name ->` in the single-line completion path
 /// (from `find_named_lambda_param_type`).
+/// Selects which implicit lambda parameter is being inferred.
+///
+/// Replaces the `for_this: bool` flag in `find_it_element_type_in_lines_impl`
+/// and `cst_it_or_this_type` with an explicit, self-documenting variant.
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum LambdaParamKind {
+    /// Infer the type of `it` (the implicit element parameter).
+    It,
+    /// Infer the type of `this` (the receiver in a receiver lambda).
+    This,
+}
+
 const LAMBDA_PARAM_SCAN_BACK: usize = 20;
 
 /// Lines to scan backward when searching for the enclosing lambda opener
@@ -92,7 +104,7 @@ pub(crate) fn find_it_element_type_in_lines(
     idx: &Indexer,
     uri: &Url,
 ) -> Option<String> {
-    find_it_element_type_in_lines_impl(lines, pos, idx, uri, false)
+    find_it_element_type_in_lines_impl(lines, pos, idx, uri, LambdaParamKind::It)
 }
 
 pub(crate) fn find_this_element_type_in_lines(
@@ -101,7 +113,7 @@ pub(crate) fn find_this_element_type_in_lines(
     idx: &Indexer,
     uri: &Url,
 ) -> Option<String> {
-    find_it_element_type_in_lines_impl(lines, pos, idx, uri, true)
+    find_it_element_type_in_lines_impl(lines, pos, idx, uri, LambdaParamKind::This)
 }
 
 /// Multi-line version of `find_named_lambda_param_type` for hover/goto-def.
@@ -381,7 +393,7 @@ fn cst_it_or_this_type(
     start_node: tree_sitter::Node<'_>,
     doc: &crate::indexer::live_tree::LiveDoc,
     lines: &[String],
-    for_this: bool,
+    kind: LambdaParamKind,
     idx: &Indexer,
     uri: &Url,
 ) -> Option<String> {
@@ -400,7 +412,7 @@ fn cst_it_or_this_type(
                 .trim_end();
             let ln = cur.start_position().row;
 
-            if for_this {
+            if kind == LambdaParamKind::This {
                 match classify_this_lambda_context(before_brace, idx, uri) {
                     ThisLambdaCtx::Resolved(t) => return Some(t),
                     // Receiver-lambda context but type not found: stop walking up.
@@ -435,7 +447,7 @@ fn find_it_element_type_in_lines_impl(
     pos: CursorPos,
     idx: &Indexer,
     uri: &Url,
-    for_this: bool,
+    kind: LambdaParamKind,
 ) -> Option<String> {
     // ── CST fast path ────────────────────────────────────────────────────────
     if let Some(doc) = idx.live_doc(uri) {
@@ -451,7 +463,7 @@ fn find_it_element_type_in_lines_impl(
             .root_node()
             .descendant_for_point_range(point, point)
         {
-            return cst_it_or_this_type(node, &doc, lines, for_this, idx, uri);
+            return cst_it_or_this_type(node, &doc, lines, kind, idx, uri);
         }
         // Node not found for this position — fall through to text scan.
     }
@@ -501,7 +513,7 @@ fn find_it_element_type_in_lines_impl(
                             depth = 0;
                             continue;
                         }
-                        if for_this {
+                        if kind == LambdaParamKind::This {
                             // `this` only gets a hint from receiver lambdas (`T.() -> R`).
                             return lambda_receiver_this_type_from_context(before_brace, idx, uri);
                         }

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -52,6 +52,8 @@ const LAMBDA_PARAM_SCAN_BACK_LINES: usize = 40;
 
 /// Lines to scan backward for `{ param_name ->` in the single-line completion path
 /// (from `find_named_lambda_param_type`).
+const LAMBDA_PARAM_SCAN_BACK: usize = 20;
+
 /// Selects which implicit lambda parameter is being inferred.
 ///
 /// Replaces the `for_this: bool` flag in `find_it_element_type_in_lines_impl`
@@ -63,8 +65,6 @@ enum LambdaParamKind {
     /// Infer the type of `this` (the receiver in a receiver lambda).
     This,
 }
-
-const LAMBDA_PARAM_SCAN_BACK: usize = 20;
 
 /// Lines to scan backward when searching for the enclosing lambda opener
 /// in the text-fallback path of `find_it_element_type_in_lines_impl`.

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -7,11 +7,11 @@
 //! - `args`     — call argument parsing (pure)
 //! - `it_this`  — resolving `it`/`this` element types inside Kotlin lambda bodies
 
-pub mod args;
-pub mod deps;
-pub mod it_this;
-pub mod lambda;
-pub mod sig;
+pub(super) mod args;
+pub(super) mod deps;
+pub(super) mod it_this;
+pub(super) mod lambda;
+pub(super) mod sig;
 
 pub(crate) use deps::InferDeps;
 #[cfg(test)]

--- a/src/indexer/live_tree.rs
+++ b/src/indexer/live_tree.rs
@@ -1,6 +1,6 @@
 use tree_sitter::{Language, Parser, Tree};
 
-pub struct LiveDoc {
+pub(crate) struct LiveDoc {
     pub bytes: Vec<u8>,
     pub tree: Tree,
 }
@@ -11,7 +11,7 @@ pub struct LiveDoc {
 /// recognised by `parser.rs`'s `parse_by_extension`.  Unlike that function,
 /// `lang_for_path` never falls back to a default language for unknown
 /// extensions — it returns `None` so callers can skip live-tree work entirely.
-pub fn lang_for_path(path: &str) -> Option<Language> {
+pub(crate) fn lang_for_path(path: &str) -> Option<Language> {
     if path.ends_with(".swift") {
         Some(tree_sitter_swift_bundled::language())
     } else if path.ends_with(".java") {
@@ -25,7 +25,7 @@ pub fn lang_for_path(path: &str) -> Option<Language> {
 
 /// Convert a UTF-16 column offset (as used in LSP positions) to a byte offset
 /// within `line_text`.  Tree-sitter `Point::column` expects byte offsets.
-pub fn utf16_col_to_byte(line_text: &str, utf16_col: usize) -> usize {
+pub(crate) fn utf16_col_to_byte(line_text: &str, utf16_col: usize) -> usize {
     let mut utf16 = 0usize;
     for (bi, ch) in line_text.char_indices() {
         if utf16 >= utf16_col {
@@ -38,7 +38,7 @@ pub fn utf16_col_to_byte(line_text: &str, utf16_col: usize) -> usize {
 
 /// Parse `content` with `lang` and return a `LiveDoc`, or `None` if the
 /// parser fails (malformed grammar state — extremely rare).
-pub fn parse_live(content: &str, lang: Language) -> Option<LiveDoc> {
+pub(crate) fn parse_live(content: &str, lang: Language) -> Option<LiveDoc> {
     let mut parser = Parser::new();
     parser.set_language(&lang).ok()?;
     let tree = parser.parse(content, None)?;

--- a/src/indexer/live_tree_impl.rs
+++ b/src/indexer/live_tree_impl.rs
@@ -9,7 +9,7 @@ impl Indexer {
     ///
     /// If the file extension is unsupported or parsing fails, any previously
     /// stored tree for `uri` is removed so consumers never read a stale doc.
-    pub fn store_live_tree(&self, uri: &Url, content: &str) {
+    pub(crate) fn store_live_tree(&self, uri: &Url, content: &str) {
         let path = uri.path();
         match lang_for_path(path).and_then(|lang| parse_live(content, lang)) {
             Some(doc) => {
@@ -22,12 +22,12 @@ impl Indexer {
     }
 
     /// Return the `LiveDoc` for `uri`, or `None` if the file is not open.
-    pub fn live_doc(&self, uri: &Url) -> Option<Arc<LiveDoc>> {
+    pub(crate) fn live_doc(&self, uri: &Url) -> Option<Arc<LiveDoc>> {
         self.live_trees.get(uri.as_str()).map(|r| Arc::clone(&*r))
     }
 
     /// Remove the live parse tree for `uri` (called on `textDocument/didClose`).
-    pub fn remove_live_tree(&self, uri: &Url) {
+    pub(crate) fn remove_live_tree(&self, uri: &Url) {
         self.live_trees.remove(uri.as_str());
     }
 }

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -19,7 +19,7 @@ use crate::StrExt;
 
 impl Indexer {
     /// Returns true if `name` has at least one definition location inside `uri`.
-    pub fn is_declared_in(&self, uri: &Url, name: &str) -> bool {
+    pub(crate) fn is_declared_in(&self, uri: &Url, name: &str) -> bool {
         self.definitions
             .get(name)
             .map(|locs| locs.iter().any(|l| l.uri == *uri))
@@ -28,11 +28,11 @@ impl Indexer {
 
     /// Resolve definition locations for `name` (with optional dot-qualifier).
     #[allow(dead_code)]
-    pub fn find_definition(&self, name: &str, from_uri: &Url) -> Vec<Location> {
+    pub(crate) fn find_definition(&self, name: &str, from_uri: &Url) -> Vec<Location> {
         self.resolve_symbol(name, None, from_uri)
     }
 
-    pub fn find_definition_qualified(
+    pub(crate) fn find_definition_qualified(
         &self,
         name: &str,
         qualifier: Option<&str>,
@@ -42,7 +42,7 @@ impl Indexer {
     }
 
     /// All symbols declared in the given file (for `documentSymbol`).
-    pub fn file_symbols(&self, uri: &Url) -> Vec<SymbolEntry> {
+    pub(crate) fn file_symbols(&self, uri: &Url) -> Vec<SymbolEntry> {
         self.files
             .get(uri.as_str())
             .map(|d| d.symbols.clone())
@@ -50,13 +50,13 @@ impl Indexer {
     }
 
     /// Return the package declared in the given file, if any.
-    pub fn package_of(&self, uri: &Url) -> Option<String> {
+    pub(crate) fn package_of(&self, uri: &Url) -> Option<String> {
         self.files.get(uri.as_str())?.package.clone()
     }
 
     /// Return the package in which `name` is declared, by looking up its
     /// definition locations and reading the `package` field of those files.
-    pub fn declared_package_of(&self, name: &str) -> Option<String> {
+    pub(crate) fn declared_package_of(&self, name: &str) -> Option<String> {
         let locs = self.definitions.get(name)?;
         for loc in locs.iter() {
             if let Some(f) = self.files.get(loc.uri.as_str()) {
@@ -71,7 +71,7 @@ impl Indexer {
     /// If `name` is declared as an inner/nested class, return the name of its
     /// enclosing class at the declaration site in `preferred_uri` (if found there),
     /// otherwise the first definition site.
-    pub fn declared_parent_class_of(&self, name: &str, preferred_uri: &Url) -> Option<String> {
+    pub(crate) fn declared_parent_class_of(&self, name: &str, preferred_uri: &Url) -> Option<String> {
         let locs = self.definitions.get(name)?;
         // Try declaration in the preferred (current) file first.
         for loc in locs.iter() {
@@ -92,7 +92,7 @@ impl Indexer {
     /// as resolved from the import statement.  E.g.:
     ///   `import com.example.DashboardViewModel.Effect`
     ///   → parent_class = Some("DashboardViewModel"), pkg = Some("com.example.DashboardViewModel")
-    pub fn resolve_symbol_via_import(
+    pub(crate) fn resolve_symbol_via_import(
         &self,
         uri: &Url,
         name: &str,

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -11,7 +11,7 @@ use crate::types::{FileData, SymbolEntry};
 use crate::LinesExt;
 
 /// Domain-level resolution result. Small, owned data suitable for LSP adapters.
-pub struct ResolvedSymbol {
+pub(crate) struct ResolvedSymbol {
     /// Symbol definition location; only accessed in tests and future callers.
     #[allow(dead_code)]
     pub location: Location,
@@ -29,7 +29,7 @@ pub struct ResolvedSymbol {
 }
 
 /// Options controlling resolution behaviour and allowed fallbacks.
-pub struct ResolveOptions {
+pub(crate) struct ResolveOptions {
     pub allow_rg: bool,
     pub include_doc: bool,
     pub apply_subst: bool,
@@ -39,7 +39,7 @@ pub struct ResolveOptions {
 }
 
 impl ResolveOptions {
-    pub fn hover() -> Self {
+    pub(crate) fn hover() -> Self {
         Self {
             allow_rg: true,
             include_doc: true,
@@ -47,7 +47,7 @@ impl ResolveOptions {
             prefer_cached_detail: false,
         }
     }
-    pub fn completion() -> Self {
+    pub(crate) fn completion() -> Self {
         Self {
             allow_rg: false,
             include_doc: true,
@@ -56,7 +56,7 @@ impl ResolveOptions {
         }
     }
     #[allow(dead_code)]
-    pub fn goto_def() -> Self {
+    pub(crate) fn goto_def() -> Self {
         Self {
             allow_rg: true,
             include_doc: false,
@@ -67,7 +67,7 @@ impl ResolveOptions {
 }
 
 /// Substitution context used by the pipeline.
-pub enum SubstitutionContext<'a> {
+pub(crate) enum SubstitutionContext<'a> {
     None,
     /// Cross-file substitution: the symbol is from another file and we need to
     /// substitute generic type params with the concrete args used by the caller.
@@ -84,7 +84,7 @@ pub enum SubstitutionContext<'a> {
 }
 
 /// Test seam trait: read-only view into index state. Keep this lightweight for tests.
-pub trait IndexRead {
+pub(crate) trait IndexRead {
     fn get_definitions(&self, name: &str) -> Option<Vec<Location>>;
     fn get_file_data(&self, uri: &str) -> Option<Arc<FileData>>;
 
@@ -116,7 +116,7 @@ pub trait IndexRead {
 
 /// Core resolution pipeline: locate → load → enrich → substitute → extract.
 /// Thin coordinator that delegates to pure functions and trait methods.
-pub fn resolve_symbol_info<I: IndexRead>(
+pub(crate) fn resolve_symbol_info<I: IndexRead>(
     index: &I,
     name: &str,
     qualifier: Option<&str>,
@@ -133,7 +133,7 @@ pub fn resolve_symbol_info<I: IndexRead>(
 ///
 /// Used when the caller already holds a `Location` (e.g., from
 /// `resolve_with_receiver_fallback`) and only needs enrichment.
-pub fn enrich_at_location<I: IndexRead>(
+pub(crate) fn enrich_at_location<I: IndexRead>(
     index: &I,
     location: &Location,
     name: &str,
@@ -149,7 +149,7 @@ pub fn enrich_at_location<I: IndexRead>(
 /// Used by `completion_resolve` which stores line/col in the completion item
 /// data rather than a full `Location`.  If no symbol is at the exact position,
 /// falls back to first symbol whose selection range starts on `line`.
-pub fn enrich_at_line<I: IndexRead>(
+pub(crate) fn enrich_at_line<I: IndexRead>(
     index: &I,
     uri_str: &str,
     line: u32,
@@ -177,7 +177,7 @@ pub fn enrich_at_line<I: IndexRead>(
 }
 
 /// Build substitution map for enclosing class at cursor position.
-pub fn build_subst_map<I: IndexRead>(
+pub(crate) fn build_subst_map<I: IndexRead>(
     index: &I,
     uri: &str,
     cursor_line: u32,

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -283,14 +283,17 @@ fn discover_workspace_paths(
     cache: &Option<super::cache::IndexCache>,
     matcher_ref: Option<&IgnoreMatcher>,
 ) -> DiscoveredPaths {
-    let warm_start = cache.as_ref().map(|c| c.complete_scan).unwrap_or(false);
-    let mut paths = if warm_start {
-        warm_discover_files(root, cache.as_ref().unwrap(), matcher_ref)
+    let mut paths = if let Some(cache) = cache.as_ref().filter(|c| c.complete_scan) {
+        warm_discover_files(root, cache, matcher_ref)
     } else {
         find_source_files(root, matcher_ref)
     };
     let total = paths.len();
-    let effective_max = if warm_start { MAX_FILES_UNLIMITED } else { max };
+    let effective_max = if cache.as_ref().is_some_and(|c| c.complete_scan) {
+        MAX_FILES_UNLIMITED
+    } else {
+        max
+    };
 
     paths.sort_by_key(|p| p.components().count());
     let paths: Vec<_> = paths.into_iter().take(effective_max).collect();
@@ -646,7 +649,7 @@ async fn parse_work_item(
         }
     };
 
-    let _permit = sem.acquire().await.unwrap();
+    let _permit = sem.acquire().await.expect("parse semaphore closed unexpectedly");
     let t0 = std::time::Instant::now();
     let uri_clone = uri.clone();
     let parse_result = match tokio::task::spawn_blocking(move || {

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -86,7 +86,7 @@ pub(super) const DEFAULT_MAX_INDEX_FILES: usize = MAX_FILES_UNLIMITED;
 /// - LSP mode callers pass `DEFAULT_MAX_INDEX_FILES` (unlimited).
 /// - CLI `--index-only` callers pass `MAX_FILES_UNLIMITED`.
 ///   Note: setting `KOTLIN_LSP_MAX_FILES` in the environment will still cap the count.
-pub fn resolve_max_files(default: usize) -> usize {
+pub(super) fn resolve_max_files(default: usize) -> usize {
     std::env::var("KOTLIN_LSP_MAX_FILES")
         .ok()
         .and_then(|v| v.parse().ok())
@@ -699,7 +699,7 @@ impl Indexer {
     /// Full reindex passing `MAX_FILES_UNLIMITED` as the default file cap —
     /// used by `--index-only` CLI mode and the `kotlin-lsp/reindex` workspace command.
     /// The `KOTLIN_LSP_MAX_FILES` environment variable can still override the count.
-    pub async fn index_workspace_full(
+    pub(crate) async fn index_workspace_full(
         self: Arc<Self>,
         root: &Path,
         client: Option<tower_lsp::Client>,
@@ -722,7 +722,7 @@ impl Indexer {
     /// Sends LSP `$/progress` notifications so the editor shows a status spinner.
     /// On subsequent startups the on-disk cache is used for unchanged files so only
     /// modified or new files need to be re-parsed by tree-sitter.
-    pub async fn index_workspace(self: Arc<Self>, root: &Path, client: Option<tower_lsp::Client>) {
+    pub(crate) async fn index_workspace(self: Arc<Self>, root: &Path, client: Option<tower_lsp::Client>) {
         // workspace_root is updated inside index_workspace_impl after the
         // concurrency guard is acquired, so we never set a stale root here.
         let max = resolve_max_files(DEFAULT_MAX_INDEX_FILES);
@@ -742,7 +742,7 @@ impl Indexer {
     /// Prioritized indexing: parse `initial_paths` first (high-priority files such as the
     /// currently-open document and its supertypes), then continue with normal bounded indexing.
     /// This gives fast symbol availability for the files the user is actually working on.
-    pub async fn index_workspace_prioritized(
+    pub(crate) async fn index_workspace_prioritized(
         self: Arc<Self>,
         root: &Path,
         initial_paths: Vec<PathBuf>,
@@ -1028,7 +1028,7 @@ impl Indexer {
 
     /// Serialize the current index to `~/.cache/kotlin-lsp/<root-hash>/index.bin`.
     /// Safe to call from a background thread. Logs warnings on error; never panics.
-    pub fn save_cache_to_disk(&self) {
+    pub(crate) fn save_cache_to_disk(&self) {
         let root_guard = self.workspace_root.read().unwrap();
         let root = match root_guard.as_ref() {
             Some(r) => r,

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -27,6 +27,22 @@ use crate::types::{FileIndexResult, IndexStats, WorkspaceIndexResult};
 
 // ─── LSP progress notification ────────────────────────────────────────────────
 
+/// Counters describing a workspace scan pass, used for progress notifications
+/// and the status-file JSON.
+#[derive(Copy, Clone)]
+struct ProgressSummary {
+    /// Number of files that need (re-)parsing (cache misses).
+    parse_count: usize,
+    /// Number of files discovered minus truncation (used in progress message).
+    indexed_count: usize,
+    /// Total files discovered before any truncation limit.
+    total: usize,
+    /// Number of files satisfied from disk cache.
+    cache_hits: usize,
+    /// Whether discovery was truncated by a file-count limit.
+    truncated: bool,
+}
+
 mod progress {
     use tower_lsp::lsp_types::ProgressParams;
 
@@ -417,12 +433,13 @@ fn spawn_progress_reporter(
     })
 }
 
-fn write_indexing_started_status(root: &Path, parse_count: usize, cache_hits: usize) {
+fn write_indexing_started_status(root: &Path, summary: &ProgressSummary) {
     let started_unix = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0);
     let root_escaped = serde_json::to_string(&root.to_string_lossy().as_ref()).unwrap_or_default();
+    let (parse_count, cache_hits) = (summary.parse_count, summary.cache_hits);
     write_status_file(&format!(
         r#"{{"phase":"indexing","workspace":{root_escaped},"indexed":0,"total":{parse_count},"cache_hits":{cache_hits},"symbols":0,"started_at":{started_unix},"elapsed_secs":0,"estimated_total_secs":null}}"#
     ));
@@ -445,11 +462,7 @@ fn write_indexing_done_status(
 async fn send_progress_begin(
     client: &Option<tower_lsp::Client>,
     token: &NumberOrString,
-    parse_count: usize,
-    indexed_count: usize,
-    total: usize,
-    cache_hits: usize,
-    truncated: bool,
+    summary: &ProgressSummary,
 ) {
     if let Some(client) = client.as_ref() {
         let _ = tokio::time::timeout(
@@ -463,6 +476,13 @@ async fn send_progress_begin(
         .await;
     }
 
+    let (parse_count, indexed_count, total, cache_hits, truncated) = (
+        summary.parse_count,
+        summary.indexed_count,
+        summary.total,
+        summary.cache_hits,
+        summary.truncated,
+    );
     let begin_msg = if cache_hits > 0 {
         format!("Indexing {parse_count}/{indexed_count} files ({cache_hits} cached)…")
     } else if truncated {
@@ -955,17 +975,15 @@ impl Indexer {
 
         let index_start = std::time::Instant::now();
         let token = NumberOrString::String("kotlin-lsp/indexing".into());
-        write_indexing_started_status(root, parse_count, cache_hits);
-        send_progress_begin(
-            &client,
-            &token,
+        let progress = ProgressSummary {
             parse_count,
-            discovered.indexed_count,
-            discovered.total,
+            indexed_count: discovered.indexed_count,
+            total: discovered.total,
             cache_hits,
-            discovered.truncated,
-        )
-        .await;
+            truncated: discovered.truncated,
+        };
+        write_indexing_started_status(root, &progress);
+        send_progress_begin(&client, &token, &progress).await;
 
         let (results, scheduling_aborted) = run_parse_phase(
             Arc::clone(&self),

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -7,6 +7,7 @@
 //! - [`Indexer::index_workspace_prioritized`]— fast first-open: priority files first, then full scan.
 //! - [`Indexer::save_cache_to_disk`]         — serialise current index to `~/.cache/kotlin-lsp/`.
 
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::Arc;
@@ -43,15 +44,28 @@ struct ProgressSummary {
     truncated: bool,
 }
 
-mod progress {
-    use tower_lsp::lsp_types::ProgressParams;
+/// Outbound port for LSP progress notifications.
+///
+/// The indexer calls these methods during workspace scanning;
+/// the concrete adapter (`LspProgressReporter` in `backend`) sends the
+/// actual `$/progress` notifications.  `NoopReporter` is used in CLI mode
+/// and in tests where no LSP client is connected.
+pub(crate) trait ProgressReporter: Send + Sync {
+    /// Register the progress token and send the WorkDone Begin notification.
+    fn begin(&self, token: &NumberOrString, message: &str) -> impl Future<Output = ()> + Send;
+    /// Send an intermediate progress update (called periodically during parse).
+    fn report(&self, token: &NumberOrString, done: usize, total: usize) -> impl Future<Output = ()> + Send;
+    /// Send the WorkDone End notification.
+    fn end(&self, token: &NumberOrString, message: &str) -> impl Future<Output = ()> + Send;
+}
 
-    /// `$/progress` notification — reports workspace indexing status to the editor.
-    pub(super) enum KotlinProgress {}
-    impl tower_lsp::lsp_types::notification::Notification for KotlinProgress {
-        type Params = ProgressParams;
-        const METHOD: &'static str = "$/progress";
-    }
+/// No-op reporter used when no LSP client is connected (CLI `--index-only`, tests).
+pub(crate) struct NoopReporter;
+
+impl ProgressReporter for NoopReporter {
+    async fn begin(&self, _: &NumberOrString, _: &str) {}
+    async fn report(&self, _: &NumberOrString, _: usize, _: usize) {}
+    async fn end(&self, _: &NumberOrString, _: &str) {}
 }
 
 // ─── RAII guard ───────────────────────────────────────────────────────────────
@@ -397,14 +411,14 @@ fn schedule_parse_work(
     (work_items, aborted)
 }
 
-fn spawn_progress_reporter(
+fn spawn_progress_reporter<R: ProgressReporter + 'static>(
     idx: Arc<Indexer>,
-    client: Option<tower_lsp::Client>,
+    reporter: Arc<R>,
     token: NumberOrString,
     total: usize,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        if client.is_none() || total == 0 {
+        if total == 0 {
             return;
         }
 
@@ -415,20 +429,7 @@ fn spawn_progress_reporter(
             let done = idx
                 .parse_tasks_completed
                 .load(std::sync::atomic::Ordering::Relaxed);
-            let pct = ((done * 100) / total) as u32;
-            if let Some(ref c) = client {
-                c.send_notification::<progress::KotlinProgress>(ProgressParams {
-                    token: token.clone(),
-                    value: ProgressParamsValue::WorkDone(WorkDoneProgress::Report(
-                        WorkDoneProgressReport {
-                            cancellable: Some(false),
-                            message: Some(format!("{done}/{total} files…")),
-                            percentage: Some(pct),
-                        },
-                    )),
-                })
-                .await;
-            }
+            reporter.report(&token, done, total).await;
             if done >= total {
                 break;
             }
@@ -462,23 +463,11 @@ fn write_indexing_done_status(
     ));
 }
 
-async fn send_progress_begin(
-    client: &Option<tower_lsp::Client>,
+async fn send_progress_begin<R: ProgressReporter>(
+    reporter: &R,
     token: &NumberOrString,
     summary: &ProgressSummary,
 ) {
-    if let Some(client) = client.as_ref() {
-        let _ = tokio::time::timeout(
-            std::time::Duration::from_millis(500),
-            client.send_request::<tower_lsp::lsp_types::request::WorkDoneProgressCreate>(
-                WorkDoneProgressCreateParams {
-                    token: token.clone(),
-                },
-            ),
-        )
-        .await;
-    }
-
     let (parse_count, indexed_count, total, cache_hits, truncated) = (
         summary.parse_count,
         summary.indexed_count,
@@ -493,29 +482,14 @@ async fn send_progress_begin(
     } else {
         format!("Indexing {total} Kotlin files…")
     };
-
-    if let Some(client) = client.as_ref() {
-        client
-            .send_notification::<progress::KotlinProgress>(ProgressParams {
-                token: token.clone(),
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(
-                    WorkDoneProgressBegin {
-                        title: "kotlin-lsp".into(),
-                        cancellable: Some(false),
-                        message: Some(begin_msg),
-                        percentage: Some(0),
-                    },
-                )),
-            })
-            .await;
-    }
+    reporter.begin(token, &begin_msg).await;
 }
 
-async fn run_parse_phase(
+async fn run_parse_phase<R: ProgressReporter + 'static>(
     idx: Arc<Indexer>,
     need_parse: Vec<PathBuf>,
     session: &ScanSession<'_>,
-    client: &Option<tower_lsp::Client>,
+    reporter: &Arc<R>,
     token: &NumberOrString,
     parse_count: usize,
 ) -> (Vec<Option<FileIndexResult>>, bool) {
@@ -526,7 +500,7 @@ async fn run_parse_phase(
     let idx_ref = Arc::clone(&idx);
     let sem = Arc::clone(&idx.parse_sem);
     let progress_handle =
-        spawn_progress_reporter(Arc::clone(&idx), client.clone(), token.clone(), parse_count);
+        spawn_progress_reporter(Arc::clone(&idx), Arc::clone(reporter), token.clone(), parse_count);
     let counters = ParseCounters::default();
     let task_counters = counters.clone();
     let results = run_concurrent(work_items, sem, move |item, sem| {
@@ -584,26 +558,22 @@ fn build_workspace_result(
     }
 }
 
-async fn send_progress_end(
-    client: &Option<tower_lsp::Client>,
+async fn send_progress_end<R: ProgressReporter>(
+    reporter: &R,
     token: &NumberOrString,
     result: &WorkspaceIndexResult,
 ) {
-    if let Some(client) = client.as_ref() {
-        client
-            .send_notification::<progress::KotlinProgress>(ProgressParams {
-                token: token.clone(),
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(WorkDoneProgressEnd {
-                    message: Some(format!(
-                        "Indexed {} files ({} cached, {} parsed)",
-                        result.files.len(),
-                        result.stats.cache_hits,
-                        result.stats.files_parsed
-                    )),
-                })),
-            })
-            .await;
-    }
+    reporter
+        .end(
+            token,
+            &format!(
+                "Indexed {} files ({} cached, {} parsed)",
+                result.files.len(),
+                result.stats.cache_hits,
+                result.stats.files_parsed
+            ),
+        )
+        .await;
 }
 
 async fn parse_work_item(
@@ -699,54 +669,54 @@ impl Indexer {
     /// Full reindex passing `MAX_FILES_UNLIMITED` as the default file cap —
     /// used by `--index-only` CLI mode and the `kotlin-lsp/reindex` workspace command.
     /// The `KOTLIN_LSP_MAX_FILES` environment variable can still override the count.
-    pub(crate) async fn index_workspace_full(
+    pub(crate) async fn index_workspace_full<R: ProgressReporter + 'static>(
         self: Arc<Self>,
         root: &Path,
-        client: Option<tower_lsp::Client>,
+        reporter: Arc<R>,
     ) {
         let max = resolve_max_files(MAX_FILES_UNLIMITED);
         let (result, guard_opt) = Arc::clone(&self)
-            .index_workspace_impl(root, max, client.clone())
+            .index_workspace_impl(root, max, Arc::clone(&reporter))
             .await;
         if let Some(guard) = guard_opt {
             if !result.aborted {
                 Arc::clone(&self)
-                    .finalize_workspace_scan(result, guard, client.clone())
+                    .finalize_workspace_scan(result, guard)
                     .await;
             }
         }
-        Arc::clone(&self).run_pending_reindex(client).await;
+        Arc::clone(&self).run_pending_reindex(reporter).await;
     }
 
-    /// Normal LSP startup: bounded workspace scan.
-    /// Sends LSP `$/progress` notifications so the editor shows a status spinner.
-    /// On subsequent startups the on-disk cache is used for unchanged files so only
-    /// modified or new files need to be re-parsed by tree-sitter.
-    pub(crate) async fn index_workspace(self: Arc<Self>, root: &Path, client: Option<tower_lsp::Client>) {
+    pub(crate) async fn index_workspace<R: ProgressReporter + 'static>(
+        self: Arc<Self>,
+        root: &Path,
+        reporter: Arc<R>,
+    ) {
         // workspace_root is updated inside index_workspace_impl after the
         // concurrency guard is acquired, so we never set a stale root here.
         let max = resolve_max_files(DEFAULT_MAX_INDEX_FILES);
         let (result, guard_opt) = Arc::clone(&self)
-            .index_workspace_impl(root, max, client.clone())
+            .index_workspace_impl(root, max, Arc::clone(&reporter))
             .await;
         if let Some(guard) = guard_opt {
             if !result.aborted {
                 Arc::clone(&self)
-                    .finalize_workspace_scan(result, guard, client.clone())
+                    .finalize_workspace_scan(result, guard)
                     .await;
             }
         }
-        Arc::clone(&self).run_pending_reindex(client).await;
+        Arc::clone(&self).run_pending_reindex(reporter).await;
     }
 
     /// Prioritized indexing: parse `initial_paths` first (high-priority files such as the
     /// currently-open document and its supertypes), then continue with normal bounded indexing.
     /// This gives fast symbol availability for the files the user is actually working on.
-    pub(crate) async fn index_workspace_prioritized(
+    pub(crate) async fn index_workspace_prioritized<R: ProgressReporter + 'static>(
         self: Arc<Self>,
         root: &Path,
         initial_paths: Vec<PathBuf>,
-        client: Option<tower_lsp::Client>,
+        reporter: Arc<R>,
     ) {
         // workspace_root is updated inside index_workspace_impl; don't set it
         // here to avoid leaving a stale root if the impl aborts early.
@@ -826,16 +796,16 @@ impl Indexer {
 
         let max = resolve_max_files(DEFAULT_MAX_INDEX_FILES);
         let (result, guard_opt) = Arc::clone(&self)
-            .index_workspace_impl(root, max, client.clone())
+            .index_workspace_impl(root, max, Arc::clone(&reporter))
             .await;
         if let Some(guard) = guard_opt {
             if !result.aborted {
                 Arc::clone(&self)
-                    .finalize_workspace_scan(result, guard, client.clone())
+                    .finalize_workspace_scan(result, guard)
                     .await;
             }
         }
-        Arc::clone(&self).run_pending_reindex(client).await;
+        Arc::clone(&self).run_pending_reindex(reporter).await;
     }
 
     /// If a reindex was queued while a scan was in progress, run it now.
@@ -843,7 +813,10 @@ impl Indexer {
     /// Called at the end of every public scan function, after the full workflow
     /// (impl + apply + source_paths + save_cache) completes. Mirrors RA's
     /// `OpQueue` pattern: at most one pending request is retained (last wins).
-    async fn run_pending_reindex(self: Arc<Self>, client: Option<tower_lsp::Client>) {
+    async fn run_pending_reindex<R: ProgressReporter + 'static>(
+        self: Arc<Self>,
+        reporter: Arc<R>,
+    ) {
         loop {
             // Never consume the pending flag while another scan is still active.
             // The finishing scan will call run_pending_reindex itself and drain it.
@@ -884,7 +857,7 @@ impl Indexer {
                 root.display()
             );
             let (result, guard_opt) = Arc::clone(&self)
-                .index_workspace_impl(&root, max, client.clone())
+                .index_workspace_impl(&root, max, Arc::clone(&reporter))
                 .await;
             if result.aborted {
                 // Lost the scan guard to a concurrent caller — restore the queued
@@ -901,7 +874,7 @@ impl Indexer {
             }
             if let Some(guard) = guard_opt {
                 Arc::clone(&self)
-                    .finalize_workspace_scan(result, guard, client.clone())
+                    .finalize_workspace_scan(result, guard)
                     .await;
             }
             // Loop: drain any request that arrived while this queued reindex was running.
@@ -914,7 +887,6 @@ impl Indexer {
         self: Arc<Self>,
         result: WorkspaceIndexResult,
         _guard: IndexingGuard,
-        _client: Option<tower_lsp::Client>,
     ) {
         self.last_scan_complete
             .store(result.complete_scan, std::sync::atomic::Ordering::Release);
@@ -931,11 +903,11 @@ impl Indexer {
     /// (apply + source_paths + save_cache). `result.aborted` may be true with either
     /// `Some` or `None` guard depending on the abort reason; callers should skip finalization
     /// whenever `result.aborted` is true.
-    async fn index_workspace_impl(
+    async fn index_workspace_impl<R: ProgressReporter + 'static>(
         self: Arc<Self>,
         root: &Path,
         max: usize,
-        client: Option<tower_lsp::Client>,
+        reporter: Arc<R>,
     ) -> (WorkspaceIndexResult, Option<IndexingGuard>) {
         if self
             .indexing_in_progress
@@ -986,13 +958,13 @@ impl Indexer {
             truncated: discovered.truncated,
         };
         write_indexing_started_status(root, &progress);
-        send_progress_begin(&client, &token, &progress).await;
+        send_progress_begin(&*reporter, &token, &progress).await;
 
         let (results, scheduling_aborted) = run_parse_phase(
             Arc::clone(&self),
             need_parse,
             &session,
-            &client,
+            &reporter,
             &token,
             parse_count,
         )
@@ -1014,7 +986,7 @@ impl Indexer {
             parse_count,
             cache_hits,
         );
-        send_progress_end(&client, &token, &result).await;
+        send_progress_end(&*reporter, &token, &result).await;
         write_indexing_done_status(
             root,
             result.stats.files_parsed,

--- a/src/indexer/scan_tests.rs
+++ b/src/indexer/scan_tests.rs
@@ -12,7 +12,7 @@
 
 use std::sync::Arc;
 
-use super::{find_files_for_types, resolve_max_files, IndexingGuard};
+use super::{find_files_for_types, resolve_max_files, IndexingGuard, NoopReporter};
 use crate::indexer::test_helpers::{with_env_var, with_env_var_unset, ENV_VAR_LOCK};
 use crate::indexer::Indexer;
 
@@ -131,7 +131,7 @@ async fn index_workspace_full_indexes_kt_files_issue_scan() {
     let _xdg = crate::indexer::test_helpers::EnvVarGuard::set("XDG_CACHE_HOME", tmp.path());
 
     Arc::clone(&idx)
-        .index_workspace_full(&workspace, None)
+        .index_workspace_full(&workspace, Arc::new(NoopReporter))
         .await;
 
     assert!(
@@ -165,7 +165,7 @@ async fn queued_reindex_executes_after_first_scan_completes_issue_scan() {
     idx.indexing_in_progress.store(true, Ordering::Release);
 
     // A concurrent scan request queues itself and returns immediately (aborted).
-    Arc::clone(&idx).index_workspace(&workspace, None).await;
+    Arc::clone(&idx).index_workspace(&workspace, Arc::new(NoopReporter)).await;
 
     assert!(
         idx.pending_reindex.load(Ordering::Acquire),
@@ -180,7 +180,7 @@ async fn queued_reindex_executes_after_first_scan_completes_issue_scan() {
     idx.indexing_in_progress.store(false, Ordering::Release);
 
     // Drain the queue — this should run the queued reindex.
-    Arc::clone(&idx).run_pending_reindex(None).await;
+    Arc::clone(&idx).run_pending_reindex(Arc::new(NoopReporter)).await;
 
     assert!(
         !idx.pending_reindex.load(Ordering::Acquire),
@@ -208,7 +208,7 @@ async fn index_workspace_skips_second_concurrent_run_issue_scan() {
     let idx = Arc::new(Indexer::new());
     idx.indexing_in_progress.store(true, Ordering::Release);
 
-    Arc::clone(&idx).index_workspace(&workspace, None).await;
+    Arc::clone(&idx).index_workspace(&workspace, Arc::new(NoopReporter)).await;
 
     // indexing_in_progress was already true → impl returned early WITHOUT creating
     // the guard, so the flag was NOT cleared. The flag stays true.

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -27,12 +27,12 @@ const ENCLOSING_CALL_SCAN_BACK: usize = 20;
 impl Indexer {
     /// LSP positions are UTF-16; for ASCII-heavy Kotlin/Java identifiers the
     /// character offset is identical to the UTF-16 unit offset.
-    pub fn word_at(&self, uri: &Url, position: Position) -> Option<String> {
+    pub(crate) fn word_at(&self, uri: &Url, position: Position) -> Option<String> {
         self.word_and_qualifier_at(uri, position).map(|(w, _)| w)
     }
 
     /// Like `word_at` but also returns the `Range` of the word in LSP (UTF-16) coordinates.
-    pub fn word_and_range_at(&self, uri: &Url, position: Position) -> Option<(String, Range)> {
+    pub(crate) fn word_and_range_at(&self, uri: &Url, position: Position) -> Option<(String, Range)> {
         let lines = self.lines_for(uri)?;
         let line_text = lines.get(position.line as usize)?;
         let target_utf16 = position.character as usize;
@@ -86,7 +86,7 @@ impl Indexer {
     }
 
     /// Returns a clone of the live (possibly unsaved) lines for a URI.
-    pub fn lines_for(&self, uri: &Url) -> Option<Arc<Vec<String>>> {
+    pub(crate) fn lines_for(&self, uri: &Url) -> Option<Arc<Vec<String>>> {
         // Prefer live (unsaved) lines, fall back to indexed file.
         if let Some(live) = self.live_lines.get(uri.as_str()) {
             return Some(live.clone());
@@ -113,7 +113,7 @@ impl Indexer {
     ///
     /// `List<StaticDocument>` cursor on `StaticDocument`
     ///   → `Some(("StaticDocument", None))`
-    pub fn word_and_qualifier_at(
+    pub(crate) fn word_and_qualifier_at(
         &self,
         uri: &Url,
         position: Position,
@@ -200,7 +200,7 @@ impl Indexer {
     /// Used by hover and go-to-definition to provide useful info for lambda params.
     /// Handles both same-line and multi-line lambda declarations by scanning
     /// backward through file lines (not just the text before the cursor).
-    pub fn infer_lambda_param_type_at(
+    pub(crate) fn infer_lambda_param_type_at(
         &self,
         name: &str,
         uri: &Url,
@@ -270,7 +270,7 @@ impl Indexer {
     /// Example — cursor inside `{ resultState -> … }`:
     ///   `reloadableProduct(…, { isRefresh -> … }) { resultState -> │ }`
     ///   → returns `["resultState"]`,  NOT `["isRefresh", "resultState"]`
-    pub fn lambda_params_at(&self, uri: &Url, cursor_line: usize) -> Vec<String> {
+    pub(crate) fn lambda_params_at(&self, uri: &Url, cursor_line: usize) -> Vec<String> {
         self.lambda_params_at_col(uri, cursor_line, usize::MAX)
     }
 
@@ -283,7 +283,7 @@ impl Indexer {
     ///                                                  ^ cursor here
     /// Without the limit, the scan hits `}` first (depth→1), then `{` resets to 0
     /// (not <0), so the lambda params are never collected.
-    pub fn lambda_params_at_col(
+    pub(crate) fn lambda_params_at_col(
         &self,
         uri: &Url,
         cursor_line: usize,
@@ -391,7 +391,7 @@ impl Indexer {
     /// Find the `{ name ->` declaration line for a lambda parameter in scope at
     /// `cursor_line`.  Returns a `Location` pointing to the opening `{` of the
     /// enclosing lambda (the parameter's declaration site).
-    pub fn find_lambda_param_decl(
+    pub(crate) fn find_lambda_param_decl(
         &self,
         uri: &Url,
         param_name: &str,
@@ -438,7 +438,7 @@ impl Indexer {
     /// Used by `references` to scope a short symbol name (e.g. `Loading`) to
     /// its parent sealed class so we can filter out unrelated `Loading` classes
     /// in other sealed hierarchies.
-    pub fn enclosing_class_at(&self, uri: &Url, row: u32) -> Option<String> {
+    pub(crate) fn enclosing_class_at(&self, uri: &Url, row: u32) -> Option<String> {
         let row = row as usize;
 
         // ── CST fast path ────────────────────────────────────────────────────

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -1886,7 +1886,7 @@ async fn e2e_ignore_patterns_excludes_symbols() {
         root,
     )));
 
-    Arc::clone(&indexer).index_workspace_full(root, None).await;
+    Arc::clone(&indexer).index_workspace_full(root, Arc::new(NoopReporter)).await;
 
     assert!(
         indexer.definitions.contains_key("MainClass"),
@@ -1925,7 +1925,7 @@ async fn e2e_ignore_patterns_bare_pattern_any_depth() {
         root,
     )));
 
-    Arc::clone(&indexer).index_workspace_full(root, None).await;
+    Arc::clone(&indexer).index_workspace_full(root, Arc::new(NoopReporter)).await;
 
     assert!(
         indexer.definitions.contains_key("KeepMe"),

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -21,7 +21,7 @@ use crate::queries::{KIND_CALL_EXPR, KIND_LAMBDA_PARAMS};
 use crate::resolver::{infer_receiver_type, ReceiverKind};
 use crate::StrExt;
 
-pub fn compute_inlay_hints(idx: &Arc<Indexer>, uri: &Url, range: Range) -> Vec<InlayHint> {
+pub(crate) fn compute_inlay_hints(idx: &Arc<Indexer>, uri: &Url, range: Range) -> Vec<InlayHint> {
     // Fast path: editor has the file open → use pre-parsed live tree.
     if let Some(doc) = idx.live_doc(uri) {
         return cst_hints(idx, uri, &doc.tree, &doc.bytes, range);

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,7 @@ async fn async_main() {
         let root = pb.canonicalize().unwrap_or(pb);
         println!("Indexing workspace: {}", root.display());
         std::sync::Arc::clone(&idx)
-            .index_workspace_full(&root, None)
+            .index_workspace_full(&root, std::sync::Arc::new(indexer::NoopReporter))
             .await;
         println!(
             "Indexing complete: {} files, {} symbols",

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![warn(unreachable_pub)]
 mod backend;
 mod indexer;
 mod inlay_hints;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -109,7 +109,7 @@ thread_local! {
 
 // ─── public entry points ────────────────────────────────────────────────────
 
-pub fn parse_kotlin(content: &str) -> FileData {
+pub(crate) fn parse_kotlin(content: &str) -> FileData {
     let lines = std::sync::Arc::new(content.lines().map(str::to_owned).collect());
     let mut data = FileData {
         lines,
@@ -165,7 +165,7 @@ pub fn parse_kotlin(content: &str) -> FileData {
     data
 }
 
-pub fn parse_java(content: &str) -> FileData {
+pub(crate) fn parse_java(content: &str) -> FileData {
     let lines = std::sync::Arc::new(content.lines().map(str::to_owned).collect());
     let mut data = FileData {
         lines,
@@ -191,7 +191,7 @@ pub fn parse_java(content: &str) -> FileData {
     data
 }
 
-pub fn parse_swift(content: &str) -> FileData {
+pub(crate) fn parse_swift(content: &str) -> FileData {
     let lines = std::sync::Arc::new(content.lines().map(str::to_owned).collect());
     let mut data = FileData {
         lines,
@@ -268,7 +268,7 @@ pub fn parse_swift(content: &str) -> FileData {
 }
 
 /// Dispatch to the correct parser based on file extension.
-pub fn parse_by_extension(path: &str, content: &str) -> FileData {
+pub(crate) fn parse_by_extension(path: &str, content: &str) -> FileData {
     match crate::Language::from_path(path) {
         crate::Language::Swift => parse_swift(content),
         crate::Language::Java => parse_java(content),
@@ -945,7 +945,7 @@ fn parse_import_header(header: &tree_sitter::Node, bytes: &[u8], data: &mut File
 /// Lightweight import scanner for live (unsaved) buffer lines.
 /// Handles: `import pkg.Name`, `import pkg.Name as Alias`, `import pkg.*`
 /// Used by completion to read the current buffer state without a full re-parse.
-pub fn parse_imports_from_lines(lines: &[String]) -> Vec<crate::types::ImportEntry> {
+pub(crate) fn parse_imports_from_lines(lines: &[String]) -> Vec<crate::types::ImportEntry> {
     let mut imports = Vec::new();
     for line in lines {
         let trimmed = line.trim_start();

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -23,7 +23,7 @@
 // ────────────────────────────────────────────────────────────────────────────
 
 /// Pattern indices → SymbolKind mapping lives in `parser.rs`.
-pub const KOTLIN_DEFINITIONS: &str = r#"
+pub(crate) const KOTLIN_DEFINITIONS: &str = r#"
 ; 0 — enum class  MUST be before plain "class" pattern (both have "class" keyword).
 ;     enum_class_body is unique to enum classes — no ambiguity.
 (class_declaration
@@ -149,7 +149,7 @@ pub const KOTLIN_DEFINITIONS: &str = r#"
 // child or by checking whether @path ends with ".*".
 // ────────────────────────────────────────────────────────────────────────────
 #[allow(dead_code)]
-pub const KOTLIN_IMPORTS: &str = r#"
+pub(crate) const KOTLIN_IMPORTS: &str = r#"
 ; plain import
 (import_header
   (identifier) @path)
@@ -168,7 +168,7 @@ pub const KOTLIN_IMPORTS: &str = r#"
 //   @name — full dotted package name, e.g. "com.example.app"
 // ────────────────────────────────────────────────────────────────────────────
 #[allow(dead_code)]
-pub const KOTLIN_PACKAGE: &str = r#"
+pub(crate) const KOTLIN_PACKAGE: &str = r#"
 (package_header
   (identifier) @name)
 "#;
@@ -194,7 +194,7 @@ pub const KOTLIN_PACKAGE: &str = r#"
 //   type_identifier    — type annotations, super-types, generic args
 // ────────────────────────────────────────────────────────────────────────────
 #[allow(dead_code)]
-pub const KOTLIN_REFS_ALL: &str = r#"
+pub(crate) const KOTLIN_REFS_ALL: &str = r#"
 [
   (simple_identifier) @ref
   (type_identifier)   @ref
@@ -209,7 +209,7 @@ pub const KOTLIN_REFS_ALL: &str = r#"
 /// // → r#"[(simple_identifier) @ref (type_identifier) @ref] (#eq? @ref "MyClass")"#
 /// ```
 #[allow(dead_code)]
-pub fn kotlin_refs_for(name: &str) -> String {
+pub(crate) fn kotlin_refs_for(name: &str) -> String {
     // Escape any double-quotes in the name (identifiers normally can't have them,
     // but be defensive).
     let safe = name.replace('\\', r"\\").replace('"', r#"\""#);
@@ -231,7 +231,7 @@ use tower_lsp::lsp_types::SymbolKind;
 /// Maps a pattern index from `KOTLIN_DEFINITIONS` to `(SymbolKind, detail_label)`.
 ///
 /// `detail_label` is shown as `DocumentSymbol::detail` (e.g. "data class").
-pub fn def_pattern_meta(pattern_index: usize) -> (SymbolKind, Option<&'static str>) {
+pub(crate) fn def_pattern_meta(pattern_index: usize) -> (SymbolKind, Option<&'static str>) {
     match pattern_index {
         0 => (SymbolKind::ENUM, None),                 // enum class
         1 => (SymbolKind::STRUCT, Some("data class")), // data class
@@ -276,7 +276,7 @@ pub fn def_pattern_meta(pattern_index: usize) -> (SymbolKind, Option<&'static st
 // • init → `init_declaration` (no name capture; caller can label "init").
 // ────────────────────────────────────────────────────────────────────────────
 
-pub const SWIFT_DEFINITIONS: &str = r#"
+pub(crate) const SWIFT_DEFINITIONS: &str = r#"
 ; 0 — class
 (class_declaration "class" name: (type_identifier) @name) @def
 
@@ -315,7 +315,7 @@ pub const SWIFT_DEFINITIONS: &str = r#"
 "#;
 
 /// Maps a pattern index from `SWIFT_DEFINITIONS` to `(SymbolKind, detail_label)`.
-pub fn swift_def_pattern_meta(pattern_index: usize) -> (SymbolKind, Option<&'static str>) {
+pub(crate) fn swift_def_pattern_meta(pattern_index: usize) -> (SymbolKind, Option<&'static str>) {
     match pattern_index {
         0 => (SymbolKind::CLASS, None),                 // class
         1 => (SymbolKind::STRUCT, None),                // struct
@@ -335,10 +335,10 @@ pub fn swift_def_pattern_meta(pattern_index: usize) -> (SymbolKind, Option<&'sta
 
 /// Pattern index of `init_declaration` in `SWIFT_DEFINITIONS`.
 /// Pattern 8 has no `@name` capture — the parser synthesises `"init"` instead.
-pub const SWIFT_INIT_PATTERN_IDX: usize = 8;
+pub(crate) const SWIFT_INIT_PATTERN_IDX: usize = 8;
 
 /// Synthesised name for Swift init declarations.
-pub const SWIFT_INIT_NAME: &str = "init";
+pub(crate) const SWIFT_INIT_NAME: &str = "init";
 
 // ─── tree-sitter node kind constants ─────────────────────────────────────────
 // These match the `node.kind()` strings produced by tree-sitter-kotlin,

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -286,7 +286,7 @@ fn complete_super(idx: &Indexer, from_uri: &Url, snippets: bool) -> Vec<Completi
     }
     let mut items: Vec<CompletionItem> = Vec::new();
     let mut visited: Vec<String> = vec![from_uri.as_str().to_owned()];
-    collect_hierarchy_completions(idx, from_uri, &mut visited, 0, &mut items, snippets);
+    SuperWalker { idx, snippets }.collect(from_uri, &mut visited, 0, &mut items);
     // Filter out private/protected members — inaccessible even via super.
     items.retain(|i| {
         i.sort_text
@@ -299,41 +299,51 @@ fn complete_super(idx: &Indexer, from_uri: &Url, snippets: bool) -> Vec<Completi
     items
 }
 
-fn collect_hierarchy_completions(
-    idx: &Indexer,
-    from_uri: &Url,
-    visited: &mut Vec<String>,
-    depth: u8,
-    out: &mut Vec<CompletionItem>,
+/// Walks the supertype hierarchy from a given file URI, collecting completion items.
+///
+/// Visited keys are file URIs (not type-qualified) — this is a file-oriented
+/// walk, distinct from [`InheritanceWalker`] which is type-oriented.
+struct SuperWalker<'a> {
+    idx: &'a Indexer,
     snippets: bool,
-) {
-    const MAX_DEPTH: u8 = 4;
-    if depth >= MAX_DEPTH {
-        return;
-    }
+}
 
-    let supers: Vec<String> = match idx.files.get(from_uri.as_str()) {
-        Some(f) => f.supers.iter().map(|(_, n, _)| n.clone()).collect(),
-        None => return,
-    };
+impl<'a> SuperWalker<'a> {
+    fn collect(
+        &self,
+        from_uri: &Url,
+        visited: &mut Vec<String>,
+        depth: u8,
+        out: &mut Vec<CompletionItem>,
+    ) {
+        const MAX_DEPTH: u8 = 4;
+        if depth >= MAX_DEPTH {
+            return;
+        }
 
-    for super_name in supers {
-        let super_locs = resolve_symbol_inner(idx, &super_name, from_uri, false);
-        for super_loc in &super_locs {
-            let uri_str = super_loc.uri.as_str();
-            if visited.contains(&uri_str.to_owned()) {
-                continue;
-            }
-            visited.push(uri_str.to_owned());
-            let mut new_items = symbols_from_uri_as_completions(idx, uri_str);
-            if !snippets {
-                for item in &mut new_items {
-                    item.insert_text = None;
-                    item.insert_text_format = None;
+        let supers: Vec<String> = match self.idx.files.get(from_uri.as_str()) {
+            Some(f) => f.supers.iter().map(|(_, n, _)| n.clone()).collect(),
+            None => return,
+        };
+
+        for super_name in supers {
+            let super_locs = resolve_symbol_inner(self.idx, &super_name, from_uri, false);
+            for super_loc in &super_locs {
+                let uri_str = super_loc.uri.as_str();
+                if visited.contains(&uri_str.to_owned()) {
+                    continue;
                 }
+                visited.push(uri_str.to_owned());
+                let mut new_items = symbols_from_uri_as_completions(self.idx, uri_str);
+                if !self.snippets {
+                    for item in &mut new_items {
+                        item.insert_text = None;
+                        item.insert_text_format = None;
+                    }
+                }
+                out.extend(new_items);
+                self.collect(&super_loc.uri, visited, depth + 1, out);
             }
-            out.extend(new_items);
-            collect_hierarchy_completions(idx, &super_loc.uri, visited, depth + 1, out, snippets);
         }
     }
 }

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -330,7 +330,7 @@ impl<'a> SuperWalker<'a> {
             let super_locs = resolve_symbol_inner(self.idx, &super_name, from_uri, false);
             for super_loc in &super_locs {
                 let uri_str = super_loc.uri.as_str();
-                if visited.contains(&uri_str.to_owned()) {
+                if visited.iter().any(|s| s == uri_str) {
                     continue;
                 }
                 visited.push(uri_str.to_owned());

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -118,7 +118,7 @@ const MIN_CASE_INSENSITIVE_PREFIX: usize = 2;
 /// - **Bare-word** (`dot_receiver = None`): return all symbols from the current
 ///   file, same-package files, and the whole project index whose name starts with
 ///   `prefix` (case-insensitive).
-pub fn complete_symbol(
+pub(crate) fn complete_symbol(
     idx: &Indexer,
     prefix: &str,
     dot_receiver: Option<&str>,
@@ -130,7 +130,7 @@ pub fn complete_symbol(
 
 /// Like `complete_symbol` but with explicit annotation context flag.
 /// Called from `indexer::completions` after detecting a `@` trigger.
-pub fn complete_symbol_with_context(
+pub(crate) fn complete_symbol_with_context(
     idx: &Indexer,
     prefix: &str,
     dot_receiver: Option<&str>,
@@ -1073,7 +1073,7 @@ fn make_completion_item(
 
 /// Public wrapper around `symbols_from_uri_as_completions` for use by the
 /// pre-warmer in `indexer.rs`.  Builds + caches completion items for a file.
-pub fn symbols_from_uri_as_completions_pub(idx: &Indexer, file_uri: &str) -> Vec<CompletionItem> {
+pub(crate) fn symbols_from_uri_as_completions_pub(idx: &Indexer, file_uri: &str) -> Vec<CompletionItem> {
     symbols_from_uri_as_completions(idx, file_uri)
 }
 
@@ -1119,7 +1119,7 @@ impl crate::indexer::Indexer {
     pub(super) fn build_completion_items_w(&self, file_uri: &str) -> Vec<CompletionItem> {
         build_completion_items(self, file_uri)
     }
-    pub fn symbols_from_uri_as_completions_pub(&self, file_uri: &str) -> Vec<CompletionItem> {
+    pub(crate) fn symbols_from_uri_as_completions_pub(&self, file_uri: &str) -> Vec<CompletionItem> {
         symbols_from_uri_as_completions_pub(self, file_uri)
     }
 }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -13,7 +13,7 @@ use crate::StrExt;
 /// - `Contextual`: `it`, `this`, or a named lambda parameter.
 ///   Requires cursor `position` for scope analysis; falls back to
 ///   `infer_variable_type_raw` only if scope analysis returns nothing.
-pub enum ReceiverKind<'a> {
+pub(crate) enum ReceiverKind<'a> {
     Variable(&'a str),
     Contextual { name: &'a str, position: Position },
 }
@@ -25,7 +25,7 @@ pub enum ReceiverKind<'a> {
 /// - `qualified` — no generics, dots preserved: `"Outer.Inner"`
 /// - `outer`     — first dot-segment: `"Outer"`  (used for file lookup)
 /// - `leaf`      — last dot-segment: `"Inner"`   (used for fallback member lookup)
-pub struct ReceiverType {
+pub(crate) struct ReceiverType {
     pub raw: String,
     pub qualified: String,
     pub outer: String,
@@ -33,7 +33,7 @@ pub struct ReceiverType {
 }
 
 impl ReceiverType {
-    pub fn from_raw(raw: String) -> Self {
+    pub(crate) fn from_raw(raw: String) -> Self {
         // Strip generics: take chars until first `<`.
         let qualified: String = raw.chars().take_while(|&c| c != '<').collect();
         let outer = qualified
@@ -61,7 +61,7 @@ impl ReceiverType {
 /// Returns `None` when type inference fails (no annotation, unindexed file,
 /// or lambda scope not resolvable).  Call sites then decide whether to skip
 /// or fall back; this function never performs a global rg scan.
-pub fn infer_receiver_type(
+pub(crate) fn infer_receiver_type(
     idx: &Indexer,
     kind: ReceiverKind<'_>,
     uri: &Url,
@@ -93,7 +93,7 @@ pub(crate) fn infer_variable_type(idx: &Indexer, var_name: &str, uri: &Url) -> O
 /// type string.  e.g. `val items: List<Product>` → `"List<Product>"`.
 ///
 /// Used by the `it`-completion path to extract the collection element type.
-pub fn infer_variable_type_raw(idx: &Indexer, var_name: &str, uri: &Url) -> Option<String> {
+pub(crate) fn infer_variable_type_raw(idx: &Indexer, var_name: &str, uri: &Url) -> Option<String> {
     infer_variable_type_raw_impl(idx, var_name, uri, 4)
 }
 
@@ -216,7 +216,7 @@ fn infer_variable_type_raw_impl(
 /// Returns `None` when the base type is not in the known collection list, or when
 /// the generic parameter is a primitive/lowercase type.  In those cases the
 /// caller should treat `it` as the receiver type itself (scope functions).
-pub fn extract_collection_element_type(raw_type: &str) -> Option<String> {
+pub(crate) fn extract_collection_element_type(raw_type: &str) -> Option<String> {
     const COLLECTION_TYPES: &[&str] = &[
         "List",
         "MutableList",
@@ -346,7 +346,7 @@ impl crate::indexer::Indexer {
     pub(crate) fn infer_variable_type(&self, var_name: &str, uri: &Url) -> Option<String> {
         infer_variable_type(self, var_name, uri)
     }
-    pub fn infer_variable_type_raw(&self, var_name: &str, uri: &Url) -> Option<String> {
+    pub(crate) fn infer_variable_type_raw(&self, var_name: &str, uri: &Url) -> Option<String> {
         infer_variable_type_raw(self, var_name, uri)
     }
     pub(crate) fn infer_field_type(&self, file_uri: &str, field_name: &str) -> Option<String> {

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -30,7 +30,7 @@ use crate::types::ImportEntry;
 use crate::LinesExt;
 use crate::StrExt;
 
-pub mod complete;
+pub(crate) mod complete;
 pub(crate) mod find;
 pub(crate) mod infer;
 #[cfg(test)]
@@ -39,10 +39,10 @@ mod tests;
 // ─── re-exports ───────────────────────────────────────────────────────────────
 
 pub(crate) use complete::is_annotation_context;
-pub use complete::{
+pub(crate) use complete::{
     complete_symbol, complete_symbol_with_context, symbols_from_uri_as_completions_pub,
 };
-pub use infer::{
+pub(crate) use infer::{
     extract_collection_element_type, infer_receiver_type, infer_variable_type_raw, ReceiverKind,
     ReceiverType,
 };
@@ -151,7 +151,7 @@ pub(crate) fn make_import_edit(fqn: &str, lines: &[String], needs_semicolon: boo
 /// Resolve `name` as seen from `from_uri`, returning all known definition
 /// `Location`s in priority order.  Returns an empty vec only when nothing was
 /// found by any strategy including `rg`.
-pub fn resolve_symbol(
+pub(crate) fn resolve_symbol(
     idx: &Indexer,
     name: &str,
     qualifier: Option<&str>,
@@ -966,7 +966,7 @@ pub(crate) fn is_stdlib(pkg: &str) -> bool {
 
 #[allow(dead_code)]
 impl crate::indexer::Indexer {
-    pub fn resolve_symbol(
+    pub(crate) fn resolve_symbol(
         &self,
         name: &str,
         qualifier: Option<&str>,

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -24,7 +24,7 @@ use tower_lsp::lsp_types::{Location, Position, Range, Url};
 /// - A bare pattern with no `/` (e.g. `bazel-*`) matches at any depth.
 /// - A pattern containing `/` (e.g. `build/**`) matches relative to the workspace root.
 /// - Absolute paths under the workspace root are normalized to relative before matching.
-pub struct IgnoreMatcher {
+pub(crate) struct IgnoreMatcher {
     /// Original patterns as provided by the client (passed to `fd --exclude` as-is).
     pub patterns: Vec<String>,
     /// Arc-wrapped so the compiled set can be shared into `filter_entry` closures.
@@ -35,7 +35,7 @@ pub struct IgnoreMatcher {
 
 impl IgnoreMatcher {
     /// Build an `IgnoreMatcher` from raw client patterns against `root`.
-    pub fn new(patterns: Vec<String>, root: &Path) -> Self {
+    pub(crate) fn new(patterns: Vec<String>, root: &Path) -> Self {
         let mut builder = globset::GlobSetBuilder::new();
         for pat in &patterns {
             // Normalize absolute paths that fall under the workspace root.
@@ -87,23 +87,23 @@ impl IgnoreMatcher {
         }
     }
 
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.patterns.is_empty()
     }
 
     /// Returns `true` if `rel_path` (relative to workspace root) should be excluded.
-    pub fn matches(&self, rel_path: &Path) -> bool {
+    pub(crate) fn matches(&self, rel_path: &Path) -> bool {
         self.glob_set.is_match(rel_path)
     }
 
     /// Clone the Arc-wrapped glob set for use in `filter_entry` closures.
-    pub fn glob_set(&self) -> Arc<globset::GlobSet> {
+    pub(crate) fn glob_set(&self) -> Arc<globset::GlobSet> {
         Arc::clone(&self.glob_set)
     }
 
     /// Remove locations whose file path is inside an ignored directory.
     /// Paths are relativized against the workspace root this matcher was built for.
-    pub fn filter_locs(&self, locs: Vec<Location>) -> Vec<Location> {
+    pub(crate) fn filter_locs(&self, locs: Vec<Location>) -> Vec<Location> {
         locs.into_iter()
             .filter(|loc| {
                 if let Ok(path) = loc.uri.to_file_path() {
@@ -117,7 +117,7 @@ impl IgnoreMatcher {
     }
 
     /// Remove file paths (absolute strings) that fall inside an ignored directory.
-    pub fn filter_file_strings(&self, files: Vec<String>) -> Vec<String> {
+    pub(crate) fn filter_file_strings(&self, files: Vec<String>) -> Vec<String> {
         files
             .into_iter()
             .filter(|f| {
@@ -129,7 +129,7 @@ impl IgnoreMatcher {
     }
 
     /// Remove `PathBuf` entries that fall inside an ignored directory.
-    pub fn filter_paths(&self, paths: Vec<std::path::PathBuf>) -> Vec<std::path::PathBuf> {
+    pub(crate) fn filter_paths(&self, paths: Vec<std::path::PathBuf>) -> Vec<std::path::PathBuf> {
         paths
             .into_iter()
             .filter(|p| {
@@ -143,7 +143,7 @@ impl IgnoreMatcher {
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Supported file extensions for indexing and rg/fd searches.
-pub const SOURCE_EXTENSIONS: &[&str] = &["kt", "java", "swift"];
+pub(crate) const SOURCE_EXTENSIONS: &[&str] = &["kt", "java", "swift"];
 
 // ─── Pattern builder ─────────────────────────────────────────────────────────
 
@@ -274,7 +274,7 @@ pub(crate) fn rg_find_definition(
 ///
 /// Results in directories matched by `matcher` are filtered out.
 #[allow(clippy::too_many_arguments)]
-pub fn rg_find_references(
+pub(crate) fn rg_find_references(
     name: &str,
     parent_class: Option<&str>,
     declared_pkg: Option<&str>,
@@ -483,7 +483,7 @@ pub fn rg_find_references(
 /// subtype index is empty during cold indexing.
 ///
 /// Results in directories matched by `matcher` are filtered out.
-pub fn rg_find_implementors(
+pub(crate) fn rg_find_implementors(
     name: &str,
     root: Option<&Path>,
     matcher: Option<&IgnoreMatcher>,

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -7,7 +7,7 @@
 
 /// A single stdlib entry: name, signature (shown in hover), and kind.
 #[derive(Clone, Copy)]
-pub struct StdlibEntry {
+pub(crate) struct StdlibEntry {
     pub name: &'static str,
     pub signature: &'static str,
     /// True = method/extension (dot-completable).  False = top-level.
@@ -28,7 +28,7 @@ impl StdlibEntry {
 
 // ─── scope / control-flow functions (available on every type) ─────────────────
 
-pub static SCOPE_FUNS: &[StdlibEntry] = &[
+pub(crate) static SCOPE_FUNS: &[StdlibEntry] = &[
     StdlibEntry {
         name: "let",
         signature: "inline fun <T, R> T.let(block: (T) -> R): R",
@@ -78,7 +78,7 @@ pub static SCOPE_FUNS: &[StdlibEntry] = &[
 
 // ─── collection / iterable extension functions ────────────────────────────────
 
-pub static COLLECTION_FUNS: &[StdlibEntry] = &[
+pub(crate) static COLLECTION_FUNS: &[StdlibEntry] = &[
     StdlibEntry { name: "map",              signature: "inline fun <T, R> Iterable<T>.map(transform: (T) -> R): List<R>",                            is_extension: true },
     StdlibEntry { name: "mapNotNull",       signature: "inline fun <T, R: Any> Iterable<T>.mapNotNull(transform: (T) -> R?): List<R>",               is_extension: true },
     StdlibEntry { name: "mapIndexed",       signature: "inline fun <T, R> Iterable<T>.mapIndexed(transform: (Int, T) -> R): List<R>",                is_extension: true },
@@ -146,7 +146,7 @@ pub static COLLECTION_FUNS: &[StdlibEntry] = &[
 
 // ─── String / CharSequence extension functions ────────────────────────────────
 
-pub static STRING_FUNS: &[StdlibEntry] = &[
+pub(crate) static STRING_FUNS: &[StdlibEntry] = &[
     StdlibEntry { name: "isEmpty",          signature: "fun CharSequence.isEmpty(): Boolean",                                       is_extension: true },
     StdlibEntry { name: "isNotEmpty",       signature: "fun CharSequence.isNotEmpty(): Boolean",                                    is_extension: true },
     StdlibEntry { name: "isBlank",          signature: "fun CharSequence.isBlank(): Boolean",                                       is_extension: true },
@@ -190,7 +190,7 @@ pub static STRING_FUNS: &[StdlibEntry] = &[
 
 // ─── Nullable extensions ──────────────────────────────────────────────────────
 
-pub static NULLABLE_FUNS: &[StdlibEntry] = &[
+pub(crate) static NULLABLE_FUNS: &[StdlibEntry] = &[
     StdlibEntry {
         name: "orEmpty",
         signature: "fun <T> List<T>?.orEmpty(): List<T>",
@@ -210,7 +210,7 @@ pub static NULLABLE_FUNS: &[StdlibEntry] = &[
 
 // ─── Top-level functions ──────────────────────────────────────────────────────
 
-pub static TOP_LEVEL_FUNS: &[StdlibEntry] = &[
+pub(crate) static TOP_LEVEL_FUNS: &[StdlibEntry] = &[
     StdlibEntry { name: "run",          signature: "inline fun <R> run(block: () -> R): R",                                         is_extension: false },
     StdlibEntry { name: "with",         signature: "inline fun <T, R> with(receiver: T, block: T.() -> R): R",                     is_extension: false },
     StdlibEntry { name: "repeat",       signature: "inline fun repeat(times: Int, action: (Int) -> Unit)",                          is_extension: false },
@@ -273,7 +273,7 @@ fn all() -> impl Iterator<Item = &'static StdlibEntry> {
 }
 
 /// Hover markdown for a stdlib symbol, or `None` if not known.
-pub fn hover(name: &str) -> Option<String> {
+pub(crate) fn hover(name: &str) -> Option<String> {
     // Collect all matching signatures (same name can appear in multiple tables).
     let sigs: Vec<&str> = all()
         .filter(|e| e.name == name)
@@ -330,7 +330,7 @@ fn build_bare_completions(snippets: bool) -> Vec<tower_lsp::lsp_types::Completio
 
 /// Returns stdlib dot-completions filtered to those applicable for `receiver_type`.
 /// Falls back to scope-functions-only for unknown project types.
-pub fn dot_completions_for(
+pub(crate) fn dot_completions_for(
     receiver_type: &str,
     snippets: bool,
 ) -> Vec<tower_lsp::lsp_types::CompletionItem> {
@@ -395,7 +395,7 @@ pub fn dot_completions_for(
 }
 
 /// Completion items for bare (non-dot) trigger — returns a shared cached slice.
-pub fn bare_completions(snippets: bool) -> Vec<tower_lsp::lsp_types::CompletionItem> {
+pub(crate) fn bare_completions(snippets: bool) -> Vec<tower_lsp::lsp_types::CompletionItem> {
     if snippets {
         BARE_COMPLETIONS_SNIPPETS
             .get_or_init(|| build_bare_completions(true))
@@ -411,7 +411,7 @@ pub fn bare_completions(snippets: bool) -> Vec<tower_lsp::lsp_types::CompletionI
 ///
 /// Modelled on IntelliJ's built-in Kotlin live templates.
 /// Each item has a short trigger label and expands to a multi-line snippet.
-pub fn live_templates() -> Vec<tower_lsp::lsp_types::CompletionItem> {
+pub(crate) fn live_templates() -> Vec<tower_lsp::lsp_types::CompletionItem> {
     use tower_lsp::lsp_types::{
         CompletionItem, CompletionItemKind, Documentation, InsertTextFormat, MarkupContent,
         MarkupKind,

--- a/src/stdlib_tail.rs
+++ b/src/stdlib_tail.rs
@@ -4,7 +4,7 @@ use crate::stdlib::dot_completions_for;
 /// and `.kts` files, Swift-specific templates for `.swift` files, and nothing
 /// for Java (handled by JVM tooling). `from_path` should be the file path
 /// portion of the request URI (e.g., "/home/user/project/src/Foo.kt").
-pub fn dot_completions_for_lang(
+pub(crate) fn dot_completions_for_lang(
     from_path: &str,
     receiver_type: &str,
     snippets: bool,

--- a/src/task_runner.rs
+++ b/src/task_runner.rs
@@ -18,7 +18,7 @@ use tokio::sync::Semaphore;
 ///
 /// # Returns
 /// Vector of results in same order as input items
-pub async fn run_concurrent<T, R, F, Fut>(
+pub(crate) async fn run_concurrent<T, R, F, Fut>(
     items: Vec<T>,
     semaphore: Arc<Semaphore>,
     worker: F,

--- a/src/types.rs
+++ b/src/types.rs
@@ -7,7 +7,7 @@ use tower_lsp::lsp_types::{Range, SymbolKind};
 /// Used to centralise all `path.ends_with(".kt")` / `".swift"` / `".java"` dispatch.
 /// Obtain via [`Language::from_path`]; the default is `Kotlin` (most common case).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
-pub enum Language {
+pub(crate) enum Language {
     #[default]
     Kotlin,
     Java,
@@ -20,7 +20,7 @@ impl Language {
     /// Explicit matches: `.java` → Java, `.swift` → Swift.
     /// Everything else (`.kt`, `.kts`, unknown extensions) → Kotlin, since this
     /// server is Kotlin-primary and `.kts` files use the same language features.
-    pub fn from_path(path: &str) -> Self {
+    pub(crate) fn from_path(path: &str) -> Self {
         if path.ends_with(".swift") {
             Language::Swift
         } else if path.ends_with(".java") {
@@ -30,13 +30,13 @@ impl Language {
         }
     }
 
-    pub fn is_kotlin(self) -> bool {
+    pub(crate) fn is_kotlin(self) -> bool {
         matches!(self, Language::Kotlin)
     }
-    pub fn is_java(self) -> bool {
+    pub(crate) fn is_java(self) -> bool {
         matches!(self, Language::Java)
     }
-    pub fn is_swift(self) -> bool {
+    pub(crate) fn is_swift(self) -> bool {
         matches!(self, Language::Swift)
     }
 }
@@ -47,14 +47,14 @@ impl Language {
 /// Using a named struct (rather than a bare `(usize, usize)` pair) prevents silent
 /// transposition of line and column arguments at call sites.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct CursorPos {
+pub(crate) struct CursorPos {
     pub line: usize,
     pub utf16_col: usize,
 }
 
 /// Kotlin/Java visibility of a declared symbol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
-pub enum Visibility {
+pub(crate) enum Visibility {
     #[default]
     Public,
     Internal,
@@ -64,7 +64,7 @@ pub enum Visibility {
 
 /// Single symbol definition entry stored in the index.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SymbolEntry {
+pub(crate) struct SymbolEntry {
     pub name: String,
     pub kind: SymbolKind,
     pub visibility: Visibility,
@@ -96,14 +96,14 @@ impl SymbolEntry {
     /// This is a convenience accessor for `.selection_range.start.line` (the identifier line),
     /// distinguishing it from `.range.start.line` (the full declaration start, which may differ on
     /// multiline declarations). Reduces coupling and avoids repeated deep field access.
-    pub fn selection_start(&self) -> u32 {
+    pub(crate) fn selection_start(&self) -> u32 {
         self.selection_range.start.line
     }
 }
 
 /// One import statement parsed from a Kotlin file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ImportEntry {
+pub(crate) struct ImportEntry {
     /// Fully-qualified path without the trailing `.*`.
     /// e.g. `"com.example.Foo"` or `"com.example"` for star imports.
     pub full_path: String,
@@ -119,14 +119,14 @@ pub struct ImportEntry {
 /// garbled syntax from a bad edit.  They are NOT serialized to the disk cache
 /// (cheap to recompute on every parse).
 #[derive(Debug, Clone)]
-pub struct SyntaxError {
+pub(crate) struct SyntaxError {
     pub range: Range,
     pub message: String,
 }
 
 /// All data we keep in memory for one source file.
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct FileData {
+pub(crate) struct FileData {
     pub symbols: Vec<SymbolEntry>,
     pub imports: Vec<ImportEntry>,
     /// Package declaration, e.g. `"com.example.app"`.
@@ -166,7 +166,7 @@ impl FileData {
     /// Find the name of the innermost class/interface/object/enum that contains
     /// `line` in this file's symbol list. Returns `None` if the symbol is
     /// top-level (not inside any class).
-    pub fn containing_class_at(&self, line: u32) -> Option<String> {
+    pub(crate) fn containing_class_at(&self, line: u32) -> Option<String> {
         const CLASS_KINDS: &[SymbolKind] = &[
             SymbolKind::CLASS,
             SymbolKind::INTERFACE,
@@ -186,7 +186,7 @@ impl FileData {
 /// Result of parsing a single file. Pure data, no side effects.
 /// This is what index_content will return instead of mutating DashMaps.
 #[derive(Debug, Clone)]
-pub struct FileIndexResult {
+pub(crate) struct FileIndexResult {
     /// File URI that was parsed.
     pub uri: tower_lsp::lsp_types::Url,
     /// Parsed file data (symbols, imports, package, lines).
@@ -203,7 +203,7 @@ pub struct FileIndexResult {
 
 /// Statistics about an indexing run.
 #[derive(Debug, Clone, Default)]
-pub struct IndexStats {
+pub(crate) struct IndexStats {
     /// Total files discovered.
     #[allow(dead_code)]
     pub files_discovered: usize,
@@ -224,7 +224,7 @@ pub struct IndexStats {
 /// Result of indexing an entire workspace. Pure data, no side effects.
 /// This is what index_workspace will return instead of mutating state.
 #[derive(Debug, Clone)]
-pub struct WorkspaceIndexResult {
+pub(crate) struct WorkspaceIndexResult {
     /// All successfully parsed files.
     pub files: Vec<FileIndexResult>,
     /// Statistics about the indexing run.


### PR DESCRIPTION
## Phase 12 — Natural Data Structures

Replaces raw tuples and boolean flags with named structs/enums. Zero behavioral changes.

### Changes

**`CallInfo` struct** (`handlers.rs`)
- Replaces `Option<(String, Option<String>, u32)>` in `extract_call_info`, `cst_call_info`, `text_call_info`
- Fields: `fn_name: String`, `qualifier: Option<String>`, `active_param: u32`
- `scan_multiline_call_open` keeps its own tuple (`extra_commas ≠ active_param`)

**`SuperWalker<'a>` struct** (`resolver/complete.rs`)
- Wraps `collect_hierarchy_completions` recursion into `impl SuperWalker { fn collect(...) }`
- Preserves file-URI visited keys and `symbols_from_uri_as_completions` (distinct from type-oriented `InheritanceWalker`)
- Reduces 6 threading params to 4 by moving `idx`/`snippets` to struct fields

**`LambdaParamKind` enum** (`indexer/infer/it_this.rs`)
- Replaces `for_this: bool` in `cst_it_or_this_type` and `find_it_element_type_in_lines_impl`
- `#[derive(Copy, Clone, Eq, PartialEq)]` — zero-size variants per best practices
- Public API (`find_it_element_type_in_lines`, `find_this_element_type_in_lines`) unchanged

**`ProgressSummary` struct** (`indexer/scan.rs`)
- Bundles 5 scan counters passed to `send_progress_begin` and `write_indexing_started_status`
- `#[derive(Copy, Clone)]` — all-`usize`/`bool` fields
- Reduces `send_progress_begin` from 7 params to 3

### Testing
664/664 tests passing. 2/2 swift grammar tests passing.