### PR TITLE
refactor: split oversized functions into named helpers

### DIFF
--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -175,7 +175,7 @@ impl Backend {
         let parent2 = parent_class.clone();
         let decl2 = declared_pkg.clone();
         let mut locs = tokio::task::spawn_blocking(move || {
-            crate::rg::rg_find_references(
+            let request = crate::rg::RgSearchRequest::new(
                 &name2,
                 parent2.as_deref(),
                 decl2.as_deref(),
@@ -183,8 +183,8 @@ impl Backend {
                 include_decl,
                 &uri_clone,
                 &decl_files,
-                matcher.as_deref(),
-            )
+            );
+            crate::rg::rg_find_references(&request, matcher.as_deref())
         })
         .await
         .unwrap_or_default();

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,3 +1,4 @@
+use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -105,6 +106,25 @@ pub(crate) struct Backend {
     pub(super) snippet_support: Arc<AtomicBool>,
 }
 
+#[derive(Clone)]
+struct OpenedDocumentContext {
+    uri: Url,
+    text: String,
+    opened_file_path: Option<PathBuf>,
+}
+
+impl OpenedDocumentContext {
+    fn from_open_params(params: DidOpenTextDocumentParams) -> Self {
+        let uri = params.text_document.uri;
+        let opened_file_path = uri.to_file_path().ok();
+        Self {
+            uri,
+            text: params.text_document.text,
+            opened_file_path,
+        }
+    }
+}
+
 impl Backend {
     pub(crate) fn new(client: Client) -> Self {
         Self {
@@ -132,6 +152,351 @@ impl Backend {
         } else {
             locs
         }
+    }
+
+    fn detect_snippet_support(params: &InitializeParams) -> bool {
+        params
+            .capabilities
+            .text_document
+            .as_ref()
+            .and_then(|text_document| text_document.completion.as_ref())
+            .and_then(|completion| completion.completion_item.as_ref())
+            .and_then(|completion_item| completion_item.snippet_support)
+            .unwrap_or(false)
+    }
+
+    fn resolve_workspace_root(params: &InitializeParams) -> Option<PathBuf> {
+        Self::workspace_root_from_environment()
+            .or_else(|| Self::workspace_root_from_client(params))
+            .or_else(Self::workspace_root_from_config)
+    }
+
+    fn workspace_root_from_environment() -> Option<PathBuf> {
+        std::env::var("KOTLIN_LSP_WORKSPACE_ROOT")
+            .ok()
+            .map(PathBuf::from)
+            .filter(|workspace_root| workspace_root.is_dir())
+    }
+
+    fn workspace_root_from_client(params: &InitializeParams) -> Option<PathBuf> {
+        Self::initialize_root_uri(params)
+            .and_then(|root_uri| root_uri.to_file_path().ok())
+            .filter(|workspace_root| workspace_root.is_dir())
+            .map(|workspace_root| Self::walk_up_to_git_root(&workspace_root))
+    }
+
+    fn initialize_root_uri(params: &InitializeParams) -> Option<Url> {
+        params.root_uri.clone().or_else(|| {
+            params
+                .workspace_folders
+                .as_deref()
+                .and_then(|workspace_folders| workspace_folders.first())
+                .map(|workspace_folder| workspace_folder.uri.clone())
+        })
+    }
+
+    fn walk_up_to_git_root(workspace_root: &Path) -> PathBuf {
+        let mut current_directory = workspace_root;
+        loop {
+            if current_directory.join(".git").exists() {
+                return current_directory.to_path_buf();
+            }
+            match current_directory.parent() {
+                Some(parent_directory) => current_directory = parent_directory,
+                None => return workspace_root.to_path_buf(),
+            }
+        }
+    }
+
+    fn workspace_root_from_config() -> Option<PathBuf> {
+        let home_directory = std::env::var("HOME")
+            .ok()
+            .unwrap_or_else(|| "/tmp".to_string());
+        let config_file = Path::new(&home_directory).join(".config/kotlin-lsp/workspace");
+        std::fs::read_to_string(config_file)
+            .ok()
+            .map(|workspace_root| PathBuf::from(workspace_root.trim()))
+            .filter(|workspace_root| workspace_root.is_dir())
+    }
+
+    fn configure_initialized_workspace(
+        &self,
+        params: &InitializeParams,
+        workspace_root: &Path,
+        workspace_pinned: bool,
+    ) {
+        self.set_workspace_root(workspace_root.to_path_buf());
+        if workspace_pinned {
+            self.indexer.workspace_pinned.store(true, Ordering::Relaxed);
+        }
+        self.apply_initialization_options(params.initialization_options.as_ref(), workspace_root);
+        self.spawn_workspace_indexing(workspace_root.to_path_buf(), Vec::new());
+    }
+
+    fn apply_initialization_options(
+        &self,
+        initialization_options: Option<&serde_json::Value>,
+        workspace_root: &Path,
+    ) {
+        if let Some(ignore_patterns) =
+            Self::collect_indexing_option_strings(initialization_options, "ignorePatterns")
+        {
+            log::info!("ignorePatterns: {:?}", ignore_patterns);
+            match self.indexer.ignore_matcher.write() {
+                Ok(mut ignore_matcher) => {
+                    *ignore_matcher = Some(Arc::new(IgnoreMatcher::new(
+                        ignore_patterns,
+                        workspace_root,
+                    )));
+                }
+                Err(error) => {
+                    log::warn!("Failed to update ignore matcher: {error}");
+                }
+            }
+        }
+
+        if let Some(source_paths) =
+            Self::collect_indexing_option_strings(initialization_options, "sourcePaths")
+        {
+            log::info!("sourcePaths: {:?}", source_paths);
+            match self.indexer.source_paths_raw.write() {
+                Ok(mut source_paths_raw) => {
+                    *source_paths_raw = source_paths;
+                }
+                Err(error) => {
+                    log::warn!("Failed to update source paths: {error}");
+                }
+            }
+        }
+    }
+
+    fn collect_indexing_option_strings(
+        initialization_options: Option<&serde_json::Value>,
+        option_name: &str,
+    ) -> Option<Vec<String>> {
+        let option_values = initialization_options?
+            .get("indexingOptions")?
+            .get(option_name)?
+            .as_array()?;
+        let collected_values: Vec<String> = option_values
+            .iter()
+            .filter_map(|value| value.as_str().map(str::to_owned))
+            .collect();
+        (!collected_values.is_empty()).then_some(collected_values)
+    }
+
+    fn set_workspace_root(&self, workspace_root: PathBuf) {
+        match self.indexer.workspace_root.write() {
+            Ok(mut current_workspace_root) => {
+                *current_workspace_root = Some(workspace_root);
+            }
+            Err(error) => {
+                log::warn!("Failed to update workspace root: {error}");
+            }
+        }
+    }
+
+    fn current_workspace_root(&self) -> Option<PathBuf> {
+        match self.indexer.workspace_root.read() {
+            Ok(current_workspace_root) => current_workspace_root.clone(),
+            Err(error) => {
+                log::warn!("Failed to read workspace root: {error}");
+                None
+            }
+        }
+    }
+
+    fn spawn_workspace_indexing(&self, workspace_root: PathBuf, prioritized_paths: Vec<PathBuf>) {
+        let indexer = Arc::clone(&self.indexer);
+        let client = self.client.clone();
+        tokio::spawn(async move {
+            indexer
+                .index_workspace_prioritized(
+                    &workspace_root,
+                    prioritized_paths,
+                    Arc::new(LspProgressReporter(client)),
+                )
+                .await;
+        });
+    }
+
+    fn detect_workspace_root_switch(
+        &self,
+        workspace_pinned: bool,
+        opened_file_path: Option<&Path>,
+    ) -> Option<PathBuf> {
+        if workspace_pinned {
+            return None;
+        }
+
+        let opened_file_path = opened_file_path?;
+        let candidate_workspace_root = Self::auto_detect_workspace_root(opened_file_path)?;
+        self.should_switch_workspace_root(opened_file_path, &candidate_workspace_root)
+            .then_some(candidate_workspace_root)
+    }
+
+    fn auto_detect_workspace_root(opened_file_path: &Path) -> Option<PathBuf> {
+        let strong_markers = [
+            "build.gradle",
+            "settings.gradle",
+            "build.gradle.kts",
+            "Cargo.toml",
+            "pom.xml",
+            "settings.gradle.kts",
+        ];
+        let weak_markers = ["Package.swift"];
+        let mut current_directory = opened_file_path.parent().map(Path::to_path_buf);
+        let mut nearest_strong_marker_root: Option<PathBuf> = None;
+        let mut git_root: Option<PathBuf> = None;
+        let mut nearest_weak_marker_root: Option<PathBuf> = None;
+
+        while let Some(directory) = current_directory {
+            if nearest_strong_marker_root.is_none()
+                && strong_markers
+                    .iter()
+                    .any(|marker| directory.join(marker).exists())
+            {
+                nearest_strong_marker_root = Some(directory.clone());
+            }
+            if directory.join(".git").exists() {
+                git_root = Some(directory.clone());
+                break;
+            }
+            if nearest_weak_marker_root.is_none()
+                && weak_markers
+                    .iter()
+                    .any(|marker| directory.join(marker).exists())
+            {
+                nearest_weak_marker_root = Some(directory.clone());
+            }
+            current_directory = directory.parent().map(Path::to_path_buf);
+        }
+
+        nearest_strong_marker_root
+            .or(git_root)
+            .or(nearest_weak_marker_root)
+            .or_else(|| opened_file_path.parent().map(Path::to_path_buf))
+    }
+
+    fn should_switch_workspace_root(
+        &self,
+        opened_file_path: &Path,
+        candidate_workspace_root: &Path,
+    ) -> bool {
+        let candidate_workspace_root = Self::canonicalize_or_clone(candidate_workspace_root);
+        match self.current_workspace_root() {
+            None => true,
+            Some(current_workspace_root) => {
+                let current_workspace_root = Self::canonicalize_or_clone(&current_workspace_root);
+                let opened_file_path = Self::canonicalize_or_clone(opened_file_path);
+                !opened_file_path.starts_with(&current_workspace_root)
+                    && candidate_workspace_root != current_workspace_root
+            }
+        }
+    }
+
+    fn canonicalize_or_clone(path: &Path) -> PathBuf {
+        std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    }
+
+    fn switch_workspace_root_for_opened_document(
+        &self,
+        workspace_root: PathBuf,
+        opened_file_path: Option<PathBuf>,
+    ) {
+        self.set_workspace_root(workspace_root.clone());
+        self.indexer.workspace_pinned.store(true, Ordering::Relaxed);
+        self.indexer.root_generation.fetch_add(1, Ordering::SeqCst);
+        self.indexer.reset_index_state();
+        log::info!(
+            "Auto-detected workspace root (now pinned): {}",
+            workspace_root.display()
+        );
+        self.spawn_workspace_indexing(workspace_root, opened_file_path.into_iter().collect());
+    }
+
+    fn is_outside_pinned_workspace_root(
+        &self,
+        workspace_pinned: bool,
+        opened_file_path: Option<&Path>,
+    ) -> bool {
+        if !workspace_pinned {
+            return false;
+        }
+
+        match (opened_file_path, self.current_workspace_root()) {
+            (Some(opened_file_path), Some(current_workspace_root)) => {
+                let opened_file_path = Self::canonicalize_or_clone(opened_file_path);
+                let current_workspace_root =
+                    Self::canonicalize_or_clone(current_workspace_root.as_path());
+                !opened_file_path.starts_with(&current_workspace_root)
+            }
+            _ => false,
+        }
+    }
+
+    async fn store_live_document_state(&self, opened_document: &OpenedDocumentContext) {
+        self.indexer
+            .set_live_lines(&opened_document.uri, &opened_document.text);
+
+        let indexer = Arc::clone(&self.indexer);
+        let uri = opened_document.uri.clone();
+        let text = opened_document.text.clone();
+        let _ = tokio::task::spawn_blocking(move || indexer.store_live_tree(&uri, &text)).await;
+    }
+
+    fn spawn_outside_root_document_indexing(&self, opened_document: OpenedDocumentContext) {
+        let indexer = Arc::clone(&self.indexer);
+        let semaphore = indexer.parse_sem();
+        tokio::task::spawn(async move {
+            if let Ok(permit) = semaphore.acquire_owned().await {
+                let uri = opened_document.uri;
+                let text = opened_document.text;
+                let _ = tokio::task::spawn_blocking(move || {
+                    let _permit = permit;
+                    indexer.index_content(&uri, &text);
+                })
+                .await;
+            }
+        });
+    }
+
+    fn spawn_open_document_indexing(&self, opened_document: OpenedDocumentContext) {
+        let indexer = Arc::clone(&self.indexer);
+        let semaphore = indexer.parse_sem();
+        let client = self.client.clone();
+        let cached_indexer = Arc::clone(&self.indexer);
+        tokio::task::spawn(async move {
+            let uri = opened_document.uri;
+            let text = opened_document.text;
+            let uri_for_diagnostics = uri.clone();
+            let Ok(permit) = semaphore.acquire_owned().await else {
+                return;
+            };
+            let result = tokio::task::spawn_blocking(move || {
+                let _permit = permit;
+                let data = indexer.index_content(&uri, &text);
+                Arc::clone(&indexer).prewarm_completion_cache(&uri);
+                data
+            })
+            .await;
+
+            let diagnostics = match result {
+                Ok(Some(indexed_file_data)) => syntax_diagnostics(&indexed_file_data.syntax_errors),
+                Ok(None) => {
+                    let uri_string = uri_for_diagnostics.to_string();
+                    cached_indexer
+                        .files
+                        .get(&uri_string)
+                        .map(|file_data| syntax_diagnostics(&file_data.syntax_errors))
+                        .unwrap_or_default()
+                }
+                Err(_) => Vec::new(),
+            };
+            client
+                .publish_diagnostics(uri_for_diagnostics, diagnostics, None)
+                .await;
+        });
     }
 }
 
@@ -189,136 +554,15 @@ impl LanguageServer for Backend {
     // ── lifecycle ────────────────────────────────────────────────────────────
 
     async fn initialize(&self, params: InitializeParams) -> Result<InitializeResult> {
-        // Detect snippet support from client capabilities.
-        let supports_snippets = params
-            .capabilities
-            .text_document
-            .as_ref()
-            .and_then(|td| td.completion.as_ref())
-            .and_then(|c| c.completion_item.as_ref())
-            .and_then(|ci| ci.snippet_support)
-            .unwrap_or(false);
+        let supports_snippets = Self::detect_snippet_support(&params);
         self.snippet_support
             .store(supports_snippets, Ordering::Relaxed);
         log::info!("client snippet support: {supports_snippets}");
 
-        // Accept either rootUri or the first workspaceFolder.
-        let root_uri = params.root_uri.or_else(|| {
-            params
-                .workspace_folders
-                .as_deref()
-                .and_then(|f| f.first())
-                .map(|f| f.uri.clone())
-        });
-
-        // Priority:
-        //   1. KOTLIN_LSP_WORKSPACE_ROOT env var  — explicit override, always wins
-        //   2. LSP client rootUri / workspaceFolders — editor knows best when present
-        //   3. ~/.config/kotlin-lsp/workspace file — fallback for clients that send no root
-        //      (e.g. Copilot CLI agentic use)
-        let env_override = std::env::var("KOTLIN_LSP_WORKSPACE_ROOT")
-            .ok()
-            .map(std::path::PathBuf::from)
-            .filter(|p| p.is_dir());
-
-        let client_root = root_uri
-            .as_ref()
-            .and_then(|uri| uri.to_file_path().ok())
-            .filter(|p| p.is_dir())
-            .map(|p| {
-                // Walk up to the nearest .git root so that opening a sub-module
-                // (e.g. ios/Modules/ScenesCommon) still indexes the whole repo.
-                // This is critical for cross-module go-to-definition.
-                let mut cur = p.as_path();
-                loop {
-                    if cur.join(".git").exists() {
-                        return cur.to_path_buf();
-                    }
-                    match cur.parent() {
-                        Some(p) => cur = p,
-                        None => return p.clone(),
-                    }
-                }
-            });
-
-        let config_fallback = || -> Option<std::path::PathBuf> {
-            let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".into());
-            let config_file = std::path::Path::new(&home).join(".config/kotlin-lsp/workspace");
-            std::fs::read_to_string(&config_file)
-                .ok()
-                .map(|s| std::path::PathBuf::from(s.trim()))
-                .filter(|p| p.is_dir())
-        };
-
-        // Any resolved workspace root — env var, client rootUri, or config file — pins the
-        // workspace and disables did_open auto-detection.  Without pinning, opening a file from
-        // a second project in the same editor session triggers a spurious root switch that aborts
-        // the in-progress workspace index and discards half its results.
-        // Pure auto-detection (no config at all) still works: workspace_pinned stays false until
-        // did_open fires and a root is detected for the first time.
-        let resolved_root = env_override.or(client_root).or_else(config_fallback);
-        let workspace_pinned = resolved_root.is_some();
-
-        if let Some(path) = resolved_root {
-            // Set workspace_root immediately so rg/fd calls work even before
-            // indexing finishes (the background task can be slow on large projects).
-            *self.indexer.workspace_root.write().unwrap() = Some(path.clone());
-            if workspace_pinned {
-                // Explicitly configured — prevent did_open auto-detection from overriding.
-                self.indexer
-                    .workspace_pinned
-                    .store(true, std::sync::atomic::Ordering::Relaxed);
-            }
-
-            // Parse ignore patterns from initializationOptions.indexingOptions.ignorePatterns.
-            if let Some(opts) = params.initialization_options.as_ref() {
-                if let Some(patterns) = opts
-                    .get("indexingOptions")
-                    .and_then(|o| o.get("ignorePatterns"))
-                    .and_then(|v| v.as_array())
-                {
-                    let pats: Vec<String> = patterns
-                        .iter()
-                        .filter_map(|v| v.as_str().map(str::to_owned))
-                        .collect();
-                    if !pats.is_empty() {
-                        log::info!("ignorePatterns: {:?}", pats);
-                        *self.indexer.ignore_matcher.write().unwrap() =
-                            Some(std::sync::Arc::new(IgnoreMatcher::new(pats, &path)));
-                    }
-                }
-
-                // Parse sourcePaths — extra directories to index for hover/definition/autocomplete.
-                // Stored as raw strings; resolved against workspace root when indexing starts.
-                if let Some(source_paths) = opts
-                    .get("indexingOptions")
-                    .and_then(|o| o.get("sourcePaths"))
-                    .and_then(|v| v.as_array())
-                {
-                    let paths_raw: Vec<String> = source_paths
-                        .iter()
-                        .filter_map(|v| v.as_str().map(str::to_owned))
-                        .collect();
-                    if !paths_raw.is_empty() {
-                        log::info!("sourcePaths: {:?}", paths_raw);
-                        *self.indexer.source_paths_raw.write().unwrap() = paths_raw;
-                    }
-                }
-            }
-
-            let indexer = Arc::clone(&self.indexer);
-            let client = self.client.clone();
-            // Background task — server is usable before indexing finishes.
-            tokio::spawn(async move {
-                // No specific open-file priorities at initialize.
-                indexer
-                    .index_workspace_prioritized(
-                        &path,
-                        Vec::new(),
-                        Arc::new(LspProgressReporter(client)),
-                    )
-                    .await;
-            });
+        let resolved_workspace_root = Self::resolve_workspace_root(&params);
+        let workspace_pinned = resolved_workspace_root.is_some();
+        if let Some(workspace_root) = resolved_workspace_root {
+            self.configure_initialized_workspace(&params, &workspace_root, workspace_pinned);
         }
 
         Ok(InitializeResult {
@@ -460,202 +704,38 @@ impl LanguageServer for Backend {
     // ── document sync ────────────────────────────────────────────────────────
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
-        let uri = params.text_document.uri;
-        let text = params.text_document.text;
+        let opened_document = OpenedDocumentContext::from_open_params(params);
+        let workspace_pinned = self.indexer.workspace_pinned.load(Ordering::Relaxed);
 
-        // Keep the opened file path (if available) so prioritized indexing can seed it.
-        let opened_path_opt = uri.to_file_path().ok();
-
-        // Auto-detect workspace root from the opened file when workspace is not yet pinned
-        // (i.e. no explicit env var / config file override was set at initialize).
-        // Marker tiers (highest → lowest priority):
-        //   1. Strong project markers (build.gradle.kts, settings.gradle, pom.xml, Cargo.toml)
-        //      — typically appear exactly once at the project root. Nearest wins over .git.
-        //   2. .git — repo root; wins over weak markers like Package.swift.
-        //   3. Weak markers (Package.swift) — present at every Swift module; last resort.
-        //
-        // This correctly handles mono-repos where .git is at the parent of a subproject
-        // (e.g. Moneta/.git with Moneta/android/settings.gradle.kts) and Swift mono-repos
-        // where ios/.git is the right root but ios/Modules/*/Package.swift should be ignored.
-        let pinned = self
-            .indexer
-            .workspace_pinned
-            .load(std::sync::atomic::Ordering::Relaxed);
-        let mut need_root_switch: Option<std::path::PathBuf> = None;
-
-        if !pinned {
-            if let Some(ref path) = opened_path_opt {
-                let strong_markers = [
-                    "build.gradle",
-                    "settings.gradle",
-                    "build.gradle.kts",
-                    "Cargo.toml",
-                    "pom.xml",
-                    "settings.gradle.kts",
-                ];
-                let weak_markers = ["Package.swift"];
-                let mut cur = path.parent().map(|p| p.to_path_buf());
-                let mut nearest_strong: Option<std::path::PathBuf> = None;
-                let mut git_root: Option<std::path::PathBuf> = None;
-                let mut nearest_weak: Option<std::path::PathBuf> = None;
-                while let Some(ref dir) = cur {
-                    if nearest_strong.is_none()
-                        && strong_markers.iter().any(|m| dir.join(m).exists())
-                    {
-                        nearest_strong = Some(dir.clone());
-                    }
-                    if dir.join(".git").exists() {
-                        git_root = Some(dir.clone());
-                        break;
-                    }
-                    if nearest_weak.is_none() && weak_markers.iter().any(|m| dir.join(m).exists()) {
-                        nearest_weak = Some(dir.clone());
-                    }
-                    cur = dir.parent().map(|p| p.to_path_buf());
-                }
-                let found = nearest_strong.or(git_root).or(nearest_weak);
-                let chosen = found.or_else(|| path.parent().map(|p| p.to_path_buf()));
-                if let Some(candidate_root) = chosen {
-                    let current_root = self.indexer.workspace_root.read().unwrap().clone();
-                    let cand_canon = std::fs::canonicalize(&candidate_root)
-                        .unwrap_or_else(|_| candidate_root.clone());
-                    let should_switch = match current_root {
-                        None => true,
-                        Some(ref r) => {
-                            let cur_canon = std::fs::canonicalize(r).unwrap_or_else(|_| r.clone());
-                            let path_canon =
-                                std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
-                            !path_canon.starts_with(&cur_canon) && cand_canon != cur_canon
-                        }
-                    };
-                    if should_switch {
-                        need_root_switch = Some(candidate_root);
-                    }
-                }
-            }
-        }
-
-        if let Some(root) = need_root_switch {
-            *self.indexer.workspace_root.write().unwrap() = Some(root.clone());
-            // Pin the workspace after the first auto-detection so that opening a file
-            // from a second project later in the same session doesn't switch again.
-            self.indexer
-                .workspace_pinned
-                .store(true, std::sync::atomic::Ordering::Relaxed);
-            self.indexer
-                .root_generation
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-            self.indexer.reset_index_state();
-            log::info!(
-                "Auto-detected workspace root (now pinned): {}",
-                root.display()
+        if let Some(workspace_root) = self.detect_workspace_root_switch(
+            workspace_pinned,
+            opened_document.opened_file_path.as_deref(),
+        ) {
+            self.switch_workspace_root_for_opened_document(
+                workspace_root,
+                opened_document.opened_file_path.clone(),
             );
-            let idx = Arc::clone(&self.indexer);
-            let client = self.client.clone();
-            let root2 = root.clone();
-            let opened = opened_path_opt.clone();
-            tokio::spawn(async move {
-                let reporter = Arc::new(LspProgressReporter(client));
-                if let Some(op) = opened {
-                    idx.index_workspace_prioritized(&root2, vec![op], reporter)
-                        .await;
-                } else {
-                    idx.index_workspace_prioritized(&root2, Vec::new(), reporter)
-                        .await;
-                }
-            });
         }
 
-        // For files outside the current workspace root (e.g. agent opened a file from
-        // another project): still index the file itself so hover/go-to-def work on it,
-        // but skip workspace-wide re-indexing to avoid polluting workspaceSymbol results.
-        let outside_root = pinned && {
-            matches!(
-                (opened_path_opt.as_ref(), self.indexer.workspace_root.read().unwrap().clone()),
-                (Some(path), Some(root)) if {
-                    // Use canonical paths to avoid symlink/path-form mismatches
-                    // (consistent with the root-switch guard above).
-                    let canon_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.clone());
-                    let canon_root = std::fs::canonicalize(&root).unwrap_or_else(|_| root.clone());
-                    !canon_path.starts_with(&canon_root)
-                }
-            )
-        };
-        if outside_root {
+        if self.is_outside_pinned_workspace_root(
+            workspace_pinned,
+            opened_document.opened_file_path.as_deref(),
+        ) {
             log::info!(
                 "Outside-root file — indexing content only: {}",
-                opened_path_opt
+                opened_document
+                    .opened_file_path
                     .as_deref()
-                    .map(|p| p.display().to_string())
+                    .map(|path| path.display().to_string())
                     .unwrap_or_default()
             );
-            self.indexer.set_live_lines(&uri, &text);
-            {
-                let idx2 = Arc::clone(&self.indexer);
-                let uri2 = uri.clone();
-                let text2 = text.clone();
-                let _ =
-                    tokio::task::spawn_blocking(move || idx2.store_live_tree(&uri2, &text2)).await;
-            }
-            // Index just this file so hover/go-to-def work, then return.
-            let idx = Arc::clone(&self.indexer);
-            let sem = idx.parse_sem();
-            tokio::task::spawn(async move {
-                if let Ok(permit) = sem.acquire_owned().await {
-                    tokio::task::spawn_blocking(move || {
-                        let _permit = permit;
-                        idx.index_content(&uri, &text);
-                    })
-                    .await
-                    .ok();
-                }
-            });
+            self.store_live_document_state(&opened_document).await;
+            self.spawn_outside_root_document_indexing(opened_document);
             return;
         }
 
-        // Set live_lines immediately so completion can read the current file content
-        // even before the async index_content task finishes.
-        self.indexer.set_live_lines(&uri, &text);
-        {
-            let idx2 = Arc::clone(&self.indexer);
-            let uri2 = uri.clone();
-            let text2 = text.clone();
-            let _ = tokio::task::spawn_blocking(move || idx2.store_live_tree(&uri2, &text2)).await;
-        }
-
-        let idx = Arc::clone(&self.indexer);
-        let sem = idx.parse_sem();
-        let client = self.client.clone();
-        let idx2 = Arc::clone(&self.indexer);
-        tokio::task::spawn(async move {
-            let uri2 = uri.clone();
-            let Ok(permit) = sem.acquire_owned().await else {
-                return;
-            };
-            let result = tokio::task::spawn_blocking(move || {
-                let _permit = permit;
-                let data = idx.index_content(&uri, &text);
-                // Pre-warm completion cache for all types referenced in this file.
-                Arc::clone(&idx).prewarm_completion_cache(&uri);
-                data
-            })
-            .await;
-
-            // Publish diagnostics from syntax errors (or clear if hash-skipped).
-            let diags = match result {
-                Ok(Some(data)) => syntax_diagnostics(&data.syntax_errors),
-                Ok(None) => {
-                    // Hash-skipped — read cached errors.
-                    let uri_str = uri2.to_string();
-                    idx2.files
-                        .get(&uri_str)
-                        .map(|fd| syntax_diagnostics(&fd.syntax_errors))
-                        .unwrap_or_default()
-                }
-                Err(_) => Vec::new(),
-            };
-            client.publish_diagnostics(uri2, diags, None).await;
-        });
+        self.store_live_document_state(&opened_document).await;
+        self.spawn_open_document_indexing(opened_document);
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {

--- a/src/backend/rename.rs
+++ b/src/backend/rename.rs
@@ -63,10 +63,8 @@ fn cst_cursor_is_local_var(indexer: &crate::indexer::Indexer, uri: &Url, pos: Po
                 in_binding = true;
             }
             // Inside a binding and hit a function/lambda boundary → local variable.
-            KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT
-                if in_binding =>
-            {
-                return true
+            KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT if in_binding => {
+                return true;
             }
             // Function/method/lambda without being in a binding → not a local var.
             KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT => return false,
@@ -77,11 +75,11 @@ fn cst_cursor_is_local_var(indexer: &crate::indexer::Indexer, uri: &Url, pos: Po
             KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | KIND_SOURCE_FILE
                 if in_binding =>
             {
-                return false
+                return false;
             }
             // Scope boundary without being in a binding → not applicable.
             KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | KIND_SOURCE_FILE => {
-                return false
+                return false;
             }
             _ => {}
         }
@@ -119,8 +117,10 @@ fn any_local_var_decl_in_scope(
     file.symbols
         .iter()
         .filter(|s| {
-            matches!(s.kind, SymbolKind::PROPERTY | SymbolKind::VARIABLE | SymbolKind::CONSTANT)
-                && s.name == name
+            matches!(
+                s.kind,
+                SymbolKind::PROPERTY | SymbolKind::VARIABLE | SymbolKind::CONSTANT
+            ) && s.name == name
                 && (s.selection_range.start.line as usize) >= scope.0
                 && (s.selection_range.start.line as usize) <= scope.1
         })
@@ -182,7 +182,7 @@ fn cst_cursor_is_method(indexer: &crate::indexer::Indexer, uri: &Url, pos: Posit
             KIND_NAV_EXPR => return true,
             // Stop at top-level scope boundaries without a verdict.
             KIND_SOURCE_FILE | KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ => {
-                return false
+                return false;
             }
             _ => {}
         }
@@ -349,7 +349,179 @@ pub(super) fn rename_in_scope(
     edits
 }
 
+struct RenameCursorSymbol {
+    name: String,
+    parent_class: Option<String>,
+    declared_package: Option<String>,
+    scope_limited_to_current_file: bool,
+}
+
 impl Backend {
+    fn resolve_cursor_symbol(&self, uri: &Url, pos: Position) -> Option<RenameCursorSymbol> {
+        let name = self.indexer.word_at(uri, pos)?;
+        let (parent_class, declared_package, scope_limited_to_current_file) =
+            if name.starts_with_uppercase() {
+                let (parent_class, declared_package) =
+                    resolve_references_scope(&self.indexer, uri, pos.line, &name);
+                (parent_class, declared_package, false)
+            } else {
+                (None, None, true)
+            };
+
+        Some(RenameCursorSymbol {
+            name,
+            parent_class,
+            declared_package,
+            scope_limited_to_current_file,
+        })
+    }
+
+    fn rename_local_symbol(
+        &self,
+        uri: &Url,
+        pos: Position,
+        name: &str,
+        new_name: &str,
+    ) -> Option<WorkspaceEdit> {
+        let lines = self.indexer.lines_for(uri)?;
+        let scope = enclosing_scope(&lines, pos.line as usize);
+        let skip_dotted = cst_cursor_is_local_var(&self.indexer, uri, pos)
+            || any_local_var_decl_in_scope(&self.indexer, uri, name, scope);
+        let mut file_edits = rename_in_scope(&lines, name, new_name, scope, skip_dotted);
+        if file_edits.is_empty() {
+            return None;
+        }
+        file_edits.sort_by(|a, b| b.range.start.cmp(&a.range.start));
+
+        let mut changes = std::collections::HashMap::new();
+        changes.insert(uri.clone(), file_edits);
+        Some(WorkspaceEdit {
+            changes: Some(changes),
+            document_changes: None,
+            change_annotations: None,
+        })
+    }
+
+    fn definition_files_for_rename(&self, name: &str, parent_class: Option<&str>) -> Vec<String> {
+        self.indexer
+            .definitions
+            .get(name)
+            .map(|locations| {
+                locations
+                    .iter()
+                    .filter(|location| {
+                        parent_class.is_none_or(|parent| {
+                            self.indexer
+                                .enclosing_class_at(&location.uri, location.range.start.line)
+                                .as_deref()
+                                == Some(parent)
+                        })
+                    })
+                    .filter_map(|location| location.uri.to_file_path().ok())
+                    .filter_map(|path| path.to_str().map(str::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    async fn collect_reference_locations(
+        &self,
+        uri: &Url,
+        rename_target: &RenameCursorSymbol,
+    ) -> Vec<Location> {
+        let decl_files = self.definition_files_for_rename(
+            &rename_target.name,
+            rename_target.parent_class.as_deref(),
+        );
+        let root = self.indexer.workspace_root.read().unwrap().clone();
+        let matcher = self.indexer.ignore_matcher.read().unwrap().clone();
+        let uri_clone = uri.clone();
+        let name = rename_target.name.clone();
+        let parent_class = rename_target.parent_class.clone();
+        let declared_package = rename_target.declared_package.clone();
+        let mut reference_locations = tokio::task::spawn_blocking(move || {
+            crate::rg::rg_find_references(
+                &name,
+                parent_class.as_deref(),
+                declared_package.as_deref(),
+                root.as_deref(),
+                true,
+                &uri_clone,
+                &decl_files,
+                matcher.as_deref(),
+            )
+        })
+        .await
+        .unwrap_or_default();
+
+        let library_uris = &self.indexer.library_uris;
+        if !library_uris.is_empty() {
+            reference_locations.retain(|location| !library_uris.contains(location.uri.as_str()));
+        }
+        reference_locations
+    }
+
+    fn reference_candidate_files(
+        &self,
+        current_uri: &Url,
+        reference_locations: &[Location],
+    ) -> Vec<Url> {
+        let mut files = vec![current_uri.clone()];
+        for location in reference_locations {
+            if !files.contains(&location.uri) {
+                files.push(location.uri.clone());
+            }
+        }
+        eprintln!(
+            "[rename] rg found {} locs across {} files",
+            reference_locations.len(),
+            files.len()
+        );
+        files
+    }
+
+    fn rename_lines_for_file(&self, file_uri: &Url) -> Option<Vec<String>> {
+        if let Some(lines) = self.indexer.lines_for(file_uri) {
+            return Some(lines.as_slice().to_vec());
+        }
+
+        let path = file_uri.to_file_path().ok()?;
+        let content = std::fs::read_to_string(path).ok()?;
+        Some(content.lines().map(str::to_owned).collect())
+    }
+
+    fn build_workspace_edit(
+        &self,
+        file_uris: &[Url],
+        name: &str,
+        new_name: &str,
+    ) -> Option<WorkspaceEdit> {
+        let mut changes = std::collections::HashMap::new();
+
+        for file_uri in file_uris {
+            let Some(lines) = self.rename_lines_for_file(file_uri) else {
+                continue;
+            };
+            let scope = (0, lines.len().saturating_sub(1));
+            let mut edits = rename_in_scope(&lines, name, new_name, scope, false);
+            if edits.is_empty() {
+                continue;
+            }
+            edits.sort_by(|a, b| b.range.start.cmp(&a.range.start));
+            changes.insert(file_uri.clone(), edits);
+        }
+
+        if changes.is_empty() {
+            None
+        } else {
+            Some(WorkspaceEdit {
+                changes: Some(changes),
+                document_changes: None,
+                change_annotations: None,
+            })
+        }
+    }
+
     pub(super) async fn prepare_rename_impl(
         &self,
         params: TextDocumentPositionParams,
@@ -378,165 +550,21 @@ impl Backend {
         let pos = params.text_document_position.position;
         let new_name = &params.new_name;
 
-        let name = match self.indexer.word_at(uri, pos) {
-            Some(w) => w,
-            None => return Ok(None),
+        let Some(rename_target) = self.resolve_cursor_symbol(uri, pos) else {
+            return Ok(None);
         };
 
-        // ── Resolve scoping (delegates to the shared helper used by findReferences) ─
-        let (parent_class, declared_pkg) = if name.starts_with_uppercase() {
-            resolve_references_scope(&self.indexer, uri, pos.line, &name)
-        } else {
-            // Lowercase symbol — limit to enclosing scope in current file only.
-            let lines = match self.indexer.lines_for(uri) {
-                Some(l) => l,
-                None => return Ok(None),
-            };
-            let scope = enclosing_scope(&lines, pos.line as usize);
-
-            // `skip_dotted = true` only for local variables — a `val`/`var` whose
-            // nearest scope ancestor is a function body (not a class body or source file).
-            // Class properties, top-level vals, and method call sites all need dotted
-            // accesses included so that `this.myProp` / `obj.myProp` are also renamed.
-            //
-            // Check both the cursor position (declaration case) and the file index
-            // (reference case: cursor on a reference, not the declaration itself).
-            let skip_dotted = cst_cursor_is_local_var(&self.indexer, uri, pos)
-                || any_local_var_decl_in_scope(&self.indexer, uri, &name, scope);
-
-            let mut file_edits = rename_in_scope(&lines, &name, new_name, scope, skip_dotted);
-            if file_edits.is_empty() {
-                return Ok(None);
-            }
-            file_edits.sort_by(|a, b| b.range.start.cmp(&a.range.start));
-            let mut changes = std::collections::HashMap::new();
-            changes.insert(uri.clone(), file_edits);
-            return Ok(Some(WorkspaceEdit {
-                changes: Some(changes),
-                document_changes: None,
-                change_annotations: None,
-            }));
-        };
-
-        let decl_files: Vec<String> = self
-            .indexer
-            .definitions
-            .get(&name)
-            .map(|locs| {
-                locs.iter()
-                    .filter(|l| {
-                        if let Some(ref parent) = parent_class {
-                            self.indexer
-                                .enclosing_class_at(&l.uri, l.range.start.line)
-                                .as_deref()
-                                == Some(parent.as_str())
-                        } else {
-                            true
-                        }
-                    })
-                    .filter_map(|l| l.uri.to_file_path().ok())
-                    .filter_map(|p| p.to_str().map(|s| s.to_owned()))
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        // ── Find all reference locations (off-thread, same as references handler) ──
-        let root = self.indexer.workspace_root.read().unwrap().clone();
-        let matcher = self.indexer.ignore_matcher.read().unwrap().clone();
-        let uri_clone = uri.clone();
-        let name2 = name.clone();
-        let parent2 = parent_class.clone();
-        let decl2 = declared_pkg.clone();
-        // include_declaration=true so we also rename the declaration site
-        let ref_locs = tokio::task::spawn_blocking(move || {
-            crate::rg::rg_find_references(
-                &name2,
-                parent2.as_deref(),
-                decl2.as_deref(),
-                root.as_deref(),
-                true,
-                &uri_clone,
-                &decl_files,
-                matcher.as_deref(),
-            )
-        })
-        .await
-        .unwrap_or_default();
-
-        // Filter out library-source locations — library files are read-only (not user code).
-        let mut ref_locs = ref_locs;
-        let lib = &self.indexer.library_uris;
-        if !lib.is_empty() {
-            ref_locs.retain(|loc| !lib.contains(loc.uri.as_str()));
+        if rename_target.scope_limited_to_current_file {
+            return Ok(self.rename_local_symbol(uri, pos, &rename_target.name, new_name));
         }
 
-        if ref_locs.is_empty() {
+        let reference_locations = self.collect_reference_locations(uri, &rename_target).await;
+        if reference_locations.is_empty() {
             return Ok(None);
         }
 
-        // ── Collect unique files that have references ───────────────────────
-        // Always include current file (may have unsaved content rg can't see).
-        let mut files: Vec<Url> = vec![uri.clone()];
-        for loc in &ref_locs {
-            if !files.contains(&loc.uri) {
-                files.push(loc.uri.clone());
-            }
-        }
-        eprintln!(
-            "[rename] rg found {} locs across {} files",
-            ref_locs.len(),
-            files.len()
-        );
-
-        // ── Build TextEdits per file using rename_in_scope ──────────────────
-        // We do NOT use rg location columns directly because Pass A uses a
-        // qualified pattern (ParentClass.Name) so the match column points to
-        // ParentClass, not Name. Instead we use rg_find_references only to
-        // identify which files need editing, then do precise word replacement.
-        let mut changes: std::collections::HashMap<Url, Vec<TextEdit>> =
-            std::collections::HashMap::new();
-
-        for file_uri in &files {
-            // Prefer in-memory lines (open buffer with unsaved edits), then fall
-            // back to reading from disk so we can rename closed files too.
-            let mem_lines = self.indexer.lines_for(file_uri);
-            let disk_lines: Vec<String>;
-            let lines: &[String] = match mem_lines {
-                Some(ref arc) => arc.as_slice(),
-                None => {
-                    let path = match file_uri.to_file_path() {
-                        Ok(p) => p,
-                        Err(_) => continue,
-                    };
-                    match std::fs::read_to_string(&path) {
-                        Ok(content) => {
-                            disk_lines = content.lines().map(|l| l.to_owned()).collect();
-                            &disk_lines
-                        }
-                        Err(_) => continue,
-                    }
-                }
-            };
-            let lines = lines.to_vec();
-
-            let scope = (0, lines.len().saturating_sub(1));
-            let edits = rename_in_scope(&lines, &name, new_name, scope, false);
-
-            if !edits.is_empty() {
-                let mut edits = edits;
-                edits.sort_by(|a, b| b.range.start.cmp(&a.range.start));
-                changes.insert(file_uri.clone(), edits);
-            }
-        }
-
-        if changes.is_empty() {
-            return Ok(None);
-        }
-        Ok(Some(WorkspaceEdit {
-            changes: Some(changes),
-            document_changes: None,
-            change_annotations: None,
-        }))
+        let files = self.reference_candidate_files(uri, &reference_locations);
+        Ok(self.build_workspace_edit(&files, &rename_target.name, new_name))
     }
 }
 

--- a/src/backend/rename.rs
+++ b/src/backend/rename.rs
@@ -1,13 +1,13 @@
-use super::Backend;
 use super::actions::is_non_call_keyword;
 use super::helpers::resolve_references_scope;
-use crate::StrExt;
+use super::Backend;
 use crate::indexer::live_tree::utf16_col_to_byte;
 use crate::queries::{
     KIND_ANON_FUN, KIND_CLASS_BODY, KIND_COMPANION_OBJ, KIND_FUN_DECL, KIND_LAMBDA_LIT,
     KIND_METHOD_DECL, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_OBJECT_DECL, KIND_PROP_DECL,
     KIND_SOURCE_FILE, KIND_VAR_DECL,
 };
+use crate::StrExt;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 
@@ -440,7 +440,7 @@ impl Backend {
         let parent_class = rename_target.parent_class.clone();
         let declared_package = rename_target.declared_package.clone();
         let mut reference_locations = tokio::task::spawn_blocking(move || {
-            crate::rg::rg_find_references(
+            let request = crate::rg::RgSearchRequest::new(
                 &name,
                 parent_class.as_deref(),
                 declared_package.as_deref(),
@@ -448,8 +448,8 @@ impl Backend {
                 true,
                 &uri_clone,
                 &decl_files,
-                matcher.as_deref(),
-            )
+            );
+            crate::rg::rg_find_references(&request, matcher.as_deref())
         })
         .await
         .unwrap_or_default();

--- a/src/backend/rename.rs
+++ b/src/backend/rename.rs
@@ -1,13 +1,13 @@
+use super::Backend;
 use super::actions::is_non_call_keyword;
 use super::helpers::resolve_references_scope;
-use super::Backend;
+use crate::StrExt;
 use crate::indexer::live_tree::utf16_col_to_byte;
 use crate::queries::{
     KIND_ANON_FUN, KIND_CLASS_BODY, KIND_COMPANION_OBJ, KIND_FUN_DECL, KIND_LAMBDA_LIT,
     KIND_METHOD_DECL, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_OBJECT_DECL, KIND_PROP_DECL,
     KIND_SOURCE_FILE, KIND_VAR_DECL,
 };
-use crate::StrExt;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 
@@ -63,10 +63,8 @@ fn cst_cursor_is_local_var(indexer: &crate::indexer::Indexer, uri: &Url, pos: Po
                 in_binding = true;
             }
             // Inside a binding and hit a function/lambda boundary → local variable.
-            KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT
-                if in_binding =>
-            {
-                return true
+            KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT if in_binding => {
+                return true;
             }
             // Function/method/lambda without being in a binding → not a local var.
             KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT => return false,
@@ -77,11 +75,11 @@ fn cst_cursor_is_local_var(indexer: &crate::indexer::Indexer, uri: &Url, pos: Po
             KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | KIND_SOURCE_FILE
                 if in_binding =>
             {
-                return false
+                return false;
             }
             // Scope boundary without being in a binding → not applicable.
             KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | KIND_SOURCE_FILE => {
-                return false
+                return false;
             }
             _ => {}
         }
@@ -119,8 +117,10 @@ fn any_local_var_decl_in_scope(
     file.symbols
         .iter()
         .filter(|s| {
-            matches!(s.kind, SymbolKind::PROPERTY | SymbolKind::VARIABLE | SymbolKind::CONSTANT)
-                && s.name == name
+            matches!(
+                s.kind,
+                SymbolKind::PROPERTY | SymbolKind::VARIABLE | SymbolKind::CONSTANT
+            ) && s.name == name
                 && (s.selection_range.start.line as usize) >= scope.0
                 && (s.selection_range.start.line as usize) <= scope.1
         })
@@ -182,7 +182,7 @@ fn cst_cursor_is_method(indexer: &crate::indexer::Indexer, uri: &Url, pos: Posit
             KIND_NAV_EXPR => return true,
             // Stop at top-level scope boundaries without a verdict.
             KIND_SOURCE_FILE | KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ => {
-                return false
+                return false;
             }
             _ => {}
         }
@@ -349,7 +349,179 @@ pub(super) fn rename_in_scope(
     edits
 }
 
+struct RenameCursorSymbol {
+    name: String,
+    parent_class: Option<String>,
+    declared_package: Option<String>,
+    scope_limited_to_current_file: bool,
+}
+
 impl Backend {
+    fn resolve_cursor_symbol(&self, uri: &Url, pos: Position) -> Option<RenameCursorSymbol> {
+        let name = self.indexer.word_at(uri, pos)?;
+        let (parent_class, declared_package, scope_limited_to_current_file) =
+            if name.starts_with_uppercase() {
+                let (parent_class, declared_package) =
+                    resolve_references_scope(&self.indexer, uri, pos.line, &name);
+                (parent_class, declared_package, false)
+            } else {
+                (None, None, true)
+            };
+
+        Some(RenameCursorSymbol {
+            name,
+            parent_class,
+            declared_package,
+            scope_limited_to_current_file,
+        })
+    }
+
+    fn rename_local_symbol(
+        &self,
+        uri: &Url,
+        pos: Position,
+        name: &str,
+        new_name: &str,
+    ) -> Option<WorkspaceEdit> {
+        let lines = self.indexer.lines_for(uri)?;
+        let scope = enclosing_scope(&lines, pos.line as usize);
+        let skip_dotted = cst_cursor_is_local_var(&self.indexer, uri, pos)
+            || any_local_var_decl_in_scope(&self.indexer, uri, name, scope);
+        let mut file_edits = rename_in_scope(&lines, name, new_name, scope, skip_dotted);
+        if file_edits.is_empty() {
+            return None;
+        }
+        file_edits.sort_by(|a, b| b.range.start.cmp(&a.range.start));
+
+        let mut changes = std::collections::HashMap::new();
+        changes.insert(uri.clone(), file_edits);
+        Some(WorkspaceEdit {
+            changes: Some(changes),
+            document_changes: None,
+            change_annotations: None,
+        })
+    }
+
+    fn definition_files_for_rename(&self, name: &str, parent_class: Option<&str>) -> Vec<String> {
+        self.indexer
+            .definitions
+            .get(name)
+            .map(|locations| {
+                locations
+                    .iter()
+                    .filter(|location| {
+                        parent_class.is_none_or(|parent| {
+                            self.indexer
+                                .enclosing_class_at(&location.uri, location.range.start.line)
+                                .as_deref()
+                                == Some(parent)
+                        })
+                    })
+                    .filter_map(|location| location.uri.to_file_path().ok())
+                    .filter_map(|path| path.to_str().map(str::to_owned))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    async fn collect_reference_locations(
+        &self,
+        uri: &Url,
+        rename_target: &RenameCursorSymbol,
+    ) -> Vec<Location> {
+        let decl_files = self.definition_files_for_rename(
+            &rename_target.name,
+            rename_target.parent_class.as_deref(),
+        );
+        let root = self.indexer.workspace_root.read().unwrap().clone();
+        let matcher = self.indexer.ignore_matcher.read().unwrap().clone();
+        let uri_clone = uri.clone();
+        let name = rename_target.name.clone();
+        let parent_class = rename_target.parent_class.clone();
+        let declared_package = rename_target.declared_package.clone();
+        let mut reference_locations = tokio::task::spawn_blocking(move || {
+            crate::rg::rg_find_references(
+                &name,
+                parent_class.as_deref(),
+                declared_package.as_deref(),
+                root.as_deref(),
+                true,
+                &uri_clone,
+                &decl_files,
+                matcher.as_deref(),
+            )
+        })
+        .await
+        .unwrap_or_default();
+
+        let library_uris = &self.indexer.library_uris;
+        if !library_uris.is_empty() {
+            reference_locations.retain(|location| !library_uris.contains(location.uri.as_str()));
+        }
+        reference_locations
+    }
+
+    fn reference_candidate_files(
+        &self,
+        current_uri: &Url,
+        reference_locations: &[Location],
+    ) -> Vec<Url> {
+        let mut files = vec![current_uri.clone()];
+        for location in reference_locations {
+            if !files.contains(&location.uri) {
+                files.push(location.uri.clone());
+            }
+        }
+        eprintln!(
+            "[rename] rg found {} locs across {} files",
+            reference_locations.len(),
+            files.len()
+        );
+        files
+    }
+
+    fn rename_lines_for_file(&self, file_uri: &Url) -> Option<Vec<String>> {
+        if let Some(lines) = self.indexer.lines_for(file_uri) {
+            return Some(lines.as_slice().to_vec());
+        }
+
+        let path = file_uri.to_file_path().ok()?;
+        let content = std::fs::read_to_string(path).ok()?;
+        Some(content.lines().map(str::to_owned).collect())
+    }
+
+    fn build_workspace_edit(
+        &self,
+        file_uris: &[Url],
+        name: &str,
+        new_name: &str,
+    ) -> Option<WorkspaceEdit> {
+        let mut changes = std::collections::HashMap::new();
+
+        for file_uri in file_uris {
+            let Some(lines) = self.rename_lines_for_file(file_uri) else {
+                continue;
+            };
+            let scope = (0, lines.len().saturating_sub(1));
+            let mut edits = rename_in_scope(&lines, name, new_name, scope, false);
+            if edits.is_empty() {
+                continue;
+            }
+            edits.sort_by(|a, b| b.range.start.cmp(&a.range.start));
+            changes.insert(file_uri.clone(), edits);
+        }
+
+        if changes.is_empty() {
+            None
+        } else {
+            Some(WorkspaceEdit {
+                changes: Some(changes),
+                document_changes: None,
+                change_annotations: None,
+            })
+        }
+    }
+
     pub(super) async fn prepare_rename_impl(
         &self,
         params: TextDocumentPositionParams,
@@ -378,165 +550,21 @@ impl Backend {
         let pos = params.text_document_position.position;
         let new_name = &params.new_name;
 
-        let name = match self.indexer.word_at(uri, pos) {
-            Some(w) => w,
-            None => return Ok(None),
+        let Some(rename_target) = self.resolve_cursor_symbol(uri, pos) else {
+            return Ok(None);
         };
 
-        // ── Resolve scoping (delegates to the shared helper used by findReferences) ─
-        let (parent_class, declared_pkg) = if name.starts_with_uppercase() {
-            resolve_references_scope(&self.indexer, uri, pos.line, &name)
-        } else {
-            // Lowercase symbol — limit to enclosing scope in current file only.
-            let lines = match self.indexer.lines_for(uri) {
-                Some(l) => l,
-                None => return Ok(None),
-            };
-            let scope = enclosing_scope(&lines, pos.line as usize);
-
-            // `skip_dotted = true` only for local variables — a `val`/`var` whose
-            // nearest scope ancestor is a function body (not a class body or source file).
-            // Class properties, top-level vals, and method call sites all need dotted
-            // accesses included so that `this.myProp` / `obj.myProp` are also renamed.
-            //
-            // Check both the cursor position (declaration case) and the file index
-            // (reference case: cursor on a reference, not the declaration itself).
-            let skip_dotted = cst_cursor_is_local_var(&self.indexer, uri, pos)
-                || any_local_var_decl_in_scope(&self.indexer, uri, &name, scope);
-
-            let mut file_edits = rename_in_scope(&lines, &name, new_name, scope, skip_dotted);
-            if file_edits.is_empty() {
-                return Ok(None);
-            }
-            file_edits.sort_by(|a, b| b.range.start.cmp(&a.range.start));
-            let mut changes = std::collections::HashMap::new();
-            changes.insert(uri.clone(), file_edits);
-            return Ok(Some(WorkspaceEdit {
-                changes: Some(changes),
-                document_changes: None,
-                change_annotations: None,
-            }));
-        };
-
-        let decl_files: Vec<String> = self
-            .indexer
-            .definitions
-            .get(&name)
-            .map(|locs| {
-                locs.iter()
-                    .filter(|l| {
-                        if let Some(ref parent) = parent_class {
-                            self.indexer
-                                .enclosing_class_at(&l.uri, l.range.start.line)
-                                .as_deref()
-                                == Some(parent.as_str())
-                        } else {
-                            true
-                        }
-                    })
-                    .filter_map(|l| l.uri.to_file_path().ok())
-                    .filter_map(|p| p.to_str().map(|s| s.to_owned()))
-                    .collect()
-            })
-            .unwrap_or_default();
-
-        // ── Find all reference locations (off-thread, same as references handler) ──
-        let root = self.indexer.workspace_root.read().unwrap().clone();
-        let matcher = self.indexer.ignore_matcher.read().unwrap().clone();
-        let uri_clone = uri.clone();
-        let name2 = name.clone();
-        let parent2 = parent_class.clone();
-        let decl2 = declared_pkg.clone();
-        // include_declaration=true so we also rename the declaration site
-        let ref_locs = tokio::task::spawn_blocking(move || {
-            crate::rg::rg_find_references(
-                &name2,
-                parent2.as_deref(),
-                decl2.as_deref(),
-                root.as_deref(),
-                true,
-                &uri_clone,
-                &decl_files,
-                matcher.as_deref(),
-            )
-        })
-        .await
-        .unwrap_or_default();
-
-        // Filter out library-source locations — library files are read-only (not user code).
-        let mut ref_locs = ref_locs;
-        let lib = &self.indexer.library_uris;
-        if !lib.is_empty() {
-            ref_locs.retain(|loc| !lib.contains(loc.uri.as_str()));
+        if rename_target.scope_limited_to_current_file {
+            return Ok(self.rename_local_symbol(uri, pos, &rename_target.name, new_name));
         }
 
-        if ref_locs.is_empty() {
+        let reference_locations = self.collect_reference_locations(uri, &rename_target).await;
+        if reference_locations.is_empty() {
             return Ok(None);
         }
 
-        // ── Collect unique files that have references ───────────────────────
-        // Always include current file (may have unsaved content rg can't see).
-        let mut files: Vec<Url> = vec![uri.clone()];
-        for loc in &ref_locs {
-            if !files.contains(&loc.uri) {
-                files.push(loc.uri.clone());
-            }
-        }
-        eprintln!(
-            "[rename] rg found {} locs across {} files",
-            ref_locs.len(),
-            files.len()
-        );
-
-        // ── Build TextEdits per file using rename_in_scope ──────────────────
-        // We do NOT use rg location columns directly because Pass A uses a
-        // qualified pattern (ParentClass.Name) so the match column points to
-        // ParentClass, not Name. Instead we use rg_find_references only to
-        // identify which files need editing, then do precise word replacement.
-        let mut changes: std::collections::HashMap<Url, Vec<TextEdit>> =
-            std::collections::HashMap::new();
-
-        for file_uri in &files {
-            // Prefer in-memory lines (open buffer with unsaved edits), then fall
-            // back to reading from disk so we can rename closed files too.
-            let mem_lines = self.indexer.lines_for(file_uri);
-            let disk_lines: Vec<String>;
-            let lines: &[String] = match mem_lines {
-                Some(ref arc) => arc.as_slice(),
-                None => {
-                    let path = match file_uri.to_file_path() {
-                        Ok(p) => p,
-                        Err(_) => continue,
-                    };
-                    match std::fs::read_to_string(&path) {
-                        Ok(content) => {
-                            disk_lines = content.lines().map(|l| l.to_owned()).collect();
-                            &disk_lines
-                        }
-                        Err(_) => continue,
-                    }
-                }
-            };
-            let lines = lines.to_vec();
-
-            let scope = (0, lines.len().saturating_sub(1));
-            let edits = rename_in_scope(&lines, &name, new_name, scope, false);
-
-            if !edits.is_empty() {
-                let mut edits = edits;
-                edits.sort_by(|a, b| b.range.start.cmp(&a.range.start));
-                changes.insert(file_uri.clone(), edits);
-            }
-        }
-
-        if changes.is_empty() {
-            return Ok(None);
-        }
-        Ok(Some(WorkspaceEdit {
-            changes: Some(changes),
-            document_changes: None,
-            change_annotations: None,
-        }))
+        let files = self.reference_candidate_files(uri, &reference_locations);
+        Ok(self.build_workspace_edit(&files, &rename_target.name, new_name))
     }
 }
 

--- a/src/backend/rename.rs
+++ b/src/backend/rename.rs
@@ -472,7 +472,7 @@ impl Backend {
                 files.push(location.uri.clone());
             }
         }
-        eprintln!(
+        log::debug!(
             "[rename] rg found {} locs across {} files",
             reference_locations.len(),
             files.len()

--- a/src/indexer/doc.rs
+++ b/src/indexer/doc.rs
@@ -151,6 +151,16 @@ fn render_block_doc(raw_lines: &[&str]) -> String {
     format_doc_tags(&joined)
 }
 
+#[derive(Default)]
+struct ParsedDocTags {
+    description: Vec<String>,
+    params: Vec<(String, String)>,
+    returns: Option<String>,
+    throws: Vec<(String, String)>,
+    see: Vec<String>,
+    since: Option<String>,
+}
+
 /// Convert KDoc/Javadoc tags to readable Markdown.
 ///
 /// - `@param name desc`   → `**Parameters**\n- \`name\` desc`
@@ -163,127 +173,148 @@ fn render_block_doc(raw_lines: &[&str]) -> String {
 /// - `{@link T}` (Java)   → `` `T` ``
 /// - Suppressed: `@suppress`, `@hide`, `@internal`
 fn format_doc_tags(text: &str) -> String {
-    // Split on Javadoc/KDoc tag boundaries (lines starting with @).
-    // We need to preserve multi-line tag bodies.
-    let mut description: Vec<String> = Vec::new();
-    let mut params: Vec<(String, String)> = Vec::new();
-    let mut returns: Option<String> = None;
-    let mut throws: Vec<(String, String)> = Vec::new();
-    let mut see: Vec<String> = Vec::new();
-    let mut since: Option<String> = None;
+    render_doc_markdown(&parse_doc_tags(text)).trim().to_owned()
+}
 
-    // Accumulate current tag body across newlines.
-    let mut cur_tag: Option<String> = None;
-    let mut cur_body: Vec<String> = Vec::new();
-
-    let flush = |cur_tag: &Option<String>,
-                 cur_body: &Vec<String>,
-                 params: &mut Vec<(String, String)>,
-                 returns: &mut Option<String>,
-                 throws: &mut Vec<(String, String)>,
-                 see: &mut Vec<String>,
-                 since: &mut Option<String>| {
-        let body = cur_body.join(" ").trim().to_owned();
-        if let Some(tag) = cur_tag {
-            match tag.as_str() {
-                "param" | "property" => {
-                    let (name, rest) = split_first_word(&body);
-                    params.push((name.to_owned(), rest.trim().to_owned()));
-                }
-                "return" | "returns" => *returns = Some(body),
-                "throws" | "exception" => {
-                    let (name, rest) = split_first_word(&body);
-                    throws.push((name.to_owned(), rest.trim().to_owned()));
-                }
-                "see" => see.push(body),
-                "since" => *since = Some(body),
-                _ => {} // suppress, hide, internal, author, etc.
-            }
-        }
-    };
+fn parse_doc_tags(text: &str) -> ParsedDocTags {
+    let mut parsed = ParsedDocTags::default();
+    let mut current_tag: Option<String> = None;
+    let mut current_body: Vec<String> = Vec::new();
 
     for line in text.lines() {
         let trimmed = line.trim();
         if let Some(rest) = trimmed.strip_prefix('@') {
-            // Flush previous tag
-            flush(
-                &cur_tag,
-                &cur_body,
-                &mut params,
-                &mut returns,
-                &mut throws,
-                &mut see,
-                &mut since,
-            );
-            cur_body.clear();
+            flush_doc_tag(current_tag.as_deref(), &current_body, &mut parsed);
+            current_body.clear();
 
             let (tag, body) = split_first_word(rest);
-            cur_tag = Some(tag.to_lowercase());
+            current_tag = Some(tag.to_lowercase());
             if !body.is_empty() {
-                cur_body.push(body.trim().to_owned());
+                current_body.push(body.trim().to_owned());
             }
-        } else if cur_tag.is_some() {
+        } else if current_tag.is_some() {
             if !trimmed.is_empty() {
-                cur_body.push(trimmed.to_owned());
+                current_body.push(trimmed.to_owned());
             }
         } else {
-            description.push(trimmed.to_owned());
+            parsed.description.push(trimmed.to_owned());
         }
     }
-    flush(
-        &cur_tag,
-        &cur_body,
-        &mut params,
-        &mut returns,
-        &mut throws,
-        &mut see,
-        &mut since,
+
+    flush_doc_tag(current_tag.as_deref(), &current_body, &mut parsed);
+    parsed
+}
+
+fn flush_doc_tag(current_tag: Option<&str>, current_body: &[String], parsed: &mut ParsedDocTags) {
+    let body = current_body.join(" ").trim().to_owned();
+    if let Some(tag) = current_tag {
+        match tag {
+            "param" | "property" => {
+                let (name, rest) = split_first_word(&body);
+                parsed
+                    .params
+                    .push((name.to_owned(), rest.trim().to_owned()));
+            }
+            "return" | "returns" => parsed.returns = Some(body),
+            "throws" | "exception" => {
+                let (type_name, rest) = split_first_word(&body);
+                parsed
+                    .throws
+                    .push((type_name.to_owned(), rest.trim().to_owned()));
+            }
+            "see" => parsed.see.push(body),
+            "since" => parsed.since = Some(body),
+            _ => {}
+        }
+    }
+}
+
+fn render_doc_markdown(parsed: &ParsedDocTags) -> String {
+    let description = parsed.description.join("\n");
+    let mut markdown = inline_doc_markup(description.trim());
+
+    append_markdown_section(&mut markdown, format_param_section(&parsed.params));
+    append_markdown_section(
+        &mut markdown,
+        parsed.returns.as_deref().map(format_return_tag),
     );
+    append_markdown_section(&mut markdown, format_throws_section(&parsed.throws));
+    append_markdown_section(&mut markdown, format_see_section(&parsed.see));
+    append_markdown_section(&mut markdown, parsed.since.as_deref().map(format_since_tag));
 
-    // Reassemble as Markdown.
-    let mut md = description.join("\n").trim().to_owned();
+    markdown
+}
 
-    // Inline substitutions (KDoc links + Java {@code} / {@link})
-    md = inline_doc_markup(&md);
+fn append_markdown_section(markdown: &mut String, section: Option<String>) {
+    if let Some(section) = section {
+        markdown.push_str("\n\n");
+        markdown.push_str(&section);
+    }
+}
 
-    if !params.is_empty() {
-        md.push_str("\n\n**Parameters**");
-        for (name, desc) in &params {
-            let desc = inline_doc_markup(desc);
-            if desc.is_empty() {
-                md.push_str(&format!("\n- `{name}`"));
-            } else {
-                md.push_str(&format!("\n- `{name}` — {desc}"));
-            }
-        }
-    }
-    if let Some(ret) = returns {
-        md.push_str(&format!("\n\n**Returns** {}", inline_doc_markup(&ret)));
-    }
-    if !throws.is_empty() {
-        md.push_str("\n\n**Throws**");
-        for (ty, desc) in &throws {
-            let desc = inline_doc_markup(desc);
-            if desc.is_empty() {
-                md.push_str(&format!("\n- `{ty}`"));
-            } else {
-                md.push_str(&format!("\n- `{ty}` — {desc}"));
-            }
-        }
-    }
-    if !see.is_empty() {
-        let refs = see
-            .iter()
-            .map(|s| format!("`{}`", s.trim()))
-            .collect::<Vec<_>>()
-            .join(", ");
-        md.push_str(&format!("\n\n**See also:** {refs}"));
-    }
-    if let Some(s) = since {
-        md.push_str(&format!("\n\n**Since:** {s}"));
+fn format_param_section(params: &[(String, String)]) -> Option<String> {
+    if params.is_empty() {
+        return None;
     }
 
-    md.trim().to_owned()
+    let mut section = String::from("**Parameters**");
+    for (name, body) in params {
+        section.push('\n');
+        section.push_str(&format_param_tag(name, body));
+    }
+    Some(section)
+}
+
+fn format_param_tag(name: &str, body: &str) -> String {
+    let description = inline_doc_markup(body);
+    if description.is_empty() {
+        format!("- `{name}`")
+    } else {
+        format!("- `{name}` — {description}")
+    }
+}
+
+fn format_return_tag(body: &str) -> String {
+    format!("**Returns** {}", inline_doc_markup(body))
+}
+
+fn format_throws_section(throws: &[(String, String)]) -> Option<String> {
+    if throws.is_empty() {
+        return None;
+    }
+
+    let mut section = String::from("**Throws**");
+    for (type_name, body) in throws {
+        section.push('\n');
+        section.push_str(&format_throws_tag(type_name, body));
+    }
+    Some(section)
+}
+
+fn format_throws_tag(type_name: &str, body: &str) -> String {
+    let description = inline_doc_markup(body);
+    if description.is_empty() {
+        format!("- `{type_name}`")
+    } else {
+        format!("- `{type_name}` — {description}")
+    }
+}
+
+fn format_see_section(see: &[String]) -> Option<String> {
+    if see.is_empty() {
+        return None;
+    }
+
+    let refs = see
+        .iter()
+        .map(|value| format!("`{}`", value.trim()))
+        .collect::<Vec<_>>()
+        .join(", ");
+    Some(format!("**See also:** {refs}"))
+}
+
+fn format_since_tag(body: &str) -> String {
+    format!("**Since:** {body}")
 }
 
 /// Apply inline markup substitutions.

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -39,130 +39,169 @@ pub(crate) fn find_as_call_arg_type(
     idx: &Indexer,
     uri: &Url,
 ) -> Option<String> {
-    let line = lines.get(pos.line)?;
-    // Slice the line up to (but not including) the cursor position.
-    let before_cursor = {
-        let byte_end = crate::indexer::live_tree::utf16_col_to_byte(line, pos.utf16_col);
-        &line[..byte_end]
-    };
-    let col = before_cursor.chars().count();
+    let (before_cursor, cursor_column) = line_prefix_before_cursor(lines, pos)?;
 
-    // ── CST fast path ────────────────────────────────────────────────────────
-    // Walk from the cursor node upward to find the enclosing `value_argument`,
-    // then up to `call_expression`.  O(depth) vs the O(lines × chars) text scan.
     if let Some(result) = cst_call_arg_type(pos, idx, uri) {
         return Some(result);
     }
 
-    // ── Named arg: `param = ` just before cursor ─────────────────────────────
-    let s = before_cursor.trim_end();
-    if let Some(s) = s.strip_suffix('=') {
-        if !s.ends_with(|c: char| "!<>=".contains(c)) {
-            let s = s.trim_end();
-            let ident_start = s
-                .rfind(|c: char| !c.is_alphanumeric() && c != '_')
-                .map(|i| i + 1)
-                .unwrap_or(0);
-            let named_arg = &s[ident_start..];
-            if !named_arg.is_empty()
-                && named_arg
-                    .chars()
-                    .next()
-                    .map(|c| !c.is_uppercase())
-                    .unwrap_or(false)
-            {
-                let preceding = s[..ident_start].trim_end().chars().last();
-                if matches!(preceding, Some('(') | Some(',')) {
-                    if let Some(fn_full) = find_enclosing_call_name(lines, pos.line, col) {
-                        if let Some(fn_name) =
-                            fn_full.split('.').next_back().filter(|n| !n.is_empty())
-                        {
-                            if let Some(sig) = find_fun_signature_full(fn_name, idx, uri) {
-                                if let Some(param_type) =
-                                    find_named_param_type_in_sig(&sig, named_arg)
-                                {
-                                    let base = param_type.trim().ident_prefix();
-                                    if !base.is_empty() {
-                                        return Some(base);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    if let Some(result) =
+        find_named_call_arg_type(lines, pos.line, cursor_column, idx, uri, before_cursor)
+    {
+        return Some(result);
     }
 
-    // ── Positional arg: `fn(a, keyword)` ────────────────────────────────────
-    // Scan backward tracking paren/bracket depth; count top-level commas to
-    // determine which argument position the cursor is in.
-    //
-    // Also track brace depth: if we encounter an unmatched `{` going backward,
-    // the cursor is inside a nested lambda body — NOT directly a function arg.
-    // Stop immediately so we don't mis-infer the outer function's param type.
+    find_positional_call_arg_type(lines, pos.line, cursor_column, idx, uri)
+}
+
+struct CallContext {
+    function_name: String,
+    argument_position: usize,
+}
+
+fn line_prefix_before_cursor(lines: &[String], pos: CursorPos) -> Option<(&str, usize)> {
+    let line = lines.get(pos.line)?;
+    let byte_end = crate::indexer::live_tree::utf16_col_to_byte(line, pos.utf16_col);
+    let before_cursor = &line[..byte_end];
+    Some((before_cursor, before_cursor.chars().count()))
+}
+
+fn find_named_call_arg_type(
+    lines: &[String],
+    cursor_line: usize,
+    cursor_column: usize,
+    idx: &Indexer,
+    uri: &Url,
+    before_cursor: &str,
+) -> Option<String> {
+    let before_assignment = before_cursor.trim_end().strip_suffix('=')?;
+    if before_assignment.ends_with(|ch: char| "!<>=".contains(ch)) {
+        return None;
+    }
+
+    let before_assignment = before_assignment.trim_end();
+    let identifier_start = before_assignment
+        .rfind(|ch: char| !ch.is_alphanumeric() && ch != '_')
+        .map_or(0, |index| index + 1);
+    let named_argument = &before_assignment[identifier_start..];
+    if named_argument.is_empty() || named_argument.chars().next().is_none_or(char::is_uppercase) {
+        return None;
+    }
+
+    let preceding_char = before_assignment[..identifier_start]
+        .trim_end()
+        .chars()
+        .last();
+    if !matches!(preceding_char, Some('(') | Some(',')) {
+        return None;
+    }
+
+    let full_name = find_enclosing_call_name(lines, cursor_line, cursor_column)?;
+    let function_name = full_name
+        .split('.')
+        .next_back()
+        .filter(|name| !name.is_empty())?;
+    let signature = find_fun_signature_full(function_name, idx, uri)?;
+    let parameter_type = find_named_param_type_in_sig(&signature, named_argument)?;
+    normalize_parameter_base_type(&parameter_type)
+}
+
+fn find_positional_call_arg_type(
+    lines: &[String],
+    cursor_line: usize,
+    cursor_column: usize,
+    idx: &Indexer,
+    uri: &Url,
+) -> Option<String> {
+    let call_context = find_call_context(lines, cursor_line, cursor_column)?;
+    let signature = find_fun_signature_full(&call_context.function_name, idx, uri)?;
+    let parameter_type = nth_fun_param_type_str(&signature, call_context.argument_position)?;
+    normalize_parameter_base_type(&parameter_type)
+}
+
+fn find_call_context(
+    lines: &[String],
+    cursor_line: usize,
+    cursor_column: usize,
+) -> Option<CallContext> {
     let mut depth: i32 = 0;
     let mut brace_depth: i32 = 0;
-    let mut arg_pos: usize = 0;
-    let scan_start = pos.line.saturating_sub(ARG_SCAN_BACK_LINES);
+    let mut argument_position: usize = 0;
+    let scan_start = cursor_line.saturating_sub(ARG_SCAN_BACK_LINES);
 
-    for ln in (scan_start..=pos.line).rev() {
-        let chars: Vec<char> = lines[ln].chars().collect();
-        let scan_to = if ln == pos.line {
-            col.min(chars.len())
+    for line_index in (scan_start..=cursor_line).rev() {
+        let chars: Vec<char> = lines[line_index].chars().collect();
+        let scan_to = if line_index == cursor_line {
+            cursor_column.min(chars.len())
         } else {
             chars.len()
         };
 
-        for i in (0..scan_to).rev() {
-            match chars[i] {
-                // Skip string interpolation `${`: treat `{` preceded by `$` as neutral.
-                '{' if i > 0 && chars[i - 1] == '$' => {}
+        for column_index in (0..scan_to).rev() {
+            match chars[column_index] {
+                '{' if column_index > 0 && chars[column_index - 1] == '$' => {}
                 '}' => brace_depth += 1,
                 '{' => {
                     brace_depth -= 1;
                     if brace_depth < 0 {
-                        // Cursor is inside a lambda body — do not match the outer call.
                         return None;
                     }
                 }
                 ')' | ']' => depth += 1,
-                // `>` going backward = entering a generic block; guard against `->`.
-                '>' if i == 0 || chars[i - 1] != '-' => depth += 1,
+                '>' if column_index == 0 || chars[column_index - 1] != '-' => depth += 1,
                 '(' | '[' => {
                     depth -= 1;
                     if depth < 0 {
-                        if i == 0 {
-                            return None;
-                        }
-                        // Extract function name (possibly dotted) before `(`.
-                        let mut end = i;
-                        while end > 0 && (is_id_char(chars[end - 1]) || chars[end - 1] == '.') {
-                            end -= 1;
-                        }
-                        if end >= i {
-                            return None;
-                        }
-                        let full_name: String = chars[end..i].iter().collect();
-                        let fn_name = full_name
-                            .trim_matches('.')
-                            .split('.')
-                            .next_back()
-                            .filter(|n| !n.is_empty())?;
-                        let sig = find_fun_signature_full(fn_name, idx, uri)?;
-                        let param_type = nth_fun_param_type_str(&sig, arg_pos)?;
-                        let base = param_type.trim().ident_prefix();
-                        return if base.is_empty() { None } else { Some(base) };
+                        let function_name = extract_called_function_name(&chars, column_index)?;
+                        return Some(CallContext {
+                            function_name,
+                            argument_position,
+                        });
                     }
                 }
-                // `<` going backward = leaving a generic block; only close if inside one.
                 '<' if depth > 0 => depth -= 1,
-                ',' if depth == 0 => arg_pos += 1,
+                ',' if depth == 0 => argument_position += 1,
                 _ => {}
             }
         }
     }
+
     None
+}
+
+fn extract_called_function_name(chars: &[char], opening_paren_index: usize) -> Option<String> {
+    if opening_paren_index == 0 {
+        return None;
+    }
+
+    let mut identifier_start = opening_paren_index;
+    while identifier_start > 0
+        && (is_id_char(chars[identifier_start - 1]) || chars[identifier_start - 1] == '.')
+    {
+        identifier_start -= 1;
+    }
+    if identifier_start >= opening_paren_index {
+        return None;
+    }
+
+    let full_name: String = chars[identifier_start..opening_paren_index]
+        .iter()
+        .collect();
+    full_name
+        .trim_matches('.')
+        .split('.')
+        .next_back()
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned)
+}
+
+fn normalize_parameter_base_type(parameter_type: &str) -> Option<String> {
+    let base_type = parameter_type.trim().ident_prefix();
+    if base_type.is_empty() {
+        None
+    } else {
+        Some(base_type.to_owned())
+    }
 }
 
 // ─── Named-arg helpers ────────────────────────────────────────────────────────

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -5,14 +5,14 @@
 
 use tower_lsp::lsp_types::Url;
 
+use crate::StrExt;
+use crate::indexer::NodeExt;
 use crate::indexer::infer::sig::{
     find_fun_signature_full, nth_fun_param_type_str, split_params_at_depth_zero,
 };
-use crate::indexer::NodeExt;
-use crate::indexer::{find_enclosing_call_name, is_id_char, Indexer};
+use crate::indexer::{Indexer, find_enclosing_call_name, is_id_char};
 use crate::queries::KIND_CALL_EXPR;
 use crate::types::CursorPos;
-use crate::StrExt;
 
 // ─── Type-directed call-argument inference ────────────────────────────────────
 
@@ -39,130 +39,169 @@ pub(crate) fn find_as_call_arg_type(
     idx: &Indexer,
     uri: &Url,
 ) -> Option<String> {
-    let line = lines.get(pos.line)?;
-    // Slice the line up to (but not including) the cursor position.
-    let before_cursor = {
-        let byte_end = crate::indexer::live_tree::utf16_col_to_byte(line, pos.utf16_col);
-        &line[..byte_end]
-    };
-    let col = before_cursor.chars().count();
+    let (before_cursor, cursor_column) = line_prefix_before_cursor(lines, pos)?;
 
-    // ── CST fast path ────────────────────────────────────────────────────────
-    // Walk from the cursor node upward to find the enclosing `value_argument`,
-    // then up to `call_expression`.  O(depth) vs the O(lines × chars) text scan.
     if let Some(result) = cst_call_arg_type(pos, idx, uri) {
         return Some(result);
     }
 
-    // ── Named arg: `param = ` just before cursor ─────────────────────────────
-    let s = before_cursor.trim_end();
-    if let Some(s) = s.strip_suffix('=') {
-        if !s.ends_with(|c: char| "!<>=".contains(c)) {
-            let s = s.trim_end();
-            let ident_start = s
-                .rfind(|c: char| !c.is_alphanumeric() && c != '_')
-                .map(|i| i + 1)
-                .unwrap_or(0);
-            let named_arg = &s[ident_start..];
-            if !named_arg.is_empty()
-                && named_arg
-                    .chars()
-                    .next()
-                    .map(|c| !c.is_uppercase())
-                    .unwrap_or(false)
-            {
-                let preceding = s[..ident_start].trim_end().chars().last();
-                if matches!(preceding, Some('(') | Some(',')) {
-                    if let Some(fn_full) = find_enclosing_call_name(lines, pos.line, col) {
-                        if let Some(fn_name) =
-                            fn_full.split('.').next_back().filter(|n| !n.is_empty())
-                        {
-                            if let Some(sig) = find_fun_signature_full(fn_name, idx, uri) {
-                                if let Some(param_type) =
-                                    find_named_param_type_in_sig(&sig, named_arg)
-                                {
-                                    let base = param_type.trim().ident_prefix();
-                                    if !base.is_empty() {
-                                        return Some(base);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
+    if let Some(result) =
+        find_named_call_arg_type(lines, pos.line, cursor_column, idx, uri, before_cursor)
+    {
+        return Some(result);
     }
 
-    // ── Positional arg: `fn(a, keyword)` ────────────────────────────────────
-    // Scan backward tracking paren/bracket depth; count top-level commas to
-    // determine which argument position the cursor is in.
-    //
-    // Also track brace depth: if we encounter an unmatched `{` going backward,
-    // the cursor is inside a nested lambda body — NOT directly a function arg.
-    // Stop immediately so we don't mis-infer the outer function's param type.
+    find_positional_call_arg_type(lines, pos.line, cursor_column, idx, uri)
+}
+
+struct CallContext {
+    function_name: String,
+    argument_position: usize,
+}
+
+fn line_prefix_before_cursor(lines: &[String], pos: CursorPos) -> Option<(&str, usize)> {
+    let line = lines.get(pos.line)?;
+    let byte_end = crate::indexer::live_tree::utf16_col_to_byte(line, pos.utf16_col);
+    let before_cursor = &line[..byte_end];
+    Some((before_cursor, before_cursor.chars().count()))
+}
+
+fn find_named_call_arg_type(
+    lines: &[String],
+    cursor_line: usize,
+    cursor_column: usize,
+    idx: &Indexer,
+    uri: &Url,
+    before_cursor: &str,
+) -> Option<String> {
+    let before_assignment = before_cursor.trim_end().strip_suffix('=')?;
+    if before_assignment.ends_with(|ch: char| "!<>=".contains(ch)) {
+        return None;
+    }
+
+    let before_assignment = before_assignment.trim_end();
+    let identifier_start = before_assignment
+        .rfind(|ch: char| !ch.is_alphanumeric() && ch != '_')
+        .map_or(0, |index| index + 1);
+    let named_argument = &before_assignment[identifier_start..];
+    if named_argument.is_empty() || named_argument.chars().next().is_none_or(char::is_uppercase) {
+        return None;
+    }
+
+    let preceding_char = before_assignment[..identifier_start]
+        .trim_end()
+        .chars()
+        .last();
+    if !matches!(preceding_char, Some('(') | Some(',')) {
+        return None;
+    }
+
+    let full_name = find_enclosing_call_name(lines, cursor_line, cursor_column)?;
+    let function_name = full_name
+        .split('.')
+        .next_back()
+        .filter(|name| !name.is_empty())?;
+    let signature = find_fun_signature_full(function_name, idx, uri)?;
+    let parameter_type = find_named_param_type_in_sig(&signature, named_argument)?;
+    normalize_parameter_base_type(&parameter_type)
+}
+
+fn find_positional_call_arg_type(
+    lines: &[String],
+    cursor_line: usize,
+    cursor_column: usize,
+    idx: &Indexer,
+    uri: &Url,
+) -> Option<String> {
+    let call_context = find_call_context(lines, cursor_line, cursor_column)?;
+    let signature = find_fun_signature_full(&call_context.function_name, idx, uri)?;
+    let parameter_type = nth_fun_param_type_str(&signature, call_context.argument_position)?;
+    normalize_parameter_base_type(&parameter_type)
+}
+
+fn find_call_context(
+    lines: &[String],
+    cursor_line: usize,
+    cursor_column: usize,
+) -> Option<CallContext> {
     let mut depth: i32 = 0;
     let mut brace_depth: i32 = 0;
-    let mut arg_pos: usize = 0;
-    let scan_start = pos.line.saturating_sub(ARG_SCAN_BACK_LINES);
+    let mut argument_position: usize = 0;
+    let scan_start = cursor_line.saturating_sub(ARG_SCAN_BACK_LINES);
 
-    for ln in (scan_start..=pos.line).rev() {
-        let chars: Vec<char> = lines[ln].chars().collect();
-        let scan_to = if ln == pos.line {
-            col.min(chars.len())
+    for line_index in (scan_start..=cursor_line).rev() {
+        let chars: Vec<char> = lines[line_index].chars().collect();
+        let scan_to = if line_index == cursor_line {
+            cursor_column.min(chars.len())
         } else {
             chars.len()
         };
 
-        for i in (0..scan_to).rev() {
-            match chars[i] {
-                // Skip string interpolation `${`: treat `{` preceded by `$` as neutral.
-                '{' if i > 0 && chars[i - 1] == '$' => {}
+        for column_index in (0..scan_to).rev() {
+            match chars[column_index] {
+                '{' if column_index > 0 && chars[column_index - 1] == '$' => {}
                 '}' => brace_depth += 1,
                 '{' => {
                     brace_depth -= 1;
                     if brace_depth < 0 {
-                        // Cursor is inside a lambda body — do not match the outer call.
                         return None;
                     }
                 }
                 ')' | ']' => depth += 1,
-                // `>` going backward = entering a generic block; guard against `->`.
-                '>' if i == 0 || chars[i - 1] != '-' => depth += 1,
+                '>' if column_index == 0 || chars[column_index - 1] != '-' => depth += 1,
                 '(' | '[' => {
                     depth -= 1;
                     if depth < 0 {
-                        if i == 0 {
-                            return None;
-                        }
-                        // Extract function name (possibly dotted) before `(`.
-                        let mut end = i;
-                        while end > 0 && (is_id_char(chars[end - 1]) || chars[end - 1] == '.') {
-                            end -= 1;
-                        }
-                        if end >= i {
-                            return None;
-                        }
-                        let full_name: String = chars[end..i].iter().collect();
-                        let fn_name = full_name
-                            .trim_matches('.')
-                            .split('.')
-                            .next_back()
-                            .filter(|n| !n.is_empty())?;
-                        let sig = find_fun_signature_full(fn_name, idx, uri)?;
-                        let param_type = nth_fun_param_type_str(&sig, arg_pos)?;
-                        let base = param_type.trim().ident_prefix();
-                        return if base.is_empty() { None } else { Some(base) };
+                        let function_name = extract_called_function_name(&chars, column_index)?;
+                        return Some(CallContext {
+                            function_name,
+                            argument_position,
+                        });
                     }
                 }
-                // `<` going backward = leaving a generic block; only close if inside one.
                 '<' if depth > 0 => depth -= 1,
-                ',' if depth == 0 => arg_pos += 1,
+                ',' if depth == 0 => argument_position += 1,
                 _ => {}
             }
         }
     }
+
     None
+}
+
+fn extract_called_function_name(chars: &[char], opening_paren_index: usize) -> Option<String> {
+    if opening_paren_index == 0 {
+        return None;
+    }
+
+    let mut identifier_start = opening_paren_index;
+    while identifier_start > 0
+        && (is_id_char(chars[identifier_start - 1]) || chars[identifier_start - 1] == '.')
+    {
+        identifier_start -= 1;
+    }
+    if identifier_start >= opening_paren_index {
+        return None;
+    }
+
+    let full_name: String = chars[identifier_start..opening_paren_index]
+        .iter()
+        .collect();
+    full_name
+        .trim_matches('.')
+        .split('.')
+        .next_back()
+        .filter(|name| !name.is_empty())
+        .map(str::to_owned)
+}
+
+fn normalize_parameter_base_type(parameter_type: &str) -> Option<String> {
+    let base_type = parameter_type.trim().ident_prefix();
+    if base_type.is_empty() {
+        None
+    } else {
+        Some(base_type.to_owned())
+    }
 }
 
 // ─── Named-arg helpers ────────────────────────────────────────────────────────
@@ -333,11 +372,7 @@ pub(crate) fn extract_first_arg(call_expr: &str) -> Option<&str> {
         prev = ch;
     }
     let arg = rest[..end].trim();
-    if arg.is_empty() {
-        None
-    } else {
-        Some(arg)
-    }
+    if arg.is_empty() { None } else { Some(arg) }
 }
 
 // ─── CST helpers for call-argument type inference ────────────────────────────
@@ -405,11 +440,7 @@ fn cst_call_arg_type(pos: CursorPos, idx: &Indexer, uri: &Url) -> Option<String>
     }?;
 
     let base = param_type.trim().ident_prefix();
-    if base.is_empty() {
-        None
-    } else {
-        Some(base)
-    }
+    if base.is_empty() { None } else { Some(base) }
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -858,17 +858,17 @@ impl CurrentFileCompletionContext {
     }
 
     fn needs_import(&self, fully_qualified_name: &str) -> bool {
-        let package_name = fully_qualified_name
+        let qualifier = fully_qualified_name
             .rsplit_once('.')
-            .map(|(package_name, _)| package_name)
+            .map(|(qualifier, _)| qualifier)
             .unwrap_or_default();
 
         !already_imported(fully_qualified_name, &self.imports)
             && !self
                 .imports
                 .iter()
-                .any(|import_entry| import_entry.is_star && import_entry.full_path == package_name)
-            && package_name != self.package_name
+                .any(|import_entry| import_entry.is_star && import_entry.full_path == qualifier)
+            && qualifier != self.package_name
     }
 }
 
@@ -1039,9 +1039,9 @@ impl<'a> BareCompletionWalk<'a> {
             return;
         }
 
-        let package_name = fully_qualified_name
+        let qualifier = fully_qualified_name
             .rsplit_once('.')
-            .map(|(package_name, _)| package_name)
+            .map(|(qualifier, _)| qualifier)
             .unwrap_or_default();
         let needs_import = current_context.needs_import(fully_qualified_name);
         let additional_text_edits = needs_import.then(|| {
@@ -1049,7 +1049,7 @@ impl<'a> BareCompletionWalk<'a> {
                 .lines
                 .make_import_edit(fully_qualified_name, current_context.is_java)]
         });
-        let detail = needs_import.then(|| package_name.to_string());
+        let detail = needs_import.then(|| qualifier.to_string());
 
         self.completer.items.push(CompletionItem {
             label: bare_name.to_string(),

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -709,8 +709,8 @@ fn vis_tag(vis: Visibility) -> &'static str {
 /// key and is handled manually by `complete_bare` so per-FQN import edits
 /// are preserved correctly.
 struct BareCompleter {
-    pub items: Vec<CompletionItem>,
-    pub seen: std::collections::HashSet<String>,
+    items: Vec<CompletionItem>,
+    seen: std::collections::HashSet<String>,
     lowercase_mode: bool,
     uppercase_mode: bool,
     camel_mode: bool,
@@ -817,6 +817,283 @@ impl BareCompleter {
     }
 }
 
+struct CurrentFileCompletionContext {
+    imports: Vec<crate::types::ImportEntry>,
+    package_name: String,
+    lines: Arc<Vec<String>>,
+    is_java: bool,
+}
+
+impl CurrentFileCompletionContext {
+    fn from_indexer(indexer: &Indexer, from_uri: &Url) -> Self {
+        let is_java = crate::Language::from_path(from_uri.as_str()).is_java();
+        let live_lines = indexer
+            .live_lines
+            .get(from_uri.as_str())
+            .map(|lines| lines.clone());
+        let (imports, package_name, lines) = indexer
+            .files
+            .get(from_uri.as_str())
+            .map(|file| {
+                let lines = live_lines.clone().unwrap_or_else(|| file.lines.clone());
+                let imports = if live_lines.is_some() {
+                    lines.parse_imports()
+                } else {
+                    file.imports.clone()
+                };
+                (imports, file.package.clone().unwrap_or_default(), lines)
+            })
+            .unwrap_or_else(|| {
+                let lines = live_lines.clone().unwrap_or_default();
+                let imports = lines.parse_imports();
+                (imports, String::new(), lines)
+            });
+
+        Self {
+            imports,
+            package_name,
+            lines,
+            is_java,
+        }
+    }
+
+    fn needs_import(&self, fully_qualified_name: &str) -> bool {
+        let package_name = fully_qualified_name
+            .rsplit_once('.')
+            .map(|(package_name, _)| package_name)
+            .unwrap_or_default();
+
+        !already_imported(fully_qualified_name, &self.imports)
+            && !self
+                .imports
+                .iter()
+                .any(|import_entry| import_entry.is_star && import_entry.full_path == package_name)
+            && package_name != self.package_name
+    }
+}
+
+struct BareCompletionWalk<'a> {
+    indexer: &'a Indexer,
+    prefix: &'a str,
+    from_uri: &'a Url,
+    completer: BareCompleter,
+}
+
+impl<'a> BareCompletionWalk<'a> {
+    fn new(
+        indexer: &'a Indexer,
+        prefix: &'a str,
+        from_uri: &'a Url,
+        snippets: bool,
+        annotation_only: bool,
+    ) -> Self {
+        Self {
+            indexer,
+            prefix,
+            from_uri,
+            completer: BareCompleter::new(prefix, snippets, annotation_only),
+        }
+    }
+
+    fn collect_local_file(&mut self) {
+        let Some(file) = self.indexer.files.get(self.from_uri.as_str()) else {
+            return;
+        };
+
+        for symbol in &file.symbols {
+            self.completer.add(
+                &symbol.name,
+                symbol_kind_to_completion(symbol.kind),
+                0,
+                self.prefix,
+                &symbol.detail,
+                Some(serde_json::json!({"u": self.from_uri.as_str(), "l": symbol.selection_start(), "c": symbol.selection_range.start.character})),
+            );
+        }
+
+        if self.completer.lowercase_mode {
+            for declared_name in &file.declared_names {
+                self.completer.add(
+                    declared_name,
+                    CompletionItemKind::VARIABLE,
+                    0,
+                    self.prefix,
+                    "",
+                    None,
+                );
+            }
+        }
+    }
+
+    fn collect_same_package(&mut self) {
+        let Some(package_name) = self.current_package_name() else {
+            return;
+        };
+        let Some(package_uris) = self.indexer.packages.get(&package_name) else {
+            return;
+        };
+
+        for package_uri in package_uris.iter() {
+            if package_uri == self.from_uri.as_str() {
+                continue;
+            }
+            let Some(file) = self.indexer.files.get(package_uri.as_str()) else {
+                continue;
+            };
+            for symbol in &file.symbols {
+                self.completer.add(
+                    &symbol.name,
+                    symbol_kind_to_completion(symbol.kind),
+                    1,
+                    self.prefix,
+                    &symbol.detail,
+                    Some(serde_json::json!({"u": package_uri.as_str(), "l": symbol.selection_start(), "c": symbol.selection_range.start.character})),
+                );
+            }
+        }
+    }
+
+    fn current_package_name(&self) -> Option<String> {
+        self.indexer
+            .files
+            .get(self.from_uri.as_str())
+            .and_then(|file| file.package.clone())
+            .filter(|package_name| !package_name.is_empty())
+    }
+
+    fn collect_cross_package(&mut self) {
+        if self.completer.lowercase_mode || self.prefix.len() < MIN_CASE_INSENSITIVE_PREFIX {
+            return;
+        }
+
+        let current_context =
+            CurrentFileCompletionContext::from_indexer(self.indexer, self.from_uri);
+        let Ok(cache) = self.indexer.bare_name_cache.read() else {
+            return;
+        };
+
+        for bare_name in cache.iter() {
+            self.add_cross_package_name(bare_name, &current_context);
+        }
+    }
+
+    fn add_cross_package_name(
+        &mut self,
+        bare_name: &str,
+        current_context: &CurrentFileCompletionContext,
+    ) {
+        if bare_name.starts_with_lowercase() {
+            return;
+        }
+        if self.completer.camel_mode && is_screaming_snake(bare_name) {
+            return;
+        }
+        let Some(score) = self.cross_package_score(bare_name) else {
+            return;
+        };
+        if self.completer.seen.contains(bare_name) {
+            return;
+        }
+
+        let fully_qualified_names = fqns_for_name(self.indexer, bare_name);
+        if fully_qualified_names.is_empty() {
+            self.add_cross_package_name_without_imports(bare_name, score);
+            return;
+        }
+
+        for fully_qualified_name in &fully_qualified_names {
+            self.add_cross_package_symbol(bare_name, fully_qualified_name, score, current_context);
+        }
+    }
+
+    fn cross_package_score(&self, bare_name: &str) -> Option<u8> {
+        match match_score(bare_name, self.prefix) {
+            Some(score) if score <= 1 => Some(score),
+            _ => None,
+        }
+    }
+
+    fn add_cross_package_name_without_imports(&mut self, bare_name: &str, score: u8) {
+        if !self.completer.seen.insert(bare_name.to_string()) {
+            return;
+        }
+
+        self.completer.items.push(CompletionItem {
+            label: bare_name.to_string(),
+            kind: Some(CompletionItemKind::CLASS),
+            filter_text: Some(bare_name.to_string()),
+            sort_text: Some(format!("2{}:{}", score, bare_name.to_lowercase())),
+            ..Default::default()
+        });
+    }
+
+    fn add_cross_package_symbol(
+        &mut self,
+        bare_name: &str,
+        fully_qualified_name: &str,
+        score: u8,
+        current_context: &CurrentFileCompletionContext,
+    ) {
+        let item_key = format!("{}:{}", bare_name, fully_qualified_name);
+        if !self.completer.seen.insert(item_key) {
+            return;
+        }
+
+        let package_name = fully_qualified_name
+            .rsplit_once('.')
+            .map(|(package_name, _)| package_name)
+            .unwrap_or_default();
+        let needs_import = current_context.needs_import(fully_qualified_name);
+        let additional_text_edits = needs_import.then(|| {
+            vec![current_context
+                .lines
+                .make_import_edit(fully_qualified_name, current_context.is_java)]
+        });
+        let detail = needs_import.then(|| package_name.to_string());
+
+        self.completer.items.push(CompletionItem {
+            label: bare_name.to_string(),
+            kind: Some(CompletionItemKind::CLASS),
+            filter_text: Some(bare_name.to_string()),
+            sort_text: Some(format!("2{}:{}", score, bare_name.to_lowercase())),
+            detail,
+            additional_text_edits,
+            ..Default::default()
+        });
+    }
+
+    fn collect_stdlib(&mut self) {
+        for mut item in bare_completions(self.completer.snippets) {
+            let label = item.label.clone();
+            if self.completer.lowercase_mode && label.starts_with_uppercase() {
+                continue;
+            }
+            if self.completer.camel_mode && is_screaming_snake(&label) {
+                continue;
+            }
+            let score = match match_score(&label, self.prefix) {
+                Some(score) if score <= 2 => score,
+                _ => continue,
+            };
+            if self.completer.seen.insert(label.clone()) {
+                item.filter_text = Some(label.clone());
+                item.sort_text = Some(format!("3{}:{}", score, label.to_lowercase()));
+                self.completer.items.push(item);
+            }
+        }
+    }
+
+    fn finish(mut self) -> (Vec<CompletionItem>, bool) {
+        self.completer
+            .items
+            .sort_by(|left, right| left.sort_text.cmp(&right.sort_text));
+
+        let hit_cap = self.completer.items.len() > COMPLETION_CAP;
+        self.completer.items.truncate(COMPLETION_CAP);
+        (self.completer.items, hit_cap)
+    }
+}
+
 /// Bare-word completion: match-scored across local file + same-package + index.
 ///
 /// Case heuristic:
@@ -834,190 +1111,13 @@ pub(crate) fn complete_bare(
     snippets: bool,
     annotation_only: bool,
 ) -> (Vec<CompletionItem>, bool) {
-    let mut bc = BareCompleter::new(prefix, snippets, annotation_only);
-    // `src_tier` encodes symbol origin (0=same file, 1=same pkg, 2=cross-pkg, 3=stdlib).
-    // Full sort_text: "{src_tier}{match_score}:{name_lower}" so that
-    //   same-file exact match ("000:column") beats same-file acronym ("001:columnbutton")
-    //   which beats same-pkg exact ("010:column"), etc.
-
-    // 1. Local file symbols — src_tier 0, substring fallback only for short prefixes.
-    if let Some(f) = idx.files.get(from_uri.as_str()) {
-        for sym in &f.symbols {
-            bc.add(
-                &sym.name,
-                symbol_kind_to_completion(sym.kind),
-                0,
-                prefix,
-                &sym.detail,
-                Some(serde_json::json!({"u": from_uri.as_str(), "l": sym.selection_start(), "c": sym.selection_range.start.character})),
-            );
-        }
-        if bc.lowercase_mode {
-            for name in &f.declared_names {
-                bc.add(name, CompletionItemKind::VARIABLE, 0, prefix, "", None);
-            }
-        }
-    }
-
-    // 2. Same-package symbols — src_tier 1, substring fallback only for short prefixes.
-    let pkg = idx
-        .files
-        .get(from_uri.as_str())
-        .and_then(|f| f.package.clone())
-        .unwrap_or_default();
-    if !pkg.is_empty() {
-        if let Some(uris) = idx.packages.get(&pkg) {
-            for uri_str in uris.iter() {
-                if uri_str == from_uri.as_str() {
-                    continue;
-                }
-                if let Some(f) = idx.files.get(uri_str.as_str()) {
-                    for sym in &f.symbols {
-                        bc.add(
-                            &sym.name,
-                            symbol_kind_to_completion(sym.kind),
-                            1,
-                            prefix,
-                            &sym.detail,
-                            Some(serde_json::json!({"u": uri_str.as_str(), "l": sym.selection_start(), "c": sym.selection_range.start.character})),
-                        );
-                    }
-                }
-            }
-        }
-    }
-
-    // 3. Cross-package symbols — src_tier 2, uppercase mode only, prefix ≥ 2 chars,
-    //    prefix/acronym matches only (max_score=1) — no substring flood.
-    // Emits one CompletionItem per distinct FQN, with additionalTextEdits for auto-import.
-    // NOTE: tier-2 uses "name:fqn" as dedup key (not just name) so each FQN gets its
-    // own import edit. bc.seen is accessed directly to preserve that invariant.
-    if !bc.lowercase_mode && prefix.len() >= MIN_CASE_INSENSITIVE_PREFIX {
-        let is_java = crate::Language::from_path(from_uri.as_str()).is_java();
-        // Prefer live_lines (updated on every keystroke) over the indexed snapshot so that
-        // import deduplication and insertion position are based on the current buffer state.
-        let live = idx.live_lines.get(from_uri.as_str()).map(|ll| ll.clone());
-        let (cur_imports, cur_pkg, cur_lines) = idx
-            .files
-            .get(from_uri.as_str())
-            .map(|f| {
-                let lines = live.clone().unwrap_or_else(|| f.lines.clone());
-                // Re-scan live lines for imports so we don't use a stale snapshot.
-                let imports = if live.is_some() {
-                    lines.parse_imports()
-                } else {
-                    f.imports.clone()
-                };
-                (imports, f.package.clone().unwrap_or_default(), lines)
-            })
-            .unwrap_or_else(|| {
-                let lines = live.clone().unwrap_or_default();
-                let imports = lines.parse_imports();
-                (imports, String::new(), lines)
-            });
-
-        if let Ok(cache) = idx.bare_name_cache.read() {
-            for name in cache.iter() {
-                // Case gate + match quality gate (prefix or acronym only).
-                if name.starts_with_lowercase() {
-                    continue;
-                }
-                if bc.camel_mode && is_screaming_snake(name) {
-                    continue;
-                }
-                let score = match match_score(name, prefix) {
-                    Some(s) if s <= 1 => s,
-                    _ => continue,
-                };
-
-                // Already visible via tier-0 or tier-1 — skip, no import needed.
-                if bc.seen.contains(name.as_str()) {
-                    continue;
-                }
-
-                let fqns = fqns_for_name(idx, name);
-
-                if fqns.is_empty() {
-                    if bc.seen.insert(name.clone()) {
-                        bc.items.push(CompletionItem {
-                            label: name.clone(),
-                            kind: Some(CompletionItemKind::CLASS),
-                            filter_text: Some(name.clone()),
-                            sort_text: Some(format!("2{}:{}", score, name.to_lowercase())),
-                            ..Default::default()
-                        });
-                    }
-                    continue;
-                }
-
-                for fqn in &fqns {
-                    let pkg_of_fqn = match fqn.rfind('.') {
-                        Some(i) => &fqn[..i],
-                        None => "",
-                    };
-
-                    let needs_import = !already_imported(fqn, &cur_imports)
-                        && !cur_imports
-                            .iter()
-                            .any(|imp| imp.is_star && imp.full_path == pkg_of_fqn)
-                        && pkg_of_fqn != cur_pkg;
-
-                    let item_key = format!("{}:{}", name, fqn);
-                    if !bc.seen.insert(item_key) {
-                        continue;
-                    }
-
-                    let import_edit = if needs_import {
-                        Some(vec![cur_lines.make_import_edit(fqn, is_java)])
-                    } else {
-                        None
-                    };
-                    let detail = if needs_import {
-                        Some(pkg_of_fqn.to_string())
-                    } else {
-                        None
-                    };
-
-                    bc.items.push(CompletionItem {
-                        label: name.clone(),
-                        kind: Some(CompletionItemKind::CLASS),
-                        filter_text: Some(name.clone()),
-                        sort_text: Some(format!("2{}:{}", score, name.to_lowercase())),
-                        detail,
-                        additional_text_edits: import_edit,
-                        ..Default::default()
-                    });
-                }
-            }
-        }
-    }
-
-    // 4. Stdlib top-level / scope functions — src_tier 3.
-    for mut item in bare_completions(snippets) {
-        let label = item.label.clone();
-        if bc.lowercase_mode && label.starts_with_uppercase() {
-            continue;
-        }
-        if bc.camel_mode && is_screaming_snake(&label) {
-            continue;
-        }
-        let score = match match_score(&label, prefix) {
-            Some(s) if s <= 2 => s,
-            _ => continue,
-        };
-        if bc.seen.insert(label.clone()) {
-            item.filter_text = Some(label.clone());
-            item.sort_text = Some(format!("3{}:{}", score, label.to_lowercase()));
-            bc.items.push(item);
-        }
-    }
-
-    // Sort by computed sort_text so the best matches are first even before capping.
-    bc.items.sort_by(|a, b| a.sort_text.cmp(&b.sort_text));
-
-    let hit_cap = bc.items.len() > COMPLETION_CAP;
-    bc.items.truncate(COMPLETION_CAP);
-    (bc.items, hit_cap)
+    let mut completion_walk =
+        BareCompletionWalk::new(idx, prefix, from_uri, snippets, annotation_only);
+    completion_walk.collect_local_file();
+    completion_walk.collect_same_package();
+    completion_walk.collect_cross_package();
+    completion_walk.collect_stdlib();
+    completion_walk.finish()
 }
 
 /// Collect all symbols from a file URI as completion items.

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -264,6 +264,236 @@ pub(crate) fn rg_find_definition(
     }
 }
 
+/// Request parameters for a ripgrep reference search.
+pub(crate) struct RgSearchRequest<'a> {
+    name: &'a str,
+    parent_class: Option<&'a str>,
+    declared_pkg: Option<&'a str>,
+    search_root: std::borrow::Cow<'a, Path>,
+    include_decl: bool,
+    from_uri: &'a Url,
+    decl_files: &'a [String],
+}
+
+impl<'a> RgSearchRequest<'a> {
+    pub(crate) fn new(
+        name: &'a str,
+        parent_class: Option<&'a str>,
+        declared_pkg: Option<&'a str>,
+        root: Option<&'a Path>,
+        include_decl: bool,
+        from_uri: &'a Url,
+        decl_files: &'a [String],
+    ) -> Self {
+        let search_root = match root {
+            Some(root) => std::borrow::Cow::Borrowed(root),
+            None => std::borrow::Cow::Owned(std::env::current_dir().unwrap_or_default()),
+        };
+        Self {
+            name,
+            parent_class,
+            declared_pkg,
+            search_root,
+            include_decl,
+            from_uri,
+            decl_files,
+        }
+    }
+}
+
+const REFERENCE_DECLARATION_KEYWORDS: &[&str] = &[
+    "class ",
+    "interface ",
+    "object ",
+    "fun ",
+    "val ",
+    "var ",
+    "typealias ",
+    "enum class ",
+    "enum ",
+    "struct ",
+    "protocol ",
+    "func ",
+    "let ",
+    "extension ",
+];
+
+fn build_rg_patterns(request: &RgSearchRequest<'_>) -> Vec<String> {
+    let safe_name = regex_escape(request.name);
+    if let Some(parent_class) = request.parent_class {
+        let safe_parent = regex_escape(parent_class);
+        let qualified_pattern = format!(r"\b{}\.\b{}\b", safe_parent, safe_name);
+        let direct_import_pattern =
+            format!(r"import[^\n]*\b{}\.(?:{}\b|\*)", safe_parent, safe_name);
+        vec![qualified_pattern, direct_import_pattern, safe_name]
+    } else if let Some(declared_pkg) = request.declared_pkg {
+        let safe_package = regex_escape(declared_pkg);
+        let import_pattern = format!(
+            r"import[^\n]*\b{safe_package}\b[^\n]*\b{safe_name}\b|import[^\n]*\b{safe_package}\b\.\*"
+        );
+        let package_pattern = format!(r"^\s*package\s+{safe_package}\s*$");
+        vec![import_pattern, package_pattern, safe_name]
+    } else {
+        vec![safe_name]
+    }
+}
+
+fn build_rg_command(request: &RgSearchRequest<'_>, patterns: &[String]) -> Command {
+    let mut command = Command::new("rg");
+    command.args([
+        "--no-heading",
+        "--with-filename",
+        "--line-number",
+        "--column",
+    ]);
+    if request.parent_class.is_none() && request.declared_pkg.is_none() {
+        command.arg("--word-regexp");
+    }
+    for ext in SOURCE_EXTENSIONS {
+        command.args(["--glob", &format!("*.{ext}")]);
+    }
+    for pattern in patterns {
+        command.args(["-e", pattern.as_str()]);
+    }
+    command.arg(request.search_root.as_ref());
+    command
+}
+
+fn should_skip_reference(loc: &Location, content: &str, request: &RgSearchRequest<'_>) -> bool {
+    let trimmed = content.trim_start();
+    if trimmed.starts_with("import ") || trimmed.starts_with("package ") {
+        return true;
+    }
+    if !request.include_decl {
+        let is_declaration = REFERENCE_DECLARATION_KEYWORDS
+            .iter()
+            .any(|keyword| content.contains(keyword))
+            && loc.uri.as_str() == request.from_uri.as_str();
+        if is_declaration {
+            return true;
+        }
+    }
+    false
+}
+
+fn parse_rg_output(output: &[u8], request: &RgSearchRequest<'_>) -> Vec<Location> {
+    String::from_utf8_lossy(output)
+        .lines()
+        .filter_map(|line| parse_rg_line_with_content_rooted(line, request.search_root.as_ref()))
+        .filter_map(|(loc, content)| {
+            (!should_skip_reference(&loc, &content, request)).then_some(loc)
+        })
+        .collect()
+}
+
+fn run_rg_search(request: &RgSearchRequest<'_>, patterns: &[String]) -> Vec<Location> {
+    let mut command = build_rg_command(request, patterns);
+    let output = match command.output() {
+        Ok(output) if output.status.success() && !output.stdout.is_empty() => output,
+        _ => return vec![],
+    };
+    parse_rg_output(&output.stdout, request)
+}
+
+fn filter_candidate_files(
+    candidate_files: Vec<String>,
+    matcher: Option<&IgnoreMatcher>,
+) -> Vec<String> {
+    match matcher {
+        Some(matcher) => matcher.filter_file_strings(candidate_files),
+        None => candidate_files,
+    }
+}
+
+fn extend_unique_files(files: &mut Vec<String>, new_files: Vec<String>) {
+    for file in new_files {
+        if !files.contains(&file) {
+            files.push(file);
+        }
+    }
+}
+
+fn merge_decl_files(candidate_files: &mut Vec<String>, decl_files: &[String]) {
+    let mut existing: std::collections::HashSet<String> = candidate_files.iter().cloned().collect();
+    for decl_file in decl_files {
+        if existing.insert(decl_file.clone()) {
+            candidate_files.push(decl_file.clone());
+        }
+    }
+}
+
+fn append_unique_reference_hits(
+    locations: &mut Vec<Location>,
+    hits: Vec<(Location, String)>,
+    request: &RgSearchRequest<'_>,
+) {
+    let mut seen: std::collections::HashSet<(String, u32, u32)> = locations
+        .iter()
+        .map(|location| {
+            (
+                location.uri.to_string(),
+                location.range.start.line,
+                location.range.start.character,
+            )
+        })
+        .collect();
+
+    for (location, content) in hits {
+        if should_skip_reference(&location, &content, request) {
+            continue;
+        }
+
+        let key = (
+            location.uri.to_string(),
+            location.range.start.line,
+            location.range.start.character,
+        );
+        if seen.insert(key) {
+            locations.push(location);
+        }
+    }
+}
+
+fn parent_scoped_reference_locations(
+    request: &RgSearchRequest<'_>,
+    patterns: &[String],
+    matcher: Option<&IgnoreMatcher>,
+) -> Vec<Location> {
+    let mut locations = run_rg_search(request, &patterns[..1]);
+    let mut candidate_files = filter_candidate_files(
+        rg_files_with_matches(&patterns[1], request.search_root.as_ref()),
+        matcher,
+    );
+    merge_decl_files(&mut candidate_files, request.decl_files);
+    if !candidate_files.is_empty() {
+        let bare_hits = rg_word_in_files(&patterns[2], &candidate_files);
+        append_unique_reference_hits(&mut locations, bare_hits, request);
+    }
+    locations
+}
+
+fn package_scoped_reference_locations(
+    request: &RgSearchRequest<'_>,
+    patterns: &[String],
+    matcher: Option<&IgnoreMatcher>,
+) -> Vec<Location> {
+    let mut candidate_files = rg_files_with_matches(&patterns[0], request.search_root.as_ref());
+    extend_unique_files(
+        &mut candidate_files,
+        rg_files_with_matches(&patterns[1], request.search_root.as_ref()),
+    );
+    let candidate_files = filter_candidate_files(candidate_files, matcher);
+    if candidate_files.is_empty() {
+        return vec![];
+    }
+    rg_word_in_files(&patterns[2], &candidate_files)
+        .into_iter()
+        .filter_map(|(location, content)| {
+            (!should_skip_reference(&location, &content, request)).then_some(location)
+        })
+        .collect()
+}
+
 /// Run `rg` to find all *usages* of `name` in the project.
 ///
 /// Uses `--word-regexp` so only whole-word matches are returned.
@@ -273,204 +503,21 @@ pub(crate) fn rg_find_definition(
 /// `include_decl` is false (the definition is already known).
 ///
 /// Results in directories matched by `matcher` are filtered out.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn rg_find_references(
-    name: &str,
-    parent_class: Option<&str>,
-    declared_pkg: Option<&str>,
-    root: Option<&Path>,
-    include_decl: bool,
-    from_uri: &Url,
-    // Absolute file paths where `name` is declared — always included in bare-word
-    // search so the declaration site itself is never missed (it uses bare `Name`,
-    // not the qualified `Parent.Name` form that Pass A searches for).
-    decl_files: &[String],
+    request: &RgSearchRequest<'_>,
     matcher: Option<&IgnoreMatcher>,
 ) -> Vec<Location> {
-    let search_root: std::borrow::Cow<Path> = match root {
-        Some(r) => std::borrow::Cow::Borrowed(r),
-        None => std::borrow::Cow::Owned(std::env::current_dir().unwrap_or_default()),
-    };
-
-    let safe_name: String = regex_escape(name);
-    let decl_kws = [
-        "class ",
-        "interface ",
-        "object ",
-        "fun ",
-        "val ",
-        "var ",
-        "typealias ",
-        "enum class ",
-        "enum ",
-        // Swift
-        "struct ",
-        "protocol ",
-        "func ",
-        "let ",
-        "extension ",
-    ];
-
-    let filter = |(loc, content): (Location, String)| -> Option<Location> {
-        let trimmed = content.trim_start();
-        // Import and package lines are never real references.
-        if trimmed.starts_with("import ") || trimmed.starts_with("package ") {
-            return None;
-        }
-        if !include_decl {
-            let is_decl = decl_kws.iter().any(|kw| content.contains(kw))
-                && loc.uri.as_str() == from_uri.as_str();
-            if is_decl {
-                return None;
-            }
-        }
-        Some(loc)
-    };
-
-    let result = if let Some(parent) = parent_class {
-        // ── Scoped references: parent class is known ──────────────────────────
-        //
-        // Pass A: qualified form `ParentClass.Name` — works in any file.
-        let safe_parent = regex_escape(parent);
-        let qualified_pat = format!(r"\b{}\.\b{}\b", safe_parent, safe_name);
-        let mut locs: Vec<Location> = rg_raw(&qualified_pat, &search_root)
-            .into_iter()
-            .filter_map(filter)
-            .collect();
-
-        // Pass B: bare `Name` restricted to files that directly import the inner
-        // class itself (`import …ParentClass.Name` or `import …ParentClass.*`)
-        // OR are in the same package.
-        //
-        // NOTE: we intentionally do NOT match files that only import the parent
-        // class itself (`import …ParentClass`) — those files use the qualified
-        // form `ParentClass.Name` which is already captured by Pass A, and
-        // including them causes massive false-positive counts (e.g. every
-        // ViewModel importing another ViewModel that also has a sealed `Effect`).
-        //
-        // Step B1 — files with explicit inner-class import.
-        // Pattern must match the parent and name as ADJACENT dot-segments:
-        //   import …ParentClass.Name   or   import …ParentClass.*
-        // NOT files that merely mention both words (e.g. OtherContract.State).
-        let direct_import_pat = format!(r"import[^\n]*\b{}\.(?:{}\b|\*)", safe_parent, safe_name);
-        let candidate_files = rg_files_with_matches(&direct_import_pat, &search_root);
-        // Filter candidate files against ignore patterns before searching them.
-        let candidate_files = match matcher {
-            Some(m) => m.filter_file_strings(candidate_files),
-            None => candidate_files,
-        };
-
-        // Step B2 — files in the same package as the parent class declaration.
-        // NOTE: for inner classes, same-package files use the QUALIFIED form
-        // `ParentClass.Name` which is already caught by Pass A. Adding them to
-        // the bare-name search causes false positives (e.g. AbilitiesSectionViewModel
-        // in the same package has its own `State`). So we skip same-package here.
-
-        // Merge candidate file sets.
-        // Always include declaration files so the declaration site itself is
-        // never missed (it uses bare `Name`, not the qualified `Parent.Name` form).
-        let mut all_files: Vec<String> = candidate_files;
-        // Build new entries first (borrows all_files), then extend after the borrow ends.
-        let new_decl: Vec<&String> = {
-            let existing: std::collections::HashSet<&str> =
-                all_files.iter().map(|s| s.as_str()).collect();
-            decl_files
-                .iter()
-                .filter(|f| !existing.contains(f.as_str()))
-                .collect()
-        };
-        for f in new_decl {
-            all_files.push(f.clone());
-        }
-
-        if !all_files.is_empty() {
-            let bare_hits = rg_word_in_files(&safe_name, &all_files);
-            // Deduplicate against the qualified hits using a HashSet for O(1) lookup.
-            let seen: std::collections::HashSet<(String, u32, u32)> = locs
-                .iter()
-                .map(|l| {
-                    (
-                        l.uri.to_string(),
-                        l.range.start.line,
-                        l.range.start.character,
-                    )
-                })
-                .collect();
-            for (loc, content) in bare_hits {
-                if let Some(loc) = filter((loc, content)) {
-                    let key = (
-                        loc.uri.to_string(),
-                        loc.range.start.line,
-                        loc.range.start.character,
-                    );
-                    if !seen.contains(&key) {
-                        locs.push(loc);
-                    }
-                }
-            }
-        }
-
-        locs
-    } else if let Some(dpkg) = declared_pkg {
-        // ── Top-level symbol with known declared package ──────────────────────
-        // Only search files that import `declared_pkg.Name` or `declared_pkg.*`
-        // or are in the same package. This avoids the "13000 matches for Effect"
-        // problem where every ViewModel has an inner class with the same name.
-        let safe_pkg = regex_escape(dpkg);
-        let import_pat = format!(
-            r"import[^\n]*\b{safe_pkg}\b[^\n]*\b{safe_name}\b|import[^\n]*\b{safe_pkg}\b\.\*"
-        );
-        let pkg_pat = format!(r"^\s*package\s+{safe_pkg}\s*$");
-
-        let mut candidate_files = rg_files_with_matches(&import_pat, &search_root);
-        for f in rg_files_with_matches(&pkg_pat, &search_root) {
-            if !candidate_files.contains(&f) {
-                candidate_files.push(f);
-            }
-        }
-        // Filter candidate files against ignore patterns before searching them.
-        let candidate_files = match matcher {
-            Some(m) => m.filter_file_strings(candidate_files),
-            None => candidate_files,
-        };
-
-        if candidate_files.is_empty() {
-            return vec![];
-        }
-        rg_word_in_files(&safe_name, &candidate_files)
-            .into_iter()
-            .filter_map(filter)
-            .collect()
+    let patterns = build_rg_patterns(request);
+    let result = if request.parent_class.is_some() {
+        parent_scoped_reference_locations(request, &patterns, matcher)
+    } else if request.declared_pkg.is_some() {
+        package_scoped_reference_locations(request, &patterns, matcher)
     } else {
-        // ── Fully unscoped: lowercase / unknown symbol ────────────────────────
-        let mut cmd = Command::new("rg");
-        cmd.args([
-            "--no-heading",
-            "--with-filename",
-            "--line-number",
-            "--column",
-            "--word-regexp",
-        ]);
-        for ext in SOURCE_EXTENSIONS {
-            cmd.args(["--glob", &format!("*.{ext}")]);
-        }
-        cmd.args(["-e", &safe_name]);
-        cmd.arg(search_root.as_ref());
-
-        let out = match cmd.output() {
-            Ok(o) if !o.stdout.is_empty() => o,
-            _ => return vec![],
-        };
-
-        String::from_utf8_lossy(&out.stdout)
-            .lines()
-            .filter_map(|l| parse_rg_line_with_content_rooted(l, &search_root))
-            .filter_map(filter)
-            .collect()
+        run_rg_search(request, &patterns)
     };
 
-    if let Some(m) = matcher {
-        m.filter_locs(result)
+    if let Some(matcher) = matcher {
+        matcher.filter_locs(result)
     } else {
         result
     }
@@ -581,29 +628,6 @@ pub(crate) fn regex_escape(s: &str) -> String {
                 vec!['\\', c]
             }
         })
-        .collect()
-}
-
-/// Run rg with a regex pattern; return `(Location, line_content)` pairs.
-fn rg_raw(pattern: &str, root: &Path) -> Vec<(Location, String)> {
-    let mut cmd = Command::new("rg");
-    cmd.args([
-        "--no-heading",
-        "--with-filename",
-        "--line-number",
-        "--column",
-    ]);
-    for ext in SOURCE_EXTENSIONS {
-        cmd.args(["--glob", &format!("*.{ext}")]);
-    }
-    cmd.args(["-e", pattern]).arg(root);
-    let out = match cmd.output() {
-        Ok(o) if !o.stdout.is_empty() => o,
-        _ => return vec![],
-    };
-    String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .filter_map(|l| parse_rg_line_with_content_rooted(l, root))
         .collect()
 }
 

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -497,10 +497,10 @@ fn package_scoped_reference_locations(
 /// Run `rg` to find all *usages* of `name` in the project.
 ///
 /// Uses `--word-regexp` so only whole-word matches are returned.
-/// If `include_decl` is false, declaration lines are filtered out by
-/// excluding lines that contain declaration keywords before `name`.
-/// If `from_uri` is provided, the source file is excluded when
-/// `include_decl` is false (the definition is already known).
+/// If `include_decl` is false, lines in `from_uri` that contain declaration
+/// keywords (e.g. `fun`, `val`, `class`) alongside `name` are filtered out.
+/// Other lines from `from_uri` are still included (e.g. call sites in the
+/// same file).
 ///
 /// Results in directories matched by `matcher` are filtered out.
 pub(crate) fn rg_find_references(

--- a/src/rg_tests.rs
+++ b/src/rg_tests.rs
@@ -9,7 +9,9 @@
 
 use tower_lsp::lsp_types::Url;
 
-use crate::rg::{parse_rg_line, rg_find_definition, rg_find_references, IgnoreMatcher};
+use crate::rg::{
+    parse_rg_line, rg_find_definition, rg_find_references, IgnoreMatcher, RgSearchRequest,
+};
 
 // ─── parse_rg_line ────────────────────────────────────────────────────────────
 
@@ -112,16 +114,17 @@ fn refs_inner_class_does_not_bleed_across_contracts() {
 
     // Simulate: cursor on declaration of Event inside ActivateUpdateAppContract.
     // parent_class = "ActivateUpdateAppContract", declared_pkg = "com.example.activate"
-    let locs = rg_find_references(
+    let decl_files = [activate_decl];
+    let request = RgSearchRequest::new(
         "Event",
         Some("ActivateUpdateAppContract"),
         Some("com.example.activate"), // declared_pkg
         Some(root),
         true, // include_declaration
         &activate_uri,
-        &[activate_decl],
-        None, // no ignore patterns in this test
+        &decl_files,
     );
+    let locs = rg_find_references(&request, None);
 
     let hit_files: std::collections::HashSet<String> = locs
         .iter()
@@ -210,16 +213,17 @@ fn refs_inner_class_resolved_from_import_in_reference_file() {
     let other_vm_uri = Url::from_file_path(root.join("other_vm.kt")).unwrap();
     let other_decl = root.join("other_contract.kt").to_str().unwrap().to_owned();
 
-    let locs = rg_find_references(
+    let decl_files = [other_decl];
+    let request = RgSearchRequest::new(
         "Event",
         Some("OtherContract"),
         Some("com.example.other"),
         Some(root),
         true,
         &other_vm_uri,
-        &[other_decl],
-        None,
+        &decl_files,
     );
+    let locs = rg_find_references(&request, None);
 
     let hit_files: std::collections::HashSet<String> = locs
         .iter()
@@ -313,16 +317,17 @@ fn refs_decl_files_filtered_by_enclosing_class() {
         .unwrap()
         .to_owned();
 
-    let locs = rg_find_references(
+    let decl_files = [dashboard_decl];
+    let request = RgSearchRequest::new(
         "Event",
         Some("DashboardContract"),
         Some("com.example.dashboard"),
         Some(root),
         true,
         &dashboard_uri,
-        &[dashboard_decl], // NOT including VisitBranchContract.kt
-        None,
+        &decl_files, // NOT including VisitBranchContract.kt
     );
+    let locs = rg_find_references(&request, None);
 
     let hit_files: std::collections::HashSet<String> = locs
         .iter()
@@ -424,16 +429,17 @@ fn rg_find_references_filters_ignored_dirs() {
     let decl = root.join("src/Contract.kt").to_str().unwrap().to_owned();
     let matcher = IgnoreMatcher::new(vec!["buildSrc".to_owned()], root);
 
-    let locs = rg_find_references(
+    let decl_files = [decl];
+    let request = RgSearchRequest::new(
         "Event",
         Some("Contract"),
         Some("com.example"),
         Some(root),
         true,
         &uri,
-        &[decl],
-        Some(&matcher),
+        &decl_files,
     );
+    let locs = rg_find_references(&request, Some(&matcher));
     let files: Vec<String> = locs
         .iter()
         .map(|l| l.uri.to_file_path().unwrap().to_string_lossy().into_owned())

--- a/src/stdlib.rs
+++ b/src/stdlib.rs
@@ -26,6 +26,242 @@ impl StdlibEntry {
     }
 }
 
+#[derive(Clone, Copy)]
+struct TemplateData {
+    label: &'static str,
+    description: &'static str,
+    snippet_body: &'static str,
+}
+
+const DECLARATION_TEMPLATES: &[TemplateData] = &[
+    TemplateData {
+        label: "fun",
+        description: "Function declaration",
+        snippet_body: "fun ${1:name}(${2}): ${3:Unit} {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "pfun",
+        description: "Private function declaration",
+        snippet_body: "private fun ${1:name}(${2}): ${3:Unit} {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "class",
+        description: "Class declaration",
+        snippet_body: "class ${1:Name}(${2}) {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "dclass",
+        description: "Data class declaration",
+        snippet_body: "data class ${1:Name}(
+	val ${2:field}: ${3:Type}
+)",
+    },
+    TemplateData {
+        label: "sclass",
+        description: "Sealed class declaration",
+        snippet_body: "sealed class ${1:Name} {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "object",
+        description: "Object declaration",
+        snippet_body: "object ${1:Name} {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "iface",
+        description: "Interface declaration",
+        snippet_body: "interface ${1:Name} {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "comp",
+        description: "Companion object",
+        snippet_body: "companion object {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "enum",
+        description: "Enum class",
+        snippet_body: "enum class ${1:Name} {
+	${0}
+}",
+    },
+];
+
+const PROPERTY_TEMPLATES: &[TemplateData] = &[
+    TemplateData {
+        label: "val",
+        description: "Immutable property",
+        snippet_body: "val ${1:name}: ${2:Type} = ${0}",
+    },
+    TemplateData {
+        label: "var",
+        description: "Mutable property",
+        snippet_body: "var ${1:name}: ${2:Type} = ${0}",
+    },
+    TemplateData {
+        label: "lazy",
+        description: "Lazy property",
+        snippet_body: "val ${1:name}: ${2:Type} by lazy {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "lateinit",
+        description: "Late-init property",
+        snippet_body: "lateinit var ${1:name}: ${2:Type}",
+    },
+];
+
+const CONTROL_FLOW_TEMPLATES: &[TemplateData] = &[
+    TemplateData {
+        label: "if",
+        description: "If expression",
+        snippet_body: "if (${1:condition}) {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "ife",
+        description: "If-else expression",
+        snippet_body: "if (${1:condition}) {
+	${2}
+} else {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "when",
+        description: "When expression",
+        snippet_body: "when (${1:value}) {
+	${2} -> ${3}
+	else -> ${0}
+}",
+    },
+    TemplateData {
+        label: "for",
+        description: "For loop",
+        snippet_body: "for (${1:item} in ${2:collection}) {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "fori",
+        description: "For loop with index",
+        snippet_body: "for ((${1:index}, ${2:item}) in ${3:collection}.withIndex()) {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "while",
+        description: "While loop",
+        snippet_body: "while (${1:condition}) {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "try",
+        description: "Try-catch",
+        snippet_body: "try {
+	${1}
+} catch (${2:e}: ${3:Exception}) {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "trycf",
+        description: "Try-catch-finally",
+        snippet_body: "try {
+	${1}
+} catch (${2:e}: ${3:Exception}) {
+	${4}
+} finally {
+	${0}
+}",
+    },
+];
+
+const FUNCTION_TEMPLATES: &[TemplateData] = &[
+    TemplateData {
+        label: "lam",
+        description: "Lambda expression",
+        snippet_body: "{ ${1:it} ->
+	${0}
+}",
+    },
+    TemplateData {
+        label: "main",
+        description: "Main function",
+        snippet_body: "fun main(args: Array<String>) {
+	${0}
+}",
+    },
+];
+
+const COROUTINE_TEMPLATES: &[TemplateData] = &[
+    TemplateData {
+        label: "launch",
+        description: "Coroutine launch",
+        snippet_body: "viewModelScope.launch {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "async",
+        description: "Coroutine async",
+        snippet_body: "viewModelScope.async {
+	${0}
+}",
+    },
+    TemplateData {
+        label: "flow",
+        description: "Flow builder",
+        snippet_body: "flow {
+	emit(${1})
+	${0}
+}",
+    },
+];
+
+const COMMON_TEMPLATES: &[TemplateData] = &[
+    TemplateData {
+        label: "logd",
+        description: "Log.d",
+        snippet_body: r#"Log.d(TAG, "${0}")"#,
+    },
+    TemplateData {
+        label: "loge",
+        description: "Log.e",
+        snippet_body: r#"Log.e(TAG, "${1}", ${0})"#,
+    },
+    TemplateData {
+        label: "tag",
+        description: "TAG constant",
+        snippet_body: r#"private const val TAG = "${1:${TM_FILENAME_BASE}}""#,
+    },
+    TemplateData {
+        label: "todo",
+        description: "TODO stub",
+        snippet_body: r#"TODO("${0:Not yet implemented}")"#,
+    },
+    TemplateData {
+        label: "sout",
+        description: "println",
+        snippet_body: r#"println("${0}")"#,
+    },
+];
+
 // ─── scope / control-flow functions (available on every type) ─────────────────
 
 pub(crate) static SCOPE_FUNS: &[StdlibEntry] = &[
@@ -412,154 +648,51 @@ pub(crate) fn bare_completions(snippets: bool) -> Vec<tower_lsp::lsp_types::Comp
 /// Modelled on IntelliJ's built-in Kotlin live templates.
 /// Each item has a short trigger label and expands to a multi-line snippet.
 pub(crate) fn live_templates() -> Vec<tower_lsp::lsp_types::CompletionItem> {
+    live_template_groups()
+        .into_iter()
+        .flatten()
+        .map(build_live_template_completion)
+        .collect()
+}
+
+fn live_template_groups() -> [&'static [TemplateData]; 6] {
+    [
+        DECLARATION_TEMPLATES,
+        PROPERTY_TEMPLATES,
+        CONTROL_FLOW_TEMPLATES,
+        FUNCTION_TEMPLATES,
+        COROUTINE_TEMPLATES,
+        COMMON_TEMPLATES,
+    ]
+}
+
+fn build_live_template_completion(template: &TemplateData) -> tower_lsp::lsp_types::CompletionItem {
     use tower_lsp::lsp_types::{
         CompletionItem, CompletionItemKind, Documentation, InsertTextFormat, MarkupContent,
         MarkupKind,
     };
 
-    // (label, description, snippet_body)
-    let templates: &[(&str, &str, &str)] = &[
-        // ── declarations ────────────────────────────────────────────────────
-        (
-            "fun",
-            "Function declaration",
-            "fun ${1:name}(${2}): ${3:Unit} {\n\t${0}\n}",
-        ),
-        (
-            "pfun",
-            "Private function declaration",
-            "private fun ${1:name}(${2}): ${3:Unit} {\n\t${0}\n}",
-        ),
-        (
-            "class",
-            "Class declaration",
-            "class ${1:Name}(${2}) {\n\t${0}\n}",
-        ),
-        (
-            "dclass",
-            "Data class declaration",
-            "data class ${1:Name}(\n\tval ${2:field}: ${3:Type}\n)",
-        ),
-        (
-            "sclass",
-            "Sealed class declaration",
-            "sealed class ${1:Name} {\n\t${0}\n}",
-        ),
-        (
-            "object",
-            "Object declaration",
-            "object ${1:Name} {\n\t${0}\n}",
-        ),
-        (
-            "iface",
-            "Interface declaration",
-            "interface ${1:Name} {\n\t${0}\n}",
-        ),
-        ("comp", "Companion object", "companion object {\n\t${0}\n}"),
-        ("enum", "Enum class", "enum class ${1:Name} {\n\t${0}\n}"),
-        // ── properties ──────────────────────────────────────────────────────
-        (
-            "val",
-            "Immutable property",
-            "val ${1:name}: ${2:Type} = ${0}",
-        ),
-        ("var", "Mutable property", "var ${1:name}: ${2:Type} = ${0}"),
-        (
-            "lazy",
-            "Lazy property",
-            "val ${1:name}: ${2:Type} by lazy {\n\t${0}\n}",
-        ),
-        (
-            "lateinit",
-            "Late-init property",
-            "lateinit var ${1:name}: ${2:Type}",
-        ),
-        // ── control flow ────────────────────────────────────────────────────
-        ("if", "If expression", "if (${1:condition}) {\n\t${0}\n}"),
-        (
-            "ife",
-            "If-else expression",
-            "if (${1:condition}) {\n\t${2}\n} else {\n\t${0}\n}",
-        ),
-        (
-            "when",
-            "When expression",
-            "when (${1:value}) {\n\t${2} -> ${3}\n\telse -> ${0}\n}",
-        ),
-        (
-            "for",
-            "For loop",
-            "for (${1:item} in ${2:collection}) {\n\t${0}\n}",
-        ),
-        (
-            "fori",
-            "For loop with index",
-            "for ((${1:index}, ${2:item}) in ${3:collection}.withIndex()) {\n\t${0}\n}",
-        ),
-        ("while", "While loop", "while (${1:condition}) {\n\t${0}\n}"),
-        (
-            "try",
-            "Try-catch",
-            "try {\n\t${1}\n} catch (${2:e}: ${3:Exception}) {\n\t${0}\n}",
-        ),
-        (
-            "trycf",
-            "Try-catch-finally",
-            "try {\n\t${1}\n} catch (${2:e}: ${3:Exception}) {\n\t${4}\n} finally {\n\t${0}\n}",
-        ),
-        // ── lambdas / higher-order ───────────────────────────────────────────
-        ("lam", "Lambda expression", "{ ${1:it} ->\n\t${0}\n}"),
-        (
-            "main",
-            "Main function",
-            "fun main(args: Array<String>) {\n\t${0}\n}",
-        ),
-        // ── coroutines ───────────────────────────────────────────────────────
-        (
-            "launch",
-            "Coroutine launch",
-            "viewModelScope.launch {\n\t${0}\n}",
-        ),
-        (
-            "async",
-            "Coroutine async",
-            "viewModelScope.async {\n\t${0}\n}",
-        ),
-        ("flow", "Flow builder", "flow {\n\temit(${1})\n\t${0}\n}"),
-        // ── Android / common ─────────────────────────────────────────────────
-        ("logd", "Log.d", "Log.d(TAG, \"${0}\")"),
-        ("loge", "Log.e", "Log.e(TAG, \"${1}\", ${0})"),
-        (
-            "tag",
-            "TAG constant",
-            "private const val TAG = \"${1:${TM_FILENAME_BASE}}\"",
-        ),
-        ("todo", "TODO stub", "TODO(\"${0:Not yet implemented}\")"),
-        ("sout", "println", "println(\"${0}\")"),
-    ];
-
-    templates
-        .iter()
-        .map(|(label, desc, body)| {
-            CompletionItem {
-                label: label.to_string(),
-                kind: Some(CompletionItemKind::SNIPPET),
-                detail: Some(desc.to_string()),
-                documentation: Some(Documentation::MarkupContent(MarkupContent {
-                    kind: MarkupKind::Markdown,
-                    value: format!(
-                        "```kotlin\n{}\n```",
-                        body.replace("${0}", "").replace(['$', '{', '}'], "")
-                    ),
-                })),
-                insert_text: Some(body.to_string()),
-                insert_text_format: Some(InsertTextFormat::SNIPPET),
-                // Templates sort just before stdlib (prefix "y:") but after project symbols.
-                sort_text: Some(format!("y:{label}")),
-                ..Default::default()
-            }
-        })
-        .collect()
+    CompletionItem {
+        label: template.label.to_string(),
+        kind: Some(CompletionItemKind::SNIPPET),
+        detail: Some(template.description.to_string()),
+        documentation: Some(Documentation::MarkupContent(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: format!(
+                "```kotlin
+{}
+```",
+                template
+                    .snippet_body
+                    .replace("${0}", "")
+                    .replace(['$', '{', '}'], "")
+            ),
+        })),
+        insert_text: Some(template.snippet_body.to_string()),
+        insert_text_format: Some(InsertTextFormat::SNIPPET),
+        sort_text: Some(format!("y:{}", template.label)),
+        ..Default::default()
+    }
 }
 
 fn make_item_ex(


### PR DESCRIPTION
## Summary

Splits every function that exceeded the 100-line or cognitive-complexity-25 thresholds. Identified by `cargo clippy -W clippy::too_many_lines -W clippy::cognitive_complexity`. No functional behaviour changes — pure structural refactoring.

## Motivation

Pre-commit checklist (added in #53) requires:
- Functions > 100 lines must be split into named helpers
- Section comments signal a split point
- Max 3 nesting levels
- Long argument lists → named request struct

## Changes

| File | Function | Lines before | Key extractions |
|------|----------|-------------|-----------------|
| `src/backend/mod.rs` | `initialize` + `did_open` | 342 combined | `detect_snippet_support`, `resolve_workspace_root`, `workspace_root_from_*`, `spawn_open_document_indexing`, + 13 more |
| `src/backend/rename.rs` | `rename_impl` | 130 | `RenameCursorSymbol` struct, `resolve_cursor_symbol`, `collect_reference_locations`, `build_workspace_edit` |
| `src/indexer/infer/args.rs` | `find_as_call_arg_type` | 102 | `CallContext` struct, `find_call_context`, `extract_called_function_name`, `normalize_parameter_base_type` |
| `src/resolver/complete.rs` | `complete_bare` | 151 (complexity 32) | `BareCompletionWalk` + `CurrentFileCompletionContext` structs/methods |
| `src/rg.rs` | `rg_find_references` | 138 | `RgSearchRequest` struct (removes `allow(too_many_arguments)`), `build_rg_patterns`, `build_rg_command`, `parse_rg_output` |
| `src/indexer/doc.rs` | `format_doc_tags` | 107 | `ParsedDocTags` struct, `format_param_tag`, `format_return_tag`, `format_throws_tag` |
| `src/stdlib.rs` | `live_templates` | 138 | `TemplateData` struct, `live_template_groups`, `build_live_template_completion` |

## Validation

- `cargo test`: **678 tests pass** (up from 676 — 2 new tests added during refactor)
- `cargo clippy -W clippy::too_many_lines -W clippy::cognitive_complexity`: **0 warnings** on all refactored files