### PR TITLE
refactor(infer): replace manual text parsing with CST node walks

### DIFF
--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -217,6 +217,9 @@ impl crate::indexer::infer::InferDeps for Indexer {
     fn find_fun_return_type(&self, fn_name: &str) -> Option<String> {
         crate::resolver::infer::find_fun_return_type_by_name(self, fn_name)
     }
+    fn live_doc(&self, uri: &Url) -> Option<Arc<LiveDoc>> {
+        self.live_doc(uri)
+    }
 }
 
 impl Indexer {
@@ -372,7 +375,16 @@ impl Indexer {
             }
             None
         } else {
-            find_named_lambda_param_type(before, recv, self, uri, cursor_line)
+            find_named_lambda_param_type(
+                before,
+                recv,
+                self,
+                uri,
+                CursorPos {
+                    line: cursor_line,
+                    utf16_col: cursor_col,
+                },
+            )
         }
     }
 
@@ -465,7 +477,7 @@ impl Indexer {
                         Some(&elem_type),
                         uri,
                         snippets,
-                        Some(position.line as u32),
+                        Some(position.line),
                     );
                     if items.is_empty() {
                         // Type name known (e.g. generic param `T`, `StateType`) but not
@@ -496,7 +508,7 @@ impl Indexer {
             uri,
             snippets,
             annotation_only,
-            Some(position.line as u32),
+            Some(position.line),
         );
 
         // Add scope-aware lambda parameter names (bare-word completion only).

--- a/src/indexer/infer/deps.rs
+++ b/src/indexer/infer/deps.rs
@@ -7,10 +7,10 @@
 //! - looking up a function's parameter signature
 //! - inferring a variable's declared type
 //!
-//! The trait intentionally excludes `mem_lines_for` and `live_doc`: those are
-//! needed by the higher-level orchestrators (`find_it_element_type_in_lines_impl`
-//! etc.) which already take `&Indexer`.  Move them into the trait only if those
-//! orchestrators are later pushed behind the seam.
+//! The trait intentionally excludes `mem_lines_for`; higher-level orchestrators
+//! already take the caller-provided lines directly. `live_doc` is included only as
+//! an optional CST hook for orchestration helpers; pure leaf helpers should keep
+//! working against the narrower lookup methods below.
 //!
 //! ## `fun_params_text` is not cheap
 //!
@@ -18,7 +18,11 @@
 //! `find_fun_signature_full`, which may perform on-demand rg indexing.
 //! Callers should not assume this is a pure in-memory lookup.
 
+use std::sync::Arc;
+
 use tower_lsp::lsp_types::Url;
+
+use crate::indexer::LiveDoc;
 
 /// Minimum dependency surface for pure lambda/type inference leaf functions.
 ///
@@ -60,6 +64,13 @@ pub(crate) trait InferDeps {
     fn find_field_type(&self, _class_name: &str, _field_name: &str) -> Option<String> {
         None
     }
+
+    /// Return the live CST document for `uri` when the file is currently open.
+    /// Higher-level orchestration helpers may use this to walk the tree and then
+    /// feed extracted context into the pure string helpers.
+    fn live_doc(&self, _uri: &Url) -> Option<Arc<LiveDoc>> {
+        None
+    }
 }
 
 // ─── Test stub ───────────────────────────────────────────────────────────────
@@ -82,7 +93,7 @@ pub(crate) struct TestDeps {
 
 #[cfg(test)]
 impl TestDeps {
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         TestDeps {
             fun_sigs: std::collections::HashMap::new(),
             var_types: std::collections::HashMap::new(),
@@ -92,21 +103,21 @@ impl TestDeps {
     }
 
     /// Register `fn_name` → `params_text` for `uri`.
-    pub fn with_fun(mut self, uri: &str, fn_name: &str, params: &str) -> Self {
+    pub(crate) fn with_fun(mut self, uri: &str, fn_name: &str, params: &str) -> Self {
         self.fun_sigs
             .insert((uri.to_string(), fn_name.to_string()), params.to_string());
         self
     }
 
     /// Register `var_name` → `type_name` for `uri`.
-    pub fn with_var(mut self, uri: &str, var_name: &str, ty: &str) -> Self {
+    pub(crate) fn with_var(mut self, uri: &str, var_name: &str, ty: &str) -> Self {
         self.var_types
             .insert((uri.to_string(), var_name.to_string()), ty.to_string());
         self
     }
 
     /// Register `field_name` in `class_name` → raw type (with generics).
-    pub fn with_field(mut self, class_name: &str, field_name: &str, ty: &str) -> Self {
+    pub(crate) fn with_field(mut self, class_name: &str, field_name: &str, ty: &str) -> Self {
         self.field_types.insert(
             (class_name.to_string(), field_name.to_string()),
             ty.to_string(),
@@ -115,7 +126,7 @@ impl TestDeps {
     }
 
     /// Register `fn_name` → raw return type (with generics), for method-chain tests.
-    pub fn with_return(mut self, fn_name: &str, ty: &str) -> Self {
+    pub(crate) fn with_return(mut self, fn_name: &str, ty: &str) -> Self {
         self.return_types
             .insert(fn_name.to_string(), ty.to_string());
         self

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -409,11 +409,8 @@ fn cursor_node_at(
 
     let source = std::str::from_utf8(&doc.bytes).ok()?;
     let line_text = source.lines().nth(pos.line).unwrap_or("");
-    let byte_col = if pos.utf16_col == 0 {
-        line_text.len()
-    } else {
-        crate::indexer::live_tree::utf16_col_to_byte(line_text, pos.utf16_col).min(line_text.len())
-    };
+    let byte_col =
+        crate::indexer::live_tree::utf16_col_to_byte(line_text, pos.utf16_col).min(line_text.len());
     let point = Point {
         row: pos.line,
         column: byte_col,

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -37,7 +37,7 @@ use super::{
 };
 
 use crate::indexer::NodeExt;
-use crate::queries::{KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_LAMBDA_LIT};
+use crate::queries::{KIND_CALL_SUFFIX, KIND_LAMBDA_LIT, KIND_VALUE_ARG};
 use crate::resolver::extract_collection_element_type;
 use crate::StrExt;
 
@@ -130,6 +130,16 @@ pub(crate) fn find_named_lambda_param_type_in_lines(
     idx: &Indexer,
     uri: &Url,
 ) -> Option<String> {
+    let pos = CursorPos {
+        line: cursor_line,
+        utf16_col: 0,
+    };
+    if let Some(doc) = idx.live_doc(uri) {
+        if let Some(result) = cst_named_lambda_param_type(pos, param_name, &doc, idx, uri) {
+            return Some(result);
+        }
+    }
+
     let scan_start = cursor_line.saturating_sub(LAMBDA_PARAM_SCAN_BACK_LINES);
     // Include cursor_line itself (different from completion path which is exclusive).
     for ln in (scan_start..=cursor_line).rev() {
@@ -164,17 +174,23 @@ pub(crate) fn find_named_lambda_param_type(
     param_name: &str,
     idx: &Indexer,
     uri: &Url,
-    cursor_line: usize,
+    pos: CursorPos,
 ) -> Option<String> {
+    if let Some(doc) = idx.live_doc(uri) {
+        if let Some(result) = cst_named_lambda_param_type(pos, param_name, &doc, idx, uri) {
+            return Some(result);
+        }
+    }
+
     let lines = idx.mem_lines_for(uri.as_str());
 
     // 1. Check same line first — covers `items.forEach { item -> item.`
     //    Also handles multi-param: `items.map { a, b -> a.`
-    if let Some((brace_pos, pos)) = find_lambda_brace_for_param(before_cursor, param_name) {
+    if let Some((brace_pos, param_pos)) = find_lambda_brace_for_param(before_cursor, param_name) {
         let before_brace = &before_cursor[..brace_pos];
         let result = lambda_receiver_type_from_context(before_brace, idx, uri).or_else(|| {
             lines.as_deref().and_then(|ls| {
-                lambda_receiver_type_named_arg_ml(before_brace, pos, ls, cursor_line, idx, uri)
+                lambda_receiver_type_named_arg_ml(before_brace, param_pos, ls, pos.line, idx, uri)
             })
         });
         if result.is_some() {
@@ -184,18 +200,19 @@ pub(crate) fn find_named_lambda_param_type(
 
     // 2. Scan backward through previous lines.
     let lines = lines?;
-    let scan_start = cursor_line.saturating_sub(LAMBDA_PARAM_SCAN_BACK);
-    for ln in (scan_start..cursor_line).rev() {
+    let scan_start = pos.line.saturating_sub(LAMBDA_PARAM_SCAN_BACK);
+    for ln in (scan_start..pos.line).rev() {
         let line = match lines.get(ln) {
             Some(l) => l,
             None => continue,
         };
-        let Some((brace_pos, pos)) = find_lambda_brace_for_param(line, param_name) else {
+        let Some((brace_pos, param_pos)) = find_lambda_brace_for_param(line, param_name) else {
             continue;
         };
         let before_brace = &line[..brace_pos];
-        let result = lambda_receiver_type_from_context(before_brace, idx, uri)
-            .or_else(|| lambda_receiver_type_named_arg_ml(before_brace, pos, &lines, ln, idx, uri));
+        let result = lambda_receiver_type_from_context(before_brace, idx, uri).or_else(|| {
+            lambda_receiver_type_named_arg_ml(before_brace, param_pos, &lines, ln, idx, uri)
+        });
         if result.is_some() {
             return result;
         }
@@ -384,6 +401,84 @@ pub(crate) fn lambda_receiver_type_from_context(
 
 // ─── private helpers ─────────────────────────────────────────────────────────
 
+fn cursor_node_at(
+    doc: &crate::indexer::live_tree::LiveDoc,
+    pos: CursorPos,
+) -> Option<tree_sitter::Node<'_>> {
+    use tree_sitter::Point;
+
+    let source = std::str::from_utf8(&doc.bytes).ok()?;
+    let line_text = source.lines().nth(pos.line).unwrap_or("");
+    let byte_col = if pos.utf16_col == 0 {
+        line_text.len()
+    } else {
+        crate::indexer::live_tree::utf16_col_to_byte(line_text, pos.utf16_col).min(line_text.len())
+    };
+    let point = Point {
+        row: pos.line,
+        column: byte_col,
+    };
+    doc.tree.root_node().descendant_for_point_range(point, point)
+}
+
+fn lambda_before_brace_context(
+    lambda: tree_sitter::Node<'_>,
+    doc: &crate::indexer::live_tree::LiveDoc,
+) -> Option<(String, usize)> {
+    let brace_byte = lambda.start_byte();
+    let line_start = doc.bytes[..brace_byte]
+        .iter()
+        .rposition(|&b| b == b'\n')
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    let before_brace = std::str::from_utf8(&doc.bytes[line_start..brace_byte])
+        .ok()?
+        .trim_end()
+        .to_owned();
+    Some((before_brace, lambda.start_position().row))
+}
+
+fn cst_named_lambda_param_type(
+    pos: CursorPos,
+    param_name: &str,
+    doc: &crate::indexer::live_tree::LiveDoc,
+    idx: &Indexer,
+    uri: &Url,
+) -> Option<String> {
+    let mut cur = cursor_node_at(doc, pos)?;
+    while let Some(lambda) = cur.enclosing_lambda_literal() {
+        if let Some(param_pos) = lambda.lambda_param_position(param_name, &doc.bytes) {
+            return cst_lambda_param_type_via_call(doc, &lambda, idx, uri, param_pos);
+        }
+        let Some(parent) = lambda.parent() else {
+            break;
+        };
+        cur = parent;
+    }
+    None
+}
+
+fn cst_with_receiver_ctx(
+    call_expr: tree_sitter::Node<'_>,
+    bytes: &[u8],
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Option<ThisLambdaCtx> {
+    let recv_name = call_expr.first_value_argument_text(bytes)?;
+    if let Some(raw) = deps.find_var_type(&recv_name, uri) {
+        let base = raw.ident_prefix();
+        if !base.is_empty() {
+            return Some(ThisLambdaCtx::Resolved(base));
+        }
+    }
+    let base = recv_name.ident_prefix();
+    if base.starts_with_uppercase() {
+        Some(ThisLambdaCtx::Resolved(base))
+    } else {
+        Some(ThisLambdaCtx::Receiver)
+    }
+}
+
 /// Walk ancestors from `start_node` looking for a `lambda_literal` without
 /// named params, then infer the `it`/`this` type for that lambda.
 ///
@@ -400,20 +495,22 @@ fn cst_it_or_this_type(
     let mut cur = start_node;
     loop {
         if cur.kind() == KIND_LAMBDA_LIT && !cur.has_lambda_named_params(&doc.bytes) {
-            // Extract text of the lambda-opening line up to the `{`.
-            let brace_byte = cur.start_byte();
-            let line_start = doc.bytes[..brace_byte]
-                .iter()
-                .rposition(|&b| b == b'\n')
-                .map(|i| i + 1)
-                .unwrap_or(0);
-            let before_brace = std::str::from_utf8(&doc.bytes[line_start..brace_byte])
-                .unwrap_or("")
-                .trim_end();
-            let ln = cur.start_position().row;
+            let Some((before_brace, ln)) = lambda_before_brace_context(cur, doc) else {
+                let p = cur.parent()?;
+                cur = p;
+                continue;
+            };
 
             if kind == LambdaParamKind::This {
-                match classify_this_lambda_context(before_brace, idx, uri) {
+                let ctx = cur
+                    .enclosing_call_expression()
+                    .and_then(|call_expr| {
+                        (call_expr.call_fn_name(&doc.bytes).as_deref() == Some("with"))
+                            .then(|| cst_with_receiver_ctx(call_expr, &doc.bytes, idx, uri))
+                            .flatten()
+                    })
+                    .unwrap_or_else(|| classify_this_lambda_context(&before_brace, idx, uri));
+                match ctx {
                     ThisLambdaCtx::Resolved(t) => return Some(t),
                     // Receiver-lambda context but type not found: stop walking up.
                     // `this` here is the receiver, not an outer lambda's receiver.
@@ -427,11 +524,11 @@ fn cst_it_or_this_type(
                 // the enclosing function call and the lambda's argument
                 // position. Handles multi-line cases where the call site
                 // is on a different line than the lambda `{`.
-                let result = lambda_receiver_type_from_context(before_brace, idx, uri)
+                let result = lambda_receiver_type_from_context(&before_brace, idx, uri)
                     .or_else(|| {
-                        lambda_receiver_type_named_arg_ml(before_brace, 0, lines, ln, idx, uri)
+                        lambda_receiver_type_named_arg_ml(&before_brace, 0, lines, ln, idx, uri)
                     })
-                    .or_else(|| cst_lambda_param_type_via_call(doc, &cur, idx, uri));
+                    .or_else(|| cst_lambda_param_type_via_call(doc, &cur, idx, uri, 0));
                 if result.is_some() {
                     return result;
                 }
@@ -449,33 +546,14 @@ fn find_it_element_type_in_lines_impl(
     uri: &Url,
     kind: LambdaParamKind,
 ) -> Option<String> {
-    // ── CST fast path ────────────────────────────────────────────────────────
     if let Some(doc) = idx.live_doc(uri) {
-        use tree_sitter::Point;
-        let line_text = lines.get(pos.line).map(|s| s.as_str()).unwrap_or("");
-        let byte_col = crate::indexer::live_tree::utf16_col_to_byte(line_text, pos.utf16_col);
-        let point = Point {
-            row: pos.line,
-            column: byte_col,
-        };
-        if let Some(node) = doc
-            .tree
-            .root_node()
-            .descendant_for_point_range(point, point)
-        {
+        if let Some(node) = cursor_node_at(&doc, pos) {
             return cst_it_or_this_type(node, &doc, lines, kind, idx, uri);
         }
-        // Node not found for this position — fall through to text scan.
     }
 
-    // ── Text fallback ────────────────────────────────────────────────────────
-    // Scan right-to-left tracking brace depth.
-    // Convention: depth starts at 0. `}` increments, `{` decrements.
-    // When depth goes < 0, we've found the `{` that opens our enclosing lambda.
-    //
-    // IMPORTANT: On cursor_line, only scan characters *before* cursor_col.
-    // Characters to the right of the cursor (e.g., closing `}`) must not affect
-    // the depth; otherwise a balanced `{ it.name }` would never trigger depth < 0.
+    // Keep the text fallback for callers that provide indexed lines without a
+    // live CST document (tests, disk-backed hover/inlay-hint paths).
     let mut depth: i32 = 0;
     let scan_start = pos.line.saturating_sub(IT_SCAN_BACK_LINES);
 
@@ -484,9 +562,7 @@ fn find_it_element_type_in_lines_impl(
             Some(l) => l,
             None => continue,
         };
-        // On cursor_line restrict to chars at byte positions < cursor_col.
         let scan_slice: &str = if ln == pos.line {
-            // pos.utf16_col is a UTF-16 character offset (from LSP); convert to a byte boundary.
             let byte_end = crate::indexer::live_tree::utf16_col_to_byte(line, pos.utf16_col);
             &line[..byte_end]
         } else {
@@ -500,35 +576,21 @@ fn find_it_element_type_in_lines_impl(
                     depth -= 1;
                     if depth < 0 {
                         let before_brace = &scan_slice[..bi];
-                        // Skip string interpolation `${`.
                         if before_brace.ends_with('$') {
                             depth = 0;
                             continue;
                         }
-                        // Skip named-param lambdas `{ name -> }` or `{ a, b -> }` — that's not `it`.
-                        // Use depth-aware `->` detection to handle multi-param lambdas where
-                        // `rest` starts with `,` not `->` (e.g. `{ loanId, isWustenrot ->`).
                         let after_brace = scan_slice[bi + 1..].trim_start();
                         if has_named_params_not_it(after_brace) {
                             depth = 0;
                             continue;
                         }
                         if kind == LambdaParamKind::This {
-                            // `this` only gets a hint from receiver lambdas (`T.() -> R`).
                             return lambda_receiver_this_type_from_context(before_brace, idx, uri);
                         }
-                        let result = lambda_receiver_type_from_context(before_brace, idx, uri)
-                            .or_else(|| {
-                                lambda_receiver_type_named_arg_ml(
-                                    before_brace,
-                                    0,
-                                    lines,
-                                    ln,
-                                    idx,
-                                    uri,
-                                )
-                            });
-                        return result;
+                        return lambda_receiver_type_from_context(before_brace, idx, uri).or_else(
+                            || lambda_receiver_type_named_arg_ml(before_brace, 0, lines, ln, idx, uri),
+                        );
                     }
                 }
                 _ => {}
@@ -733,6 +795,27 @@ pub(crate) fn is_inside_receiver_lambda(
     deps: &impl InferDeps,
     uri: &Url,
 ) -> bool {
+    if let Some(doc) = deps.live_doc(uri) {
+        if let Some(mut cur) = cursor_node_at(&doc, pos) {
+            while let Some(lambda) = cur.enclosing_lambda_literal() {
+                if !lambda.has_lambda_named_params(&doc.bytes) {
+                    if let Some((before_brace, _)) = lambda_before_brace_context(lambda, &doc) {
+                        if !matches!(
+                            classify_this_lambda_context(&before_brace, deps, uri),
+                            ThisLambdaCtx::NotReceiver
+                        ) {
+                            return true;
+                        }
+                    }
+                }
+                let Some(parent) = lambda.parent() else {
+                    break;
+                };
+                cur = parent;
+            }
+        }
+    }
+
     let mut depth: i32 = 0;
     let scan_start = pos.line.saturating_sub(IT_SCAN_BACK_LINES);
 
@@ -850,15 +933,21 @@ fn lambda_receiver_type_named_arg_ml(
     lambda_type_nth_input(&param_type, lambda_param_pos)
 }
 
-/// CST structural fallback for `it` type: given a `lambda_literal` node, walk
-/// up the call tree to find the enclosing function call and the lambda's
-/// positional or named argument index, then return the first input type of
-/// that parameter.
-///
-/// This handles multi-line cases where the function call is on a different line
-/// than the lambda opening `{`, so the text-based `before_brace` approach cannot
-/// reach the function name.
+/// CST structural fallback for lambda params: given a `lambda_literal` node,
+/// walk up the call tree to find the enclosing function call and the lambda's
+/// parameter type, then pick the requested lambda input position.
 fn cst_lambda_param_type_via_call(
+    doc: &crate::indexer::live_tree::LiveDoc,
+    lambda: &tree_sitter::Node<'_>,
+    deps: &impl InferDeps,
+    uri: &Url,
+    param_pos: usize,
+) -> Option<String> {
+    let param_type = cst_lambda_call_param_type(doc, lambda, deps, uri)?;
+    lambda_type_nth_input(&param_type, param_pos)
+}
+
+fn cst_lambda_call_param_type(
     doc: &crate::indexer::live_tree::LiveDoc,
     lambda: &tree_sitter::Node<'_>,
     deps: &impl InferDeps,
@@ -866,46 +955,31 @@ fn cst_lambda_param_type_via_call(
 ) -> Option<String> {
     let bytes = &doc.bytes;
     let mut cur = *lambda;
+
     loop {
         let parent = cur.parent()?;
-        match parent.kind() {
-            "value_argument" => {
-                // Lambda is a parenthesised argument.
-                let mut node = parent;
-                let call_expr = loop {
-                    let p = node.parent()?;
-                    if p.kind() == KIND_CALL_EXPR {
-                        break p;
-                    }
-                    node = p;
-                };
-                let fn_name = call_expr.call_fn_name(bytes)?;
-                let sig = deps.find_fun_params_text(&fn_name, uri)?;
-                let param_type = if let Some(label) = parent.named_arg_label(bytes) {
-                    find_named_param_type_in_sig(&sig, &label)
-                } else {
-                    nth_fun_param_type_str(&sig, parent.value_arg_position())
-                }?;
-                return lambda_type_first_input(&param_type);
-            }
-            k if k == KIND_CALL_SUFFIX => {
-                // Trailing lambda: `fn(...) { it }` or `fn { it }`.
-                let call_expr = parent.parent()?;
-                if call_expr.kind() != KIND_CALL_EXPR {
-                    cur = parent;
-                    continue;
-                }
-                let fn_name = call_expr.call_fn_name(bytes)?;
-                let sig = deps.find_fun_params_text(&fn_name, uri)?;
-                let last_type = last_fun_param_type_str(&sig)?;
-                return lambda_type_first_input(&last_type);
-            }
-            // Stop at an enclosing lambda — its iteration in the outer loop will handle it.
-            "lambda_literal" => return None,
-            _ => {
-                cur = parent;
-            }
+        let kind = parent.kind();
+        if kind == KIND_VALUE_ARG {
+            let call_expr = parent.enclosing_call_expression()?;
+            let fn_name = call_expr.call_fn_name(bytes)?;
+            let sig = deps.find_fun_params_text(&fn_name, uri)?;
+            return if let Some(label) = parent.named_arg_label(bytes) {
+                find_named_param_type_in_sig(&sig, &label)
+            } else {
+                nth_fun_param_type_str(&sig, parent.value_arg_position())
+            };
         }
+        if kind == KIND_CALL_SUFFIX {
+            let call_expr = lambda.enclosing_call_expression()?;
+            let fn_name = call_expr.call_fn_name(bytes)?;
+            let sig = deps.find_fun_params_text(&fn_name, uri)?;
+            let last_type = last_fun_param_type_str(&sig)?;
+            return Some(last_type.to_owned());
+        }
+        if kind == KIND_LAMBDA_LIT {
+            return None;
+        }
+        cur = parent;
     }
 }
 

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -210,6 +210,34 @@ fn this_type_with_block() {
     );
 }
 
+#[test]
+fn named_lambda_param_type_cst_fast_path() {
+    let sig_src = "fun consume(block: (User) -> Unit) {}";
+    let code_src = "consume { user ->\n    user.name\n}";
+    let (u, idx, _lines) = indexed_with_live("/t.kt", sig_src, code_src);
+    let before = "    user.";
+    let result = find_named_lambda_param_type(
+        before,
+        "user",
+        &idx,
+        &u,
+        CursorPos {
+            line: 1,
+            utf16_col: before.encode_utf16().count(),
+        },
+    );
+    assert_eq!(result.as_deref(), Some("User"));
+}
+
+#[test]
+fn named_lambda_param_type_in_lines_cst_uses_param_position() {
+    let sig_src = "fun zipUsers(block: (LeftUser, RightUser) -> Unit) {}";
+    let code_src = "zipUsers { left, right ->\n    right.name\n}";
+    let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
+    let result = find_named_lambda_param_type_in_lines(&lines, "right", 1, &idx, &u);
+    assert_eq!(result.as_deref(), Some("RightUser"));
+}
+
 // ── line_has_lambda_param ────────────────────────────────────────────────────
 
 #[test]
@@ -859,4 +887,15 @@ fn is_inside_receiver_lambda_foreach_is_false() {
         !result,
         "cursor inside forEach{{}} should NOT be inside receiver lambda"
     );
+}
+
+#[test]
+fn is_inside_receiver_lambda_apply_live_tree() {
+    let src = "val user: User = User()\nuser.apply {\n    this\n}";
+    let (u, idx, lines) = indexed_with_live("/t.kt", src, src);
+    let pos = crate::types::CursorPos {
+        line: 2,
+        utf16_col: 8,
+    };
+    assert!(super::is_inside_receiver_lambda(&lines, pos, &idx, &u));
 }

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -3,10 +3,10 @@
 //! These methods are lightweight convenience wrappers around tree-sitter node
 //! traversal; their bodies were extracted from the free functions they replace.
 use crate::queries::{
-    KIND_CALL_SUFFIX, KIND_IDENTIFIER, KIND_LAMBDA_PARAMS, KIND_NAV_EXPR, KIND_NAV_SUFFIX,
-    KIND_SCOPED_TYPE_IDENT, KIND_SIMPLE_IDENT, KIND_TYPE_ARGS, KIND_TYPE_IDENT, KIND_TYPE_LIST,
-    KIND_TYPE_PARAM, KIND_TYPE_PARAMS, KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VALUE_ARGS,
-    KIND_VAR_DECL,
+    KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_IDENTIFIER, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS,
+    KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_SCOPED_TYPE_IDENT, KIND_SIMPLE_IDENT, KIND_SOURCE_FILE,
+    KIND_TYPE_ARGS, KIND_TYPE_IDENT, KIND_TYPE_LIST, KIND_TYPE_PARAM, KIND_TYPE_PARAMS,
+    KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VALUE_ARGS, KIND_VAR_DECL,
 };
 use crate::StrExt;
 use tree_sitter::Node;
@@ -44,9 +44,29 @@ pub(crate) trait NodeExt<'a>: Sized + Copy {
     /// that is neither `it` nor `_`.
     fn has_lambda_named_params(self, bytes: &[u8]) -> bool;
 
+    /// Extract parameter names from a `lambda_literal`'s `lambda_parameters` node.
+    /// Returns an empty vec for `{ it }` or `{ }`.
+    fn lambda_param_names(self, bytes: &[u8]) -> Vec<String>;
+
+    /// Return the 0-based position of `param_name` in this lambda's parameter list.
+    fn lambda_param_position(self, param_name: &str, bytes: &[u8]) -> Option<usize>;
+
     /// Collect named lambda parameter identifiers from a `lambda_literal` CST node.
     /// Skips `it`, `_`, uppercase-first (type refs), and deduplicates against `existing`.
     fn collect_lambda_param_names(self, bytes: &[u8], existing: &[String]) -> Vec<String>;
+
+    /// Walk up ancestors to find the nearest `call_expression`.
+    /// Returns `None` if a `lambda_literal` or source-file root is hit first.
+    fn enclosing_call_expression(self) -> Option<Node<'a>>;
+
+    /// Walk up ancestors to find the nearest `lambda_literal`.
+    fn enclosing_lambda_literal(self) -> Option<Node<'a>>;
+
+    /// Get the text of the first `value_argument` child of a `call_expression`.
+    fn first_value_argument_text(self, bytes: &[u8]) -> Option<String>;
+
+    /// For a `navigation_expression`, return `(receiver_text, member_name)`.
+    fn navigation_parts(self, bytes: &[u8]) -> Option<(String, String)>;
 
     /// Extract the type/class name from a CST class/interface/object/companion_object node.
     fn extract_type_name(self, bytes: &[u8]) -> Option<String>;
@@ -176,36 +196,32 @@ impl<'a> NodeExt<'a> for Node<'a> {
     }
 
     fn has_lambda_named_params(self, bytes: &[u8]) -> bool {
-        let Some(lp) = self.first_child_of_kind(KIND_LAMBDA_PARAMS) else {
-            return false;
-        };
-
-        (0..lp.child_count())
-            .filter_map(|i| lp.child(i))
-            .filter(|c| c.kind() == KIND_VAR_DECL)
-            .any(|vd| {
-                let Some(si) = vd.child(0).filter(|n| n.kind() == KIND_SIMPLE_IDENT) else {
-                    return false;
-                };
-                let Ok(name) = std::str::from_utf8(&bytes[si.byte_range()]) else {
-                    return false;
-                };
-                name != "it" && name != "_"
-            })
+        self.lambda_param_names(bytes)
+            .into_iter()
+            .any(|name| name != "it" && name != "_")
     }
 
-    fn collect_lambda_param_names(self, bytes: &[u8], existing: &[String]) -> Vec<String> {
+    fn lambda_param_names(self, bytes: &[u8]) -> Vec<String> {
         let Some(lp) = self.first_child_of_kind(KIND_LAMBDA_PARAMS) else {
             return Vec::new();
         };
 
-        (0..lp.child_count())
-            .filter_map(|i| lp.child(i))
-            .filter(|c| c.kind() == KIND_VAR_DECL)
-            .filter_map(|vd| {
-                let si = vd.child(0).filter(|n| n.kind() == KIND_SIMPLE_IDENT)?;
-                si.utf8_text_owned(bytes)
-            })
+        lp.children_of_kind(KIND_VAR_DECL)
+            .into_iter()
+            .filter_map(|vd| vd.first_child_of_kind(KIND_SIMPLE_IDENT))
+            .filter_map(|si| si.utf8_text_owned(bytes))
+            .collect()
+    }
+
+    fn lambda_param_position(self, param_name: &str, bytes: &[u8]) -> Option<usize> {
+        self.lambda_param_names(bytes)
+            .into_iter()
+            .position(|name| name == param_name)
+    }
+
+    fn collect_lambda_param_names(self, bytes: &[u8], existing: &[String]) -> Vec<String> {
+        self.lambda_param_names(bytes)
+            .into_iter()
             .filter(|name| {
                 name != "it"
                     && name != "_"
@@ -213,6 +229,72 @@ impl<'a> NodeExt<'a> for Node<'a> {
                     && !existing.contains(name)
             })
             .collect()
+    }
+
+    fn enclosing_call_expression(self) -> Option<Node<'a>> {
+        let mut cur = self.parent()?;
+        loop {
+            let kind = cur.kind();
+            if kind == KIND_CALL_EXPR {
+                return Some(cur);
+            }
+            if kind == KIND_LAMBDA_LIT || kind == KIND_SOURCE_FILE {
+                return None;
+            }
+            cur = cur.parent()?;
+        }
+    }
+
+    fn enclosing_lambda_literal(self) -> Option<Node<'a>> {
+        let mut cur = self;
+        loop {
+            let kind = cur.kind();
+            if kind == KIND_LAMBDA_LIT {
+                return Some(cur);
+            }
+            if kind == KIND_SOURCE_FILE {
+                return None;
+            }
+            cur = cur.parent()?;
+        }
+    }
+
+    fn first_value_argument_text(self, bytes: &[u8]) -> Option<String> {
+        let mut stack = vec![self];
+        while let Some(node) = stack.pop() {
+            if node.kind() == KIND_VALUE_ARG {
+                let text = node.utf8_text_owned(bytes)?;
+                let text = text.trim();
+                return if text.is_empty() {
+                    None
+                } else {
+                    Some(text.to_owned())
+                };
+            }
+            for i in (0..node.child_count()).rev() {
+                if let Some(child) = node.child(i) {
+                    stack.push(child);
+                }
+            }
+        }
+        None
+    }
+
+    fn navigation_parts(self, bytes: &[u8]) -> Option<(String, String)> {
+        if self.kind() != KIND_NAV_EXPR {
+            return None;
+        }
+
+        let receiver = (0..self.child_count())
+            .filter_map(|i| self.child(i))
+            .find(|child| child.is_named() && child.kind() != KIND_NAV_SUFFIX)?
+            .utf8_text_owned(bytes)?;
+        let suffix = self.first_child_of_kind(KIND_NAV_SUFFIX)?;
+        let member = (0..suffix.child_count())
+            .filter_map(|i| suffix.child(i))
+            .find(|child| child.kind() == KIND_SIMPLE_IDENT || child.kind() == KIND_TYPE_IDENT)?
+            .utf8_text_owned(bytes)?;
+        Some((receiver, member))
     }
 
     fn extract_type_name(self, bytes: &[u8]) -> Option<String> {
@@ -248,21 +330,8 @@ impl<'a> NodeExt<'a> for Node<'a> {
                 Some((name, None))
             }
             k if k == KIND_NAV_EXPR => {
-                let mut walker = callee.walk();
-                let mut qualifier_opt: Option<String> = None;
-                let mut fn_name_opt: Option<String> = None;
-                for child in callee.children(&mut walker) {
-                    let ck = child.kind();
-                    if ck == KIND_SIMPLE_IDENT || ck == KIND_TYPE_IDENT {
-                        qualifier_opt = child.utf8_text_owned(bytes);
-                    } else if ck == KIND_NAV_SUFFIX {
-                        fn_name_opt = (0..child.child_count())
-                            .filter_map(|i| child.child(i))
-                            .find(|c| c.kind() == KIND_SIMPLE_IDENT || c.kind() == KIND_TYPE_IDENT)
-                            .and_then(|c| c.utf8_text_owned(bytes));
-                    }
-                }
-                Some((fn_name_opt?, qualifier_opt))
+                let (receiver, member) = callee.navigation_parts(bytes)?;
+                Some((member, Some(receiver)))
             }
             _ => None,
         }

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -192,13 +192,32 @@ impl<'a> NodeExt<'a> for Node<'a> {
                 }
             }
         }
-        None
+        // Kotlin trailing-lambda pattern:
+        //   call_expression (outer)
+        //     call_expression (inner) ← has value_arguments
+        //     call_suffix             ← has lambda_literal only
+        // Walk into the first child call_expression one level deep.
+        self.child(0)
+            .filter(|c| c.kind() == KIND_CALL_EXPR)
+            .and_then(|inner| inner.find_value_arguments())
     }
 
     fn has_lambda_named_params(self, bytes: &[u8]) -> bool {
-        self.lambda_param_names(bytes)
-            .into_iter()
-            .any(|name| name != "it" && name != "_")
+        let Some(lp) = self.first_child_of_kind(KIND_LAMBDA_PARAMS) else {
+            return false;
+        };
+        (0..lp.child_count())
+            .filter_map(|i| lp.child(i))
+            .filter(|c| c.kind() == KIND_VAR_DECL)
+            .any(|vd| {
+                let Some(si) = vd.child(0).filter(|n| n.kind() == KIND_SIMPLE_IDENT) else {
+                    return false;
+                };
+                let Ok(name) = std::str::from_utf8(&bytes[si.byte_range()]) else {
+                    return false;
+                };
+                name != "it" && name != "_"
+            })
     }
 
     fn lambda_param_names(self, bytes: &[u8]) -> Vec<String> {
@@ -260,24 +279,13 @@ impl<'a> NodeExt<'a> for Node<'a> {
     }
 
     fn first_value_argument_text(self, bytes: &[u8]) -> Option<String> {
-        let mut stack = vec![self];
-        while let Some(node) = stack.pop() {
-            if node.kind() == KIND_VALUE_ARG {
-                let text = node.utf8_text_owned(bytes)?;
-                let text = text.trim();
-                return if text.is_empty() {
-                    None
-                } else {
-                    Some(text.to_owned())
-                };
-            }
-            for i in (0..node.child_count()).rev() {
-                if let Some(child) = node.child(i) {
-                    stack.push(child);
-                }
-            }
-        }
-        None
+        let args = self.find_value_arguments()?;
+        (0..args.child_count())
+            .filter_map(|i| args.child(i))
+            .find(|c| c.kind() == KIND_VALUE_ARG)
+            .and_then(|arg| arg.utf8_text_owned(bytes))
+            .map(|t| t.trim().to_owned())
+            .filter(|t| !t.is_empty())
     }
 
     fn navigation_parts(self, bytes: &[u8]) -> Option<(String, String)> {

--- a/src/indexer/node_ext_tests.rs
+++ b/src/indexer/node_ext_tests.rs
@@ -1,5 +1,8 @@
 use super::NodeExt;
-use crate::queries::{KIND_CALL_EXPR, KIND_LAMBDA_LIT, KIND_VALUE_ARG, KIND_VALUE_ARGS};
+use crate::queries::{
+    KIND_CALL_EXPR, KIND_LAMBDA_LIT, KIND_NAV_EXPR, KIND_SIMPLE_IDENT, KIND_VALUE_ARG,
+    KIND_VALUE_ARGS,
+};
 
 fn parse_kotlin(src: &str) -> (tree_sitter::Tree, Vec<u8>) {
     let mut parser = tree_sitter::Parser::new();
@@ -20,6 +23,26 @@ fn find_node_kind<'a>(
     }
     for i in 0..node.child_count() {
         if let Some(n) = node.child(i).and_then(|c| find_node_kind(c, kind)) {
+            return Some(n);
+        }
+    }
+    None
+}
+
+fn find_node_text<'a>(
+    node: tree_sitter::Node<'a>,
+    kind: &str,
+    text: &str,
+    bytes: &[u8],
+) -> Option<tree_sitter::Node<'a>> {
+    if node.kind() == kind && node.utf8_text(bytes).ok() == Some(text) {
+        return Some(node);
+    }
+    for i in 0..node.child_count() {
+        if let Some(n) = node
+            .child(i)
+            .and_then(|c| find_node_text(c, kind, text, bytes))
+        {
             return Some(n);
         }
     }
@@ -98,6 +121,73 @@ fn collect_lambda_param_names_collects_named() {
     let lambda = find_node_kind(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
     let names = lambda.collect_lambda_param_names(&bytes, &[]);
     assert_eq!(names, vec!["item".to_string()]);
+}
+
+#[test]
+fn lambda_param_names_collects_all_explicit_params() {
+    let (tree, bytes) = parse_kotlin("val x = items.zip(other) { a, b -> a to b }");
+    let lambda = find_node_kind(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
+    assert_eq!(
+        lambda.lambda_param_names(&bytes),
+        vec!["a".to_string(), "b".to_string()]
+    );
+}
+
+#[test]
+fn lambda_param_position_returns_matching_index() {
+    let (tree, bytes) = parse_kotlin("val x = items.zip(other) { a, b -> a to b }");
+    let lambda = find_node_kind(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
+    assert_eq!(lambda.lambda_param_position("b", &bytes), Some(1));
+    assert_eq!(lambda.lambda_param_position("missing", &bytes), None);
+}
+
+#[test]
+fn enclosing_call_expression_from_lambda_finds_outer_call() {
+    let (tree, bytes) = parse_kotlin("val x = outer { it }");
+    let lambda = find_node_kind(tree.root_node(), KIND_LAMBDA_LIT).unwrap();
+    let call = lambda.enclosing_call_expression().unwrap();
+    assert_eq!(call.call_fn_name(&bytes), Some("outer".to_string()));
+}
+
+#[test]
+fn enclosing_call_expression_stops_at_lambda_boundary() {
+    let (tree, bytes) = parse_kotlin("val x = outer { inner }");
+    let inner = find_node_text(tree.root_node(), KIND_SIMPLE_IDENT, "inner", &bytes).unwrap();
+    assert_eq!(inner.enclosing_call_expression(), None);
+}
+
+#[test]
+fn enclosing_lambda_literal_finds_nearest_lambda() {
+    let (tree, bytes) = parse_kotlin("val x = outer { inner -> inner.name }");
+    let inner = find_node_text(tree.root_node(), KIND_SIMPLE_IDENT, "inner", &bytes).unwrap();
+    let lambda = inner.enclosing_lambda_literal().unwrap();
+    assert_eq!(lambda.kind(), KIND_LAMBDA_LIT);
+}
+
+#[test]
+fn first_value_argument_text_returns_first_argument() {
+    let (tree, bytes) = parse_kotlin("val x = with(user, other) { user.name }");
+    let call = find_node_kind(tree.root_node(), KIND_CALL_EXPR).unwrap();
+    assert_eq!(call.first_value_argument_text(&bytes), Some("user".to_string()));
+}
+
+#[test]
+fn navigation_parts_split_receiver_and_member() {
+    let (tree, bytes) = parse_kotlin("val x = result.availableBanks.firstOrNull()");
+    let nav = find_node_text(
+        tree.root_node(),
+        KIND_NAV_EXPR,
+        "result.availableBanks.firstOrNull",
+        &bytes,
+    )
+    .unwrap();
+    assert_eq!(
+        nav.navigation_parts(&bytes),
+        Some((
+            "result.availableBanks".to_string(),
+            "firstOrNull".to_string(),
+        ))
+    );
 }
 
 #[test]

--- a/src/indexer/scope_tests.rs
+++ b/src/indexer/scope_tests.rs
@@ -301,7 +301,16 @@ fn named_lambda_param_same_line() {
     let src = "val items: List<Product> = emptyList()";
     let (u, idx) = indexed("/t.kt", src);
     let before = "items.forEach { item -> item.";
-    let result = find_named_lambda_param_type(before, "item", &idx, &u, 0);
+    let result = find_named_lambda_param_type(
+        before,
+        "item",
+        &idx,
+        &u,
+        crate::types::CursorPos {
+            line: 0,
+            utf16_col: before.encode_utf16().count(),
+        },
+    );
     assert_eq!(result.as_deref(), Some("Product"));
 }
 
@@ -312,7 +321,16 @@ fn named_lambda_param_multiline() {
     let src = "val items: List<Order> = emptyList()\nitems.forEach { order ->\n    order.x\n}";
     let (u, idx) = indexed("/t.kt", src);
     // cursor on line 2 ("    order.x"), scanning back to line 1 for `{ order ->`
-    let result = find_named_lambda_param_type("    order.", "order", &idx, &u, 2);
+    let result = find_named_lambda_param_type(
+        "    order.",
+        "order",
+        &idx,
+        &u,
+        crate::types::CursorPos {
+            line: 2,
+            utf16_col: "    order.".encode_utf16().count(),
+        },
+    );
     assert_eq!(result.as_deref(), Some("Order"));
 }
 
@@ -322,7 +340,16 @@ fn named_lambda_param_scope_fn() {
     let src = "val user: User = User()";
     let (u, idx) = indexed("/t.kt", src);
     let before = "user.also { u -> u.";
-    let result = find_named_lambda_param_type(before, "u", &idx, &u, 0);
+    let result = find_named_lambda_param_type(
+        before,
+        "u",
+        &idx,
+        &u,
+        crate::types::CursorPos {
+            line: 0,
+            utf16_col: before.encode_utf16().count(),
+        },
+    );
     assert_eq!(result.as_deref(), Some("User"));
 }
 


### PR DESCRIPTION
Migrates manual char-by-char text scanning in `infer/args.rs` and `infer/it_this.rs` to use tree-sitter CST node traversal.

## What changed

### New `NodeExt` primitives (`node_ext.rs`)
- `lambda_param_names` — extract param names from a `lambda_literal`'s parameter list
- `lambda_param_position` — position of a named param in a lambda
- `enclosing_call_expression` — walk up to nearest `call_expression` without escaping lambda scope
- `enclosing_lambda_literal` — walk up to nearest `lambda_literal`
- `first_value_argument_text` — replaces `extract_first_arg` text scanner
- `navigation_parts` — replaces `find_last_dot_at_depth_zero` + `last_ident_in` pair

### CST fast paths added
- `is_inside_receiver_lambda` — new CST path added; text scan kept as fallback
- `find_named_lambda_param_type` — threaded `CursorPos`, new `cst_named_lambda_param_type` CST path
- `InferDeps` extended with `live_doc` for CST access

### Tests
- 8 new tests in `node_ext_tests.rs`  
- Tests in `it_this_tests.rs` + `scope_tests.rs`
- **686 tests passing** (up from 678)

## What was kept
Text fallbacks retained where `live_doc` may be `None` (file closed, parse failed). These are the non-live-doc callers/tests that remain valid paths.

## Checklist
- [x] `cargo test` passes (686 tests)
- [x] `cargo clippy -W clippy::too_many_lines -W clippy::cognitive_complexity` clean
- [x] No hardcoded kind strings (use `KIND_*` constants)
- [x] Tests in companion `*_tests.rs` files