### PR TITLE
refactor(infer,handlers,complete): split long functions into named helpers

### DIFF
--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -28,210 +28,215 @@ impl Backend {
             return Ok(None);
         };
 
-        let make_hover = |md: String| Hover {
-            contents: HoverContents::Markup(MarkupContent {
-                kind: MarkupKind::Markdown,
-                value: md,
-            }),
-            range: None,
-        };
-
-        // Path 1: `it` / named lambda param — show inferred type + optional type detail.
-        if ctx.qualifier.is_none() {
-            if let Some(ref rt) = ctx.contextual {
-                let kw = if crate::Language::from_path(uri.path()).is_swift() {
-                    "let"
-                } else {
-                    "val"
-                };
-                let subst = crate::indexer::resolution::build_subst_map(
-                    self.indexer.as_ref(),
-                    uri.as_str(),
-                    position.line,
-                );
-                let type_name = if subst.is_empty() {
-                    rt.raw.clone()
-                } else {
-                    apply_type_subst(&rt.raw, &subst)
-                };
-                let leaf = type_name.rsplit('.').next().unwrap_or(type_name.as_str());
-                let type_sig_md = format!("{kw} {}: {type_name}", ctx.word);
-                // Resolve the type's own hover: import-aware, rg fallback, then stdlib.
-                let type_detail = resolve_symbol_info(
-                    self.indexer.as_ref(),
-                    leaf,
-                    None,
-                    uri,
-                    SubstitutionContext::CrossFile {
-                        calling_uri: uri.as_str(),
-                        cursor_line: Some(position.line),
-                    },
-                    &ResolveOptions::hover(),
-                )
-                .map(|i| format_symbol_hover(&i, uri.path()))
-                .or_else(|| crate::stdlib::hover(leaf));
-                let md = format_contextual_hover(&type_sig_md, uri.path(), type_detail.as_deref());
-                return Ok(Some(make_hover(md)));
-            }
-            // Lambda parameter with failed type inference — don't fall through to rg
-            // lookup (would show confusing hover for unrelated symbols).
-            if ctx.lambda_decl.is_some() {
-                return Ok(None);
-            }
+        if let Some(hover) = self.contextual_lambda_hover(&ctx, uri, position) {
+            return Ok(Some(hover));
+        }
+        if ctx.qualifier.is_none() && ctx.lambda_decl.is_some() {
+            return Ok(None);
+        }
+        if let Some(hover) = self.contextual_receiver_hover(&ctx, uri, position) {
+            return Ok(Some(hover));
         }
 
-        // Path 2: `this.field` / `it.field` — use the already-resolved contextual receiver
-        // so hover shows the member from the correct class.
+        Ok(self.regular_symbol_hover(&ctx, uri, position))
+    }
+
+    fn contextual_lambda_hover(
+        &self,
+        ctx: &CursorContext,
+        uri: &Url,
+        position: Position,
+    ) -> Option<Hover> {
         if ctx.qualifier.is_some() {
-            if let Some(ref rt) = ctx.contextual {
-                let locs = self.resolve_with_receiver_fallback(&ctx.word, rt, uri);
-                if let Some(loc) = locs.first() {
-                    let subst_ctx = SubstitutionContext::CrossFile {
-                        calling_uri: uri.as_str(),
-                        cursor_line: Some(position.line),
-                    };
-                    if let Some(info) = enrich_at_location(
-                        self.indexer.as_ref(),
-                        loc,
-                        &ctx.word,
-                        subst_ctx,
-                        &ResolveOptions::hover(),
-                    ) {
-                        return Ok(Some(make_hover(format_symbol_hover(&info, uri.path()))));
-                    }
-                }
-            }
+            return None;
         }
+        let receiver_type = ctx.contextual.as_ref()?;
+        let type_name = self.contextual_hover_type_name(receiver_type, uri, position.line);
+        let leaf = type_name.rsplit('.').next().unwrap_or(type_name.as_str());
+        let signature = format!("{} {}: {type_name}", hover_binding_keyword(uri), ctx.word);
+        let detail = self
+            .resolve_hover_markdown(leaf, None, uri, position.line)
+            .or_else(|| crate::stdlib::hover(leaf));
+        Some(make_markdown_hover(format_contextual_hover(
+            &signature,
+            uri.path(),
+            detail.as_deref(),
+        )))
+    }
 
-        // Path 3: regular symbol — import-aware resolution, rg fallback, then stdlib.
-        let subst_ctx = SubstitutionContext::CrossFile {
-            calling_uri: uri.as_str(),
-            cursor_line: Some(position.line),
-        };
-        let hover_md = resolve_symbol_info(
+    fn contextual_hover_type_name(
+        &self,
+        receiver_type: &crate::resolver::ReceiverType,
+        uri: &Url,
+        line: u32,
+    ) -> String {
+        let subst =
+            crate::indexer::resolution::build_subst_map(self.indexer.as_ref(), uri.as_str(), line);
+        if subst.is_empty() {
+            return receiver_type.raw.clone();
+        }
+        apply_type_subst(&receiver_type.raw, &subst)
+    }
+
+    fn contextual_receiver_hover(
+        &self,
+        ctx: &CursorContext,
+        uri: &Url,
+        position: Position,
+    ) -> Option<Hover> {
+        let receiver_type = ctx.contextual.as_ref()?;
+        ctx.qualifier.as_ref()?;
+        let location = self
+            .resolve_with_receiver_fallback(&ctx.word, receiver_type, uri)
+            .first()?
+            .clone();
+        let info = enrich_at_location(
             self.indexer.as_ref(),
+            &location,
             &ctx.word,
-            ctx.qualifier.as_deref(),
+            hover_substitution_context(uri, position.line),
+            &ResolveOptions::hover(),
+        )?;
+        Some(make_markdown_hover(format_symbol_hover(&info, uri.path())))
+    }
+
+    fn regular_symbol_hover(
+        &self,
+        ctx: &CursorContext,
+        uri: &Url,
+        position: Position,
+    ) -> Option<Hover> {
+        let markdown = self
+            .resolve_hover_markdown(&ctx.word, ctx.qualifier.as_deref(), uri, position.line)
+            .or_else(|| crate::stdlib::hover(&ctx.word))?;
+        Some(make_markdown_hover(markdown))
+    }
+
+    fn resolve_hover_markdown(
+        &self,
+        word: &str,
+        qualifier: Option<&str>,
+        uri: &Url,
+        line: u32,
+    ) -> Option<String> {
+        resolve_symbol_info(
+            self.indexer.as_ref(),
+            word,
+            qualifier,
             uri,
-            subst_ctx,
+            hover_substitution_context(uri, line),
             &ResolveOptions::hover(),
         )
-        .map(|i| format_symbol_hover(&i, uri.path()))
-        .or_else(|| crate::stdlib::hover(&ctx.word));
-
-        Ok(hover_md.map(make_hover))
+        .map(|info| format_symbol_hover(&info, uri.path()))
     }
 
     pub(super) async fn references_impl(
         &self,
         params: ReferenceParams,
     ) -> Result<Option<Vec<Location>>> {
-        let uri = &params.text_document_position.text_document.uri;
-        let pos = params.text_document_position.position;
-        let include_decl = params.context.include_declaration;
-
-        let (name, _qualifier) = match self.indexer.word_and_qualifier_at(uri, pos) {
-            Some(pair) => pair,
-            None => return Ok(None),
+        let Some(search) = self.reference_search(&params) else {
+            return Ok(None);
         };
 
-        // For uppercase symbols, determine parent_class and declared_pkg:
-        // - If cursor is ON the declaration of this symbol → use enclosing_class_at(cursor)
-        // - If cursor is on a REFERENCE → scan imports in current file to find which
-        //   specific class is meant (handles multiple `Effect` classes across files)
+        let mut locations = self.rg_reference_locations(&search).await;
+        self.filter_library_reference_locations(&mut locations);
+        self.add_current_file_reference_locations(&search.uri, &search.name, &mut locations);
+
+        Ok((!locations.is_empty()).then_some(locations))
+    }
+
+    fn reference_search(&self, params: &ReferenceParams) -> Option<ReferenceSearch> {
+        let uri = &params.text_document_position.text_document.uri;
+        let position = params.text_document_position.position;
+        let include_decl = params.context.include_declaration;
+        let (name, _) = self.indexer.word_and_qualifier_at(uri, position)?;
         let (parent_class, declared_pkg) =
-            resolve_references_scope(&self.indexer, uri, pos.line, &name);
-        // Collect declaration file paths — but only those where the enclosing class
-        // matches parent_class (if known).  Without this filter, every contract file
-        // that has `sealed interface Event` would be included, causing false positives
-        // for unrelated ViewModels in other packages.
-        let decl_files: Vec<String> = self
-            .indexer
+            resolve_references_scope(&self.indexer, uri, position.line, &name);
+        let decl_files = self.declaration_files_for_reference(&name, parent_class.as_deref());
+        Some(ReferenceSearch {
+            uri: uri.clone(),
+            name,
+            include_decl,
+            parent_class,
+            declared_pkg,
+            decl_files,
+        })
+    }
+
+    fn declaration_files_for_reference(
+        &self,
+        name: &str,
+        parent_class: Option<&str>,
+    ) -> Vec<String> {
+        self.indexer
             .definitions
-            .get(&name)
-            .map(|locs| {
-                locs.iter()
-                    .filter(|l| {
-                        if let Some(ref parent) = parent_class {
-                            self.indexer
-                                .enclosing_class_at(&l.uri, l.range.start.line)
-                                .as_deref()
-                                == Some(parent.as_str())
-                        } else {
-                            true
-                        }
+            .get(name)
+            .map(|locations| {
+                locations
+                    .iter()
+                    .filter(|location| {
+                        reference_matches_parent_class(&self.indexer, location, parent_class)
                     })
-                    .filter_map(|l| l.uri.to_file_path().ok())
-                    .filter_map(|p| p.to_str().map(|s| s.to_owned()))
+                    .filter_map(|location| location.uri.to_file_path().ok())
+                    .filter_map(|path| path.to_str().map(|path| path.to_owned()))
                     .collect()
             })
-            .unwrap_or_default();
+            .unwrap_or_default()
+    }
 
-        // Run rg off the async executor to avoid blocking the Tokio runtime.
-        let root = self.indexer.workspace_root.read().unwrap().clone();
-        let matcher = self.indexer.ignore_matcher.read().unwrap().clone();
-        let uri_clone = uri.clone();
-        let name2 = name.clone();
-        let parent2 = parent_class.clone();
-        let decl2 = declared_pkg.clone();
-        let mut locs = tokio::task::spawn_blocking(move || {
-            let request = crate::rg::RgSearchRequest::new(
-                &name2,
-                parent2.as_deref(),
-                decl2.as_deref(),
-                root.as_deref(),
-                include_decl,
-                &uri_clone,
-                &decl_files,
+    async fn rg_reference_locations(&self, search: &ReferenceSearch) -> Vec<Location> {
+        let workspace_root = self
+            .indexer
+            .workspace_root
+            .read()
+            .ok()
+            .and_then(|root| root.clone());
+        let ignore_matcher = self
+            .indexer
+            .ignore_matcher
+            .read()
+            .ok()
+            .and_then(|matcher| matcher.clone());
+        let request = search.clone();
+        tokio::task::spawn_blocking(move || {
+            let rg_request = crate::rg::RgSearchRequest::new(
+                &request.name,
+                request.parent_class.as_deref(),
+                request.declared_pkg.as_deref(),
+                workspace_root.as_deref(),
+                request.include_decl,
+                &request.uri,
+                &request.decl_files,
             );
-            crate::rg::rg_find_references(&request, matcher.as_deref())
+            crate::rg::rg_find_references(&rg_request, ignore_matcher.as_deref())
         })
         .await
-        .unwrap_or_default();
-        eprintln!("[refs] rg returned {} locs", locs.len());
+        .unwrap_or_default()
+    }
 
-        // Filter out library-source locations (from sourcePaths outside workspace root).
-        let lib = &self.indexer.library_uris;
-        if !lib.is_empty() {
-            locs.retain(|loc| !lib.contains(loc.uri.as_str()));
+    fn filter_library_reference_locations(&self, locations: &mut Vec<Location>) {
+        if self.indexer.library_uris.is_empty() {
+            return;
         }
+        locations.retain(|location| !self.indexer.library_uris.contains(location.uri.as_str()));
+    }
 
-        // Supplement with in-memory scan of the CURRENT file only.
-        // This catches unsaved content in the active buffer that rg cannot see on disk.
-        // We intentionally do NOT scan all files in memory because that would bypass the
-        // scoping logic (package / parent-class filtering) applied by rg_find_references.
-        let cur_uri_str = uri.as_str();
-        if let Some(data) = self.indexer.files.get(cur_uri_str) {
-            for (line_idx, line) in data.lines.iter().enumerate() {
-                let dup_line = locs
-                    .iter()
-                    .any(|l: &Location| l.uri == *uri && l.range.start.line == line_idx as u32);
-                if dup_line {
-                    continue;
-                }
-                for abs in word_byte_offsets(line, name.as_str()) {
-                    // Compute UTF-16 column (LSP units) for the match start.
-                    let col: u32 = line[..abs].chars().map(|c| c.len_utf16() as u32).sum();
-                    let col_end: u32 =
-                        col + name.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
-                    let range = Range::new(
-                        Position::new(line_idx as u32, col),
-                        Position::new(line_idx as u32, col_end),
-                    );
-                    if !locs
-                        .iter()
-                        .any(|l: &Location| l.uri == *uri && l.range.start == range.start)
-                    {
-                        locs.push(Location {
-                            uri: uri.clone(),
-                            range,
-                        });
-                    }
-                }
+    fn add_current_file_reference_locations(
+        &self,
+        uri: &Url,
+        name: &str,
+        locations: &mut Vec<Location>,
+    ) {
+        let Some(data) = self.indexer.files.get(uri.as_str()) else {
+            return;
+        };
+        for (line_idx, line) in data.lines.iter().enumerate() {
+            let line_number = line_idx as u32;
+            if has_reference_line(locations, uri, line_number) {
+                continue;
             }
+            append_line_reference_locations(uri, name, line_number, line, locations);
         }
-
-        Ok(if locs.is_empty() { None } else { Some(locs) })
     }
 
     pub(super) async fn document_symbol_impl(
@@ -289,102 +294,59 @@ impl Backend {
         &self,
         params: WorkspaceSymbolParams,
     ) -> Result<Option<Vec<SymbolInformation>>> {
-        let query = params.query.to_lowercase();
-        let mut results: Vec<SymbolInformation> = Vec::new();
+        let query = WorkspaceSymbolQuery::new(params.query);
+        let mut results = self.collect_workspace_symbols(&query);
+        if results.is_empty() {
+            results = self.rg_workspace_symbols(&query).await;
+        }
+        Ok((!results.is_empty()).then_some(results))
+    }
 
-        // For dot-qualified queries like "StoreState.isReady", split into
-        // receiver qualifier and function name to match extension functions.
-        let (query_qualifier, query_name) = if let Some(dot) = query.rfind('.') {
-            (Some(&query[..dot]), &query[dot + 1..])
-        } else {
-            (None, query.as_str())
-        };
-
+    fn collect_workspace_symbols(&self, query: &WorkspaceSymbolQuery) -> Vec<SymbolInformation> {
+        let mut results = Vec::new();
         for entry in self.indexer.files.iter() {
-            let uri_str = entry.key();
-            let file_data = entry.value();
-            let uri = match Url::parse(uri_str) {
-                Ok(u) => u,
-                Err(_) => match Url::from_file_path(uri_str) {
-                    Ok(u) => u,
-                    Err(_) => continue,
-                },
+            let Some(uri) = workspace_symbol_uri(entry.key()) else {
+                continue;
             };
-            for sym in &file_data.symbols {
-                let name_lower = sym.name.to_lowercase();
-                let matches = if query.is_empty() {
-                    true
-                } else if let Some(qualifier) = query_qualifier {
-                    // Dot-qualified: name must match AND detail must contain
-                    // the receiver type (e.g. "fun StoreState.isReady()")
-                    name_lower.contains(query_name) && sym.detail.to_lowercase().contains(qualifier)
-                } else {
-                    name_lower.contains(&query)
-                };
-                if !matches {
-                    continue;
-                }
-                #[allow(deprecated)]
-                results.push(SymbolInformation {
-                    name: sym.name.clone(),
-                    kind: sym.kind,
-                    tags: None,
-                    deprecated: None,
-                    location: Location {
-                        uri: uri.clone(),
-                        range: sym.selection_range,
-                    },
-                    container_name: if sym.detail.is_empty() {
-                        None
-                    } else {
-                        Some(sym.detail.clone())
-                    },
-                });
-                if results.len() >= WORKSPACE_SYMBOL_CAP {
-                    break;
-                }
-            }
+            collect_matching_workspace_symbols(&uri, &entry.value().symbols, query, &mut results);
             if results.len() >= WORKSPACE_SYMBOL_CAP {
                 break;
             }
         }
+        results.sort_by(|left, right| left.name.cmp(&right.name));
+        results
+    }
 
-        results.sort_by(|a, b| a.name.cmp(&b.name));
-
-        // rg fallback when index is empty (indexing in progress or cold start).
-        if results.is_empty() && !query.is_empty() && query_qualifier.is_none() {
-            let root_opt = self.indexer.workspace_root.read().unwrap().clone();
-            let matcher = self.indexer.ignore_matcher.read().unwrap().clone();
-            let q = query.to_string();
-            let rg_locs = tokio::task::spawn_blocking(move || {
-                crate::rg::rg_find_definition(&q, root_opt.as_deref(), matcher.as_deref())
-            })
-            .await
-            .unwrap_or_default();
-            if !rg_locs.is_empty() {
-                let rg_syms: Vec<SymbolInformation> = rg_locs
-                    .into_iter()
-                    .map(|loc| {
-                        #[allow(deprecated)]
-                        SymbolInformation {
-                            name: query_name.to_string(),
-                            kind: tower_lsp::lsp_types::SymbolKind::FILE,
-                            tags: None,
-                            deprecated: None,
-                            location: loc,
-                            container_name: Some("rg fallback".to_string()),
-                        }
-                    })
-                    .collect();
-                return Ok(Some(rg_syms));
-            }
+    async fn rg_workspace_symbols(&self, query: &WorkspaceSymbolQuery) -> Vec<SymbolInformation> {
+        if !query.allows_rg_fallback() {
+            return vec![];
         }
-
-        Ok(if results.is_empty() {
-            None
-        } else {
-            Some(results)
+        let workspace_root = self
+            .indexer
+            .workspace_root
+            .read()
+            .ok()
+            .and_then(|root| root.clone());
+        let ignore_matcher = self
+            .indexer
+            .ignore_matcher
+            .read()
+            .ok()
+            .and_then(|matcher| matcher.clone());
+        let query_text = query.raw.clone();
+        let rg_locations = tokio::task::spawn_blocking(move || {
+            crate::rg::rg_find_definition(
+                &query_text,
+                workspace_root.as_deref(),
+                ignore_matcher.as_deref(),
+            )
         })
+        .await
+        .unwrap_or_default();
+        rg_locations
+            .into_iter()
+            .map(|location| rg_workspace_symbol(query.name.clone(), location))
+            .collect()
     }
 
     pub(super) async fn signature_help_impl(
@@ -860,6 +822,203 @@ fn text_call_info(lines: &[String], before: &str, line_idx: usize) -> Option<Cal
         qualifier: call_qualifier,
         active_param,
     })
+}
+
+#[derive(Clone)]
+struct WorkspaceSymbolQuery {
+    raw: String,
+    qualifier: Option<String>,
+    name: String,
+}
+
+impl WorkspaceSymbolQuery {
+    fn new(query: String) -> Self {
+        let raw = query.to_lowercase();
+        if let Some(dot) = raw.rfind('.') {
+            return Self {
+                qualifier: Some(raw[..dot].to_owned()),
+                name: raw[dot + 1..].to_owned(),
+                raw,
+            };
+        }
+        Self {
+            name: raw.clone(),
+            raw,
+            qualifier: None,
+        }
+    }
+
+    fn matches(&self, symbol: &crate::types::SymbolEntry) -> bool {
+        if self.raw.is_empty() {
+            return true;
+        }
+        let name = symbol.name.to_lowercase();
+        if let Some(qualifier) = self.qualifier.as_deref() {
+            return name.contains(&self.name) && symbol.detail.to_lowercase().contains(qualifier);
+        }
+        name.contains(&self.raw)
+    }
+
+    fn allows_rg_fallback(&self) -> bool {
+        !self.raw.is_empty() && self.qualifier.is_none()
+    }
+}
+
+fn workspace_symbol_uri(uri_str: &str) -> Option<Url> {
+    Url::parse(uri_str)
+        .ok()
+        .or_else(|| Url::from_file_path(uri_str).ok())
+}
+
+fn collect_matching_workspace_symbols(
+    uri: &Url,
+    symbols: &[crate::types::SymbolEntry],
+    query: &WorkspaceSymbolQuery,
+    results: &mut Vec<SymbolInformation>,
+) {
+    for symbol in symbols {
+        if !query.matches(symbol) {
+            continue;
+        }
+        results.push(workspace_symbol_information(uri, symbol));
+        if results.len() >= WORKSPACE_SYMBOL_CAP {
+            break;
+        }
+    }
+}
+
+fn workspace_symbol_information(
+    uri: &Url,
+    symbol: &crate::types::SymbolEntry,
+) -> SymbolInformation {
+    #[allow(deprecated)]
+    SymbolInformation {
+        name: symbol.name.clone(),
+        kind: symbol.kind,
+        tags: None,
+        deprecated: None,
+        location: Location {
+            uri: uri.clone(),
+            range: symbol.selection_range,
+        },
+        container_name: (!symbol.detail.is_empty()).then(|| symbol.detail.clone()),
+    }
+}
+
+fn rg_workspace_symbol(name: String, location: Location) -> SymbolInformation {
+    #[allow(deprecated)]
+    SymbolInformation {
+        name,
+        kind: tower_lsp::lsp_types::SymbolKind::FILE,
+        tags: None,
+        deprecated: None,
+        location,
+        container_name: Some("rg fallback".to_string()),
+    }
+}
+
+#[derive(Clone)]
+struct ReferenceSearch {
+    uri: Url,
+    name: String,
+    include_decl: bool,
+    parent_class: Option<String>,
+    declared_pkg: Option<String>,
+    decl_files: Vec<String>,
+}
+
+fn reference_matches_parent_class(
+    indexer: &crate::indexer::Indexer,
+    location: &Location,
+    parent_class: Option<&str>,
+) -> bool {
+    let Some(parent_class) = parent_class else {
+        return true;
+    };
+    indexer
+        .enclosing_class_at(&location.uri, location.range.start.line)
+        .as_deref()
+        == Some(parent_class)
+}
+
+fn has_reference_line(locations: &[Location], uri: &Url, line_number: u32) -> bool {
+    locations
+        .iter()
+        .any(|location| location.uri == *uri && location.range.start.line == line_number)
+}
+
+fn append_line_reference_locations(
+    uri: &Url,
+    name: &str,
+    line_number: u32,
+    line: &str,
+    locations: &mut Vec<Location>,
+) {
+    for location in line_reference_locations(uri, name, line_number, line) {
+        if has_reference_start(locations, &location) {
+            continue;
+        }
+        locations.push(location);
+    }
+}
+
+fn line_reference_locations(uri: &Url, name: &str, line_number: u32, line: &str) -> Vec<Location> {
+    word_byte_offsets(line, name)
+        .map(|offset| reference_location(uri, name, line_number, line, offset))
+        .collect()
+}
+
+fn reference_location(
+    uri: &Url,
+    name: &str,
+    line_number: u32,
+    line: &str,
+    offset: usize,
+) -> Location {
+    let start = utf16_column(&line[..offset]);
+    let end = start + utf16_column(name);
+    Location {
+        uri: uri.clone(),
+        range: Range::new(
+            Position::new(line_number, start),
+            Position::new(line_number, end),
+        ),
+    }
+}
+
+fn utf16_column(text: &str) -> u32 {
+    text.chars().map(|ch| ch.len_utf16() as u32).sum()
+}
+
+fn has_reference_start(locations: &[Location], candidate: &Location) -> bool {
+    locations.iter().any(|location| {
+        location.uri == candidate.uri && location.range.start == candidate.range.start
+    })
+}
+
+fn hover_binding_keyword(uri: &Url) -> &'static str {
+    if crate::Language::from_path(uri.path()).is_swift() {
+        "let"
+    } else {
+        "val"
+    }
+}
+
+fn hover_substitution_context(uri: &Url, line: u32) -> SubstitutionContext<'_> {
+    SubstitutionContext::CrossFile {
+        calling_uri: uri.as_str(),
+        cursor_line: Some(line),
+    }
+}
+
+fn make_markdown_hover(markdown: String) -> Hover {
+    Hover {
+        contents: HoverContents::Markup(MarkupContent {
+            kind: MarkupKind::Markdown,
+            value: markdown,
+        }),
+        range: None,
+    }
 }
 
 /// Iterator over the byte offsets in `line` where `word` occurs as a whole

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -271,132 +271,149 @@ pub(crate) fn lambda_receiver_type_from_context(
     uri: &Url,
 ) -> Option<String> {
     let trimmed = before_brace.trim_end();
+    let callee = normalized_lambda_callee(trimmed);
 
-    // Strip a trailing balanced `(args)` to expose the callee expression.
-    let callee_raw = strip_trailing_call_args(trimmed).replace("?.", ".");
-    let callee = callee_raw.trim(); // trim both ends — leading spaces from indentation matter
+    receiver_dot_lambda_type(&callee, deps, uri)
+        .or_else(|| plain_trailing_lambda_type(trimmed, &callee, deps, uri))
+        .or_else(|| inline_lambda_param_type(trimmed, deps, uri))
+}
 
-    // ── Case A: `receiver.method` ────────────────────────────────────────────
-    // Use a depth-aware dot search so dots INSIDE argument lists are ignored
-    // (e.g., `fn(Enum.VALUE, {` must not match the dot inside `Enum.VALUE`).
-    if let Some(dot_pos) = find_last_dot_at_depth_zero(callee) {
-        let receiver_expr = callee[..dot_pos].trim_end();
-        // Strip a trailing `(args)` so method chains like `getList().joinAll().map { it }`
-        // yield `receiver_var = "joinAll"` rather than `""`.
-        let receiver_var = last_ident_in(strip_trailing_call_args(receiver_expr));
-        // Extract method name (everything after the dot up to the first non-id char).
-        let method = callee[dot_pos + 1..].trim_start().ident_prefix();
+fn normalized_lambda_callee(before_brace: &str) -> String {
+    strip_trailing_call_args(before_brace)
+        .replace("?.", ".")
+        .trim()
+        .to_owned()
+}
 
-        if !receiver_var.is_empty() {
-            if let Some(raw) = deps.find_var_type(receiver_var, uri) {
-                if let Some(elem) = extract_collection_element_type(&raw) {
-                    return Some(elem);
-                }
-                // Non-collection receiver: prefer the method's own lambda param type when
-                // the method is indexed (e.g. `flow.collectIn { it }` → T from `collectIn`'s
-                // `block: suspend (T) -> Unit`).  Fall back to receiver type when the method
-                // is not found (e.g. stdlib `run`, `apply`, `let` → receiver type is correct).
-                if !method.is_empty() {
-                    if let Some(ty) = fun_trailing_lambda_it_type(&method, deps, uri) {
-                        return Some(ty);
-                    }
-                }
-                let base = raw.ident_prefix();
-                if !base.is_empty() && base.starts_with_uppercase() {
-                    return Some(base);
-                }
-            }
-
-            // Multi-segment receiver: `outer.field.method { it }` where `field`
-            // is not a local variable but a property of `outer`.
-            // Example: `result.availableBanks.firstOrNull { it }` →
-            //   outer_var = "result", field = "availableBanks"
-            //   → infer result's type → look up availableBanks in that class.
-            if let Some(rdot) = receiver_expr.rfind('.') {
-                let outer_var = last_ident_in(&receiver_expr[..rdot]);
-                let field = &receiver_expr[rdot + 1..];
-                if !outer_var.is_empty() && !field.is_empty() {
-                    if let Some(outer_type) = deps.find_var_type(outer_var, uri) {
-                        let outer_base = outer_type.ident_prefix();
-                        if !outer_base.is_empty() {
-                            if let Some(field_raw) = deps.find_field_type(&outer_base, field) {
-                                if let Some(elem) = extract_collection_element_type(&field_raw) {
-                                    return Some(elem);
-                                }
-                                // Mirror single-segment: try method's lambda param type first.
-                                if !method.is_empty() {
-                                    if let Some(ty) =
-                                        fun_trailing_lambda_it_type(&method, deps, uri)
-                                    {
-                                        return Some(ty);
-                                    }
-                                }
-                                let base = field_raw.ident_prefix();
-                                if !base.is_empty() && base.starts_with_uppercase() {
-                                    return Some(base);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            // Method-chain receiver: `getList().joinAll().firstOrNull { it }` —
-            // receiver_var is a method name (e.g. "joinAll"), not a local variable.
-            // Look up its return type directly and extract the element type.
-            if let Some(ret_raw) = deps.find_fun_return_type(receiver_var) {
-                if let Some(elem) = extract_collection_element_type(&ret_raw) {
-                    return Some(elem);
-                }
-                if !method.is_empty() {
-                    if let Some(ty) = fun_trailing_lambda_it_type(&method, deps, uri) {
-                        return Some(ty);
-                    }
-                }
-                let base = ret_raw.ident_prefix();
-                if !base.is_empty() && base.starts_with_uppercase() {
-                    return Some(base);
-                }
-            }
-
-            if receiver_var.starts_with_uppercase() {
-                return Some(receiver_var.to_owned());
-            }
-        }
+fn receiver_dot_lambda_type(callee: &str, deps: &impl InferDeps, uri: &Url) -> Option<String> {
+    let dot_pos = find_last_dot_at_depth_zero(callee)?;
+    let receiver_expr = callee[..dot_pos].trim_end();
+    let receiver_var = last_ident_in(strip_trailing_call_args(receiver_expr));
+    let method = callee[dot_pos + 1..].trim_start().ident_prefix();
+    if receiver_var.is_empty() {
+        return None;
     }
 
-    // ── Case B: plain trailing lambda — `fnName(args) { it/this }` ─────────
-    // Extract the trailing identifier from callee — handles cases where callee
-    // is prefixed by outer-lambda context like `{ setState` (the `{` belongs
-    // to an enclosing lambda, not this call).
+    receiver_var_lambda_type(receiver_var, receiver_expr, &method, deps, uri)
+        .or_else(|| uppercase_name(receiver_var))
+}
+
+fn receiver_var_lambda_type(
+    receiver_var: &str,
+    receiver_expr: &str,
+    method: &str,
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Option<String> {
+    direct_receiver_lambda_type(receiver_var, method, deps, uri)
+        .or_else(|| nested_receiver_lambda_type(receiver_expr, method, deps, uri))
+        .or_else(|| method_chain_lambda_type(receiver_var, method, deps, uri))
+}
+
+fn direct_receiver_lambda_type(
+    receiver_var: &str,
+    method: &str,
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Option<String> {
+    let raw = deps.find_var_type(receiver_var, uri)?;
+    inferred_receiver_lambda_type(&raw, method, deps, uri)
+}
+
+fn nested_receiver_lambda_type(
+    receiver_expr: &str,
+    method: &str,
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Option<String> {
+    let (outer_var, field) = receiver_outer_field(receiver_expr)?;
+    let outer_type = deps.find_var_type(outer_var, uri)?;
+    let outer_base = outer_type.ident_prefix();
+    if outer_base.is_empty() {
+        return None;
+    }
+    let field_raw = deps.find_field_type(&outer_base, field)?;
+    inferred_receiver_lambda_type(&field_raw, method, deps, uri)
+}
+
+fn receiver_outer_field(receiver_expr: &str) -> Option<(&str, &str)> {
+    let dot = receiver_expr.rfind('.')?;
+    let outer_var = last_ident_in(&receiver_expr[..dot]);
+    let field = &receiver_expr[dot + 1..];
+    if outer_var.is_empty() || field.is_empty() {
+        return None;
+    }
+    Some((outer_var, field))
+}
+
+fn method_chain_lambda_type(
+    receiver_var: &str,
+    method: &str,
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Option<String> {
+    let ret_raw = deps.find_fun_return_type(receiver_var)?;
+    inferred_receiver_lambda_type(&ret_raw, method, deps, uri)
+}
+
+fn inferred_receiver_lambda_type(
+    raw_type: &str,
+    method: &str,
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Option<String> {
+    extract_collection_element_type(raw_type)
+        .or_else(|| method_lambda_input_type(method, deps, uri))
+        .or_else(|| uppercase_ident_prefix(raw_type))
+}
+
+fn method_lambda_input_type(method: &str, deps: &impl InferDeps, uri: &Url) -> Option<String> {
+    if method.is_empty() {
+        return None;
+    }
+    fun_trailing_lambda_it_type(method, deps, uri)
+}
+
+fn uppercase_ident_prefix(raw: &str) -> Option<String> {
+    let base = raw.ident_prefix();
+    if base.is_empty() {
+        return None;
+    }
+    uppercase_name(&base)
+}
+
+fn uppercase_name(name: &str) -> Option<String> {
+    name.starts_with_uppercase().then(|| name.to_owned())
+}
+
+fn plain_trailing_lambda_type(
+    before_brace: &str,
+    callee: &str,
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Option<String> {
     let trailing_fn = last_ident_in(callee);
-    if !trailing_fn.is_empty() {
-        // Known stdlib scope function `with(receiver) { this }` — extract the
-        // first argument as the receiver and infer its type directly.
-        if trailing_fn == "with" {
-            if let Some(recv_name) = extract_first_arg(trimmed) {
-                if let Some(raw) = deps.find_var_type(recv_name, uri) {
-                    let base = raw.ident_prefix();
-                    if !base.is_empty() {
-                        return Some(base);
-                    }
-                }
-                // If recv_name starts uppercase it IS the type (companion / object ref).
-                let base = recv_name.ident_prefix();
-                if base.starts_with_uppercase() {
-                    return Some(base);
-                }
-            }
-        }
-        if let Some(ty) = fun_trailing_lambda_it_type(trailing_fn, deps, uri) {
-            return Some(ty);
-        }
+    if trailing_fn.is_empty() {
+        return None;
     }
 
-    // ── Case C: inline lambda arg — `fn(arg, { param -> ... }, ...)` ─────────
-    // `before_brace` ends inside an unclosed `(`, so scan backward to find
-    // the function name and the positional index of this lambda argument.
-    inline_lambda_param_type(trimmed, deps, uri)
+    with_receiver_lambda_type(trailing_fn, before_brace, deps, uri)
+        .or_else(|| fun_trailing_lambda_it_type(trailing_fn, deps, uri))
+}
+
+fn with_receiver_lambda_type(
+    trailing_fn: &str,
+    before_brace: &str,
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Option<String> {
+    if trailing_fn != "with" {
+        return None;
+    }
+    let recv_name = extract_first_arg(before_brace)?;
+    deps.find_var_type(recv_name, uri)
+        .and_then(|raw| uppercase_ident_prefix(&raw))
+        .or_else(|| uppercase_ident_prefix(recv_name))
 }
 
 // ─── private helpers ─────────────────────────────────────────────────────────
@@ -415,7 +432,9 @@ fn cursor_node_at(
         row: pos.line,
         column: byte_col,
     };
-    doc.tree.root_node().descendant_for_point_range(point, point)
+    doc.tree
+        .root_node()
+        .descendant_for_point_range(point, point)
 }
 
 fn lambda_before_brace_context(
@@ -586,7 +605,16 @@ fn find_it_element_type_in_lines_impl(
                             return lambda_receiver_this_type_from_context(before_brace, idx, uri);
                         }
                         return lambda_receiver_type_from_context(before_brace, idx, uri).or_else(
-                            || lambda_receiver_type_named_arg_ml(before_brace, 0, lines, ln, idx, uri),
+                            || {
+                                lambda_receiver_type_named_arg_ml(
+                                    before_brace,
+                                    0,
+                                    lines,
+                                    ln,
+                                    idx,
+                                    uri,
+                                )
+                            },
                         );
                     }
                 }

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -295,103 +295,40 @@ impl Indexer {
         cursor_line: usize,
         cursor_col: usize,
     ) -> Vec<String> {
-        // ── CST fast path ────────────────────────────────────────────────────
-        if let Some(doc) = self.live_doc(uri) {
-            let line_text = self
-                .live_lines
-                .get(uri.as_str())
-                .and_then(|ll| ll.get(cursor_line).cloned())
-                .unwrap_or_default();
-            let byte_col = crate::indexer::live_tree::utf16_col_to_byte(&line_text, cursor_col);
-            let point = Point {
-                row: cursor_line,
-                column: byte_col,
-            };
-            if let Some(node) = doc
-                .tree
-                .root_node()
-                .descendant_for_point_range(point, point)
-            {
-                let mut params: Vec<String> = Vec::new();
-                let mut cur = node;
-                loop {
-                    if cur.kind() == KIND_LAMBDA_LIT {
-                        let new_names = cur.collect_lambda_param_names(&doc.bytes, &params);
-                        params.extend(new_names);
-                    }
-                    let Some(p) = cur.parent() else {
-                        break;
-                    };
-                    cur = p;
-                }
-                return params;
-            }
+        if let Some(params) = self.cst_lambda_params_at_col(uri, cursor_line, cursor_col) {
+            return params;
         }
 
-        // ── Text fallback ────────────────────────────────────────────────────
-        let lines = self
+        let lines = self.lambda_param_scan_lines(uri);
+        scan_lambda_params_in_lines(&lines, cursor_line, cursor_col)
+    }
+
+    fn cst_lambda_params_at_col(
+        &self,
+        uri: &Url,
+        cursor_line: usize,
+        cursor_col: usize,
+    ) -> Option<Vec<String>> {
+        let doc = self.live_doc(uri)?;
+        let line_text = self
             .live_lines
             .get(uri.as_str())
-            .map(|ll| ll.clone())
-            .or_else(|| self.files.get(uri.as_str()).map(|f| f.lines.clone()))
+            .and_then(|lines| lines.get(cursor_line).cloned())
             .unwrap_or_default();
+        let point = lambda_cursor_point(&line_text, cursor_line, cursor_col);
+        let node = doc
+            .tree
+            .root_node()
+            .descendant_for_point_range(point, point)?;
+        Some(collect_cst_lambda_params(node, &doc.bytes))
+    }
 
-        let mut params: Vec<String> = Vec::new();
-        let mut depth: i32 = 0;
-        let scan_start = cursor_line.saturating_sub(SCOPE_SCAN_BACK_LINES);
-
-        for ln in (scan_start..=cursor_line).rev() {
-            let line = match lines.get(ln) {
-                Some(l) => l,
-                None => continue,
-            };
-            let scan_line: &str = if ln == cursor_line && cursor_col < line.len() {
-                let mut utf16 = 0usize;
-                let mut byte_end = line.len();
-                for (bi, ch) in line.char_indices() {
-                    if utf16 >= cursor_col {
-                        byte_end = bi;
-                        break;
-                    }
-                    utf16 += ch.len_utf16();
-                }
-                &line[..byte_end]
-            } else {
-                line
-            };
-            for (bi, ch) in scan_line.char_indices().rev() {
-                match ch {
-                    '}' => depth += 1,
-                    '{' => {
-                        depth -= 1;
-                        if depth < 0 {
-                            if line[..bi].ends_with('$') {
-                                depth = 0;
-                                continue;
-                            }
-                            let after = line[bi + 1..].trim_start();
-                            if let Some(arrow_pos) = after.find("->") {
-                                let names_str = &after[..arrow_pos];
-                                for tok in names_str.split(',') {
-                                    let name = tok.trim().ident_prefix();
-                                    if !name.is_empty()
-                                        && name != "it"
-                                        && name != "_"
-                                        && name.starts_with_lowercase()
-                                        && !params.contains(&name)
-                                    {
-                                        params.push(name.clone());
-                                    }
-                                }
-                            }
-                            depth = 0;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-        }
-        params
+    fn lambda_param_scan_lines(&self, uri: &Url) -> Arc<Vec<String>> {
+        self.live_lines
+            .get(uri.as_str())
+            .map(|lines| lines.clone())
+            .or_else(|| self.files.get(uri.as_str()).map(|file| file.lines.clone()))
+            .unwrap_or_default()
     }
 
     /// Find the `{ name ->` declaration line for a lambda parameter in scope at
@@ -616,6 +553,123 @@ pub(crate) fn last_ident_in(s: &str) -> &str {
         .map(|c| c.len_utf8())
         .sum();
     &s[s.len() - ident_bytes..]
+}
+
+fn lambda_cursor_point(line_text: &str, cursor_line: usize, cursor_col: usize) -> Point {
+    Point {
+        row: cursor_line,
+        column: crate::indexer::live_tree::utf16_col_to_byte(line_text, cursor_col),
+    }
+}
+
+fn collect_cst_lambda_params(node: tree_sitter::Node<'_>, bytes: &[u8]) -> Vec<String> {
+    let mut params = Vec::new();
+    let mut current = node;
+    loop {
+        if current.kind() == KIND_LAMBDA_LIT {
+            params.extend(current.collect_lambda_param_names(bytes, &params));
+        }
+        let Some(parent) = current.parent() else {
+            break;
+        };
+        current = parent;
+    }
+    params
+}
+
+fn scan_lambda_params_in_lines(
+    lines: &[String],
+    cursor_line: usize,
+    cursor_col: usize,
+) -> Vec<String> {
+    let scan_start = cursor_line.saturating_sub(SCOPE_SCAN_BACK_LINES);
+    let mut scan = LambdaParamTextScan::default();
+    for line_index in (scan_start..=cursor_line).rev() {
+        let Some(line) = lines.get(line_index) else {
+            continue;
+        };
+        scan.scan_line(line_before_cursor(
+            line,
+            line_index,
+            cursor_line,
+            cursor_col,
+        ));
+    }
+    scan.params
+}
+
+fn line_before_cursor(
+    line: &str,
+    line_index: usize,
+    cursor_line: usize,
+    cursor_col: usize,
+) -> &str {
+    if line_index != cursor_line {
+        return line;
+    }
+    let byte_end = utf16_prefix_byte_end(line, cursor_col);
+    &line[..byte_end]
+}
+
+fn utf16_prefix_byte_end(line: &str, cursor_col: usize) -> usize {
+    let mut utf16 = 0usize;
+    for (byte_index, ch) in line.char_indices() {
+        if utf16 >= cursor_col {
+            return byte_index;
+        }
+        utf16 += ch.len_utf16();
+    }
+    line.len()
+}
+
+#[derive(Default)]
+struct LambdaParamTextScan {
+    params: Vec<String>,
+    depth: i32,
+}
+
+impl LambdaParamTextScan {
+    fn scan_line(&mut self, line: &str) {
+        for (byte_index, ch) in line.char_indices().rev() {
+            match ch {
+                '}' => self.depth += 1,
+                '{' => self.visit_lambda_open(line, byte_index),
+                _ => {}
+            }
+        }
+    }
+
+    fn visit_lambda_open(&mut self, line: &str, byte_index: usize) {
+        self.depth -= 1;
+        if self.depth >= 0 || line[..byte_index].ends_with('$') {
+            if line[..byte_index].ends_with('$') {
+                self.depth = 0;
+            }
+            return;
+        }
+        self.collect_param_names(&line[byte_index + 1..]);
+        self.depth = 0;
+    }
+
+    fn collect_param_names(&mut self, after_brace: &str) {
+        let Some((names, _)) = after_brace.trim_start().split_once("->") else {
+            return;
+        };
+        for token in names.split(',') {
+            let name = token.trim().ident_prefix();
+            if should_collect_lambda_param(&name, &self.params) {
+                self.params.push(name);
+            }
+        }
+    }
+}
+
+fn should_collect_lambda_param(name: &str, existing: &[String]) -> bool {
+    !name.is_empty()
+        && name != "it"
+        && name != "_"
+        && name.starts_with_lowercase()
+        && !existing.iter().any(|existing_name| existing_name == name)
 }
 
 /// Scan backward from `(line_no, col)` — where `col` is the START of the cursor

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -5,7 +5,7 @@ use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
 use crate::stdlib::bare_completions;
 use crate::stdlib_tail::dot_completions_for_lang;
-use crate::types::Visibility;
+use crate::types::{FileData, ImportEntry, SymbolEntry, Visibility};
 use crate::LinesExt;
 use crate::StrExt;
 
@@ -180,117 +180,188 @@ fn extension_fn_completions(
         return vec![];
     }
 
-    // Gather current imports + package once (to avoid repeating per symbol).
-    let is_java = false;
-    let live = idx.live_lines.get(from_uri.as_str()).map(|ll| ll.clone());
-    let (cur_imports, cur_pkg, cur_lines) = idx
-        .files
-        .get(from_uri.as_str())
-        .map(|f| {
-            let lines = live.clone().unwrap_or_else(|| f.lines.clone());
-            let imports = if live.is_some() {
-                lines.parse_imports()
-            } else {
-                f.imports.clone()
-            };
-            (imports, f.package.clone().unwrap_or_default(), lines)
-        })
-        .unwrap_or_else(|| {
-            let lines = live.clone().unwrap_or_default();
-            let imports = lines.parse_imports();
-            (imports, String::new(), lines)
-        });
-
-    let mut items = Vec::new();
-    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let context = ExtensionCompletionContext::build(idx, from_uri);
+    let mut builder = ExtensionCompletionBuilder::new(&context, receiver_type, snippets);
 
     for file_entry in idx.files.iter() {
-        let file_uri_str = file_entry.key().clone();
-        let file = file_entry.value();
-        let is_same_file = file_uri_str == from_uri.as_str();
-        // Only look at Kotlin files — extension functions are a Kotlin feature.
-        if !crate::Language::from_path(&file_uri_str).is_kotlin() {
+        let file_uri_str = file_entry.key();
+        if !crate::Language::from_path(file_uri_str).is_kotlin() {
             continue;
         }
+        builder.add_file(file_uri_str, file_entry.value());
+    }
 
-        for sym in &file.symbols {
-            if sym.extension_receiver != receiver_type {
-                continue;
-            }
-            // Skip private/protected from other files — inaccessible across file boundaries.
-            // Same-file private/protected are fine.
-            if !is_same_file
-                && matches!(sym.visibility, Visibility::Private | Visibility::Protected)
-            {
-                continue;
-            }
+    builder.finish()
+}
 
-            let dedup_key = format!("{}:{}", sym.name, file_uri_str);
-            if !seen.insert(dedup_key) {
-                continue;
-            }
+struct ExtensionCompletionContext {
+    from_uri: String,
+    imports: Vec<ImportEntry>,
+    package_name: String,
+    lines: Arc<Vec<String>>,
+}
 
-            // Build FQN for auto-import: package.funcName
-            let pkg = file.package.as_deref().unwrap_or("");
-            let fqn = if pkg.is_empty() {
-                sym.name.clone()
-            } else {
-                format!("{pkg}.{}", sym.name)
+impl ExtensionCompletionContext {
+    fn build(idx: &Indexer, from_uri: &Url) -> Self {
+        let live_lines = idx
+            .live_lines
+            .get(from_uri.as_str())
+            .map(|lines| lines.clone());
+        let Some(file) = idx.files.get(from_uri.as_str()) else {
+            let lines = live_lines.clone().unwrap_or_default();
+            return Self {
+                from_uri: from_uri.as_str().to_owned(),
+                imports: lines.parse_imports(),
+                package_name: String::new(),
+                lines,
             };
+        };
 
-            let pkg_of_fqn = match fqn.rfind('.') {
-                Some(i) => &fqn[..i],
-                None => "",
-            };
-            let needs_import = !is_same_file
-                && !already_imported(&fqn, &cur_imports)
-                && !cur_imports
-                    .iter()
-                    .any(|imp| imp.is_star && imp.full_path == pkg_of_fqn)
-                && pkg_of_fqn != cur_pkg;
+        let lines = live_lines.clone().unwrap_or_else(|| file.lines.clone());
+        let imports = if live_lines.is_some() {
+            lines.parse_imports()
+        } else {
+            file.imports.clone()
+        };
+        Self {
+            from_uri: from_uri.as_str().to_owned(),
+            imports,
+            package_name: file.package.clone().unwrap_or_default(),
+            lines,
+        }
+    }
+}
 
-            let import_edit = if needs_import {
-                Some(vec![cur_lines.make_import_edit(&fqn, is_java)])
-            } else {
-                None
-            };
+struct ExtensionCompletionBuilder<'a> {
+    context: &'a ExtensionCompletionContext,
+    receiver_type: &'a str,
+    snippets: bool,
+    seen: std::collections::HashSet<String>,
+    items: Vec<CompletionItem>,
+}
 
-            let insert_text = if snippets {
-                Some(format!("{}($1)", sym.name))
-            } else {
-                None
-            };
-            let detail = if !sym.detail.is_empty() {
-                Some(sym.detail.clone())
-            } else if needs_import {
-                Some(pkg_of_fqn.to_string())
-            } else {
-                None
-            };
-
-            items.push(CompletionItem {
-                label: sym.name.clone(),
-                kind: Some(CompletionItemKind::FUNCTION),
-                insert_text,
-                insert_text_format: if snippets {
-                    Some(InsertTextFormat::SNIPPET)
-                } else {
-                    None
-                },
-                sort_text: Some(format!("01:ext:{}", sym.name)),
-                detail,
-                command: if snippets {
-                    Some(trigger_parameter_hints())
-                } else {
-                    None
-                },
-                additional_text_edits: import_edit,
-                ..Default::default()
-            });
+impl<'a> ExtensionCompletionBuilder<'a> {
+    fn new(
+        context: &'a ExtensionCompletionContext,
+        receiver_type: &'a str,
+        snippets: bool,
+    ) -> Self {
+        Self {
+            context,
+            receiver_type,
+            snippets,
+            seen: std::collections::HashSet::new(),
+            items: Vec::new(),
         }
     }
 
-    items
+    fn add_file(&mut self, file_uri_str: &str, file: &FileData) {
+        let is_same_file = file_uri_str == self.context.from_uri;
+        for symbol in &file.symbols {
+            if !self.is_candidate(symbol, is_same_file) {
+                continue;
+            }
+            if !self.record_symbol(file_uri_str, symbol) {
+                continue;
+            }
+            self.items.push(self.build_item(
+                symbol,
+                file.package.as_deref().unwrap_or(""),
+                is_same_file,
+            ));
+        }
+    }
+
+    fn is_candidate(&self, symbol: &SymbolEntry, is_same_file: bool) -> bool {
+        if symbol.extension_receiver != self.receiver_type {
+            return false;
+        }
+        is_same_file
+            || !matches!(
+                symbol.visibility,
+                Visibility::Private | Visibility::Protected
+            )
+    }
+
+    fn record_symbol(&mut self, file_uri_str: &str, symbol: &SymbolEntry) -> bool {
+        let key = format!("{}:{file_uri_str}", symbol.name);
+        self.seen.insert(key)
+    }
+
+    fn build_item(
+        &self,
+        symbol: &SymbolEntry,
+        package_name: &str,
+        is_same_file: bool,
+    ) -> CompletionItem {
+        let fqn = extension_symbol_fqn(package_name, &symbol.name);
+        let needs_import = self.needs_import(&fqn, is_same_file);
+        CompletionItem {
+            label: symbol.name.clone(),
+            kind: Some(CompletionItemKind::FUNCTION),
+            insert_text: self.insert_text(&symbol.name),
+            insert_text_format: self.insert_text_format(),
+            sort_text: Some(format!("01:ext:{}", symbol.name)),
+            detail: self.detail(symbol, &fqn, needs_import),
+            command: self.command(),
+            additional_text_edits: self.import_edit(&fqn, needs_import),
+            ..Default::default()
+        }
+    }
+
+    fn needs_import(&self, fqn: &str, is_same_file: bool) -> bool {
+        let package_name = package_of_fqn(fqn);
+        !is_same_file
+            && !already_imported(fqn, &self.context.imports)
+            && !self
+                .context
+                .imports
+                .iter()
+                .any(|entry| entry.is_star && entry.full_path == package_name)
+            && package_name != self.context.package_name
+    }
+
+    fn insert_text(&self, symbol_name: &str) -> Option<String> {
+        self.snippets.then(|| format!("{symbol_name}($1)"))
+    }
+
+    fn insert_text_format(&self) -> Option<InsertTextFormat> {
+        self.snippets.then_some(InsertTextFormat::SNIPPET)
+    }
+
+    fn command(&self) -> Option<tower_lsp::lsp_types::Command> {
+        self.snippets.then(trigger_parameter_hints)
+    }
+
+    fn import_edit(
+        &self,
+        fqn: &str,
+        needs_import: bool,
+    ) -> Option<Vec<tower_lsp::lsp_types::TextEdit>> {
+        needs_import.then(|| vec![self.context.lines.make_import_edit(fqn, false)])
+    }
+
+    fn detail(&self, symbol: &SymbolEntry, fqn: &str, needs_import: bool) -> Option<String> {
+        if !symbol.detail.is_empty() {
+            return Some(symbol.detail.clone());
+        }
+        needs_import.then(|| package_of_fqn(fqn).to_owned())
+    }
+
+    fn finish(self) -> Vec<CompletionItem> {
+        self.items
+    }
+}
+
+fn extension_symbol_fqn(package_name: &str, symbol_name: &str) -> String {
+    if package_name.is_empty() {
+        return symbol_name.to_owned();
+    }
+    format!("{package_name}.{symbol_name}")
+}
+
+fn package_of_fqn(fqn: &str) -> &str {
+    fqn.rfind('.').map(|idx| &fqn[..idx]).unwrap_or("")
 }
 
 fn complete_super(idx: &Indexer, from_uri: &Url, snippets: bool) -> Vec<CompletionItem> {
@@ -370,86 +441,157 @@ pub(crate) fn complete_dot(
     snippets: bool,
     cursor_line: Option<u32>,
 ) -> Vec<CompletionItem> {
-    // `super.` — collect all members from the parent class hierarchy.
     if receiver == "super" {
         return complete_super(idx, from_uri, snippets);
     }
 
-    // Infer and normalise the receiver's type.
-    let rt = match infer_receiver_type(idx, ReceiverKind::Variable(receiver), from_uri) {
-        Some(r) => r,
-        None => {
-            // Could be an uppercase class/object — look it up directly.
-            if receiver.starts_with_uppercase() {
-                ReceiverType::from_raw(receiver.to_string())
-            } else {
-                return vec![];
-            }
-        }
+    let Some(context) = dot_completion_context(idx, receiver, from_uri) else {
+        return vec![];
     };
 
-    // Resolve the outer type to its source file (no rg — per-keystroke path).
-    let file_uri = match resolve_symbol_no_rg(idx, &rt.outer, from_uri).first() {
-        Some(loc) => loc.uri.to_string(),
-        None => return vec![],
-    };
-
-    // For dotted types (e.g. `Outer.Inner`), show only the inner type's members.
-    // `rt.leaf` is the last segment, so it works for both plain and dotted types.
-    let mut items = symbols_from_nested_type(
+    let mut items = direct_dot_completion_items(idx, &context, from_uri, cursor_line);
+    filter_inaccessible_completion_items(&mut items);
+    collect_inherited_dot_completion_items(
         idx,
-        &file_uri,
-        &rt.leaf,
+        &context,
+        from_uri,
+        snippets,
+        cursor_line,
+        &mut items,
+    );
+    dedup_completion_labels(&mut items);
+    strip_completion_snippets(&mut items, snippets);
+    items.sort_by_key(|item| kind_sort_rank(item.kind));
+    append_dot_tail_completions(idx, &context.receiver_type, from_uri, snippets, &mut items);
+    items
+}
+
+struct DotCompletionContext {
+    receiver_type: ReceiverType,
+    file_uri: String,
+}
+
+fn dot_completion_context(
+    idx: &Indexer,
+    receiver: &str,
+    from_uri: &Url,
+) -> Option<DotCompletionContext> {
+    let receiver_type = resolve_dot_receiver_type(idx, receiver, from_uri)?;
+    let file_uri = resolve_dot_receiver_file(idx, &receiver_type.outer, from_uri)?;
+    Some(DotCompletionContext {
+        receiver_type,
+        file_uri,
+    })
+}
+
+fn resolve_dot_receiver_type(
+    idx: &Indexer,
+    receiver: &str,
+    from_uri: &Url,
+) -> Option<ReceiverType> {
+    infer_receiver_type(idx, ReceiverKind::Variable(receiver), from_uri).or_else(|| {
+        receiver
+            .starts_with_uppercase()
+            .then(|| ReceiverType::from_raw(receiver.to_string()))
+    })
+}
+
+fn resolve_dot_receiver_file(idx: &Indexer, outer_type: &str, from_uri: &Url) -> Option<String> {
+    Some(
+        resolve_symbol_no_rg(idx, outer_type, from_uri)
+            .first()?
+            .uri
+            .to_string(),
+    )
+}
+
+fn direct_dot_completion_items(
+    idx: &Indexer,
+    context: &DotCompletionContext,
+    from_uri: &Url,
+    cursor_line: Option<u32>,
+) -> Vec<CompletionItem> {
+    symbols_from_nested_type(
+        idx,
+        &context.file_uri,
+        &context.receiver_type.leaf,
         Some(from_uri.as_str()),
         cursor_line,
-    );
+    )
+}
 
-    // Filter out private/protected members — they are inaccessible from outside the class.
-    items.retain(|i| {
-        i.sort_text
-            .as_deref()
-            .map(|s| !s.starts_with("prv:") && !s.starts_with("prt:"))
-            .unwrap_or(true)
-    });
-
-    // Walk the inheritance hierarchy to include members from parent classes/interfaces.
-    // Tracks "file_uri#TypeName" to prevent cycles; seed with the direct type.
-    let mut visited = vec![format!("{}#{}", file_uri, rt.leaf)];
+fn collect_inherited_dot_completion_items(
+    idx: &Indexer,
+    context: &DotCompletionContext,
+    from_uri: &Url,
+    snippets: bool,
+    cursor_line: Option<u32>,
+    items: &mut Vec<CompletionItem>,
+) {
+    let mut visited = vec![format!(
+        "{}#{}",
+        context.file_uri, context.receiver_type.leaf
+    )];
     InheritanceWalker {
         idx,
         calling_uri: from_uri,
         snippets,
         cursor_line,
     }
-    .collect(&file_uri, &rt.leaf, &mut visited, 0, &mut items);
+    .collect(
+        &context.file_uri,
+        &context.receiver_type.leaf,
+        &mut visited,
+        0,
+        items,
+    );
+}
 
-    // Deduplicate by label: direct members win over inherited ones (they come first).
+fn filter_inaccessible_completion_items(items: &mut Vec<CompletionItem>) {
+    items.retain(|item| {
+        item.sort_text
+            .as_deref()
+            .map(|sort_text| !sort_text.starts_with("prv:") && !sort_text.starts_with("prt:"))
+            .unwrap_or(true)
+    });
+}
+
+fn dedup_completion_labels(items: &mut Vec<CompletionItem>) {
     let mut seen_labels = std::collections::HashSet::new();
-    items.retain(|i| seen_labels.insert(i.label.clone()));
+    items.retain(|item| seen_labels.insert(item.label.clone()));
+}
 
-    // Strip snippet fields if client doesn't support them.
-    if !snippets {
-        for item in &mut items {
-            item.insert_text = None;
-            item.insert_text_format = None;
-        }
+fn strip_completion_snippets(items: &mut [CompletionItem], snippets: bool) {
+    if snippets {
+        return;
     }
+    for item in items {
+        item.insert_text = None;
+        item.insert_text_format = None;
+    }
+}
 
-    // Sort: functions/methods first, then fields/vars, then everything else.
-    items.sort_by_key(|i| kind_sort_rank(i.kind));
-
-    // Append stdlib extensions filtered to the receiver type. Only add Kotlin stdlib
-    // when the current file is a Kotlin file; add Swift-specific snippets for Swift.
+fn append_dot_tail_completions(
+    idx: &Indexer,
+    receiver_type: &ReceiverType,
+    from_uri: &Url,
+    snippets: bool,
+    items: &mut Vec<CompletionItem>,
+) {
     let from_path = from_uri.path();
-    items.extend(dot_completions_for_lang(from_path, &rt.qualified, snippets));
-
-    // Append indexed extension functions whose receiver matches `rt.outer`.
-    // These may be defined in other files and need an auto-import.
+    items.extend(dot_completions_for_lang(
+        from_path,
+        &receiver_type.qualified,
+        snippets,
+    ));
     if crate::Language::from_path(from_path).is_kotlin() {
-        items.extend(extension_fn_completions(idx, &rt.outer, from_uri, snippets));
+        items.extend(extension_fn_completions(
+            idx,
+            &receiver_type.outer,
+            from_uri,
+            snippets,
+        ));
     }
-
-    items
 }
 
 /// Recursively collect members from parent classes/interfaces of `type_name`


### PR DESCRIPTION
Second pass of function-split refactoring — all functions over 100 lines.

## Functions split

| Function | File | Lines |
|---|---|---|
| `lambda_receiver_type_from_context` | `infer/it_this.rs` | 136 |
| `extension_fn_completions` | `resolver/complete.rs` | 123 |
| `references_impl` | `backend/handlers.rs` | 112 |
| `lambda_params_at_col` | `indexer/scope.rs` | 108 |
| `hover_impl` | `backend/handlers.rs` | 103 |
| `symbol_impl` | `backend/handlers.rs` | 102 |
| `complete_dot` | `resolver/complete.rs` | 102 |

## Checklist
- [x] `cargo test` passes (686 tests)
- [x] `cargo clippy -W clippy::too_many_lines -W clippy::cognitive_complexity` clean
- [x] No `#[allow(clippy::...)]` suppressions added
- [x] All new helpers are private to their module
- [x] No public API changes