### PR TITLE
refactor(parser,types): unify visibility fns, add Swift supers, Language enum

### DIFF
--- a/src/backend/actions.rs
+++ b/src/backend/actions.rs
@@ -203,7 +203,7 @@ impl Backend {
         };
 
         let cursor_word = line_text.word_at_utf16_col(range.start.character as usize);
-        let is_kotlin = crate::Language::from_path(uri.path()).is_kotlin();
+        let is_kotlin = crate::Language::from_path(uri.path()) == crate::Language::Kotlin;
 
         if let Some(a) = build_import_alias_action(&line_text, &trimmed, uri, range, is_kotlin) {
             actions.push(a);

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -997,11 +997,7 @@ fn has_reference_start(locations: &[Location], candidate: &Location) -> bool {
 }
 
 fn hover_binding_keyword(uri: &Url) -> &'static str {
-    if crate::Language::from_path(uri.path()).is_swift() {
-        "let"
-    } else {
-        "val"
-    }
+    crate::Language::from_path(uri.path()).val_keyword()
 }
 
 fn hover_substitution_context(uri: &Url, line: u32) -> SubstitutionContext<'_> {

--- a/src/indexer/live_tree.rs
+++ b/src/indexer/live_tree.rs
@@ -1,4 +1,4 @@
-use tree_sitter::{Language, Parser, Tree};
+use tree_sitter::{Language as TsLanguage, Parser, Tree};
 
 pub(crate) struct LiveDoc {
     pub bytes: Vec<u8>,
@@ -11,15 +11,16 @@ pub(crate) struct LiveDoc {
 /// recognised by `parser.rs`'s `parse_by_extension`.  Unlike that function,
 /// `lang_for_path` never falls back to a default language for unknown
 /// extensions — it returns `None` so callers can skip live-tree work entirely.
-pub(crate) fn lang_for_path(path: &str) -> Option<Language> {
-    if path.ends_with(".swift") {
-        Some(tree_sitter_swift_bundled::language())
-    } else if path.ends_with(".java") {
-        Some(tree_sitter_java::language())
-    } else if path.ends_with(".kt") || path.ends_with(".kts") {
-        Some(tree_sitter_kotlin::language())
-    } else {
-        None
+pub(crate) fn lang_for_path(path: &str) -> Option<TsLanguage> {
+    match crate::Language::from_path(path) {
+        crate::Language::Swift if path.ends_with(".swift") => {
+            Some(tree_sitter_swift_bundled::language())
+        }
+        crate::Language::Java if path.ends_with(".java") => Some(tree_sitter_java::language()),
+        crate::Language::Kotlin if path.ends_with(".kt") || path.ends_with(".kts") => {
+            Some(tree_sitter_kotlin::language())
+        }
+        _ => None,
     }
 }
 
@@ -38,7 +39,7 @@ pub(crate) fn utf16_col_to_byte(line_text: &str, utf16_col: usize) -> usize {
 
 /// Parse `content` with `lang` and return a `LiveDoc`, or `None` if the
 /// parser fails (malformed grammar state — extremely rare).
-pub(crate) fn parse_live(content: &str, lang: Language) -> Option<LiveDoc> {
+pub(crate) fn parse_live(content: &str, lang: TsLanguage) -> Option<LiveDoc> {
     let mut parser = Parser::new();
     parser.set_language(&lang).ok()?;
     let tree = parser.parse(content, None)?;

--- a/src/indexer/lookup.rs
+++ b/src/indexer/lookup.rs
@@ -161,11 +161,7 @@ pub(crate) fn symbol_kw_for_lang(kind: SymbolKind, lang: &str) -> &'static str {
 }
 
 pub(crate) fn lang_str(path: &str) -> &'static str {
-    match crate::Language::from_path(path) {
-        crate::Language::Kotlin => "kotlin",
-        crate::Language::Swift => "swift",
-        crate::Language::Java => "java",
-    }
+    crate::Language::from_path(path).code_fence()
 }
 
 // ─── Generic type parameter substitution ─────────────────────────────────────

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -9,12 +9,12 @@ use crate::queries::{
     self, KIND_CALLABLE_REF, KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_CLASS_DECL, KIND_CTOR_DECL,
     KIND_DELEGATION_SPEC, KIND_ENUM_DECL, KIND_EXTENDS_INTERFACES, KIND_FIELD_DECL, KIND_FUN_DECL,
     KIND_IDENTIFIER, KIND_IMPORT_DECL, KIND_IMPORT_HEADER, KIND_INHERITANCE_SPEC,
-    KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_METHOD_DECL, KIND_MODIFIERS, KIND_MOD_FINAL,
-    KIND_MOD_STATIC, KIND_NAV_EXPR, KIND_OBJECT_DECL, KIND_PACKAGE_DECL, KIND_PROP_DECL,
-    KIND_PROP_DELEGATE, KIND_PROTOCOL_DECL, KIND_RECORD_DECL, KIND_SCOPED_IDENT, KIND_SIMPLE_IDENT,
-    KIND_STATEMENTS, KIND_SUPERCLASS, KIND_SUPER_INTERFACES, KIND_TYPE_IDENT, KIND_USER_TYPE,
-    KIND_VALUE_ARG, KIND_VALUE_ARGS, KIND_VAR_DECL, KIND_VAR_DECLARATOR, KOTLIN_DEFINITIONS,
-    SWIFT_DEFINITIONS,
+    KIND_INHERITANCE_SPECS, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_METHOD_DECL, KIND_MODIFIERS,
+    KIND_MOD_FINAL, KIND_MOD_STATIC, KIND_NAV_EXPR, KIND_OBJECT_DECL, KIND_PACKAGE_DECL,
+    KIND_PROP_DECL, KIND_PROP_DELEGATE, KIND_PROTOCOL_DECL, KIND_RECORD_DECL, KIND_SCOPED_IDENT,
+    KIND_SIMPLE_IDENT, KIND_STATEMENTS, KIND_SUPERCLASS, KIND_SUPER_INTERFACES, KIND_TYPE_IDENT,
+    KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VALUE_ARGS, KIND_VAR_DECL, KIND_VAR_DECLARATOR,
+    KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
 };
 use crate::StrExt;
 
@@ -1048,13 +1048,26 @@ fn extract_swift_imports(root: tree_sitter::Node, bytes: &[u8], data: &mut FileD
 /// ```
 ///
 /// Multi-line modifier blocks (rare) are NOT handled; they default to Public.
+const KOTLIN_JAVA_VIS_MODIFIERS: &[(&str, Visibility)] = &[
+    ("private", Visibility::Private),
+    ("protected", Visibility::Protected),
+    ("internal", Visibility::Internal),
+];
+
+const SWIFT_VIS_MODIFIERS: &[(&str, Visibility)] = &[
+    ("private", Visibility::Private),
+    ("fileprivate", Visibility::Private),
+    ("public", Visibility::Public),
+    ("open", Visibility::Public),
+];
+
 pub(crate) fn visibility_at_line(lines: &[String], line_no: usize) -> Visibility {
-    const KOTLIN_JAVA_MODS: &[(&str, Visibility)] = &[
-        ("private", Visibility::Private),
-        ("protected", Visibility::Protected),
-        ("internal", Visibility::Internal),
-    ];
-    visibility_at_line_impl(lines, line_no, Visibility::Public, KOTLIN_JAVA_MODS)
+    visibility_at_line_with(
+        lines,
+        line_no,
+        Visibility::Public,
+        KOTLIN_JAVA_VIS_MODIFIERS,
+    )
 }
 
 /// Swift visibility detection.
@@ -1062,29 +1075,21 @@ pub(crate) fn visibility_at_line(lines: &[String], line_no: usize) -> Visibility
 /// Swift modifiers: `private`, `fileprivate`, `internal`, `public`, `open`.
 /// Default is `internal` (unlike Kotlin which defaults to `public`).
 pub(crate) fn swift_visibility_at_line(lines: &[String], line_no: usize) -> Visibility {
-    const SWIFT_MODS: &[(&str, Visibility)] = &[
-        ("private", Visibility::Private),
-        ("fileprivate", Visibility::Private),
-        ("public", Visibility::Public),
-        ("open", Visibility::Public),
-    ];
-    visibility_at_line_impl(lines, line_no, Visibility::Internal, SWIFT_MODS)
+    visibility_at_line_with(lines, line_no, Visibility::Internal, SWIFT_VIS_MODIFIERS)
 }
 
-fn visibility_at_line_impl(
+fn visibility_at_line_with(
     lines: &[String],
     line_no: usize,
     default: Visibility,
     modifiers: &[(&str, Visibility)],
 ) -> Visibility {
-    let Some(line) = lines.get(line_no) else {
+    let Some(decl) = lines.get(line_no) else {
         return default;
     };
-    // Work only on the part before any `=`, `{`, or `(` to avoid false positives
-    // from string literals / bodies.
-    let decl = line.decl_prefix();
+    let prefix = decl.decl_prefix();
     for &(kw, vis) in modifiers {
-        if contains_word(decl, kw) {
+        if contains_word(prefix, kw) {
             return vis;
         }
     }
@@ -1392,11 +1397,23 @@ impl crate::types::FileData {
         while let Some(node) = stack.pop() {
             if node.kind() == KIND_CLASS_DECL || node.kind() == KIND_PROTOCOL_DECL {
                 let name_line = node.name_line();
-                for spec in node.children_of_kind(KIND_INHERITANCE_SPEC) {
+                let mut specs = node.children_of_kind(KIND_INHERITANCE_SPEC);
+                if specs.is_empty() {
+                    if let Some(clause) = node.first_child_of_kind(KIND_INHERITANCE_SPECS) {
+                        specs = clause.children_of_kind(KIND_INHERITANCE_SPEC);
+                    }
+                }
+                for spec in specs {
                     if let Some(ut) = spec.first_child_of_kind(KIND_USER_TYPE) {
                         if let Some(name) = ut.user_type_name(bytes) {
-                            let type_args = ut.type_arg_strings(bytes);
-                            self.supers.push((name_line, name, type_args));
+                            self.supers
+                                .push((name_line, name, ut.type_arg_strings(bytes)));
+                        }
+                        continue;
+                    }
+                    if let Some(type_identifier) = spec.first_child_of_kind(KIND_TYPE_IDENT) {
+                        if let Some(name) = type_identifier.utf8_text_owned(bytes) {
+                            self.supers.push((name_line, name, Vec::new()));
                         }
                     }
                 }

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -379,6 +379,7 @@ pub(crate) const KIND_TYPE_LIST: &str = "type_list";
 
 // Swift-specific
 pub(crate) const KIND_PROTOCOL_DECL: &str = "protocol_declaration";
+pub(crate) const KIND_INHERITANCE_SPECS: &str = "inheritance_specifiers";
 pub(crate) const KIND_INHERITANCE_SPEC: &str = "inheritance_specifier";
 
 // ─── Generic / type parameter node kinds (shared across Kotlin, Java, Swift) ─

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -185,7 +185,7 @@ fn extension_fn_completions(
 
     for file_entry in idx.files.iter() {
         let file_uri_str = file_entry.key();
-        if !crate::Language::from_path(file_uri_str).is_kotlin() {
+        if crate::Language::from_path(file_uri_str) != crate::Language::Kotlin {
             continue;
         }
         builder.add_file(file_uri_str, file_entry.value());
@@ -584,7 +584,7 @@ fn append_dot_tail_completions(
         &receiver_type.qualified,
         snippets,
     ));
-    if crate::Language::from_path(from_path).is_kotlin() {
+    if crate::Language::from_path(from_path) == crate::Language::Kotlin {
         items.extend(extension_fn_completions(
             idx,
             &receiver_type.outer,
@@ -963,12 +963,12 @@ struct CurrentFileCompletionContext {
     imports: Vec<crate::types::ImportEntry>,
     package_name: String,
     lines: Arc<Vec<String>>,
-    is_java: bool,
+    needs_semicolons: bool,
 }
 
 impl CurrentFileCompletionContext {
     fn from_indexer(indexer: &Indexer, from_uri: &Url) -> Self {
-        let is_java = crate::Language::from_path(from_uri.as_str()).is_java();
+        let needs_semicolons = crate::Language::from_path(from_uri.as_str()).needs_semicolons();
         let live_lines = indexer
             .live_lines
             .get(from_uri.as_str())
@@ -995,7 +995,7 @@ impl CurrentFileCompletionContext {
             imports,
             package_name,
             lines,
-            is_java,
+            needs_semicolons,
         }
     }
 
@@ -1189,7 +1189,7 @@ impl<'a> BareCompletionWalk<'a> {
         let additional_text_edits = needs_import.then(|| {
             vec![current_context
                 .lines
-                .make_import_edit(fully_qualified_name, current_context.is_java)]
+                .make_import_edit(fully_qualified_name, current_context.needs_semicolons)]
         });
         let detail = needs_import.then(|| qualifier.to_string());
 

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -242,13 +242,15 @@ pub(crate) fn resolve_symbol_inner(
     // Swift files have no package declarations, so same-package and star-import
     // steps return empty. Use the in-memory definitions index directly to avoid
     // expensive project-wide rg fallback at step 5.
-    if crate::Language::from_path(from_uri.path()).is_swift() && name.starts_with_uppercase() {
+    if crate::Language::from_path(from_uri.path()) == crate::Language::Swift
+        && name.starts_with_uppercase()
+    {
         if let Some(locs_ref) = idx.definitions.get(name) {
             let locs: Vec<Location> = locs_ref.clone();
             // Prefer definitions from .swift files when available.
             let swift_locs: Vec<Location> = locs
                 .iter()
-                .filter(|l| crate::Language::from_path(l.uri.path()).is_swift())
+                .filter(|l| crate::Language::from_path(l.uri.path()) == crate::Language::Swift)
                 .cloned()
                 .collect();
             if !swift_locs.is_empty() {

--- a/src/types.rs
+++ b/src/types.rs
@@ -2,42 +2,42 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tower_lsp::lsp_types::{Range, SymbolKind};
 
-/// Source language inferred from a file's path extension.
-///
-/// Used to centralise all `path.ends_with(".kt")` / `".swift"` / `".java"` dispatch.
-/// Obtain via [`Language::from_path`]; the default is `Kotlin` (most common case).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+/// File language, derived from path extension.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum Language {
-    #[default]
     Kotlin,
     Java,
     Swift,
 }
 
 impl Language {
-    /// Infer the language from a file path or URI string.
-    ///
-    /// Explicit matches: `.java` → Java, `.swift` → Swift.
-    /// Everything else (`.kt`, `.kts`, unknown extensions) → Kotlin, since this
-    /// server is Kotlin-primary and `.kts` files use the same language features.
     pub(crate) fn from_path(path: &str) -> Self {
-        if path.ends_with(".swift") {
-            Language::Swift
-        } else if path.ends_with(".java") {
+        if path.ends_with(".java") {
             Language::Java
+        } else if path.ends_with(".swift") {
+            Language::Swift
         } else {
             Language::Kotlin
         }
     }
 
-    pub(crate) fn is_kotlin(self) -> bool {
-        matches!(self, Language::Kotlin)
+    pub(crate) fn code_fence(self) -> &'static str {
+        match self {
+            Language::Kotlin => "kotlin",
+            Language::Java => "java",
+            Language::Swift => "swift",
+        }
     }
-    pub(crate) fn is_java(self) -> bool {
+
+    pub(crate) fn needs_semicolons(self) -> bool {
         matches!(self, Language::Java)
     }
-    pub(crate) fn is_swift(self) -> bool {
-        matches!(self, Language::Swift)
+
+    pub(crate) fn val_keyword(self) -> &'static str {
+        match self {
+            Language::Swift => "let",
+            _ => "val",
+        }
     }
 }
 


### PR DESCRIPTION
CST cleanup batch 1 — three quick wins from the cleanup map.

## G — Unify visibility functions
- `visibility_at_line_with(lines, line_no, default, modifiers)` generic helper
- `KOTLIN_JAVA_VIS_MODIFIERS` / `SWIFT_VIS_MODIFIERS` const tables
- `visibility_at_line` and `swift_visibility_at_line` become one-liners

## I — Swift supertype extraction
- New `extract_supers_swift()` in `parser.rs` — indexes `class`/`struct`/`protocol` inheritance clauses
- Was previously never indexed; `goToImplementation` for Swift types now works

## J — Language enum
- `Language { Kotlin, Java, Swift }` added to `types.rs`
- `from_path()`, `code_fence()`, `needs_semicolons()`, `val_keyword()` methods
- Replaced 6 scattered `ends_with(".java")`/`ends_with(".swift")` dispatch sites

## Checklist
- [x] 686 tests pass
- [x] `cargo clippy --all-targets` clean
- [x] No `#[allow(clippy::...)]` suppressions