### PR TITLE
refactor(wave1): KIND_ constants, CallerContext, ensure_file_data, walk_hierarchy

### DIFF
--- a/src/backend/actions.rs
+++ b/src/backend/actions.rs
@@ -167,15 +167,13 @@ impl Backend {
         let uri = &params.text_document.uri;
         let range = params.range;
 
+        let lines = self.indexer.mem_lines_for(uri.as_str());
         let line_text: String = {
             let ln = range.start.line as usize;
-            if let Some(ll) = self.indexer.live_lines.get(uri.as_str()) {
-                ll.get(ln).cloned().unwrap_or_default()
-            } else if let Some(data) = self.indexer.files.get(uri.as_str()) {
-                data.lines.get(ln).cloned().unwrap_or_default()
-            } else {
-                String::new()
-            }
+            lines
+                .as_ref()
+                .and_then(|lines| lines.get(ln).cloned())
+                .unwrap_or_default()
         };
 
         let trimmed = line_text.trim().to_owned();
@@ -192,15 +190,10 @@ impl Backend {
             }
         }
 
-        let all_lines: Vec<String> = {
-            if let Some(ll) = self.indexer.live_lines.get(uri.as_str()) {
-                ll.clone().to_vec()
-            } else if let Some(data) = self.indexer.files.get(uri.as_str()) {
-                data.lines.to_vec()
-            } else {
-                vec![]
-            }
-        };
+        let all_lines: Vec<String> = lines
+            .as_ref()
+            .map(|lines| lines.as_ref().clone())
+            .unwrap_or_default();
 
         let cursor_word = line_text.word_at_utf16_col(range.start.character as usize);
         let is_kotlin = crate::Language::from_path(uri.path()) == crate::Language::Kotlin;

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -3,14 +3,11 @@ use super::cursor::CursorContext;
 use super::format::{format_contextual_hover, format_symbol_hover};
 use super::helpers::resolve_references_scope;
 use super::Backend;
-use crate::indexer::apply_type_subst;
-use crate::indexer::find_fun_signature_with_receiver;
 use crate::indexer::resolution::{
     enrich_at_location, resolve_symbol_info, ResolveOptions, SubstitutionContext,
 };
-use crate::indexer::NodeExt;
+use crate::indexer::{apply_type_subst, cst_call_info, find_fun_signature_with_receiver, CallInfo};
 use crate::inlay_hints::compute_inlay_hints;
-use crate::queries::{KIND_CALL_EXPR, KIND_LAMBDA_LIT, KIND_VALUE_ARG};
 use crate::StrExt;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
@@ -169,34 +166,18 @@ impl Backend {
         parent_class: Option<&str>,
     ) -> Vec<String> {
         self.indexer
-            .definitions
-            .get(name)
-            .map(|locations| {
-                locations
-                    .iter()
-                    .filter(|location| {
-                        reference_matches_parent_class(&self.indexer, location, parent_class)
-                    })
-                    .filter_map(|location| location.uri.to_file_path().ok())
-                    .filter_map(|path| path.to_str().map(|path| path.to_owned()))
-                    .collect()
+            .definition_locations(name)
+            .into_iter()
+            .filter(|location| {
+                reference_matches_parent_class(&self.indexer, location, parent_class)
             })
-            .unwrap_or_default()
+            .filter_map(|location| location.uri.to_file_path().ok())
+            .filter_map(|path| path.to_str().map(|path| path.to_owned()))
+            .collect()
     }
 
     async fn rg_reference_locations(&self, search: &ReferenceSearch) -> Vec<Location> {
-        let workspace_root = self
-            .indexer
-            .workspace_root
-            .read()
-            .ok()
-            .and_then(|root| root.clone());
-        let ignore_matcher = self
-            .indexer
-            .ignore_matcher
-            .read()
-            .ok()
-            .and_then(|matcher| matcher.clone());
+        let (workspace_root, ignore_matcher) = self.rg_context().await;
         let request = search.clone();
         tokio::task::spawn_blocking(move || {
             let rg_request = crate::rg::RgSearchRequest::new(
@@ -215,10 +196,7 @@ impl Backend {
     }
 
     fn filter_library_reference_locations(&self, locations: &mut Vec<Location>) {
-        if self.indexer.library_uris.is_empty() {
-            return;
-        }
-        locations.retain(|location| !self.indexer.library_uris.contains(location.uri.as_str()));
+        locations.retain(|location| !self.indexer.is_library_uri(&location.uri));
     }
 
     fn add_current_file_reference_locations(
@@ -227,10 +205,10 @@ impl Backend {
         name: &str,
         locations: &mut Vec<Location>,
     ) {
-        let Some(data) = self.indexer.files.get(uri.as_str()) else {
+        let Some(lines) = self.indexer.mem_lines_for(uri.as_str()) else {
             return;
         };
-        for (line_idx, line) in data.lines.iter().enumerate() {
+        for (line_idx, line) in lines.iter().enumerate() {
             let line_number = line_idx as u32;
             if has_reference_line(locations, uri, line_number) {
                 continue;
@@ -304,11 +282,11 @@ impl Backend {
 
     fn collect_workspace_symbols(&self, query: &WorkspaceSymbolQuery) -> Vec<SymbolInformation> {
         let mut results = Vec::new();
-        for entry in self.indexer.files.iter() {
-            let Some(uri) = workspace_symbol_uri(entry.key()) else {
+        for (uri_str, data) in self.indexer.indexed_files() {
+            let Some(uri) = workspace_symbol_uri(&uri_str) else {
                 continue;
             };
-            collect_matching_workspace_symbols(&uri, &entry.value().symbols, query, &mut results);
+            collect_matching_workspace_symbols(&uri, &data.symbols, query, &mut results);
             if results.len() >= WORKSPACE_SYMBOL_CAP {
                 break;
             }
@@ -321,18 +299,7 @@ impl Backend {
         if !query.allows_rg_fallback() {
             return vec![];
         }
-        let workspace_root = self
-            .indexer
-            .workspace_root
-            .read()
-            .ok()
-            .and_then(|root| root.clone());
-        let ignore_matcher = self
-            .indexer
-            .ignore_matcher
-            .read()
-            .ok()
-            .and_then(|matcher| matcher.clone());
+        let (workspace_root, ignore_matcher) = self.rg_context().await;
         let query_text = query.raw.clone();
         let rg_locations = tokio::task::spawn_blocking(move || {
             crate::rg::rg_find_definition(
@@ -400,13 +367,11 @@ impl Backend {
         params: FoldingRangeParams,
     ) -> Result<Option<Vec<FoldingRange>>> {
         let uri = &params.text_document.uri;
-        let data = match self.indexer.files.get(uri.as_str()) {
-            Some(d) => d,
-            None => return Ok(None),
+        let Some(lines) = self.indexer.mem_lines_for(uri.as_str()) else {
+            return Ok(None);
         };
 
         let mut ranges: Vec<FoldingRange> = Vec::new();
-        let lines = &data.lines;
         let mut stack: Vec<u32> = Vec::new();
 
         for (i, line) in lines.iter().enumerate() {
@@ -484,23 +449,18 @@ impl Backend {
         // as Write highlights; all other occurrences are Read.
         let decl_lines: std::collections::HashSet<u32> = self
             .indexer
-            .definitions
-            .get(&name)
-            .map(|locs| {
-                locs.iter()
-                    .filter(|l| l.uri == *uri)
-                    .map(|l| l.range.start.line)
-                    .collect()
-            })
-            .unwrap_or_default();
+            .definition_locations(&name)
+            .into_iter()
+            .filter(|location| location.uri == *uri)
+            .map(|location| location.range.start.line)
+            .collect();
 
-        let data = match self.indexer.files.get(uri.as_str()) {
-            Some(d) => d,
-            None => return Ok(None),
+        let Some(lines) = self.indexer.mem_lines_for(uri.as_str()) else {
+            return Ok(None);
         };
 
         let mut highlights = Vec::new();
-        for (line_idx, line) in data.lines.iter().enumerate() {
+        for (line_idx, line) in lines.iter().enumerate() {
             for abs in word_byte_offsets(line, &name) {
                 let col: u32 = line[..abs].chars().map(|c| c.len_utf16() as u32).sum();
                 let col_end: u32 = col + name.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
@@ -563,16 +523,6 @@ fn build_signature_help(
     })
 }
 
-/// Resolved call-site information needed for `textDocument/signatureHelp`.
-struct CallInfo {
-    /// Name of the function being called.
-    fn_name: String,
-    /// Optional receiver before the dot (e.g. `"builder"` in `builder.build()`).
-    qualifier: Option<String>,
-    /// Zero-based index of the parameter the cursor is currently inside.
-    active_param: u32,
-}
-
 /// Extract [`CallInfo`] for the call under the cursor.
 ///
 /// Tries the CST (live tree) first — O(depth), accurate qualifier extraction.
@@ -586,87 +536,11 @@ fn extract_call_info(
     before: &str,
     line_idx: usize,
 ) -> Option<CallInfo> {
-    // ── CST path ─────────────────────────────────────────────────────────────
     if let Some(result) = cst_call_info(pos, indexer, uri) {
         return Some(result);
     }
 
-    // ── Text path ────────────────────────────────────────────────────────────
     text_call_info(lines, before, line_idx)
-}
-
-/// CST path: walk from cursor up to `call_expression`, extract name/qualifier/param.
-///
-/// Returns `None` when:
-/// - no live tree available
-/// - cursor is inside a `lambda_literal`
-/// - callee shape not recognised (`simple_identifier` / `navigation_expression`)
-fn cst_call_info(pos: Position, indexer: &crate::indexer::Indexer, uri: &Url) -> Option<CallInfo> {
-    use crate::indexer::live_tree::utf16_col_to_byte;
-    use tree_sitter::Point;
-
-    let doc = indexer.live_doc(uri)?;
-    let bytes = &doc.bytes;
-    let full_text = std::str::from_utf8(bytes).ok()?;
-
-    let line_idx = pos.line as usize;
-    let line_text = full_text.lines().nth(line_idx)?;
-    let byte_col = utf16_col_to_byte(line_text, pos.character as usize);
-    let point = Point {
-        row: line_idx,
-        column: byte_col,
-    };
-    let start_node = doc
-        .tree
-        .root_node()
-        .descendant_for_point_range(point, point)?;
-
-    // Walk up: find call_expression; bail out if we cross into a lambda literal.
-    let mut cur = start_node;
-    let call_expr = loop {
-        match cur.kind() {
-            KIND_CALL_EXPR => break Some(cur),
-            KIND_LAMBDA_LIT => break None,
-            _ => match cur.parent() {
-                Some(p) => cur = p,
-                None => break None,
-            },
-        }
-    }?;
-
-    // Extract function name and optional qualifier from the callee.
-    let (fn_name, qualifier) = call_expr.call_fn_and_qualifier(bytes)?;
-
-    // Find the value_arguments node (may be inside call_suffix).
-    let value_arguments = call_expr.find_value_arguments()?;
-
-    // Count active param: how many value_argument children end before the cursor.
-    let cursor_byte = full_text
-        .lines()
-        .take(line_idx)
-        .map(|l| l.len() + 1) // +1 for the newline
-        .sum::<usize>()
-        + byte_col;
-    let active_param = {
-        let mut count = 0u32;
-        let mut walker = value_arguments.walk();
-        for child in value_arguments.children(&mut walker) {
-            if child.kind() == KIND_VALUE_ARG {
-                if child.end_byte() <= cursor_byte {
-                    count += 1;
-                } else {
-                    break;
-                }
-            }
-        }
-        count
-    };
-
-    Some(CallInfo {
-        fn_name,
-        qualifier,
-        active_param,
-    })
 }
 
 /// Scans a single source line for an unclosed call-site opening.

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -10,7 +10,7 @@ use crate::indexer::resolution::{
 };
 use crate::indexer::NodeExt;
 use crate::inlay_hints::compute_inlay_hints;
-use crate::queries::KIND_VALUE_ARG;
+use crate::queries::{KIND_CALL_EXPR, KIND_LAMBDA_LIT, KIND_VALUE_ARG};
 use crate::StrExt;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
@@ -625,8 +625,8 @@ fn cst_call_info(pos: Position, indexer: &crate::indexer::Indexer, uri: &Url) ->
     let mut cur = start_node;
     let call_expr = loop {
         match cur.kind() {
-            "call_expression" => break Some(cur),
-            "lambda_literal" => break None,
+            KIND_CALL_EXPR => break Some(cur),
+            KIND_LAMBDA_LIT => break None,
             _ => match cur.parent() {
                 Some(p) => cur = p,
                 None => break None,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -136,18 +136,8 @@ impl Backend {
     }
 
     pub(crate) async fn rg_context(&self) -> (Option<PathBuf>, Option<Arc<IgnoreMatcher>>) {
-        let root = self
-            .indexer
-            .workspace_root
-            .read()
-            .ok()
-            .and_then(|root| root.clone());
-        let ignore = self
-            .indexer
-            .ignore_matcher
-            .read()
-            .ok()
-            .and_then(|ignore| ignore.clone());
+        let root = self.indexer.workspace_root.read().unwrap().clone();
+        let ignore = self.indexer.ignore_matcher.read().unwrap().clone();
         (root, ignore)
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -135,6 +135,22 @@ impl Backend {
         }
     }
 
+    pub(crate) async fn rg_context(&self) -> (Option<PathBuf>, Option<Arc<IgnoreMatcher>>) {
+        let root = self
+            .indexer
+            .workspace_root
+            .read()
+            .ok()
+            .and_then(|root| root.clone());
+        let ignore = self
+            .indexer
+            .ignore_matcher
+            .read()
+            .ok()
+            .and_then(|ignore| ignore.clone());
+        (root, ignore)
+    }
+
     /// Try `find_definition_qualified` with `rt.qualified`, falling back to `rt.leaf`
     /// when the first lookup is empty and the two names differ.
     pub(super) fn resolve_with_receiver_fallback(
@@ -801,7 +817,7 @@ impl LanguageServer for Backend {
         }
 
         self.indexer.remove_live_tree(uri);
-        self.indexer.live_lines.remove(uri.as_str());
+        self.indexer.remove_live_lines(uri);
         // Clear diagnostics so stale errors don't linger after the file is closed.
         self.client
             .publish_diagnostics(params.text_document.uri, Vec::new(), None)
@@ -839,7 +855,7 @@ impl LanguageServer for Backend {
         for change in params.changes {
             if change.typ == FileChangeType::DELETED {
                 // Remove from index; definition map cleanup is handled lazily.
-                self.indexer.files.remove(change.uri.as_str());
+                self.indexer.remove_indexed_file(&change.uri);
                 continue;
             }
             let uri = change.uri;

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -103,14 +103,9 @@ impl Backend {
         // Use effective_rg_root so searches use the open file's project root
         // when workspace_root points to a different project (e.g. android vs ios).
         let file_path = uri.to_file_path().ok();
-        let (root_opt, matcher) = {
-            let wr = self.indexer.workspace_root.read().unwrap().clone();
-            let m = self.indexer.ignore_matcher.read().unwrap().clone();
-            (
-                crate::rg::effective_rg_root(wr.as_deref(), file_path.as_deref()),
-                m,
-            )
-        };
+        let (workspace_root, matcher) = self.rg_context().await;
+        let root_opt =
+            crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
         let name_clone = ctx.word.clone();
         let rg_locs = tokio::task::spawn_blocking(move || {
             crate::rg::rg_find_definition(&name_clone, root_opt.as_deref(), matcher.as_deref())
@@ -144,14 +139,9 @@ impl Backend {
         // to find implementors quickly to avoid client timeouts in large projects.
         if locs.is_empty() {
             let file_path = uri.to_file_path().ok();
-            let (root_opt, matcher) = {
-                let wr = self.indexer.workspace_root.read().unwrap().clone();
-                let m = self.indexer.ignore_matcher.read().unwrap().clone();
-                (
-                    crate::rg::effective_rg_root(wr.as_deref(), file_path.as_deref()),
-                    m,
-                )
-            };
+            let (workspace_root, matcher) = self.rg_context().await;
+            let root_opt =
+                crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
             let word_clone = word.clone();
             let rg_impls = tokio::task::spawn_blocking(move || {
                 crate::rg::rg_find_implementors(
@@ -250,14 +240,9 @@ impl Backend {
     pub(super) async fn rg_resolve(&self, uri: &Url, name: &str) -> Vec<Location> {
         let name_clone = name.to_string();
         let file_path = uri.to_file_path().ok();
-        let (root_opt, matcher) = {
-            let wr = self.indexer.workspace_root.read().unwrap().clone();
-            let m = self.indexer.ignore_matcher.read().unwrap().clone();
-            (
-                crate::rg::effective_rg_root(wr.as_deref(), file_path.as_deref()),
-                m,
-            )
-        };
+        let (workspace_root, matcher) = self.rg_context().await;
+        let root_opt =
+            crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
         tokio::task::spawn_blocking(move || {
             crate::rg::rg_find_definition(&name_clone, root_opt.as_deref(), matcher.as_deref())
         })

--- a/src/backend/rename.rs
+++ b/src/backend/rename.rs
@@ -1,94 +1,18 @@
 use super::actions::is_non_call_keyword;
 use super::helpers::resolve_references_scope;
 use super::Backend;
+use crate::indexer::cst_cursor_is_local_var;
+#[cfg(test)]
 use crate::indexer::live_tree::utf16_col_to_byte;
+#[cfg(test)]
 use crate::queries::{
-    KIND_ANON_FUN, KIND_CLASS_BODY, KIND_COMPANION_OBJ, KIND_FUN_DECL, KIND_LAMBDA_LIT,
-    KIND_METHOD_DECL, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_OBJECT_DECL, KIND_PROP_DECL,
-    KIND_SOURCE_FILE, KIND_VAR_DECL,
+    KIND_ANON_FUN, KIND_CLASS_BODY, KIND_COMPANION_OBJ, KIND_FUN_DECL, KIND_METHOD_DECL,
+    KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_OBJECT_DECL, KIND_PROP_DECL, KIND_SOURCE_FILE,
+    KIND_VAR_DECL,
 };
 use crate::StrExt;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
-
-/// Return `true` when the cursor is on a local variable declaration — i.e. a
-/// `property_declaration` / `variable_declaration` whose nearest scope-boundary
-/// ancestor is a function/lambda body rather than a class body or source file.
-///
-/// This is used to decide whether to skip dotted occurrences during rename:
-/// - local var `val syncWith` inside a function → `skip_dotted = true`
-///   (avoid renaming `.syncWith()` method calls)
-/// - class property `val myProp` → `skip_dotted = false`
-///   (must rename `this.myProp` / `obj.myProp` accesses)
-/// - navigation expression (`.method()`) → `skip_dotted = false`
-/// - function declaration → `skip_dotted = false`
-fn cst_cursor_is_local_var(indexer: &crate::indexer::Indexer, uri: &Url, pos: Position) -> bool {
-    use tree_sitter::Point;
-
-    let doc = match indexer.live_doc(uri) {
-        Some(d) => d,
-        None => return false,
-    };
-    let full_text = match std::str::from_utf8(&doc.bytes) {
-        Ok(s) => s,
-        Err(_) => return false,
-    };
-    let line_idx = pos.line as usize;
-    let line_text = match full_text.lines().nth(line_idx) {
-        Some(l) => l,
-        None => return false,
-    };
-    let byte_col = utf16_col_to_byte(line_text, pos.character as usize);
-    let point = Point {
-        row: line_idx,
-        column: byte_col,
-    };
-    let start_node = match doc
-        .tree
-        .root_node()
-        .descendant_for_point_range(point, point)
-    {
-        Some(n) => n,
-        None => return false,
-    };
-
-    // Track whether we've entered a property/variable declaration binding.
-    let mut in_binding = false;
-    let mut cur = start_node;
-    loop {
-        let kind = cur.kind();
-        match kind {
-            // Entering a property/variable binding — continue walking up.
-            KIND_PROP_DECL | KIND_VAR_DECL | KIND_MULTI_VAR_DECL => {
-                in_binding = true;
-            }
-            // Inside a binding and hit a function/lambda boundary → local variable.
-            KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT if in_binding => {
-                return true;
-            }
-            // Function/method/lambda without being in a binding → not a local var.
-            KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT => return false,
-            // Navigation expression → member access, not a local var.
-            KIND_NAV_EXPR => return false,
-            // Class body, companion object, or source file reached while in a binding
-            // → class-level or top-level property, NOT a local var.
-            KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | KIND_SOURCE_FILE
-                if in_binding =>
-            {
-                return false;
-            }
-            // Scope boundary without being in a binding → not applicable.
-            KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | KIND_SOURCE_FILE => {
-                return false;
-            }
-            _ => {}
-        }
-        match cur.parent() {
-            Some(p) => cur = p,
-            None => return false,
-        }
-    }
-}
 
 /// Return `true` when the file index (within `scope`) contains a `val`/`var`
 /// declaration of `name` that is itself a local variable.
@@ -110,12 +34,9 @@ fn any_local_var_decl_in_scope(
 ) -> bool {
     use tower_lsp::lsp_types::SymbolKind;
 
-    let file = match indexer.files.get(uri.as_str()) {
-        Some(f) => f,
-        None => return false,
-    };
-    file.symbols
-        .iter()
+    indexer
+        .file_symbols(uri)
+        .into_iter()
         .filter(|s| {
             matches!(
                 s.kind,
@@ -404,24 +325,19 @@ impl Backend {
 
     fn definition_files_for_rename(&self, name: &str, parent_class: Option<&str>) -> Vec<String> {
         self.indexer
-            .definitions
-            .get(name)
-            .map(|locations| {
-                locations
-                    .iter()
-                    .filter(|location| {
-                        parent_class.is_none_or(|parent| {
-                            self.indexer
-                                .enclosing_class_at(&location.uri, location.range.start.line)
-                                .as_deref()
-                                == Some(parent)
-                        })
-                    })
-                    .filter_map(|location| location.uri.to_file_path().ok())
-                    .filter_map(|path| path.to_str().map(str::to_owned))
-                    .collect()
+            .definition_locations(name)
+            .into_iter()
+            .filter(|location| {
+                parent_class.is_none_or(|parent| {
+                    self.indexer
+                        .enclosing_class_at(&location.uri, location.range.start.line)
+                        .as_deref()
+                        == Some(parent)
+                })
             })
-            .unwrap_or_default()
+            .filter_map(|location| location.uri.to_file_path().ok())
+            .filter_map(|path| path.to_str().map(str::to_owned))
+            .collect()
     }
 
     async fn collect_reference_locations(
@@ -433,8 +349,7 @@ impl Backend {
             &rename_target.name,
             rename_target.parent_class.as_deref(),
         );
-        let root = self.indexer.workspace_root.read().unwrap().clone();
-        let matcher = self.indexer.ignore_matcher.read().unwrap().clone();
+        let (root, matcher) = self.rg_context().await;
         let uri_clone = uri.clone();
         let name = rename_target.name.clone();
         let parent_class = rename_target.parent_class.clone();
@@ -454,10 +369,7 @@ impl Backend {
         .await
         .unwrap_or_default();
 
-        let library_uris = &self.indexer.library_uris;
-        if !library_uris.is_empty() {
-            reference_locations.retain(|location| !library_uris.contains(location.uri.as_str()));
-        }
+        reference_locations.retain(|location| !self.indexer.is_library_uri(&location.uri));
         reference_locations
     }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -24,8 +24,9 @@ pub(crate) mod resolution;
 pub(crate) use self::infer::{
     collect_all_fun_params_texts,
     collect_params_from_line,
-    // sig.rs
     collect_signature,
+    cst_call_info,
+    cst_cursor_is_local_var,
     extract_first_arg,
     extract_named_arg_name,
     // args.rs
@@ -50,6 +51,8 @@ pub(crate) use self::infer::{
     line_has_lambda_param,
     nth_fun_param_type_str,
     strip_trailing_call_args,
+    // sig.rs
+    CallInfo,
 };
 
 mod cache;
@@ -314,6 +317,51 @@ impl Indexer {
             return Some(live.clone());
         }
         self.files.get(uri).map(|f| f.lines.clone())
+    }
+
+    pub(crate) fn live_lines_for(&self, uri: &Url) -> Option<Arc<Vec<String>>> {
+        self.live_lines
+            .get(uri.as_str())
+            .map(|lines| Arc::clone(lines.value()))
+    }
+
+    pub(crate) fn file_data(&self, uri: &Url) -> Option<Arc<FileData>> {
+        self.files
+            .get(uri.as_str())
+            .map(|data| Arc::clone(data.value()))
+    }
+
+    pub(crate) fn definition_locations(&self, name: &str) -> Vec<Location> {
+        self.definitions
+            .get(name)
+            .map(|locations| locations.clone())
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn subtype_locations(&self, name: &str) -> Vec<Location> {
+        self.subtypes
+            .get(name)
+            .map(|locations| locations.clone())
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn indexed_files(&self) -> Vec<(String, Arc<FileData>)> {
+        self.files
+            .iter()
+            .map(|entry| (entry.key().clone(), Arc::clone(entry.value())))
+            .collect()
+    }
+
+    pub(crate) fn is_library_uri(&self, uri: &Url) -> bool {
+        self.library_uris.contains(uri.as_str())
+    }
+
+    pub(crate) fn remove_live_lines(&self, uri: &Url) {
+        self.live_lines.remove(uri.as_str());
+    }
+
+    pub(crate) fn remove_indexed_file(&self, uri: &Url) {
+        self.files.remove(uri.as_str());
     }
 
     // ─── completion helpers (methods on Indexer) ─────────────────────────────

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -319,12 +319,14 @@ impl Indexer {
         self.files.get(uri).map(|f| f.lines.clone())
     }
 
+    #[allow(dead_code)]
     pub(crate) fn live_lines_for(&self, uri: &Url) -> Option<Arc<Vec<String>>> {
         self.live_lines
             .get(uri.as_str())
             .map(|lines| Arc::clone(lines.value()))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn file_data(&self, uri: &Url) -> Option<Arc<FileData>> {
         self.files
             .get(uri.as_str())
@@ -338,6 +340,7 @@ impl Indexer {
             .unwrap_or_default()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn subtype_locations(&self, name: &str) -> Vec<Location> {
         self.subtypes
             .get(name)

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -319,30 +319,8 @@ impl Indexer {
         self.files.get(uri).map(|f| f.lines.clone())
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn live_lines_for(&self, uri: &Url) -> Option<Arc<Vec<String>>> {
-        self.live_lines
-            .get(uri.as_str())
-            .map(|lines| Arc::clone(lines.value()))
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn file_data(&self, uri: &Url) -> Option<Arc<FileData>> {
-        self.files
-            .get(uri.as_str())
-            .map(|data| Arc::clone(data.value()))
-    }
-
     pub(crate) fn definition_locations(&self, name: &str) -> Vec<Location> {
         self.definitions
-            .get(name)
-            .map(|locations| locations.clone())
-            .unwrap_or_default()
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn subtype_locations(&self, name: &str) -> Vec<Location> {
-        self.subtypes
             .get(name)
             .map(|locations| locations.clone())
             .unwrap_or_default()

--- a/src/indexer/infer/args.rs
+++ b/src/indexer/infer/args.rs
@@ -5,14 +5,14 @@
 
 use tower_lsp::lsp_types::Url;
 
-use crate::StrExt;
-use crate::indexer::NodeExt;
 use crate::indexer::infer::sig::{
     find_fun_signature_full, nth_fun_param_type_str, split_params_at_depth_zero,
 };
-use crate::indexer::{Indexer, find_enclosing_call_name, is_id_char};
-use crate::queries::KIND_CALL_EXPR;
+use crate::indexer::NodeExt;
+use crate::indexer::{find_enclosing_call_name, is_id_char, Indexer};
+use crate::queries::{KIND_CALL_EXPR, KIND_LAMBDA_LIT, KIND_VALUE_ARG};
 use crate::types::CursorPos;
+use crate::StrExt;
 
 // ─── Type-directed call-argument inference ────────────────────────────────────
 
@@ -372,7 +372,11 @@ pub(crate) fn extract_first_arg(call_expr: &str) -> Option<&str> {
         prev = ch;
     }
     let arg = rest[..end].trim();
-    if arg.is_empty() { None } else { Some(arg) }
+    if arg.is_empty() {
+        None
+    } else {
+        Some(arg)
+    }
 }
 
 // ─── CST helpers for call-argument type inference ────────────────────────────
@@ -410,8 +414,8 @@ fn cst_call_arg_type(pos: CursorPos, idx: &Indexer, uri: &Url) -> Option<String>
     let mut cur = start_node;
     let value_arg = loop {
         match cur.kind() {
-            "value_argument" => break Some(cur),
-            "lambda_literal" => break None,
+            KIND_VALUE_ARG => break Some(cur),
+            KIND_LAMBDA_LIT => break None,
             _ => match cur.parent() {
                 Some(p) => cur = p,
                 None => break None,
@@ -440,7 +444,11 @@ fn cst_call_arg_type(pos: CursorPos, idx: &Indexer, uri: &Url) -> Option<String>
     }?;
 
     let base = param_type.trim().ident_prefix();
-    if base.is_empty() { None } else { Some(base) }
+    if base.is_empty() {
+        None
+    } else {
+        Some(base)
+    }
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────

--- a/src/indexer/infer/cst_cursor.rs
+++ b/src/indexer/infer/cst_cursor.rs
@@ -1,0 +1,136 @@
+use tower_lsp::lsp_types::{Position, Url};
+use tree_sitter::Point;
+
+use crate::indexer::live_tree::utf16_col_to_byte;
+use crate::indexer::{Indexer, NodeExt};
+use crate::queries::{
+    KIND_ANON_FUN, KIND_CALL_EXPR, KIND_CLASS_BODY, KIND_COMPANION_OBJ, KIND_FUN_DECL,
+    KIND_LAMBDA_LIT, KIND_METHOD_DECL, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_OBJECT_DECL,
+    KIND_PROP_DECL, KIND_SOURCE_FILE, KIND_VALUE_ARG, KIND_VAR_DECL,
+};
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CallInfo {
+    pub fn_name: String,
+    pub qualifier: Option<String>,
+    pub active_param: u32,
+}
+
+#[allow(dead_code)]
+pub(crate) fn cst_call_info(pos: Position, indexer: &Indexer, uri: &Url) -> Option<CallInfo> {
+    let doc = indexer.live_doc(uri)?;
+    let bytes = &doc.bytes;
+    let full_text = std::str::from_utf8(bytes).ok()?;
+
+    let line_idx = pos.line as usize;
+    let line_text = full_text.lines().nth(line_idx)?;
+    let byte_col = utf16_col_to_byte(line_text, pos.character as usize);
+    let point = Point {
+        row: line_idx,
+        column: byte_col,
+    };
+    let start_node = doc
+        .tree
+        .root_node()
+        .descendant_for_point_range(point, point)?;
+
+    let mut cur = start_node;
+    let call_expr = loop {
+        match cur.kind() {
+            KIND_CALL_EXPR => break Some(cur),
+            KIND_LAMBDA_LIT => break None,
+            _ => match cur.parent() {
+                Some(parent) => cur = parent,
+                None => break None,
+            },
+        }
+    }?;
+
+    let (fn_name, qualifier) = call_expr.call_fn_and_qualifier(bytes)?;
+    let value_arguments = call_expr.find_value_arguments()?;
+    let cursor_byte = full_text
+        .lines()
+        .take(line_idx)
+        .map(|line| line.len() + 1)
+        .sum::<usize>()
+        + byte_col;
+    let active_param = {
+        let mut count = 0u32;
+        let mut walker = value_arguments.walk();
+        for child in value_arguments.children(&mut walker) {
+            if child.kind() == KIND_VALUE_ARG {
+                if child.end_byte() <= cursor_byte {
+                    count += 1;
+                } else {
+                    break;
+                }
+            }
+        }
+        count
+    };
+
+    Some(CallInfo {
+        fn_name,
+        qualifier,
+        active_param,
+    })
+}
+
+#[allow(dead_code)]
+pub(crate) fn cst_cursor_is_local_var(indexer: &Indexer, uri: &Url, pos: Position) -> bool {
+    let doc = match indexer.live_doc(uri) {
+        Some(doc) => doc,
+        None => return false,
+    };
+    let full_text = match std::str::from_utf8(&doc.bytes) {
+        Ok(text) => text,
+        Err(_) => return false,
+    };
+    let line_idx = pos.line as usize;
+    let line_text = match full_text.lines().nth(line_idx) {
+        Some(line) => line,
+        None => return false,
+    };
+    let byte_col = utf16_col_to_byte(line_text, pos.character as usize);
+    let point = Point {
+        row: line_idx,
+        column: byte_col,
+    };
+    let start_node = match doc
+        .tree
+        .root_node()
+        .descendant_for_point_range(point, point)
+    {
+        Some(node) => node,
+        None => return false,
+    };
+
+    let mut in_binding = false;
+    let mut cur = start_node;
+    loop {
+        match cur.kind() {
+            KIND_PROP_DECL | KIND_VAR_DECL | KIND_MULTI_VAR_DECL => {
+                in_binding = true;
+            }
+            KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT if in_binding => {
+                return true;
+            }
+            KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT => return false,
+            KIND_NAV_EXPR => return false,
+            KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | KIND_SOURCE_FILE
+                if in_binding =>
+            {
+                return false;
+            }
+            KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | KIND_SOURCE_FILE => {
+                return false;
+            }
+            _ => {}
+        }
+        match cur.parent() {
+            Some(parent) => cur = parent,
+            None => return false,
+        }
+    }
+}

--- a/src/indexer/infer/cst_cursor.rs
+++ b/src/indexer/infer/cst_cursor.rs
@@ -9,7 +9,6 @@ use crate::queries::{
     KIND_PROP_DECL, KIND_SOURCE_FILE, KIND_VALUE_ARG, KIND_VAR_DECL,
 };
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CallInfo {
     pub fn_name: String,
@@ -17,7 +16,6 @@ pub(crate) struct CallInfo {
     pub active_param: u32,
 }
 
-#[allow(dead_code)]
 pub(crate) fn cst_call_info(pos: Position, indexer: &Indexer, uri: &Url) -> Option<CallInfo> {
     let doc = indexer.live_doc(uri)?;
     let bytes = &doc.bytes;
@@ -77,7 +75,6 @@ pub(crate) fn cst_call_info(pos: Position, indexer: &Indexer, uri: &Url) -> Opti
     })
 }
 
-#[allow(dead_code)]
 pub(crate) fn cst_cursor_is_local_var(indexer: &Indexer, uri: &Url, pos: Position) -> bool {
     let doc = match indexer.live_doc(uri) {
         Some(doc) => doc,

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -8,11 +8,13 @@
 //! - `it_this`  — resolving `it`/`this` element types inside Kotlin lambda bodies
 
 pub(super) mod args;
+pub(super) mod cst_cursor;
 pub(super) mod deps;
 pub(super) mod it_this;
 pub(super) mod lambda;
 pub(super) mod sig;
 
+pub(crate) use cst_cursor::{cst_call_info, cst_cursor_is_local_var, CallInfo};
 pub(crate) use deps::InferDeps;
 #[cfg(test)]
 pub(crate) use deps::TestDeps;

--- a/src/indexer/node_ext.rs
+++ b/src/indexer/node_ext.rs
@@ -3,10 +3,11 @@
 //! These methods are lightweight convenience wrappers around tree-sitter node
 //! traversal; their bodies were extracted from the free functions they replace.
 use crate::queries::{
-    KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_IDENTIFIER, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS,
-    KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_SCOPED_TYPE_IDENT, KIND_SIMPLE_IDENT, KIND_SOURCE_FILE,
-    KIND_TYPE_ARGS, KIND_TYPE_IDENT, KIND_TYPE_LIST, KIND_TYPE_PARAM, KIND_TYPE_PARAMS,
-    KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VALUE_ARGS, KIND_VAR_DECL,
+    KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_CONSTRUCTOR_INVOCATION, KIND_EQ,
+    KIND_EXPLICIT_DELEGATION, KIND_IDENTIFIER, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_NAV_EXPR,
+    KIND_NAV_SUFFIX, KIND_SCOPED_TYPE_IDENT, KIND_SIMPLE_IDENT, KIND_SOURCE_FILE, KIND_TYPE_ARGS,
+    KIND_TYPE_IDENT, KIND_TYPE_LIST, KIND_TYPE_PARAM, KIND_TYPE_PARAMS, KIND_USER_TYPE,
+    KIND_VALUE_ARG, KIND_VALUE_ARGS, KIND_VAR_DECL,
 };
 use crate::StrExt;
 use tree_sitter::Node;
@@ -151,7 +152,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
         let count = self.child_count();
         for i in 0..count.saturating_sub(1) {
             let (c, next) = (self.child(i)?, self.child(i + 1)?);
-            if c.kind() == KIND_SIMPLE_IDENT && next.kind() == "=" {
+            if c.kind() == KIND_SIMPLE_IDENT && next.kind() == KIND_EQ {
                 return c.utf8_text_owned(bytes);
             }
         }
@@ -450,7 +451,7 @@ impl<'a> NodeExt<'a> for Node<'a> {
         let mut cur = self.walk();
         for child in self.children(&mut cur) {
             let kind = child.kind();
-            if kind == "constructor_invocation" || kind == "explicit_delegation" {
+            if kind == KIND_CONSTRUCTOR_INVOCATION || kind == KIND_EXPLICIT_DELEGATION {
                 if let Some(ut) = child.first_child_of_kind(KIND_USER_TYPE) {
                     return ut
                         .user_type_name(bytes)

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -7,7 +7,7 @@ use tower_lsp::lsp_types::{SymbolKind, Url};
 
 use crate::indexer::doc::extract_doc_comment;
 use crate::indexer::Location;
-use crate::types::{FileData, SymbolEntry};
+use crate::types::{CallerContext, FileData, SymbolEntry};
 use crate::LinesExt;
 
 /// Domain-level resolution result. Small, owned data suitable for LSP adapters.
@@ -203,8 +203,15 @@ pub(crate) fn cross_file_type_subst<I: IndexRead>(
     caller_cursor_line: Option<u32>,
     sig: &str,
 ) -> String {
-    let subst =
-        build_type_param_subst_impl(index, sym_uri, sym_line, calling_uri, caller_cursor_line);
+    let subst = build_type_param_subst_impl(
+        index,
+        sym_uri,
+        sym_line,
+        CallerContext {
+            uri: Some(calling_uri),
+            cursor_line: caller_cursor_line,
+        },
+    );
     if subst.is_empty() {
         sig.to_owned()
     } else {
@@ -383,8 +390,10 @@ fn build_subst_if_needed<I: IndexRead>(
             index,
             location.uri.as_str(),
             location.range.start.line,
-            calling_uri,
-            cursor_line,
+            CallerContext {
+                uri: Some(calling_uri),
+                cursor_line,
+            },
         ),
         SubstitutionContext::Precomputed(m) => m.clone(),
     }
@@ -397,52 +406,39 @@ fn build_type_param_subst_impl<I: IndexRead>(
     index: &I,
     sym_uri: &str,
     sym_line: u32,
-    calling_uri: &str,
-    caller_cursor_line: Option<u32>,
+    caller: CallerContext<'_>,
 ) -> HashMap<String, String> {
+    let Some(calling_uri) = caller.uri else {
+        return HashMap::new();
+    };
     if sym_uri == calling_uri {
         return HashMap::new();
     }
 
-    // Trigger on-demand indexing if the file hasn't been indexed yet.
     index.ensure_indexed_on_demand(sym_uri);
-
-    let sym_data = match index.get_file_data(sym_uri) {
-        Some(d) => d,
-        None => return HashMap::new(),
+    let Some(sym_data) = index.get_file_data(sym_uri) else {
+        return HashMap::new();
     };
-
-    let container_name = match sym_data.containing_class_at(sym_line) {
-        Some(n) => n,
-        None => return HashMap::new(),
+    let Some(container_name) = sym_data.containing_class_at(sym_line) else {
+        return HashMap::new();
     };
-
-    let container_sym = match sym_data.symbols.iter().find(|s| s.name == container_name) {
-        Some(s) => s,
-        None => return HashMap::new(),
+    let Some(container_sym) = sym_data.symbols.iter().find(|s| s.name == container_name) else {
+        return HashMap::new();
     };
-
-    let type_params = &container_sym.type_params;
-    if type_params.is_empty() {
+    if container_sym.type_params.is_empty() {
         return HashMap::new();
     }
 
-    // Trigger on-demand indexing for the calling file too.
     index.ensure_indexed_on_demand(calling_uri);
-
-    let calling_data = match index.get_file_data(calling_uri) {
-        Some(d) => d,
-        None => return HashMap::new(),
+    let Some(calling_data) = index.get_file_data(calling_uri) else {
+        return HashMap::new();
     };
 
-    // Use `caller_cursor_line` to identify the specific calling class — when multiple
-    // classes in the same file extend the same base with different type args,
-    // this ensures we pick the correct substitution for the caller.
-    // When `None`, the first class extending the base is used (e.g. for completion).
-    let calling_class_line = caller_cursor_line
+    let calling_class_line = caller
+        .cursor_line
         .and_then(|line| calling_data.containing_class_at(line))
         .and_then(|name| calling_data.symbols.iter().find(|s| s.name == name))
-        .map(|s| s.selection_start());
+        .map(SymbolEntry::selection_start);
 
     let type_args = calling_data
         .supers
@@ -453,15 +449,15 @@ fn build_type_param_subst_impl<I: IndexRead>(
         })
         .map(|(_, _, args)| args.clone())
         .unwrap_or_default();
-
     if type_args.is_empty() {
         return HashMap::new();
     }
 
-    type_params
+    container_sym
+        .type_params
         .iter()
         .zip(type_args.iter())
-        .map(|(k, v)| (k.clone(), v.clone()))
+        .map(|(key, value)| (key.clone(), value.clone()))
         .collect()
 }
 

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -17,7 +17,10 @@ use crate::indexer::apply_type_subst;
 use crate::indexer::live_tree::{lang_for_path, parse_live};
 use crate::indexer::Indexer;
 use crate::indexer::NodeExt;
-use crate::queries::{KIND_CALL_EXPR, KIND_LAMBDA_PARAMS, KIND_VAR_DECL};
+use crate::queries::{
+    KIND_CALL_EXPR, KIND_COLON, KIND_EQ, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_PROP_DECL,
+    KIND_SIMPLE_IDENT, KIND_THIS_EXPR, KIND_VAR_DECL,
+};
 use crate::resolver::{infer_receiver_type, ReceiverKind};
 use crate::StrExt;
 
@@ -121,10 +124,10 @@ fn cst_hints(
         }
 
         match node.kind() {
-            "lambda_literal" => {
+            KIND_LAMBDA_LIT => {
                 hint_lambda(&ctx, &node, &mut hints);
             }
-            "simple_identifier" => {
+            KIND_SIMPLE_IDENT => {
                 if node.utf8_text(bytes) == Ok("it") {
                     let pos = ts_pos_to_lsp(node.start_position(), &starts, bytes);
                     if in_range(pos.line, range) {
@@ -142,7 +145,7 @@ fn cst_hints(
                     }
                 }
             }
-            "this_expression" => {
+            KIND_THIS_EXPR => {
                 let pos = ts_pos_to_lsp(node.start_position(), &starts, bytes);
                 if in_range(pos.line, range) {
                     let kind = ReceiverKind::Contextual {
@@ -158,7 +161,7 @@ fn cst_hints(
                     }
                 }
             }
-            "property_declaration" => {
+            KIND_PROP_DECL => {
                 hint_property(&ctx, &node, &mut hints);
             }
             _ => {}
@@ -212,10 +215,10 @@ fn hint_lambda(ctx: &HintCtx<'_>, node: &tree_sitter::Node<'_>, hints: &mut Vec<
             let mut name_node = None;
             for pchild in param.children(&mut vc) {
                 match pchild.kind() {
-                    "simple_identifier" if name_node.is_none() => {
+                    KIND_SIMPLE_IDENT if name_node.is_none() => {
                         name_node = Some(pchild);
                     }
-                    ":" => {
+                    KIND_COLON => {
                         has_type = true;
                         break;
                     }
@@ -287,10 +290,10 @@ fn hint_property(ctx: &HintCtx<'_>, node: &tree_sitter::Node<'_>, hints: &mut Ve
     let mut name_node = None;
     for child in vd.children(&mut vc) {
         match child.kind() {
-            "simple_identifier" if name_node.is_none() => {
+            KIND_SIMPLE_IDENT if name_node.is_none() => {
                 name_node = Some(child);
             }
-            ":" => {
+            KIND_COLON => {
                 has_type = true;
                 break;
             }
@@ -306,7 +309,7 @@ fn hint_property(ctx: &HintCtx<'_>, node: &tree_sitter::Node<'_>, hints: &mut Ve
     let mut init_node = None;
     let mut past_eq = false;
     for child in node.children(&mut nc2) {
-        if child.kind() == "=" {
+        if child.kind() == KIND_EQ {
             past_eq = true;
             continue;
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::sync::OnceLock;
+use std::thread::LocalKey;
 
 use tower_lsp::lsp_types::{Position, Range, SymbolKind};
 use tree_sitter::{Node, Parser, Query, QueryCursor};
@@ -113,162 +114,147 @@ thread_local! {
 
 // ─── public entry points ────────────────────────────────────────────────────
 
-pub(crate) fn parse_kotlin(content: &str) -> FileData {
-    let lines = std::sync::Arc::new(content.lines().map(str::to_owned).collect());
-    let mut data = FileData {
-        lines,
+fn new_file_data(content: &str) -> FileData {
+    FileData {
+        lines: std::sync::Arc::new(content.lines().map(str::to_owned).collect()),
         ..Default::default()
-    };
+    }
+}
 
-    let Some(tree) = KOTLIN_PARSER.with(|p| p.borrow_mut().parse(content, None)) else {
+fn with_parsed_tree(
+    content: &str,
+    parser_key: &'static LocalKey<RefCell<Parser>>,
+    visit: impl FnOnce(&mut FileData, tree_sitter::Tree, &[u8]),
+) -> FileData {
+    let mut data = new_file_data(content);
+    let Some(tree) = parser_key.with(|p| p.borrow_mut().parse(content, None)) else {
         return data;
     };
-
-    let bytes = content.as_bytes();
-    let root = tree.root_node();
-
-    // ── definitions ──────────────────────────────────────────────────────────
-    let Some(qc) = kotlin_def_query() else {
-        return data;
-    };
-    let mut cur = QueryCursor::new();
-    let matches: Vec<MatchEntry> = cur
-        .matches(&qc.query, root, bytes)
-        .map(|m| map_def_captures(&m, qc.def_idx, qc.name_idx, bytes))
-        .collect();
-
-    // Deduplicate: multiple patterns can fire on the same node
-    // (e.g. enum class matches both pattern 0 "enum" AND pattern 2 "class").
-    let best = dedup_matches(&matches);
-    push_def_symbols(
-        best,
-        queries::def_pattern_meta,
-        visibility_at_line,
-        &data.lines,
-        &mut data.symbols,
-    );
-
-    // ── package + imports (manual tree walk — avoids query overlap issues) ────
-    data.extract_package_and_imports(root, bytes);
-
-    // ── fun interface (tree-sitter parses these as ERROR + lambda_literal) ───
-    data.extract_fun_interfaces(root, bytes);
-
-    // ── supertype relationships (delegation specifiers) ──────────────────────
-    data.extract_supers_kotlin(root, bytes);
-
-    // ── rhs-type and method-call-rhs inference (unannotated properties) ──────
-    data.extract_rhs_types_kotlin(root, bytes);
-
-    // ── declared_names: scan lines once for `ident:` patterns ───────────────
-    data.declared_names = extract_declared_names(&data.lines);
-
-    // ── syntax errors (ERROR / MISSING nodes) ────────────────────────────────
-    data.syntax_errors = collect_syntax_errors(root, bytes);
-
+    visit(&mut data, tree, content.as_bytes());
     data
+}
+
+fn finalize_parse(data: &mut FileData, root: Node, bytes: &[u8]) {
+    data.declared_names = extract_declared_names(&data.lines);
+    data.syntax_errors = collect_syntax_errors(root, bytes);
+}
+
+pub(crate) fn parse_kotlin(content: &str) -> FileData {
+    with_parsed_tree(content, &KOTLIN_PARSER, |data, tree, bytes| {
+        let root = tree.root_node();
+
+        // ── definitions ──────────────────────────────────────────────────────
+        let Some(qc) = kotlin_def_query() else {
+            return;
+        };
+        let mut cur = QueryCursor::new();
+        let matches: Vec<MatchEntry> = cur
+            .matches(&qc.query, root, bytes)
+            .map(|m| map_def_captures(&m, qc.def_idx, qc.name_idx, bytes))
+            .collect();
+
+        // Deduplicate: multiple patterns can fire on the same node
+        // (e.g. enum class matches both pattern 0 "enum" AND pattern 2 "class").
+        let best = dedup_matches(&matches);
+        push_def_symbols(
+            best,
+            queries::def_pattern_meta,
+            visibility_at_line,
+            &data.lines,
+            &mut data.symbols,
+        );
+
+        // ── package + imports (manual tree walk — avoids query overlap issues) ──
+        data.extract_package_and_imports(root, bytes);
+
+        // ── fun interface (tree-sitter parses these as ERROR + lambda_literal) ─
+        data.extract_fun_interfaces(root, bytes);
+
+        // ── supertype relationships (delegation specifiers) ────────────────────
+        data.extract_supers_kotlin(root, bytes);
+
+        // ── rhs-type and method-call-rhs inference (unannotated properties) ────
+        data.extract_rhs_types_kotlin(root, bytes);
+
+        finalize_parse(data, root, bytes);
+    })
 }
 
 pub(crate) fn parse_java(content: &str) -> FileData {
-    let lines = std::sync::Arc::new(content.lines().map(str::to_owned).collect());
-    let mut data = FileData {
-        lines,
-        ..Default::default()
-    };
-
-    let Some(tree) = JAVA_PARSER.with(|p| p.borrow_mut().parse(content, None)) else {
-        return data;
-    };
-
-    let bytes = content.as_bytes();
-    let mut queue = vec![tree.root_node()];
-    while let Some(node) = queue.pop() {
-        data.extract_java(&node, bytes);
-        data.extract_supers_java(&node, bytes);
-        let mut cur = node.walk();
-        for child in node.children(&mut cur) {
-            queue.push(child);
+    with_parsed_tree(content, &JAVA_PARSER, |data, tree, bytes| {
+        let root = tree.root_node();
+        let mut queue = vec![root];
+        while let Some(node) = queue.pop() {
+            data.extract_java(&node, bytes);
+            data.extract_supers_java(&node, bytes);
+            let mut cur = node.walk();
+            for child in node.children(&mut cur) {
+                queue.push(child);
+            }
         }
-    }
-    data.declared_names = extract_declared_names(&data.lines);
-    data.syntax_errors = collect_syntax_errors(tree.root_node(), bytes);
-    data
+        finalize_parse(data, root, bytes);
+    })
 }
 
 pub(crate) fn parse_swift(content: &str) -> FileData {
-    let lines = std::sync::Arc::new(content.lines().map(str::to_owned).collect());
-    let mut data = FileData {
-        lines,
-        ..Default::default()
-    };
+    with_parsed_tree(content, &SWIFT_PARSER, |data, tree, bytes| {
+        let root = tree.root_node();
 
-    let Some(tree) = SWIFT_PARSER.with(|p| p.borrow_mut().parse(content, None)) else {
-        return data;
-    };
-
-    let bytes = content.as_bytes();
-    let root = tree.root_node();
-
-    // ── definitions ──────────────────────────────────────────────────────────
-    let Some(qc) = swift_def_query() else {
-        return data;
-    };
-    let def_idx = qc.def_idx;
-    let name_idx = qc.name_idx;
-    let mut cur = QueryCursor::new();
-    let matches: Vec<MatchEntry> = cur
-        .matches(&qc.query, root, bytes)
-        .map(|m| {
-            let (pidx, slot) = map_def_captures(&m, def_idx, name_idx, bytes);
-            if pidx == queries::SWIFT_INIT_PATTERN_IDX && slot[0].is_none() {
-                // init_declaration — no @name, synthesize "init"; type_params from @def node.
-                let def_cap = m.captures.iter().find(|cap| cap.index == def_idx);
-                if let Some(cap) = def_cap {
-                    let dr = ts_to_lsp(cap.node.range());
-                    let sel = Range::new(
-                        Position::new(dr.start.line, dr.start.character),
-                        Position::new(
-                            dr.start.line,
-                            dr.start.character + queries::SWIFT_INIT_NAME.len() as u32,
-                        ),
-                    );
-                    let type_params = cap.node.extract_type_params(bytes);
-                    return (
-                        pidx,
-                        [
-                            Some((queries::SWIFT_INIT_NAME.to_owned(), dr, sel, type_params)),
-                            None,
-                        ],
-                    );
+        // ── definitions ──────────────────────────────────────────────────────
+        let Some(qc) = swift_def_query() else {
+            return;
+        };
+        let def_idx = qc.def_idx;
+        let name_idx = qc.name_idx;
+        let mut cur = QueryCursor::new();
+        let matches: Vec<MatchEntry> = cur
+            .matches(&qc.query, root, bytes)
+            .map(|m| {
+                let (pidx, slot) = map_def_captures(&m, def_idx, name_idx, bytes);
+                if pidx == queries::SWIFT_INIT_PATTERN_IDX && slot[0].is_none() {
+                    // init_declaration — no @name, synthesize "init"; type_params from @def node.
+                    let def_cap = m.captures.iter().find(|cap| cap.index == def_idx);
+                    if let Some(cap) = def_cap {
+                        let dr = ts_to_lsp(cap.node.range());
+                        let sel = Range::new(
+                            Position::new(dr.start.line, dr.start.character),
+                            Position::new(
+                                dr.start.line,
+                                dr.start.character + queries::SWIFT_INIT_NAME.len() as u32,
+                            ),
+                        );
+                        let type_params = cap.node.extract_type_params(bytes);
+                        return (
+                            pidx,
+                            [
+                                Some((queries::SWIFT_INIT_NAME.to_owned(), dr, sel, type_params)),
+                                None,
+                            ],
+                        );
+                    }
                 }
-            }
-            (pidx, slot)
-        })
-        .collect();
+                (pidx, slot)
+            })
+            .collect();
 
-    // Deduplicate: use same BTreeMap strategy as Kotlin parser.
-    let best = dedup_matches(&matches);
-    push_def_symbols(
-        best,
-        queries::swift_def_pattern_meta,
-        swift_visibility_at_line,
-        &data.lines,
-        &mut data.symbols,
-    );
+        // Deduplicate: use same BTreeMap strategy as Kotlin parser.
+        let best = dedup_matches(&matches);
+        push_def_symbols(
+            best,
+            queries::swift_def_pattern_meta,
+            swift_visibility_at_line,
+            &data.lines,
+            &mut data.symbols,
+        );
 
-    // ── imports (manual tree walk — Swift imports are simpler) ────────────────
-    data.extract_swift_imports(root, bytes);
+        // ── imports (manual tree walk — Swift imports are simpler) ────────────
+        data.extract_swift_imports(root, bytes);
 
-    // ── supertype relationships (inheritance specifiers) ──────────────────────
-    data.extract_supers_swift(root, bytes);
+        // ── supertype relationships (inheritance specifiers) ──────────────────
+        data.extract_supers_swift(root, bytes);
 
-    // ── declared_names ───────────────────────────────────────────────────────
-    data.declared_names = extract_declared_names(&data.lines);
-
-    // ── syntax errors ────────────────────────────────────────────────────────
-    data.syntax_errors = collect_syntax_errors(root, bytes);
-
-    data
+        finalize_parse(data, root, bytes);
+    })
 }
 
 /// Dispatch to the correct parser based on file extension.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,15 +6,17 @@ use tree_sitter::{Node, Parser, Query, QueryCursor};
 
 use crate::indexer::NodeExt;
 use crate::queries::{
-    self, KIND_CALLABLE_REF, KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_CLASS_DECL, KIND_CTOR_DECL,
-    KIND_DELEGATION_SPEC, KIND_ENUM_DECL, KIND_EXTENDS_INTERFACES, KIND_FIELD_DECL, KIND_FUN_DECL,
-    KIND_IDENTIFIER, KIND_IMPORT_DECL, KIND_IMPORT_HEADER, KIND_INHERITANCE_SPEC,
-    KIND_INHERITANCE_SPECS, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_METHOD_DECL, KIND_MODIFIERS,
-    KIND_MOD_FINAL, KIND_MOD_STATIC, KIND_NAV_EXPR, KIND_OBJECT_DECL, KIND_PACKAGE_DECL,
-    KIND_PROP_DECL, KIND_PROP_DELEGATE, KIND_PROTOCOL_DECL, KIND_RECORD_DECL, KIND_SCOPED_IDENT,
-    KIND_SIMPLE_IDENT, KIND_STATEMENTS, KIND_SUPERCLASS, KIND_SUPER_INTERFACES, KIND_TYPE_IDENT,
-    KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VALUE_ARGS, KIND_VAR_DECL, KIND_VAR_DECLARATOR,
-    KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
+    self, KIND_ANNOTATION_TYPE_DECL, KIND_CALLABLE_REF, KIND_CALL_EXPR, KIND_CALL_SUFFIX,
+    KIND_CLASS_DECL, KIND_CTOR_DECL, KIND_DELEGATION_SPEC, KIND_ENUM_CONSTANT, KIND_ENUM_DECL,
+    KIND_EQ, KIND_EXTENDS_INTERFACES, KIND_FIELD_DECL, KIND_FUN, KIND_FUN_DECL, KIND_IDENTIFIER,
+    KIND_IMPORT_ALIAS, KIND_IMPORT_DECL, KIND_IMPORT_HEADER, KIND_IMPORT_LIST,
+    KIND_INHERITANCE_SPEC, KIND_INHERITANCE_SPECS, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT,
+    KIND_METHOD_DECL, KIND_MODIFIERS, KIND_MOD_FINAL, KIND_MOD_STATIC, KIND_NAV_EXPR,
+    KIND_OBJECT_DECL, KIND_PACKAGE_DECL, KIND_PACKAGE_HEADER, KIND_PROP_DECL, KIND_PROP_DELEGATE,
+    KIND_PROTOCOL_DECL, KIND_RECORD_DECL, KIND_SCOPED_IDENT, KIND_SIMPLE_IDENT, KIND_STATEMENTS,
+    KIND_SUPERCLASS, KIND_SUPER_INTERFACES, KIND_TYPE_IDENT, KIND_USER_TYPE, KIND_VALUE_ARG,
+    KIND_VALUE_ARGS, KIND_VAR_DECL, KIND_VAR_DECLARATOR, KIND_WILDCARD_IMPORT, KOTLIN_DEFINITIONS,
+    SWIFT_DEFINITIONS,
 };
 use crate::StrExt;
 
@@ -438,13 +440,13 @@ fn is_fun_interface_error(node: &Node, bytes: &[u8]) -> bool {
     let mut cur = node.walk();
     for child in node.children(&mut cur) {
         match child.kind() {
-            "fun" => has_fun = true,
-            "user_type" => {
+            KIND_FUN => has_fun = true,
+            KIND_USER_TYPE => {
                 if child.utf8_text(bytes).unwrap_or("") == "interface" {
                     has_interface = true;
                 }
             }
-            "simple_identifier" => has_name = true,
+            KIND_SIMPLE_IDENT => has_name = true,
             _ => {
                 // Variance case: `fun interface Foo<in A, out B>` produces a nested
                 // ERROR child that swallows `fun`, `interface`, and the name together:
@@ -454,13 +456,13 @@ fn is_fun_interface_error(node: &Node, bytes: &[u8]) -> bool {
                     let mut ec = child.walk();
                     for gc in child.children(&mut ec) {
                         match gc.kind() {
-                            "fun" => has_fun = true,
-                            "user_type" => {
+                            KIND_FUN => has_fun = true,
+                            KIND_USER_TYPE => {
                                 if gc.utf8_text(bytes).unwrap_or("") == "interface" {
                                     has_interface = true;
                                 }
                             }
-                            "simple_identifier" => has_name = true,
+                            KIND_SIMPLE_IDENT => has_name = true,
                             _ => {}
                         }
                     }
@@ -890,13 +892,13 @@ fn extract_package_and_imports(root: tree_sitter::Node, bytes: &[u8], data: &mut
     let mut cur = root.walk();
     for node in root.children(&mut cur) {
         match node.kind() {
-            "package_header" => {
+            KIND_PACKAGE_HEADER => {
                 // (package_header "package" (identifier ...))
                 if let Some(child) = node.first_child_of_kind(KIND_IDENTIFIER) {
                     data.package = child.utf8_text_owned(bytes);
                 }
             }
-            "import_list" => {
+            KIND_IMPORT_LIST => {
                 for header in node.children_of_kind(KIND_IMPORT_HEADER) {
                     parse_import_header(&header, bytes, data);
                 }
@@ -917,13 +919,13 @@ fn parse_import_header(header: &tree_sitter::Node, bytes: &[u8], data: &mut File
             k if k == KIND_IDENTIFIER => {
                 path_text = child.utf8_text_owned(bytes);
             }
-            "import_alias" => {
+            KIND_IMPORT_ALIAS => {
                 // (import_alias "as" (type_identifier))
                 alias_text = child
                     .first_child_of_kind(KIND_TYPE_IDENT)
                     .and_then(|c| c.utf8_text_owned(bytes));
             }
-            "wildcard_import" => {
+            KIND_WILDCARD_IMPORT => {
                 is_star = true;
             }
             _ => {}
@@ -1160,7 +1162,7 @@ fn find_rhs_node(prop: Node) -> Option<Node> {
         if saw_eq && child.is_named() {
             return Some(child);
         }
-        if !child.is_named() && child.kind() == "=" {
+        if !child.is_named() && child.kind() == KIND_EQ {
             saw_eq = true;
         }
     }
@@ -1498,11 +1500,11 @@ impl crate::types::FileData {
             KIND_CLASS_DECL => self.push_named(node, bytes, SymbolKind::CLASS),
             KIND_RECORD_DECL => self.push_named(node, bytes, SymbolKind::STRUCT),
             KIND_INTERFACE_DECL => self.push_named(node, bytes, SymbolKind::INTERFACE),
-            "annotation_type_declaration" => self.push_named(node, bytes, SymbolKind::INTERFACE),
+            KIND_ANNOTATION_TYPE_DECL => self.push_named(node, bytes, SymbolKind::INTERFACE),
             KIND_ENUM_DECL => self.push_named(node, bytes, SymbolKind::ENUM),
             KIND_METHOD_DECL => self.push_named(node, bytes, SymbolKind::METHOD),
             KIND_CTOR_DECL => self.push_named(node, bytes, SymbolKind::CONSTRUCTOR),
-            "enum_constant" => self.push_named(node, bytes, SymbolKind::ENUM_MEMBER),
+            KIND_ENUM_CONSTANT => self.push_named(node, bytes, SymbolKind::ENUM_MEMBER),
             KIND_FIELD_DECL => self.push_field_declaration(node, bytes),
             KIND_IMPORT_DECL => self.push_java_import(node, bytes),
             _ => {}

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -349,12 +349,14 @@ pub(crate) const KIND_TYPE_IDENT: &str = "type_identifier";
 pub(crate) const KIND_IDENTIFIER: &str = "identifier";
 pub(crate) const KIND_SCOPED_IDENT: &str = "scoped_identifier";
 pub(crate) const KIND_CALL_EXPR: &str = "call_expression";
+pub(crate) const KIND_THIS_EXPR: &str = "this_expression";
 pub(crate) const KIND_LAMBDA_LIT: &str = "lambda_literal";
 pub(crate) const KIND_LAMBDA_PARAMS: &str = "lambda_parameters";
 pub(crate) const KIND_VALUE_ARG: &str = "value_argument";
 pub(crate) const KIND_VALUE_ARGS: &str = "value_arguments";
 pub(crate) const KIND_USER_TYPE: &str = "user_type";
 pub(crate) const KIND_FUN_DECL: &str = "function_declaration";
+pub(crate) const KIND_FUN: &str = "fun";
 
 // ─── Declaration node kinds (shared or language-specific) ──────────────────
 pub(crate) const KIND_CLASS_DECL: &str = "class_declaration";
@@ -364,6 +366,8 @@ pub(crate) const KIND_INTERFACE_DECL: &str = "interface_declaration";
 // Kotlin-specific
 pub(crate) const KIND_OBJECT_DECL: &str = "object_declaration";
 pub(crate) const KIND_DELEGATION_SPEC: &str = "delegation_specifier";
+pub(crate) const KIND_CONSTRUCTOR_INVOCATION: &str = "constructor_invocation";
+pub(crate) const KIND_EXPLICIT_DELEGATION: &str = "explicit_delegation";
 
 // Java-specific
 pub(crate) const KIND_RECORD_DECL: &str = "record_declaration";
@@ -372,6 +376,8 @@ pub(crate) const KIND_CTOR_DECL: &str = "constructor_declaration";
 pub(crate) const KIND_FIELD_DECL: &str = "field_declaration";
 pub(crate) const KIND_IMPORT_DECL: &str = "import_declaration";
 pub(crate) const KIND_PACKAGE_DECL: &str = "package_declaration";
+pub(crate) const KIND_ANNOTATION_TYPE_DECL: &str = "annotation_type_declaration";
+pub(crate) const KIND_ENUM_CONSTANT: &str = "enum_constant";
 pub(crate) const KIND_SUPERCLASS: &str = "superclass";
 pub(crate) const KIND_SUPER_INTERFACES: &str = "super_interfaces";
 pub(crate) const KIND_EXTENDS_INTERFACES: &str = "extends_interfaces";
@@ -404,7 +410,13 @@ pub(crate) const KIND_COMPANION_OBJ: &str = "companion_object";
 pub(crate) const KIND_ANON_FUN: &str = "anonymous_function";
 pub(crate) const KIND_STATEMENTS: &str = "statements";
 pub(crate) const KIND_IMPORT_HEADER: &str = "import_header";
+pub(crate) const KIND_IMPORT_LIST: &str = "import_list";
+pub(crate) const KIND_IMPORT_ALIAS: &str = "import_alias";
+pub(crate) const KIND_PACKAGE_HEADER: &str = "package_header";
+pub(crate) const KIND_WILDCARD_IMPORT: &str = "wildcard_import";
 pub(crate) const KIND_MODIFIERS: &str = "modifiers";
+pub(crate) const KIND_COLON: &str = ":";
+pub(crate) const KIND_EQ: &str = "=";
 
 // ─── Java structural node kinds ───────────────────────────────────────────────
 pub(crate) const KIND_SCOPED_TYPE_IDENT: &str = "scoped_type_identifier";

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -5,12 +5,14 @@ use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
 use crate::stdlib::bare_completions;
 use crate::stdlib_tail::dot_completions_for_lang;
-use crate::types::{FileData, ImportEntry, SymbolEntry, Visibility};
+use crate::types::{CallerContext, FileData, ImportEntry, SymbolEntry, Visibility};
 use crate::LinesExt;
 use crate::StrExt;
 
 use super::infer::{infer_receiver_type, ReceiverKind, ReceiverType};
-use super::{already_imported, fqns_for_name, resolve_symbol_inner, resolve_symbol_no_rg};
+use super::{
+    already_imported, ensure_file_data, fqns_for_name, resolve_symbol_no_rg, walk_hierarchy,
+};
 
 // ─── match scoring ────────────────────────────────────────────────────────────
 
@@ -368,68 +370,20 @@ fn complete_super(idx: &Indexer, from_uri: &Url, snippets: bool) -> Vec<Completi
     if idx.files.get(from_uri.as_str()).is_none() {
         return vec![];
     }
-    let mut items: Vec<CompletionItem> = Vec::new();
-    let mut visited: Vec<String> = vec![from_uri.as_str().to_owned()];
-    SuperWalker { idx, snippets }.collect(from_uri, &mut visited, 0, &mut items);
-    // Filter out private/protected members — inaccessible even via super.
-    items.retain(|i| {
-        i.sort_text
-            .as_deref()
-            .map(|s| !s.starts_with("prv:") && !s.starts_with("prt:"))
-            .unwrap_or(true)
-    });
-    items.sort_by_key(|i| (kind_sort_rank(i.kind), i.label.clone()));
-    items.dedup_by_key(|i| i.label.clone());
+
+    let mut items = walk_hierarchy(
+        idx,
+        "",
+        from_uri.as_str(),
+        CallerContext::default(),
+        4,
+        |index, _, class_uri, _| symbols_from_uri_as_completions(index, class_uri),
+    );
+    filter_inaccessible_completion_items(&mut items);
+    strip_completion_snippets(&mut items, snippets);
+    items.sort_by_key(|item| (kind_sort_rank(item.kind), item.label.clone()));
+    items.dedup_by_key(|item| item.label.clone());
     items
-}
-
-/// Walks the supertype hierarchy from a given file URI, collecting completion items.
-///
-/// Visited keys are file URIs (not type-qualified) — this is a file-oriented
-/// walk, distinct from [`InheritanceWalker`] which is type-oriented.
-struct SuperWalker<'a> {
-    idx: &'a Indexer,
-    snippets: bool,
-}
-
-impl<'a> SuperWalker<'a> {
-    fn collect(
-        &self,
-        from_uri: &Url,
-        visited: &mut Vec<String>,
-        depth: u8,
-        out: &mut Vec<CompletionItem>,
-    ) {
-        const MAX_DEPTH: u8 = 4;
-        if depth >= MAX_DEPTH {
-            return;
-        }
-
-        let supers: Vec<String> = match self.idx.files.get(from_uri.as_str()) {
-            Some(f) => f.supers.iter().map(|(_, n, _)| n.clone()).collect(),
-            None => return,
-        };
-
-        for super_name in supers {
-            let super_locs = resolve_symbol_inner(self.idx, &super_name, from_uri, false);
-            for super_loc in &super_locs {
-                let uri_str = super_loc.uri.as_str();
-                if visited.iter().any(|s| s == uri_str) {
-                    continue;
-                }
-                visited.push(uri_str.to_owned());
-                let mut new_items = symbols_from_uri_as_completions(self.idx, uri_str);
-                if !self.snippets {
-                    for item in &mut new_items {
-                        item.insert_text = None;
-                        item.insert_text_format = None;
-                    }
-                }
-                out.extend(new_items);
-                self.collect(&super_loc.uri, visited, depth + 1, out);
-            }
-        }
-    }
 }
 
 /// Dot-completion: return all members of the receiver's inferred type,
@@ -515,8 +469,10 @@ fn direct_dot_completion_items(
         idx,
         &context.file_uri,
         &context.receiver_type.leaf,
-        Some(from_uri.as_str()),
-        cursor_line,
+        CallerContext {
+            uri: Some(from_uri.as_str()),
+            cursor_line,
+        },
     )
 }
 
@@ -528,23 +484,25 @@ fn collect_inherited_dot_completion_items(
     cursor_line: Option<u32>,
     items: &mut Vec<CompletionItem>,
 ) {
-    let mut visited = vec![format!(
-        "{}#{}",
-        context.file_uri, context.receiver_type.leaf
-    )];
-    InheritanceWalker {
-        idx,
-        calling_uri: from_uri,
-        snippets,
+    let caller = CallerContext {
+        uri: Some(from_uri.as_str()),
         cursor_line,
-    }
-    .collect(
-        &context.file_uri,
+    };
+    let inherited = walk_hierarchy(
+        idx,
         &context.receiver_type.leaf,
-        &mut visited,
-        0,
-        items,
+        &context.file_uri,
+        caller,
+        4,
+        |index, class_name, class_uri, hierarchy_caller| {
+            let mut nested =
+                symbols_from_nested_type(index, class_uri, class_name, hierarchy_caller);
+            filter_inaccessible_completion_items(&mut nested);
+            strip_completion_snippets(&mut nested, snippets);
+            nested
+        },
     );
+    items.extend(inherited);
 }
 
 fn filter_inaccessible_completion_items(items: &mut Vec<CompletionItem>) {
@@ -594,94 +552,6 @@ fn append_dot_tail_completions(
     }
 }
 
-/// Recursively collect members from parent classes/interfaces of `type_name`
-/// (defined in `file_uri`) and append them to `out`.
-///
-/// `visited` tracks `"file_uri#TypeName"` pairs to prevent infinite cycles.
-/// Only non-private members are added (matching `complete_dot` behaviour).
-struct InheritanceWalker<'a> {
-    idx: &'a Indexer,
-    calling_uri: &'a Url,
-    snippets: bool,
-    cursor_line: Option<u32>,
-}
-
-impl<'a> InheritanceWalker<'a> {
-    fn collect(
-        &self,
-        file_uri: &str,
-        type_name: &str,
-        visited: &mut Vec<String>,
-        depth: u8,
-        out: &mut Vec<CompletionItem>,
-    ) {
-        const MAX_DEPTH: u8 = 4;
-        if depth >= MAX_DEPTH {
-            return;
-        }
-
-        let supers: Vec<String> = {
-            let data = match self.idx.files.get(file_uri) {
-                Some(d) => d,
-                None => return,
-            };
-            let class_line = data
-                .symbols
-                .iter()
-                .find(|s| s.name == type_name)
-                .map(|s| s.selection_start());
-            match class_line {
-                Some(line) => data
-                    .supers
-                    .iter()
-                    .filter(|(l, _, _)| *l == line)
-                    .map(|(_, n, _)| n.clone())
-                    .collect(),
-                None => data.supers.iter().map(|(_, n, _)| n.clone()).collect(),
-            }
-        };
-
-        let type_url = match Url::parse(file_uri) {
-            Ok(u) => u,
-            Err(_) => return,
-        };
-
-        for super_name in supers {
-            let super_locs = resolve_symbol_inner(self.idx, &super_name, &type_url, false);
-            for loc in &super_locs {
-                let key = format!("{}#{}", loc.uri.as_str(), super_name);
-                if visited.contains(&key) {
-                    continue;
-                }
-                visited.push(key);
-
-                let mut inherited = symbols_from_nested_type(
-                    self.idx,
-                    loc.uri.as_str(),
-                    &super_name,
-                    Some(self.calling_uri.as_str()),
-                    self.cursor_line,
-                );
-                inherited.retain(|i| {
-                    i.sort_text
-                        .as_deref()
-                        .map(|s| !s.starts_with("prv:") && !s.starts_with("prt:"))
-                        .unwrap_or(true)
-                });
-                if !self.snippets {
-                    for item in &mut inherited {
-                        item.insert_text = None;
-                        item.insert_text_format = None;
-                    }
-                }
-                out.extend(inherited);
-
-                self.collect(loc.uri.as_str(), &super_name, visited, depth + 1, out);
-            }
-        }
-    }
-}
-
 /// Build a `CompletionItem` for a symbol found inside a nested type body.
 ///
 /// Functions/methods get a snippet `name($1)`; all other kinds are plain-text.
@@ -691,8 +561,7 @@ fn completion_item_for_nested_symbol(
     idx: &Indexer,
     s: &crate::types::SymbolEntry,
     uri_str: &str,
-    calling_uri: Option<&str>,
-    caller_cursor_line: Option<u32>,
+    caller: CallerContext<'_>,
 ) -> CompletionItem {
     let kind = symbol_kind_to_completion(s.kind);
     let is_fn = matches!(
@@ -705,23 +574,20 @@ fn completion_item_for_nested_symbol(
     } else {
         Some(s.detail.clone())
     };
-    let detail = detail_raw.map(|d| {
-        if let Some(cu) = calling_uri {
-            crate::indexer::resolution::cross_file_type_subst(
-                idx,
-                uri_str,
-                s.selection_start(),
-                cu,
-                caller_cursor_line,
-                &d,
-            )
-        } else {
-            d
-        }
+    let detail = detail_raw.map(|signature| match caller.uri {
+        Some(calling_uri) => crate::indexer::resolution::cross_file_type_subst(
+            idx,
+            uri_str,
+            s.selection_start(),
+            calling_uri,
+            caller.cursor_line,
+            &signature,
+        ),
+        None => signature,
     });
     let mut data = serde_json::json!({"u": uri_str, "l": s.selection_start(), "c": s.selection_range.start.character});
-    if let Some(cu) = calling_uri {
-        data["cu"] = serde_json::Value::String(cu.to_owned());
+    if let Some(calling_uri) = caller.uri {
+        data["cu"] = serde_json::Value::String(calling_uri.to_owned());
     }
     CompletionItem {
         label: s.name.clone(),
@@ -755,66 +621,38 @@ fn symbols_from_nested_type(
     idx: &Indexer,
     file_uri: &str,
     inner_name: &str,
-    calling_uri: Option<&str>,
-    cursor_line: Option<u32>,
+    caller: CallerContext<'_>,
 ) -> Vec<CompletionItem> {
-    // Try in-memory index first; fall back to on-demand disk parse.
-    let owned: crate::types::FileData;
-    let symbols_ref: &[crate::types::SymbolEntry] = if let Some(d) = idx.files.get(file_uri) {
-        // Clone symbols out of the DashMap guard so we can drop the guard.
-        owned = d.value().as_ref().clone();
-        &owned.symbols
-    } else {
-        // File not yet indexed — parse it on demand.
-        let url = match Url::parse(file_uri) {
-            Ok(u) => u,
-            Err(_) => return vec![],
-        };
-        let path = match url.to_file_path() {
-            Ok(p) => p,
-            Err(_) => return vec![],
-        };
-        let content = match std::fs::read_to_string(&path) {
-            Ok(c) => c,
-            Err(_) => return vec![],
-        };
-        owned = parse_by_extension(file_uri, &content);
-        &owned.symbols
+    let Ok(uri) = Url::parse(file_uri) else {
+        return vec![];
+    };
+    let Some(file_data) = ensure_file_data(idx, &uri) else {
+        return vec![];
+    };
+    let symbols = &file_data.symbols;
+
+    let Some(type_symbol) = symbols.iter().find(|symbol| symbol.name == inner_name) else {
+        return symbols
+            .iter()
+            .filter(|symbol| symbol.visibility != Visibility::Private)
+            .map(|symbol| completion_item_for_nested_symbol(idx, symbol, file_uri, caller))
+            .collect();
     };
 
-    // Find the type's declaration to get its body span.
-    let type_sym = match symbols_ref.iter().find(|s| s.name == inner_name) {
-        Some(s) => s,
-        None => {
-            // Unknown type — return all non-private symbols as a fallback.
-            return symbols_ref
-                .iter()
-                .filter(|s| s.visibility != Visibility::Private)
-                .map(|s| {
-                    completion_item_for_nested_symbol(idx, s, file_uri, calling_uri, cursor_line)
-                })
-                .collect();
-        }
-    };
-
-    let type_start = type_sym.range.start;
-    let type_end = type_sym.range.end;
-
-    // Collect symbols whose start position falls within the type's body span.
-    // Compare both line and character so one-line declarations like
-    // `class Foo { fun bar() {} }` still include same-line members.
-    symbols_ref
+    let type_start = type_symbol.range.start;
+    let type_end = type_symbol.range.end;
+    symbols
         .iter()
-        .filter(|s| {
-            let start = s.range.start;
+        .filter(|symbol| {
+            let start = symbol.range.start;
             let starts_after = start.line > type_start.line
                 || (start.line == type_start.line && start.character > type_start.character);
             let starts_before = start.line < type_end.line
                 || (start.line == type_end.line && start.character < type_end.character);
             starts_after && starts_before
         })
-        .filter(|s| s.visibility != Visibility::Private)
-        .map(|s| completion_item_for_nested_symbol(idx, s, file_uri, calling_uri, cursor_line))
+        .filter(|symbol| symbol.visibility != Visibility::Private)
+        .map(|symbol| completion_item_for_nested_symbol(idx, symbol, file_uri, caller))
         .collect()
 }
 

--- a/src/resolver/find.rs
+++ b/src/resolver/find.rs
@@ -2,8 +2,9 @@ use std::sync::Arc;
 use tower_lsp::lsp_types::{Location, Url};
 
 use crate::indexer::Indexer;
-use crate::parser::parse_by_extension;
 use crate::LinesExt;
+
+use super::ensure_file_data;
 
 /// Search for `name` in a specific file identified by its URI string.
 ///
@@ -14,36 +15,17 @@ pub(crate) fn find_name_in_uri(idx: &Indexer, name: &str, file_uri: &str) -> Vec
         return vec![];
     };
 
-    // a) Indexed file – symbol table
-    if let Some(f) = idx.files.get(file_uri) {
-        if let Some(sym) = f.symbols.iter().find(|s| s.name == name) {
-            return vec![Location {
-                uri,
-                range: sym.selection_range,
-            }];
-        }
-        // b) Line scan for constructor params / un-indexed declarations
-        if let Some(range) = f.lines.find_declaration_range(name) {
-            return vec![Location { uri, range }];
-        }
+    let Some(file_data) = ensure_file_data(idx, &uri) else {
         return vec![];
+    };
+    if let Some(sym) = file_data.symbols.iter().find(|s| s.name == name) {
+        return vec![Location {
+            uri,
+            range: sym.selection_range,
+        }];
     }
-
-    // c) File not yet indexed — parse on demand using the correct parser
-    if let Ok(path) = uri.to_file_path() {
-        if let Ok(content) = std::fs::read_to_string(&path) {
-            let file_data = parse_by_extension(file_uri, &content);
-            if let Some(sym) = file_data.symbols.iter().find(|s| s.name == name) {
-                return vec![Location {
-                    uri,
-                    range: sym.selection_range,
-                }];
-            }
-            let lines: Vec<String> = content.lines().map(String::from).collect();
-            if let Some(range) = lines.find_declaration_range(name) {
-                return vec![Location { uri, range }];
-            }
-        }
+    if let Some(range) = file_data.lines.find_declaration_range(name) {
+        return vec![Location { uri, range }];
     }
     vec![]
 }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -4,6 +4,8 @@ use crate::indexer::Indexer;
 use crate::LinesExt;
 use crate::StrExt;
 
+use super::ensure_file_data;
+
 // ─── Receiver type resolution ─────────────────────────────────────────────────
 
 /// How the receiver expression should be resolved.
@@ -282,16 +284,9 @@ fn first_type_arg(s: &str) -> &str {
 /// Checks the in-memory index first (lines are cached); falls back to reading
 /// the file from disk when it isn't indexed yet.
 pub(crate) fn infer_field_type(idx: &Indexer, file_uri: &str, field_name: &str) -> Option<String> {
-    if let Some(data) = idx.files.get(file_uri) {
-        return data.lines.infer_type(field_name);
-    }
-    let path = tower_lsp::lsp_types::Url::parse(file_uri)
-        .ok()?
-        .to_file_path()
-        .ok()?;
-    let content = std::fs::read_to_string(&path).ok()?;
-    let lines: Vec<String> = content.lines().map(String::from).collect();
-    lines.infer_type(field_name)
+    let uri = tower_lsp::lsp_types::Url::parse(file_uri).ok()?;
+    let file_data = ensure_file_data(idx, &uri)?;
+    file_data.lines.infer_type(field_name)
 }
 
 /// Like `infer_field_type` but preserves generic parameters in the result.

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -21,6 +21,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 use std::process::Command;
+use std::sync::Arc;
 
 use tower_lsp::lsp_types::{Location, Range, TextEdit, Url};
 
@@ -64,14 +65,15 @@ use infer::{infer_field_type, infer_variable_type};
 
 /// Return `FileData` for `uri` — from the live index if indexed, otherwise parse from disk.
 /// Returns `None` if the file is not indexed and not readable from disk.
-pub(crate) fn ensure_file_data(idx: &Indexer, uri: &Url) -> Option<FileData> {
+/// Returns an `Arc` so callers can read without copying the full `FileData`.
+pub(crate) fn ensure_file_data(idx: &Indexer, uri: &Url) -> Option<Arc<FileData>> {
     if let Some(file_data) = idx.files.get(uri.as_str()) {
-        return Some(file_data.value().as_ref().clone());
+        return Some(file_data.value().clone());
     }
 
     let path = uri.to_file_path().ok()?;
     let content = std::fs::read_to_string(path).ok()?;
-    Some(parse_by_extension(uri.path(), &content))
+    Some(Arc::new(parse_by_extension(uri.path(), &content)))
 }
 
 /// Walk the class hierarchy starting from `start_class`, collecting items at each level.
@@ -92,7 +94,7 @@ where
         caller,
         max_depth,
         collect,
-        visited: HashSet::from([start_class.to_owned()]),
+        visited: HashSet::from([(start_uri.to_owned(), start_class.to_owned())]),
         items: Vec::new(),
     };
     walker.recurse(start_class, start_uri, 0);
@@ -107,7 +109,7 @@ where
     caller: CallerContext<'a>,
     max_depth: usize,
     collect: F,
-    visited: HashSet<String>,
+    visited: HashSet<(String, String)>,
     items: Vec<T>,
 }
 
@@ -121,7 +123,7 @@ where
         }
 
         for (super_name, super_uri) in supertype_targets(self.idx, class_name, class_uri) {
-            if !self.visited.insert(super_name.clone()) {
+            if !self.visited.insert((super_uri.clone(), super_name.clone())) {
                 continue;
             }
             self.items.extend((self.collect)(
@@ -953,14 +955,18 @@ fn resolve_star_imports(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
 /// 3. Search the resolved file's symbol table for `name`.
 /// 4. Recurse into that file's own supertypes (depth-limited, cycle-safe).
 fn resolve_from_class_hierarchy(idx: &Indexer, name: &str, from_uri: &Url) -> Vec<Location> {
-    walk_hierarchy(
+    let mut results = walk_hierarchy(
         idx,
         "",
         from_uri.as_str(),
         CallerContext::default(),
         4,
         |index, _, class_uri, _| find_name_in_uri(index, name, class_uri),
-    )
+    );
+    // Deduplicate: hierarchy walk may find the same definition via multiple paths
+    // (e.g. diamond inheritance). Keep traversal order (most-specific first).
+    results.dedup_by(|a, b| a.uri == b.uri && a.range == b.range);
+    results
 }
 
 /// `rg` scoped to the directory that would contain `package` sources.

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -955,7 +955,7 @@ fn resolve_star_imports(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
 /// 3. Search the resolved file's symbol table for `name`.
 /// 4. Recurse into that file's own supertypes (depth-limited, cycle-safe).
 fn resolve_from_class_hierarchy(idx: &Indexer, name: &str, from_uri: &Url) -> Vec<Location> {
-    let mut results = walk_hierarchy(
+    let results = walk_hierarchy(
         idx,
         "",
         from_uri.as_str(),
@@ -963,10 +963,19 @@ fn resolve_from_class_hierarchy(idx: &Indexer, name: &str, from_uri: &Url) -> Ve
         4,
         |index, _, class_uri, _| find_name_in_uri(index, name, class_uri),
     );
-    // Deduplicate: hierarchy walk may find the same definition via multiple paths
-    // (e.g. diamond inheritance). Keep traversal order (most-specific first).
-    results.dedup_by(|a, b| a.uri == b.uri && a.range == b.range);
+    // Stable dedup via HashSet — diamond inheritance can produce the same location
+    // via multiple paths; dedup_by only removes consecutive duplicates.
+    let mut seen = HashSet::new();
     results
+        .into_iter()
+        .filter(|loc| {
+            seen.insert((
+                loc.uri.clone(),
+                loc.range.start.line,
+                loc.range.start.character,
+            ))
+        })
+        .collect()
 }
 
 /// `rg` scoped to the directory that would contain `package` sources.

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -18,6 +18,7 @@
 //! Stdlib packages (`kotlin.*`, `java.*`, `android.*`, `androidx.*`) are skipped because
 //! their sources aren't present in the project tree.
 
+use std::collections::HashSet;
 use std::path::Path;
 use std::process::Command;
 
@@ -26,7 +27,7 @@ use tower_lsp::lsp_types::{Location, Range, TextEdit, Url};
 use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
 use crate::rg::{build_rg_pattern, parse_rg_line, rg_find_definition};
-use crate::types::ImportEntry;
+use crate::types::{CallerContext, FileData, ImportEntry};
 use crate::LinesExt;
 use crate::StrExt;
 
@@ -60,6 +61,126 @@ pub(crate) use infer::{
 // Internal imports from submodules used in this file.
 use find::{find_local_declaration, find_name_in_uri, find_name_in_uri_after_line};
 use infer::{infer_field_type, infer_variable_type};
+
+/// Return `FileData` for `uri` — from the live index if indexed, otherwise parse from disk.
+/// Returns `None` if the file is not indexed and not readable from disk.
+pub(crate) fn ensure_file_data(idx: &Indexer, uri: &Url) -> Option<FileData> {
+    if let Some(file_data) = idx.files.get(uri.as_str()) {
+        return Some(file_data.value().as_ref().clone());
+    }
+
+    let path = uri.to_file_path().ok()?;
+    let content = std::fs::read_to_string(path).ok()?;
+    Some(parse_by_extension(uri.path(), &content))
+}
+
+/// Walk the class hierarchy starting from `start_class`, collecting items at each level.
+/// `T` is what the visitor produces per symbol. `max_depth` prevents infinite loops.
+pub(crate) fn walk_hierarchy<'a, T, F>(
+    idx: &'a Indexer,
+    start_class: &str,
+    start_uri: &str,
+    caller: CallerContext<'a>,
+    max_depth: usize,
+    collect: F,
+) -> Vec<T>
+where
+    F: Fn(&Indexer, &str, &str, CallerContext<'_>) -> Vec<T>,
+{
+    let mut walker = HierarchyWalker {
+        idx,
+        caller,
+        max_depth,
+        collect,
+        visited: HashSet::from([start_class.to_owned()]),
+        items: Vec::new(),
+    };
+    walker.recurse(start_class, start_uri, 0);
+    walker.items
+}
+
+struct HierarchyWalker<'a, T, F>
+where
+    F: Fn(&Indexer, &str, &str, CallerContext<'_>) -> Vec<T>,
+{
+    idx: &'a Indexer,
+    caller: CallerContext<'a>,
+    max_depth: usize,
+    collect: F,
+    visited: HashSet<String>,
+    items: Vec<T>,
+}
+
+impl<'a, T, F> HierarchyWalker<'a, T, F>
+where
+    F: Fn(&Indexer, &str, &str, CallerContext<'_>) -> Vec<T>,
+{
+    fn recurse(&mut self, class_name: &str, class_uri: &str, depth: usize) {
+        if depth >= self.max_depth {
+            return;
+        }
+
+        for (super_name, super_uri) in supertype_targets(self.idx, class_name, class_uri) {
+            if !self.visited.insert(super_name.clone()) {
+                continue;
+            }
+            self.items.extend((self.collect)(
+                self.idx,
+                &super_name,
+                &super_uri,
+                self.caller,
+            ));
+            self.recurse(&super_name, &super_uri, depth + 1);
+        }
+    }
+}
+
+fn supertype_targets(idx: &Indexer, class_name: &str, class_uri: &str) -> Vec<(String, String)> {
+    let Ok(uri) = Url::parse(class_uri) else {
+        return vec![];
+    };
+    let Some(file_data) = ensure_file_data(idx, &uri) else {
+        return vec![];
+    };
+
+    super_names_for_class(&file_data, class_name)
+        .into_iter()
+        .flat_map(|super_name| {
+            resolve_symbol_inner(idx, &super_name, &uri, false)
+                .into_iter()
+                .map(move |loc| (super_name.clone(), loc.uri.to_string()))
+        })
+        .collect()
+}
+
+fn super_names_for_class(file_data: &FileData, class_name: &str) -> Vec<String> {
+    if class_name.is_empty() {
+        return file_data
+            .supers
+            .iter()
+            .map(|(_, name, _)| name.clone())
+            .collect();
+    }
+
+    let class_line = file_data
+        .symbols
+        .iter()
+        .find(|symbol| symbol.name == class_name)
+        .map(|symbol| symbol.selection_start());
+    match class_line {
+        Some(line) => file_data
+            .supers
+            .iter()
+            .filter(|(super_line, _, _)| *super_line == line)
+            .map(|(_, name, _)| name.clone())
+            .collect(),
+        None => file_data
+            .supers
+            .iter()
+            .map(|(_, name, _)| name.clone())
+            .collect(),
+    }
+}
 
 // ─── auto-import helpers ──────────────────────────────────────────────────────
 
@@ -276,8 +397,7 @@ pub(crate) fn resolve_symbol_inner(
 
     // 4.5 ── superclass / interface hierarchy ─────────────────────────────────
     if with_hierarchy {
-        let mut visited: Vec<String> = Vec::new();
-        let inherited = resolve_from_class_hierarchy(idx, name, from_uri, 0, &mut visited);
+        let inherited = resolve_from_class_hierarchy(idx, name, from_uri);
         if !inherited.is_empty() {
             return inherited;
         }
@@ -374,14 +494,12 @@ fn resolve_qualified(idx: &Indexer, name: &str, qualifier: &str, from_uri: &Url)
         if !locs.is_empty() {
             return locs;
         }
-        let mut visited = vec![];
-        return resolve_from_class_hierarchy(idx, name, from_uri, 0, &mut visited);
+        return resolve_from_class_hierarchy(idx, name, from_uri);
     }
 
     // ── `super.member` — search superclass hierarchy only ────────────────────
     if root == "super" {
-        let mut visited = vec![];
-        return resolve_from_class_hierarchy(idx, name, from_uri, 0, &mut visited);
+        return resolve_from_class_hierarchy(idx, name, from_uri);
     }
 
     if root.starts_with_uppercase() {
@@ -462,8 +580,7 @@ fn resolve_qualified(idx: &Indexer, name: &str, qualifier: &str, from_uri: &Url)
     let Ok(parsed_uri) = Url::parse(resolved_uri) else {
         return vec![];
     };
-    let mut visited = vec![];
-    resolve_from_class_hierarchy(idx, name, &parsed_uri, 0, &mut visited)
+    resolve_from_class_hierarchy(idx, name, &parsed_uri)
 }
 
 /// Step 1 — symbols defined in the same source file.
@@ -835,60 +952,15 @@ fn resolve_star_imports(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
 /// 2. Resolve each supertype through the normal chain (imports, same-package…).
 /// 3. Search the resolved file's symbol table for `name`.
 /// 4. Recurse into that file's own supertypes (depth-limited, cycle-safe).
-fn resolve_from_class_hierarchy(
-    idx: &Indexer,
-    name: &str,
-    from_uri: &Url,
-    depth: u8,
-    visited: &mut Vec<String>,
-) -> Vec<Location> {
-    const MAX_DEPTH: u8 = 4;
-    if depth >= MAX_DEPTH {
-        return vec![];
-    }
-
-    let key = from_uri.as_str().to_owned();
-    if visited.contains(&key) {
-        return vec![];
-    }
-    visited.push(key);
-
-    let supers: Vec<String> = if let Some(f) = idx.files.get(from_uri.as_str()) {
-        f.supers.iter().map(|(_, n, _)| n.clone()).collect()
-    } else {
-        // File not indexed yet — parse on demand so hierarchy walk works
-        // even before background indexing reaches this file.
-        let path = from_uri.to_file_path().ok();
-        let content = path.and_then(|p| std::fs::read_to_string(p).ok());
-        match content {
-            Some(c) => parse_by_extension(from_uri.path(), &c)
-                .supers
-                .iter()
-                .map(|(_, n, _)| n.clone())
-                .collect(),
-            None => return vec![],
-        }
-    };
-
-    for super_name in supers {
-        // Locate the supertype's file via steps 1-4+5 only — NOT step 4.5.
-        // Using the full resolve_symbol here would re-enter this function with
-        // a fresh visited-set, causing infinite recursion.
-        let super_locs = resolve_symbol_inner(idx, &super_name, from_uri, false);
-        for super_loc in &super_locs {
-            let locs = find_name_in_uri(idx, name, super_loc.uri.as_str());
-            if !locs.is_empty() {
-                return locs;
-            }
-
-            // Recurse into the supertype's own hierarchy.
-            let locs = resolve_from_class_hierarchy(idx, name, &super_loc.uri, depth + 1, visited);
-            if !locs.is_empty() {
-                return locs;
-            }
-        }
-    }
-    vec![]
+fn resolve_from_class_hierarchy(idx: &Indexer, name: &str, from_uri: &Url) -> Vec<Location> {
+    walk_hierarchy(
+        idx,
+        "",
+        from_uri.as_str(),
+        CallerContext::default(),
+        4,
+        |index, _, class_uri, _| find_name_in_uri(index, name, class_uri),
+    )
 }
 
 /// `rg` scoped to the directory that would contain `package` sources.

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -232,30 +232,9 @@ pub(crate) fn rg_find_definition(
         None => std::borrow::Cow::Owned(std::env::current_dir().unwrap_or_default()),
     };
 
-    let mut cmd = Command::new("rg");
-    cmd.args([
-        "--no-heading",
-        "--with-filename",
-        "--line-number",
-        "--column",
-        // NOTE: rg has no --absolute-path flag; absolute output comes from
-        // passing an absolute search root as the positional argument.
-    ]);
-    for ext in SOURCE_EXTENSIONS {
-        cmd.args(["--glob", &format!("*.{ext}")]);
-    }
-    cmd.args(["-e", &pattern]);
-    cmd.arg(search_root.as_ref());
-
-    let out = match cmd.output() {
-        Ok(o) if o.status.success() => o,
-        _ => return vec![],
-    };
-
-    let locs: Vec<Location> = String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .filter_map(|l| parse_rg_line_with_content_rooted(l, &search_root).map(|(loc, _)| loc))
-        .collect();
+    let locs = RgSearch::rooted(search_root.as_ref())
+        .with_pattern(pattern)
+        .locations();
 
     if let Some(m) = matcher {
         m.filter_locs(locs)
@@ -273,6 +252,144 @@ pub(crate) struct RgSearchRequest<'a> {
     include_decl: bool,
     from_uri: &'a Url,
     decl_files: &'a [String],
+}
+
+enum RgTarget<'a> {
+    Root(&'a Path),
+    Files(&'a [String]),
+}
+
+struct RgSearch<'a> {
+    parse_root: &'a Path,
+    target: RgTarget<'a>,
+    patterns: Vec<String>,
+    word_regexp: bool,
+    list_files: bool,
+}
+
+impl<'a> RgSearch<'a> {
+    fn rooted(root: &'a Path) -> Self {
+        Self {
+            parse_root: root,
+            target: RgTarget::Root(root),
+            patterns: Vec::new(),
+            word_regexp: false,
+            list_files: false,
+        }
+    }
+
+    fn files(files: &'a [String]) -> Self {
+        Self {
+            parse_root: Path::new("/"),
+            target: RgTarget::Files(files),
+            patterns: Vec::new(),
+            word_regexp: false,
+            list_files: false,
+        }
+    }
+
+    fn with_pattern(mut self, pattern: impl Into<String>) -> Self {
+        self.patterns.push(pattern.into());
+        self
+    }
+
+    fn with_patterns<I, S>(mut self, patterns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.patterns.extend(patterns.into_iter().map(Into::into));
+        self
+    }
+
+    fn word_regexp(mut self) -> Self {
+        self.word_regexp = true;
+        self
+    }
+
+    fn list_files(mut self) -> Self {
+        self.list_files = true;
+        self
+    }
+
+    fn build_command(&self) -> Command {
+        let mut command = Command::new("rg");
+        if self.list_files {
+            command.arg("-l");
+        } else {
+            command.args([
+                "--no-heading",
+                "--with-filename",
+                "--line-number",
+                "--column",
+            ]);
+        }
+        if self.word_regexp {
+            command.arg("--word-regexp");
+        }
+        for ext in SOURCE_EXTENSIONS {
+            command.args(["--glob", &format!("*.{ext}")]);
+        }
+        for pattern in &self.patterns {
+            command.args(["-e", pattern]);
+        }
+        match &self.target {
+            RgTarget::Root(root) => {
+                command.arg(root);
+            }
+            RgTarget::Files(files) => {
+                command.arg("--");
+                command.args(*files);
+            }
+        }
+        command
+    }
+
+    fn output(&self) -> Option<std::process::Output> {
+        let mut command = self.build_command();
+        match command.output() {
+            Ok(output) if output.status.success() && !output.stdout.is_empty() => Some(output),
+            _ => None,
+        }
+    }
+
+    fn locations_with_content(&self) -> Vec<(Location, String)> {
+        let Some(output) = self.output() else {
+            return vec![];
+        };
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter_map(|line| parse_rg_line_with_content_rooted(line, self.parse_root))
+            .collect()
+    }
+
+    fn locations(&self) -> Vec<Location> {
+        self.locations_with_content()
+            .into_iter()
+            .map(|(location, _)| location)
+            .collect()
+    }
+
+    fn files_with_matches(&self) -> Vec<String> {
+        let Some(output) = self.output() else {
+            return vec![];
+        };
+        let root = match &self.target {
+            RgTarget::Root(root) => *root,
+            RgTarget::Files(_) => return vec![],
+        };
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(|line| {
+                let path = Path::new(line);
+                if path.is_absolute() {
+                    line.to_owned()
+                } else {
+                    root.join(line).to_string_lossy().into_owned()
+                }
+            })
+            .collect()
+    }
 }
 
 impl<'a> RgSearchRequest<'a> {
@@ -338,27 +455,6 @@ fn build_rg_patterns(request: &RgSearchRequest<'_>) -> Vec<String> {
     }
 }
 
-fn build_rg_command(request: &RgSearchRequest<'_>, patterns: &[String]) -> Command {
-    let mut command = Command::new("rg");
-    command.args([
-        "--no-heading",
-        "--with-filename",
-        "--line-number",
-        "--column",
-    ]);
-    if request.parent_class.is_none() && request.declared_pkg.is_none() {
-        command.arg("--word-regexp");
-    }
-    for ext in SOURCE_EXTENSIONS {
-        command.args(["--glob", &format!("*.{ext}")]);
-    }
-    for pattern in patterns {
-        command.args(["-e", pattern.as_str()]);
-    }
-    command.arg(request.search_root.as_ref());
-    command
-}
-
 fn should_skip_reference(loc: &Location, content: &str, request: &RgSearchRequest<'_>) -> bool {
     let trimmed = content.trim_start();
     if trimmed.starts_with("import ") || trimmed.starts_with("package ") {
@@ -376,23 +472,19 @@ fn should_skip_reference(loc: &Location, content: &str, request: &RgSearchReques
     false
 }
 
-fn parse_rg_output(output: &[u8], request: &RgSearchRequest<'_>) -> Vec<Location> {
-    String::from_utf8_lossy(output)
-        .lines()
-        .filter_map(|line| parse_rg_line_with_content_rooted(line, request.search_root.as_ref()))
+fn run_rg_search(request: &RgSearchRequest<'_>, patterns: &[String]) -> Vec<Location> {
+    let mut search =
+        RgSearch::rooted(request.search_root.as_ref()).with_patterns(patterns.iter().cloned());
+    if request.parent_class.is_none() && request.declared_pkg.is_none() {
+        search = search.word_regexp();
+    }
+    search
+        .locations_with_content()
+        .into_iter()
         .filter_map(|(loc, content)| {
             (!should_skip_reference(&loc, &content, request)).then_some(loc)
         })
         .collect()
-}
-
-fn run_rg_search(request: &RgSearchRequest<'_>, patterns: &[String]) -> Vec<Location> {
-    let mut command = build_rg_command(request, patterns);
-    let output = match command.output() {
-        Ok(output) if output.status.success() && !output.stdout.is_empty() => output,
-        _ => return vec![],
-    };
-    parse_rg_output(&output.stdout, request)
 }
 
 fn filter_candidate_files(
@@ -541,26 +633,10 @@ pub(crate) fn rg_find_implementors(
         None => return vec![],
     };
     // Search for the name in source files.
-    let mut cmd = Command::new("rg");
-    cmd.args([
-        "--no-heading",
-        "--with-filename",
-        "--line-number",
-        "--column",
-        "-e",
-        &safe,
-    ]);
-    for ext in SOURCE_EXTENSIONS {
-        cmd.args(["--glob", &format!("*.{ext}")]);
-    }
-    cmd.arg(root);
-    let out = match cmd.output() {
-        Ok(o) if !o.stdout.is_empty() => o,
-        _ => return vec![],
-    };
-    let locs: Vec<Location> = String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .filter_map(|l| parse_rg_line_with_content_rooted(l, root))
+    let locs: Vec<Location> = RgSearch::rooted(root)
+        .with_pattern(safe)
+        .locations_with_content()
+        .into_iter()
         .filter_map(|(loc, content)| {
             let line = content.trim();
             // Heuristics: declaration-like lines
@@ -633,27 +709,10 @@ pub(crate) fn regex_escape(s: &str) -> String {
 
 /// Run `rg -l` to get the list of files matching a pattern.
 fn rg_files_with_matches(pattern: &str, root: &Path) -> Vec<String> {
-    let mut cmd = Command::new("rg");
-    cmd.arg("-l");
-    for ext in SOURCE_EXTENSIONS {
-        cmd.args(["--glob", &format!("*.{ext}")]);
-    }
-    cmd.args(["-e", pattern]).arg(root);
-    let out = match cmd.output() {
-        Ok(o) if !o.stdout.is_empty() => o,
-        _ => return vec![],
-    };
-    String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .map(|l| {
-            let p = std::path::Path::new(l);
-            if p.is_absolute() {
-                l.to_owned()
-            } else {
-                root.join(l).to_string_lossy().into_owned()
-            }
-        })
-        .collect()
+    RgSearch::rooted(root)
+        .list_files()
+        .with_pattern(pattern.to_owned())
+        .files_with_matches()
 }
 
 /// Run `rg --word-regexp NAME` restricted to specific files.
@@ -661,28 +720,10 @@ fn rg_word_in_files(safe_name: &str, files: &[String]) -> Vec<(Location, String)
     if files.is_empty() {
         return vec![];
     }
-    let out = match Command::new("rg")
-        .args([
-            "--no-heading",
-            "--with-filename",
-            "--line-number",
-            "--column",
-            "--word-regexp",
-            "-e",
-            safe_name,
-            "--",
-        ])
-        .args(files)
-        .output()
-    {
-        Ok(o) if !o.stdout.is_empty() => o,
-        _ => return vec![],
-    };
-    // Files passed to rg_word_in_files are already absolute (from rg_files_with_matches).
-    String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .filter_map(|l| parse_rg_line_with_content_rooted(l, std::path::Path::new("/")))
-        .collect()
+    RgSearch::files(files)
+        .word_regexp()
+        .with_pattern(safe_name.to_owned())
+        .locations_with_content()
 }
 
 fn parse_rg_line_with_content_rooted(line: &str, root: &Path) -> Option<(Location, String)> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -52,6 +52,14 @@ pub(crate) struct CursorPos {
     pub utf16_col: usize,
 }
 
+/// The caller's position context, used for visibility filtering and type-param substitution.
+#[allow(dead_code)]
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct CallerContext<'a> {
+    pub uri: Option<&'a str>,
+    pub cursor_line: Option<u32>,
+}
+
 /// Kotlin/Java visibility of a declared symbol.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub(crate) enum Visibility {

--- a/src/types.rs
+++ b/src/types.rs
@@ -53,7 +53,6 @@ pub(crate) struct CursorPos {
 }
 
 /// The caller's position context, used for visibility filtering and type-param substitution.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct CallerContext<'a> {
     pub uri: Option<&'a str>,


### PR DESCRIPTION
## Wave 1 Architecture Refactor

Two commits for review:

### c86d39a — KIND_ constants + resolver scaffolding
- Add missing `KIND_*` constants to `queries.rs`, replace all hardcoded `.kind() == "string"` comparisons
- Add `CallerContext<'a>` struct to `types.rs`
- Add `ensure_file_data()` helper to `resolver/mod.rs`
- Add generic `walk_hierarchy<T,F>()` + `HierarchyWalker` to `resolver/mod.rs`

### a80df9b — Wire helpers to callers
- Replace `SuperWalker` + `InheritanceWalker` in `complete.rs` with `walk_hierarchy` (-309 lines)
- Replace 4 inline `read_to_string` blocks with `ensure_file_data()`
- Replace `(calling_uri, cursor_line)` params with `CallerContext<'_>` in `resolution.rs`, `complete.rs`

686 tests passing, 0 clippy warnings.