### PR TITLE
refactor(wave2): parser shared helpers, backend layer fixes, PR #58 review fixes

### DIFF
--- a/src/backend/actions.rs
+++ b/src/backend/actions.rs
@@ -167,15 +167,13 @@ impl Backend {
         let uri = &params.text_document.uri;
         let range = params.range;
 
+        let lines = self.indexer.mem_lines_for(uri.as_str());
         let line_text: String = {
             let ln = range.start.line as usize;
-            if let Some(ll) = self.indexer.live_lines.get(uri.as_str()) {
-                ll.get(ln).cloned().unwrap_or_default()
-            } else if let Some(data) = self.indexer.files.get(uri.as_str()) {
-                data.lines.get(ln).cloned().unwrap_or_default()
-            } else {
-                String::new()
-            }
+            lines
+                .as_ref()
+                .and_then(|lines| lines.get(ln).cloned())
+                .unwrap_or_default()
         };
 
         let trimmed = line_text.trim().to_owned();
@@ -192,15 +190,10 @@ impl Backend {
             }
         }
 
-        let all_lines: Vec<String> = {
-            if let Some(ll) = self.indexer.live_lines.get(uri.as_str()) {
-                ll.clone().to_vec()
-            } else if let Some(data) = self.indexer.files.get(uri.as_str()) {
-                data.lines.to_vec()
-            } else {
-                vec![]
-            }
-        };
+        let all_lines: Vec<String> = lines
+            .as_ref()
+            .map(|lines| lines.as_ref().clone())
+            .unwrap_or_default();
 
         let cursor_word = line_text.word_at_utf16_col(range.start.character as usize);
         let is_kotlin = crate::Language::from_path(uri.path()) == crate::Language::Kotlin;

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -3,14 +3,11 @@ use super::cursor::CursorContext;
 use super::format::{format_contextual_hover, format_symbol_hover};
 use super::helpers::resolve_references_scope;
 use super::Backend;
-use crate::indexer::apply_type_subst;
-use crate::indexer::find_fun_signature_with_receiver;
 use crate::indexer::resolution::{
     enrich_at_location, resolve_symbol_info, ResolveOptions, SubstitutionContext,
 };
-use crate::indexer::NodeExt;
+use crate::indexer::{apply_type_subst, cst_call_info, find_fun_signature_with_receiver, CallInfo};
 use crate::inlay_hints::compute_inlay_hints;
-use crate::queries::{KIND_CALL_EXPR, KIND_LAMBDA_LIT, KIND_VALUE_ARG};
 use crate::StrExt;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
@@ -169,34 +166,18 @@ impl Backend {
         parent_class: Option<&str>,
     ) -> Vec<String> {
         self.indexer
-            .definitions
-            .get(name)
-            .map(|locations| {
-                locations
-                    .iter()
-                    .filter(|location| {
-                        reference_matches_parent_class(&self.indexer, location, parent_class)
-                    })
-                    .filter_map(|location| location.uri.to_file_path().ok())
-                    .filter_map(|path| path.to_str().map(|path| path.to_owned()))
-                    .collect()
+            .definition_locations(name)
+            .into_iter()
+            .filter(|location| {
+                reference_matches_parent_class(&self.indexer, location, parent_class)
             })
-            .unwrap_or_default()
+            .filter_map(|location| location.uri.to_file_path().ok())
+            .filter_map(|path| path.to_str().map(|path| path.to_owned()))
+            .collect()
     }
 
     async fn rg_reference_locations(&self, search: &ReferenceSearch) -> Vec<Location> {
-        let workspace_root = self
-            .indexer
-            .workspace_root
-            .read()
-            .ok()
-            .and_then(|root| root.clone());
-        let ignore_matcher = self
-            .indexer
-            .ignore_matcher
-            .read()
-            .ok()
-            .and_then(|matcher| matcher.clone());
+        let (workspace_root, ignore_matcher) = self.rg_context().await;
         let request = search.clone();
         tokio::task::spawn_blocking(move || {
             let rg_request = crate::rg::RgSearchRequest::new(
@@ -215,10 +196,7 @@ impl Backend {
     }
 
     fn filter_library_reference_locations(&self, locations: &mut Vec<Location>) {
-        if self.indexer.library_uris.is_empty() {
-            return;
-        }
-        locations.retain(|location| !self.indexer.library_uris.contains(location.uri.as_str()));
+        locations.retain(|location| !self.indexer.is_library_uri(&location.uri));
     }
 
     fn add_current_file_reference_locations(
@@ -227,10 +205,10 @@ impl Backend {
         name: &str,
         locations: &mut Vec<Location>,
     ) {
-        let Some(data) = self.indexer.files.get(uri.as_str()) else {
+        let Some(lines) = self.indexer.mem_lines_for(uri.as_str()) else {
             return;
         };
-        for (line_idx, line) in data.lines.iter().enumerate() {
+        for (line_idx, line) in lines.iter().enumerate() {
             let line_number = line_idx as u32;
             if has_reference_line(locations, uri, line_number) {
                 continue;
@@ -304,11 +282,11 @@ impl Backend {
 
     fn collect_workspace_symbols(&self, query: &WorkspaceSymbolQuery) -> Vec<SymbolInformation> {
         let mut results = Vec::new();
-        for entry in self.indexer.files.iter() {
-            let Some(uri) = workspace_symbol_uri(entry.key()) else {
+        for (uri_str, data) in self.indexer.indexed_files() {
+            let Some(uri) = workspace_symbol_uri(&uri_str) else {
                 continue;
             };
-            collect_matching_workspace_symbols(&uri, &entry.value().symbols, query, &mut results);
+            collect_matching_workspace_symbols(&uri, &data.symbols, query, &mut results);
             if results.len() >= WORKSPACE_SYMBOL_CAP {
                 break;
             }
@@ -321,18 +299,7 @@ impl Backend {
         if !query.allows_rg_fallback() {
             return vec![];
         }
-        let workspace_root = self
-            .indexer
-            .workspace_root
-            .read()
-            .ok()
-            .and_then(|root| root.clone());
-        let ignore_matcher = self
-            .indexer
-            .ignore_matcher
-            .read()
-            .ok()
-            .and_then(|matcher| matcher.clone());
+        let (workspace_root, ignore_matcher) = self.rg_context().await;
         let query_text = query.raw.clone();
         let rg_locations = tokio::task::spawn_blocking(move || {
             crate::rg::rg_find_definition(
@@ -400,13 +367,11 @@ impl Backend {
         params: FoldingRangeParams,
     ) -> Result<Option<Vec<FoldingRange>>> {
         let uri = &params.text_document.uri;
-        let data = match self.indexer.files.get(uri.as_str()) {
-            Some(d) => d,
-            None => return Ok(None),
+        let Some(lines) = self.indexer.mem_lines_for(uri.as_str()) else {
+            return Ok(None);
         };
 
         let mut ranges: Vec<FoldingRange> = Vec::new();
-        let lines = &data.lines;
         let mut stack: Vec<u32> = Vec::new();
 
         for (i, line) in lines.iter().enumerate() {
@@ -484,23 +449,18 @@ impl Backend {
         // as Write highlights; all other occurrences are Read.
         let decl_lines: std::collections::HashSet<u32> = self
             .indexer
-            .definitions
-            .get(&name)
-            .map(|locs| {
-                locs.iter()
-                    .filter(|l| l.uri == *uri)
-                    .map(|l| l.range.start.line)
-                    .collect()
-            })
-            .unwrap_or_default();
+            .definition_locations(&name)
+            .into_iter()
+            .filter(|location| location.uri == *uri)
+            .map(|location| location.range.start.line)
+            .collect();
 
-        let data = match self.indexer.files.get(uri.as_str()) {
-            Some(d) => d,
-            None => return Ok(None),
+        let Some(lines) = self.indexer.mem_lines_for(uri.as_str()) else {
+            return Ok(None);
         };
 
         let mut highlights = Vec::new();
-        for (line_idx, line) in data.lines.iter().enumerate() {
+        for (line_idx, line) in lines.iter().enumerate() {
             for abs in word_byte_offsets(line, &name) {
                 let col: u32 = line[..abs].chars().map(|c| c.len_utf16() as u32).sum();
                 let col_end: u32 = col + name.chars().map(|c| c.len_utf16() as u32).sum::<u32>();
@@ -563,16 +523,6 @@ fn build_signature_help(
     })
 }
 
-/// Resolved call-site information needed for `textDocument/signatureHelp`.
-struct CallInfo {
-    /// Name of the function being called.
-    fn_name: String,
-    /// Optional receiver before the dot (e.g. `"builder"` in `builder.build()`).
-    qualifier: Option<String>,
-    /// Zero-based index of the parameter the cursor is currently inside.
-    active_param: u32,
-}
-
 /// Extract [`CallInfo`] for the call under the cursor.
 ///
 /// Tries the CST (live tree) first — O(depth), accurate qualifier extraction.
@@ -586,87 +536,11 @@ fn extract_call_info(
     before: &str,
     line_idx: usize,
 ) -> Option<CallInfo> {
-    // ── CST path ─────────────────────────────────────────────────────────────
     if let Some(result) = cst_call_info(pos, indexer, uri) {
         return Some(result);
     }
 
-    // ── Text path ────────────────────────────────────────────────────────────
     text_call_info(lines, before, line_idx)
-}
-
-/// CST path: walk from cursor up to `call_expression`, extract name/qualifier/param.
-///
-/// Returns `None` when:
-/// - no live tree available
-/// - cursor is inside a `lambda_literal`
-/// - callee shape not recognised (`simple_identifier` / `navigation_expression`)
-fn cst_call_info(pos: Position, indexer: &crate::indexer::Indexer, uri: &Url) -> Option<CallInfo> {
-    use crate::indexer::live_tree::utf16_col_to_byte;
-    use tree_sitter::Point;
-
-    let doc = indexer.live_doc(uri)?;
-    let bytes = &doc.bytes;
-    let full_text = std::str::from_utf8(bytes).ok()?;
-
-    let line_idx = pos.line as usize;
-    let line_text = full_text.lines().nth(line_idx)?;
-    let byte_col = utf16_col_to_byte(line_text, pos.character as usize);
-    let point = Point {
-        row: line_idx,
-        column: byte_col,
-    };
-    let start_node = doc
-        .tree
-        .root_node()
-        .descendant_for_point_range(point, point)?;
-
-    // Walk up: find call_expression; bail out if we cross into a lambda literal.
-    let mut cur = start_node;
-    let call_expr = loop {
-        match cur.kind() {
-            KIND_CALL_EXPR => break Some(cur),
-            KIND_LAMBDA_LIT => break None,
-            _ => match cur.parent() {
-                Some(p) => cur = p,
-                None => break None,
-            },
-        }
-    }?;
-
-    // Extract function name and optional qualifier from the callee.
-    let (fn_name, qualifier) = call_expr.call_fn_and_qualifier(bytes)?;
-
-    // Find the value_arguments node (may be inside call_suffix).
-    let value_arguments = call_expr.find_value_arguments()?;
-
-    // Count active param: how many value_argument children end before the cursor.
-    let cursor_byte = full_text
-        .lines()
-        .take(line_idx)
-        .map(|l| l.len() + 1) // +1 for the newline
-        .sum::<usize>()
-        + byte_col;
-    let active_param = {
-        let mut count = 0u32;
-        let mut walker = value_arguments.walk();
-        for child in value_arguments.children(&mut walker) {
-            if child.kind() == KIND_VALUE_ARG {
-                if child.end_byte() <= cursor_byte {
-                    count += 1;
-                } else {
-                    break;
-                }
-            }
-        }
-        count
-    };
-
-    Some(CallInfo {
-        fn_name,
-        qualifier,
-        active_param,
-    })
 }
 
 /// Scans a single source line for an unclosed call-site opening.

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -136,18 +136,8 @@ impl Backend {
     }
 
     pub(crate) async fn rg_context(&self) -> (Option<PathBuf>, Option<Arc<IgnoreMatcher>>) {
-        let root = self
-            .indexer
-            .workspace_root
-            .read()
-            .ok()
-            .and_then(|root| root.clone());
-        let ignore = self
-            .indexer
-            .ignore_matcher
-            .read()
-            .ok()
-            .and_then(|ignore| ignore.clone());
+        let root = self.indexer.workspace_root.read().unwrap().clone();
+        let ignore = self.indexer.ignore_matcher.read().unwrap().clone();
         (root, ignore)
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -135,6 +135,22 @@ impl Backend {
         }
     }
 
+    pub(crate) async fn rg_context(&self) -> (Option<PathBuf>, Option<Arc<IgnoreMatcher>>) {
+        let root = self
+            .indexer
+            .workspace_root
+            .read()
+            .ok()
+            .and_then(|root| root.clone());
+        let ignore = self
+            .indexer
+            .ignore_matcher
+            .read()
+            .ok()
+            .and_then(|ignore| ignore.clone());
+        (root, ignore)
+    }
+
     /// Try `find_definition_qualified` with `rt.qualified`, falling back to `rt.leaf`
     /// when the first lookup is empty and the two names differ.
     pub(super) fn resolve_with_receiver_fallback(
@@ -801,7 +817,7 @@ impl LanguageServer for Backend {
         }
 
         self.indexer.remove_live_tree(uri);
-        self.indexer.live_lines.remove(uri.as_str());
+        self.indexer.remove_live_lines(uri);
         // Clear diagnostics so stale errors don't linger after the file is closed.
         self.client
             .publish_diagnostics(params.text_document.uri, Vec::new(), None)
@@ -839,7 +855,7 @@ impl LanguageServer for Backend {
         for change in params.changes {
             if change.typ == FileChangeType::DELETED {
                 // Remove from index; definition map cleanup is handled lazily.
-                self.indexer.files.remove(change.uri.as_str());
+                self.indexer.remove_indexed_file(&change.uri);
                 continue;
             }
             let uri = change.uri;

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -103,14 +103,9 @@ impl Backend {
         // Use effective_rg_root so searches use the open file's project root
         // when workspace_root points to a different project (e.g. android vs ios).
         let file_path = uri.to_file_path().ok();
-        let (root_opt, matcher) = {
-            let wr = self.indexer.workspace_root.read().unwrap().clone();
-            let m = self.indexer.ignore_matcher.read().unwrap().clone();
-            (
-                crate::rg::effective_rg_root(wr.as_deref(), file_path.as_deref()),
-                m,
-            )
-        };
+        let (workspace_root, matcher) = self.rg_context().await;
+        let root_opt =
+            crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
         let name_clone = ctx.word.clone();
         let rg_locs = tokio::task::spawn_blocking(move || {
             crate::rg::rg_find_definition(&name_clone, root_opt.as_deref(), matcher.as_deref())
@@ -144,14 +139,9 @@ impl Backend {
         // to find implementors quickly to avoid client timeouts in large projects.
         if locs.is_empty() {
             let file_path = uri.to_file_path().ok();
-            let (root_opt, matcher) = {
-                let wr = self.indexer.workspace_root.read().unwrap().clone();
-                let m = self.indexer.ignore_matcher.read().unwrap().clone();
-                (
-                    crate::rg::effective_rg_root(wr.as_deref(), file_path.as_deref()),
-                    m,
-                )
-            };
+            let (workspace_root, matcher) = self.rg_context().await;
+            let root_opt =
+                crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
             let word_clone = word.clone();
             let rg_impls = tokio::task::spawn_blocking(move || {
                 crate::rg::rg_find_implementors(
@@ -250,14 +240,9 @@ impl Backend {
     pub(super) async fn rg_resolve(&self, uri: &Url, name: &str) -> Vec<Location> {
         let name_clone = name.to_string();
         let file_path = uri.to_file_path().ok();
-        let (root_opt, matcher) = {
-            let wr = self.indexer.workspace_root.read().unwrap().clone();
-            let m = self.indexer.ignore_matcher.read().unwrap().clone();
-            (
-                crate::rg::effective_rg_root(wr.as_deref(), file_path.as_deref()),
-                m,
-            )
-        };
+        let (workspace_root, matcher) = self.rg_context().await;
+        let root_opt =
+            crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
         tokio::task::spawn_blocking(move || {
             crate::rg::rg_find_definition(&name_clone, root_opt.as_deref(), matcher.as_deref())
         })

--- a/src/backend/rename.rs
+++ b/src/backend/rename.rs
@@ -1,94 +1,18 @@
 use super::actions::is_non_call_keyword;
 use super::helpers::resolve_references_scope;
 use super::Backend;
+use crate::indexer::cst_cursor_is_local_var;
+#[cfg(test)]
 use crate::indexer::live_tree::utf16_col_to_byte;
+#[cfg(test)]
 use crate::queries::{
-    KIND_ANON_FUN, KIND_CLASS_BODY, KIND_COMPANION_OBJ, KIND_FUN_DECL, KIND_LAMBDA_LIT,
-    KIND_METHOD_DECL, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_OBJECT_DECL, KIND_PROP_DECL,
-    KIND_SOURCE_FILE, KIND_VAR_DECL,
+    KIND_ANON_FUN, KIND_CLASS_BODY, KIND_COMPANION_OBJ, KIND_FUN_DECL, KIND_METHOD_DECL,
+    KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_OBJECT_DECL, KIND_PROP_DECL, KIND_SOURCE_FILE,
+    KIND_VAR_DECL,
 };
 use crate::StrExt;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
-
-/// Return `true` when the cursor is on a local variable declaration — i.e. a
-/// `property_declaration` / `variable_declaration` whose nearest scope-boundary
-/// ancestor is a function/lambda body rather than a class body or source file.
-///
-/// This is used to decide whether to skip dotted occurrences during rename:
-/// - local var `val syncWith` inside a function → `skip_dotted = true`
-///   (avoid renaming `.syncWith()` method calls)
-/// - class property `val myProp` → `skip_dotted = false`
-///   (must rename `this.myProp` / `obj.myProp` accesses)
-/// - navigation expression (`.method()`) → `skip_dotted = false`
-/// - function declaration → `skip_dotted = false`
-fn cst_cursor_is_local_var(indexer: &crate::indexer::Indexer, uri: &Url, pos: Position) -> bool {
-    use tree_sitter::Point;
-
-    let doc = match indexer.live_doc(uri) {
-        Some(d) => d,
-        None => return false,
-    };
-    let full_text = match std::str::from_utf8(&doc.bytes) {
-        Ok(s) => s,
-        Err(_) => return false,
-    };
-    let line_idx = pos.line as usize;
-    let line_text = match full_text.lines().nth(line_idx) {
-        Some(l) => l,
-        None => return false,
-    };
-    let byte_col = utf16_col_to_byte(line_text, pos.character as usize);
-    let point = Point {
-        row: line_idx,
-        column: byte_col,
-    };
-    let start_node = match doc
-        .tree
-        .root_node()
-        .descendant_for_point_range(point, point)
-    {
-        Some(n) => n,
-        None => return false,
-    };
-
-    // Track whether we've entered a property/variable declaration binding.
-    let mut in_binding = false;
-    let mut cur = start_node;
-    loop {
-        let kind = cur.kind();
-        match kind {
-            // Entering a property/variable binding — continue walking up.
-            KIND_PROP_DECL | KIND_VAR_DECL | KIND_MULTI_VAR_DECL => {
-                in_binding = true;
-            }
-            // Inside a binding and hit a function/lambda boundary → local variable.
-            KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT if in_binding => {
-                return true;
-            }
-            // Function/method/lambda without being in a binding → not a local var.
-            KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT => return false,
-            // Navigation expression → member access, not a local var.
-            KIND_NAV_EXPR => return false,
-            // Class body, companion object, or source file reached while in a binding
-            // → class-level or top-level property, NOT a local var.
-            KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | KIND_SOURCE_FILE
-                if in_binding =>
-            {
-                return false;
-            }
-            // Scope boundary without being in a binding → not applicable.
-            KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | KIND_SOURCE_FILE => {
-                return false;
-            }
-            _ => {}
-        }
-        match cur.parent() {
-            Some(p) => cur = p,
-            None => return false,
-        }
-    }
-}
 
 /// Return `true` when the file index (within `scope`) contains a `val`/`var`
 /// declaration of `name` that is itself a local variable.
@@ -110,12 +34,9 @@ fn any_local_var_decl_in_scope(
 ) -> bool {
     use tower_lsp::lsp_types::SymbolKind;
 
-    let file = match indexer.files.get(uri.as_str()) {
-        Some(f) => f,
-        None => return false,
-    };
-    file.symbols
-        .iter()
+    indexer
+        .file_symbols(uri)
+        .into_iter()
         .filter(|s| {
             matches!(
                 s.kind,
@@ -404,24 +325,19 @@ impl Backend {
 
     fn definition_files_for_rename(&self, name: &str, parent_class: Option<&str>) -> Vec<String> {
         self.indexer
-            .definitions
-            .get(name)
-            .map(|locations| {
-                locations
-                    .iter()
-                    .filter(|location| {
-                        parent_class.is_none_or(|parent| {
-                            self.indexer
-                                .enclosing_class_at(&location.uri, location.range.start.line)
-                                .as_deref()
-                                == Some(parent)
-                        })
-                    })
-                    .filter_map(|location| location.uri.to_file_path().ok())
-                    .filter_map(|path| path.to_str().map(str::to_owned))
-                    .collect()
+            .definition_locations(name)
+            .into_iter()
+            .filter(|location| {
+                parent_class.is_none_or(|parent| {
+                    self.indexer
+                        .enclosing_class_at(&location.uri, location.range.start.line)
+                        .as_deref()
+                        == Some(parent)
+                })
             })
-            .unwrap_or_default()
+            .filter_map(|location| location.uri.to_file_path().ok())
+            .filter_map(|path| path.to_str().map(str::to_owned))
+            .collect()
     }
 
     async fn collect_reference_locations(
@@ -433,8 +349,7 @@ impl Backend {
             &rename_target.name,
             rename_target.parent_class.as_deref(),
         );
-        let root = self.indexer.workspace_root.read().unwrap().clone();
-        let matcher = self.indexer.ignore_matcher.read().unwrap().clone();
+        let (root, matcher) = self.rg_context().await;
         let uri_clone = uri.clone();
         let name = rename_target.name.clone();
         let parent_class = rename_target.parent_class.clone();
@@ -454,10 +369,7 @@ impl Backend {
         .await
         .unwrap_or_default();
 
-        let library_uris = &self.indexer.library_uris;
-        if !library_uris.is_empty() {
-            reference_locations.retain(|location| !library_uris.contains(location.uri.as_str()));
-        }
+        reference_locations.retain(|location| !self.indexer.is_library_uri(&location.uri));
         reference_locations
     }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -24,8 +24,9 @@ pub(crate) mod resolution;
 pub(crate) use self::infer::{
     collect_all_fun_params_texts,
     collect_params_from_line,
-    // sig.rs
     collect_signature,
+    cst_call_info,
+    cst_cursor_is_local_var,
     extract_first_arg,
     extract_named_arg_name,
     // args.rs
@@ -50,6 +51,8 @@ pub(crate) use self::infer::{
     line_has_lambda_param,
     nth_fun_param_type_str,
     strip_trailing_call_args,
+    // sig.rs
+    CallInfo,
 };
 
 mod cache;
@@ -314,6 +317,51 @@ impl Indexer {
             return Some(live.clone());
         }
         self.files.get(uri).map(|f| f.lines.clone())
+    }
+
+    pub(crate) fn live_lines_for(&self, uri: &Url) -> Option<Arc<Vec<String>>> {
+        self.live_lines
+            .get(uri.as_str())
+            .map(|lines| Arc::clone(lines.value()))
+    }
+
+    pub(crate) fn file_data(&self, uri: &Url) -> Option<Arc<FileData>> {
+        self.files
+            .get(uri.as_str())
+            .map(|data| Arc::clone(data.value()))
+    }
+
+    pub(crate) fn definition_locations(&self, name: &str) -> Vec<Location> {
+        self.definitions
+            .get(name)
+            .map(|locations| locations.clone())
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn subtype_locations(&self, name: &str) -> Vec<Location> {
+        self.subtypes
+            .get(name)
+            .map(|locations| locations.clone())
+            .unwrap_or_default()
+    }
+
+    pub(crate) fn indexed_files(&self) -> Vec<(String, Arc<FileData>)> {
+        self.files
+            .iter()
+            .map(|entry| (entry.key().clone(), Arc::clone(entry.value())))
+            .collect()
+    }
+
+    pub(crate) fn is_library_uri(&self, uri: &Url) -> bool {
+        self.library_uris.contains(uri.as_str())
+    }
+
+    pub(crate) fn remove_live_lines(&self, uri: &Url) {
+        self.live_lines.remove(uri.as_str());
+    }
+
+    pub(crate) fn remove_indexed_file(&self, uri: &Url) {
+        self.files.remove(uri.as_str());
     }
 
     // ─── completion helpers (methods on Indexer) ─────────────────────────────

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -319,12 +319,14 @@ impl Indexer {
         self.files.get(uri).map(|f| f.lines.clone())
     }
 
+    #[allow(dead_code)]
     pub(crate) fn live_lines_for(&self, uri: &Url) -> Option<Arc<Vec<String>>> {
         self.live_lines
             .get(uri.as_str())
             .map(|lines| Arc::clone(lines.value()))
     }
 
+    #[allow(dead_code)]
     pub(crate) fn file_data(&self, uri: &Url) -> Option<Arc<FileData>> {
         self.files
             .get(uri.as_str())
@@ -338,6 +340,7 @@ impl Indexer {
             .unwrap_or_default()
     }
 
+    #[allow(dead_code)]
     pub(crate) fn subtype_locations(&self, name: &str) -> Vec<Location> {
         self.subtypes
             .get(name)

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -319,30 +319,8 @@ impl Indexer {
         self.files.get(uri).map(|f| f.lines.clone())
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn live_lines_for(&self, uri: &Url) -> Option<Arc<Vec<String>>> {
-        self.live_lines
-            .get(uri.as_str())
-            .map(|lines| Arc::clone(lines.value()))
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn file_data(&self, uri: &Url) -> Option<Arc<FileData>> {
-        self.files
-            .get(uri.as_str())
-            .map(|data| Arc::clone(data.value()))
-    }
-
     pub(crate) fn definition_locations(&self, name: &str) -> Vec<Location> {
         self.definitions
-            .get(name)
-            .map(|locations| locations.clone())
-            .unwrap_or_default()
-    }
-
-    #[allow(dead_code)]
-    pub(crate) fn subtype_locations(&self, name: &str) -> Vec<Location> {
-        self.subtypes
             .get(name)
             .map(|locations| locations.clone())
             .unwrap_or_default()

--- a/src/indexer/infer/cst_cursor.rs
+++ b/src/indexer/infer/cst_cursor.rs
@@ -1,0 +1,136 @@
+use tower_lsp::lsp_types::{Position, Url};
+use tree_sitter::Point;
+
+use crate::indexer::live_tree::utf16_col_to_byte;
+use crate::indexer::{Indexer, NodeExt};
+use crate::queries::{
+    KIND_ANON_FUN, KIND_CALL_EXPR, KIND_CLASS_BODY, KIND_COMPANION_OBJ, KIND_FUN_DECL,
+    KIND_LAMBDA_LIT, KIND_METHOD_DECL, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_OBJECT_DECL,
+    KIND_PROP_DECL, KIND_SOURCE_FILE, KIND_VALUE_ARG, KIND_VAR_DECL,
+};
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CallInfo {
+    pub fn_name: String,
+    pub qualifier: Option<String>,
+    pub active_param: u32,
+}
+
+#[allow(dead_code)]
+pub(crate) fn cst_call_info(pos: Position, indexer: &Indexer, uri: &Url) -> Option<CallInfo> {
+    let doc = indexer.live_doc(uri)?;
+    let bytes = &doc.bytes;
+    let full_text = std::str::from_utf8(bytes).ok()?;
+
+    let line_idx = pos.line as usize;
+    let line_text = full_text.lines().nth(line_idx)?;
+    let byte_col = utf16_col_to_byte(line_text, pos.character as usize);
+    let point = Point {
+        row: line_idx,
+        column: byte_col,
+    };
+    let start_node = doc
+        .tree
+        .root_node()
+        .descendant_for_point_range(point, point)?;
+
+    let mut cur = start_node;
+    let call_expr = loop {
+        match cur.kind() {
+            KIND_CALL_EXPR => break Some(cur),
+            KIND_LAMBDA_LIT => break None,
+            _ => match cur.parent() {
+                Some(parent) => cur = parent,
+                None => break None,
+            },
+        }
+    }?;
+
+    let (fn_name, qualifier) = call_expr.call_fn_and_qualifier(bytes)?;
+    let value_arguments = call_expr.find_value_arguments()?;
+    let cursor_byte = full_text
+        .lines()
+        .take(line_idx)
+        .map(|line| line.len() + 1)
+        .sum::<usize>()
+        + byte_col;
+    let active_param = {
+        let mut count = 0u32;
+        let mut walker = value_arguments.walk();
+        for child in value_arguments.children(&mut walker) {
+            if child.kind() == KIND_VALUE_ARG {
+                if child.end_byte() <= cursor_byte {
+                    count += 1;
+                } else {
+                    break;
+                }
+            }
+        }
+        count
+    };
+
+    Some(CallInfo {
+        fn_name,
+        qualifier,
+        active_param,
+    })
+}
+
+#[allow(dead_code)]
+pub(crate) fn cst_cursor_is_local_var(indexer: &Indexer, uri: &Url, pos: Position) -> bool {
+    let doc = match indexer.live_doc(uri) {
+        Some(doc) => doc,
+        None => return false,
+    };
+    let full_text = match std::str::from_utf8(&doc.bytes) {
+        Ok(text) => text,
+        Err(_) => return false,
+    };
+    let line_idx = pos.line as usize;
+    let line_text = match full_text.lines().nth(line_idx) {
+        Some(line) => line,
+        None => return false,
+    };
+    let byte_col = utf16_col_to_byte(line_text, pos.character as usize);
+    let point = Point {
+        row: line_idx,
+        column: byte_col,
+    };
+    let start_node = match doc
+        .tree
+        .root_node()
+        .descendant_for_point_range(point, point)
+    {
+        Some(node) => node,
+        None => return false,
+    };
+
+    let mut in_binding = false;
+    let mut cur = start_node;
+    loop {
+        match cur.kind() {
+            KIND_PROP_DECL | KIND_VAR_DECL | KIND_MULTI_VAR_DECL => {
+                in_binding = true;
+            }
+            KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT if in_binding => {
+                return true;
+            }
+            KIND_FUN_DECL | KIND_METHOD_DECL | KIND_ANON_FUN | KIND_LAMBDA_LIT => return false,
+            KIND_NAV_EXPR => return false,
+            KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | KIND_SOURCE_FILE
+                if in_binding =>
+            {
+                return false;
+            }
+            KIND_CLASS_BODY | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | KIND_SOURCE_FILE => {
+                return false;
+            }
+            _ => {}
+        }
+        match cur.parent() {
+            Some(parent) => cur = parent,
+            None => return false,
+        }
+    }
+}

--- a/src/indexer/infer/cst_cursor.rs
+++ b/src/indexer/infer/cst_cursor.rs
@@ -9,7 +9,6 @@ use crate::queries::{
     KIND_PROP_DECL, KIND_SOURCE_FILE, KIND_VALUE_ARG, KIND_VAR_DECL,
 };
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct CallInfo {
     pub fn_name: String,
@@ -17,7 +16,6 @@ pub(crate) struct CallInfo {
     pub active_param: u32,
 }
 
-#[allow(dead_code)]
 pub(crate) fn cst_call_info(pos: Position, indexer: &Indexer, uri: &Url) -> Option<CallInfo> {
     let doc = indexer.live_doc(uri)?;
     let bytes = &doc.bytes;
@@ -77,7 +75,6 @@ pub(crate) fn cst_call_info(pos: Position, indexer: &Indexer, uri: &Url) -> Opti
     })
 }
 
-#[allow(dead_code)]
 pub(crate) fn cst_cursor_is_local_var(indexer: &Indexer, uri: &Url, pos: Position) -> bool {
     let doc = match indexer.live_doc(uri) {
         Some(doc) => doc,

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -8,11 +8,13 @@
 //! - `it_this`  — resolving `it`/`this` element types inside Kotlin lambda bodies
 
 pub(super) mod args;
+pub(super) mod cst_cursor;
 pub(super) mod deps;
 pub(super) mod it_this;
 pub(super) mod lambda;
 pub(super) mod sig;
 
+pub(crate) use cst_cursor::{cst_call_info, cst_cursor_is_local_var, CallInfo};
 pub(crate) use deps::InferDeps;
 #[cfg(test)]
 pub(crate) use deps::TestDeps;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,6 @@
 use std::cell::RefCell;
 use std::sync::OnceLock;
+use std::thread::LocalKey;
 
 use tower_lsp::lsp_types::{Position, Range, SymbolKind};
 use tree_sitter::{Node, Parser, Query, QueryCursor};
@@ -113,162 +114,147 @@ thread_local! {
 
 // ─── public entry points ────────────────────────────────────────────────────
 
-pub(crate) fn parse_kotlin(content: &str) -> FileData {
-    let lines = std::sync::Arc::new(content.lines().map(str::to_owned).collect());
-    let mut data = FileData {
-        lines,
+fn new_file_data(content: &str) -> FileData {
+    FileData {
+        lines: std::sync::Arc::new(content.lines().map(str::to_owned).collect()),
         ..Default::default()
-    };
+    }
+}
 
-    let Some(tree) = KOTLIN_PARSER.with(|p| p.borrow_mut().parse(content, None)) else {
+fn with_parsed_tree(
+    content: &str,
+    parser_key: &'static LocalKey<RefCell<Parser>>,
+    visit: impl FnOnce(&mut FileData, tree_sitter::Tree, &[u8]),
+) -> FileData {
+    let mut data = new_file_data(content);
+    let Some(tree) = parser_key.with(|p| p.borrow_mut().parse(content, None)) else {
         return data;
     };
-
-    let bytes = content.as_bytes();
-    let root = tree.root_node();
-
-    // ── definitions ──────────────────────────────────────────────────────────
-    let Some(qc) = kotlin_def_query() else {
-        return data;
-    };
-    let mut cur = QueryCursor::new();
-    let matches: Vec<MatchEntry> = cur
-        .matches(&qc.query, root, bytes)
-        .map(|m| map_def_captures(&m, qc.def_idx, qc.name_idx, bytes))
-        .collect();
-
-    // Deduplicate: multiple patterns can fire on the same node
-    // (e.g. enum class matches both pattern 0 "enum" AND pattern 2 "class").
-    let best = dedup_matches(&matches);
-    push_def_symbols(
-        best,
-        queries::def_pattern_meta,
-        visibility_at_line,
-        &data.lines,
-        &mut data.symbols,
-    );
-
-    // ── package + imports (manual tree walk — avoids query overlap issues) ────
-    data.extract_package_and_imports(root, bytes);
-
-    // ── fun interface (tree-sitter parses these as ERROR + lambda_literal) ───
-    data.extract_fun_interfaces(root, bytes);
-
-    // ── supertype relationships (delegation specifiers) ──────────────────────
-    data.extract_supers_kotlin(root, bytes);
-
-    // ── rhs-type and method-call-rhs inference (unannotated properties) ──────
-    data.extract_rhs_types_kotlin(root, bytes);
-
-    // ── declared_names: scan lines once for `ident:` patterns ───────────────
-    data.declared_names = extract_declared_names(&data.lines);
-
-    // ── syntax errors (ERROR / MISSING nodes) ────────────────────────────────
-    data.syntax_errors = collect_syntax_errors(root, bytes);
-
+    visit(&mut data, tree, content.as_bytes());
     data
+}
+
+fn finalize_parse(data: &mut FileData, root: Node, bytes: &[u8]) {
+    data.declared_names = extract_declared_names(&data.lines);
+    data.syntax_errors = collect_syntax_errors(root, bytes);
+}
+
+pub(crate) fn parse_kotlin(content: &str) -> FileData {
+    with_parsed_tree(content, &KOTLIN_PARSER, |data, tree, bytes| {
+        let root = tree.root_node();
+
+        // ── definitions ──────────────────────────────────────────────────────
+        let Some(qc) = kotlin_def_query() else {
+            return;
+        };
+        let mut cur = QueryCursor::new();
+        let matches: Vec<MatchEntry> = cur
+            .matches(&qc.query, root, bytes)
+            .map(|m| map_def_captures(&m, qc.def_idx, qc.name_idx, bytes))
+            .collect();
+
+        // Deduplicate: multiple patterns can fire on the same node
+        // (e.g. enum class matches both pattern 0 "enum" AND pattern 2 "class").
+        let best = dedup_matches(&matches);
+        push_def_symbols(
+            best,
+            queries::def_pattern_meta,
+            visibility_at_line,
+            &data.lines,
+            &mut data.symbols,
+        );
+
+        // ── package + imports (manual tree walk — avoids query overlap issues) ──
+        data.extract_package_and_imports(root, bytes);
+
+        // ── fun interface (tree-sitter parses these as ERROR + lambda_literal) ─
+        data.extract_fun_interfaces(root, bytes);
+
+        // ── supertype relationships (delegation specifiers) ────────────────────
+        data.extract_supers_kotlin(root, bytes);
+
+        // ── rhs-type and method-call-rhs inference (unannotated properties) ────
+        data.extract_rhs_types_kotlin(root, bytes);
+
+        finalize_parse(data, root, bytes);
+    })
 }
 
 pub(crate) fn parse_java(content: &str) -> FileData {
-    let lines = std::sync::Arc::new(content.lines().map(str::to_owned).collect());
-    let mut data = FileData {
-        lines,
-        ..Default::default()
-    };
-
-    let Some(tree) = JAVA_PARSER.with(|p| p.borrow_mut().parse(content, None)) else {
-        return data;
-    };
-
-    let bytes = content.as_bytes();
-    let mut queue = vec![tree.root_node()];
-    while let Some(node) = queue.pop() {
-        data.extract_java(&node, bytes);
-        data.extract_supers_java(&node, bytes);
-        let mut cur = node.walk();
-        for child in node.children(&mut cur) {
-            queue.push(child);
+    with_parsed_tree(content, &JAVA_PARSER, |data, tree, bytes| {
+        let root = tree.root_node();
+        let mut queue = vec![root];
+        while let Some(node) = queue.pop() {
+            data.extract_java(&node, bytes);
+            data.extract_supers_java(&node, bytes);
+            let mut cur = node.walk();
+            for child in node.children(&mut cur) {
+                queue.push(child);
+            }
         }
-    }
-    data.declared_names = extract_declared_names(&data.lines);
-    data.syntax_errors = collect_syntax_errors(tree.root_node(), bytes);
-    data
+        finalize_parse(data, root, bytes);
+    })
 }
 
 pub(crate) fn parse_swift(content: &str) -> FileData {
-    let lines = std::sync::Arc::new(content.lines().map(str::to_owned).collect());
-    let mut data = FileData {
-        lines,
-        ..Default::default()
-    };
+    with_parsed_tree(content, &SWIFT_PARSER, |data, tree, bytes| {
+        let root = tree.root_node();
 
-    let Some(tree) = SWIFT_PARSER.with(|p| p.borrow_mut().parse(content, None)) else {
-        return data;
-    };
-
-    let bytes = content.as_bytes();
-    let root = tree.root_node();
-
-    // ── definitions ──────────────────────────────────────────────────────────
-    let Some(qc) = swift_def_query() else {
-        return data;
-    };
-    let def_idx = qc.def_idx;
-    let name_idx = qc.name_idx;
-    let mut cur = QueryCursor::new();
-    let matches: Vec<MatchEntry> = cur
-        .matches(&qc.query, root, bytes)
-        .map(|m| {
-            let (pidx, slot) = map_def_captures(&m, def_idx, name_idx, bytes);
-            if pidx == queries::SWIFT_INIT_PATTERN_IDX && slot[0].is_none() {
-                // init_declaration — no @name, synthesize "init"; type_params from @def node.
-                let def_cap = m.captures.iter().find(|cap| cap.index == def_idx);
-                if let Some(cap) = def_cap {
-                    let dr = ts_to_lsp(cap.node.range());
-                    let sel = Range::new(
-                        Position::new(dr.start.line, dr.start.character),
-                        Position::new(
-                            dr.start.line,
-                            dr.start.character + queries::SWIFT_INIT_NAME.len() as u32,
-                        ),
-                    );
-                    let type_params = cap.node.extract_type_params(bytes);
-                    return (
-                        pidx,
-                        [
-                            Some((queries::SWIFT_INIT_NAME.to_owned(), dr, sel, type_params)),
-                            None,
-                        ],
-                    );
+        // ── definitions ──────────────────────────────────────────────────────
+        let Some(qc) = swift_def_query() else {
+            return;
+        };
+        let def_idx = qc.def_idx;
+        let name_idx = qc.name_idx;
+        let mut cur = QueryCursor::new();
+        let matches: Vec<MatchEntry> = cur
+            .matches(&qc.query, root, bytes)
+            .map(|m| {
+                let (pidx, slot) = map_def_captures(&m, def_idx, name_idx, bytes);
+                if pidx == queries::SWIFT_INIT_PATTERN_IDX && slot[0].is_none() {
+                    // init_declaration — no @name, synthesize "init"; type_params from @def node.
+                    let def_cap = m.captures.iter().find(|cap| cap.index == def_idx);
+                    if let Some(cap) = def_cap {
+                        let dr = ts_to_lsp(cap.node.range());
+                        let sel = Range::new(
+                            Position::new(dr.start.line, dr.start.character),
+                            Position::new(
+                                dr.start.line,
+                                dr.start.character + queries::SWIFT_INIT_NAME.len() as u32,
+                            ),
+                        );
+                        let type_params = cap.node.extract_type_params(bytes);
+                        return (
+                            pidx,
+                            [
+                                Some((queries::SWIFT_INIT_NAME.to_owned(), dr, sel, type_params)),
+                                None,
+                            ],
+                        );
+                    }
                 }
-            }
-            (pidx, slot)
-        })
-        .collect();
+                (pidx, slot)
+            })
+            .collect();
 
-    // Deduplicate: use same BTreeMap strategy as Kotlin parser.
-    let best = dedup_matches(&matches);
-    push_def_symbols(
-        best,
-        queries::swift_def_pattern_meta,
-        swift_visibility_at_line,
-        &data.lines,
-        &mut data.symbols,
-    );
+        // Deduplicate: use same BTreeMap strategy as Kotlin parser.
+        let best = dedup_matches(&matches);
+        push_def_symbols(
+            best,
+            queries::swift_def_pattern_meta,
+            swift_visibility_at_line,
+            &data.lines,
+            &mut data.symbols,
+        );
 
-    // ── imports (manual tree walk — Swift imports are simpler) ────────────────
-    data.extract_swift_imports(root, bytes);
+        // ── imports (manual tree walk — Swift imports are simpler) ────────────
+        data.extract_swift_imports(root, bytes);
 
-    // ── supertype relationships (inheritance specifiers) ──────────────────────
-    data.extract_supers_swift(root, bytes);
+        // ── supertype relationships (inheritance specifiers) ──────────────────
+        data.extract_supers_swift(root, bytes);
 
-    // ── declared_names ───────────────────────────────────────────────────────
-    data.declared_names = extract_declared_names(&data.lines);
-
-    // ── syntax errors ────────────────────────────────────────────────────────
-    data.syntax_errors = collect_syntax_errors(root, bytes);
-
-    data
+        finalize_parse(data, root, bytes);
+    })
 }
 
 /// Dispatch to the correct parser based on file extension.

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -21,6 +21,7 @@
 use std::collections::HashSet;
 use std::path::Path;
 use std::process::Command;
+use std::sync::Arc;
 
 use tower_lsp::lsp_types::{Location, Range, TextEdit, Url};
 
@@ -64,14 +65,15 @@ use infer::{infer_field_type, infer_variable_type};
 
 /// Return `FileData` for `uri` — from the live index if indexed, otherwise parse from disk.
 /// Returns `None` if the file is not indexed and not readable from disk.
-pub(crate) fn ensure_file_data(idx: &Indexer, uri: &Url) -> Option<FileData> {
+/// Returns an `Arc` so callers can read without copying the full `FileData`.
+pub(crate) fn ensure_file_data(idx: &Indexer, uri: &Url) -> Option<Arc<FileData>> {
     if let Some(file_data) = idx.files.get(uri.as_str()) {
-        return Some(file_data.value().as_ref().clone());
+        return Some(file_data.value().clone());
     }
 
     let path = uri.to_file_path().ok()?;
     let content = std::fs::read_to_string(path).ok()?;
-    Some(parse_by_extension(uri.path(), &content))
+    Some(Arc::new(parse_by_extension(uri.path(), &content)))
 }
 
 /// Walk the class hierarchy starting from `start_class`, collecting items at each level.
@@ -92,7 +94,7 @@ where
         caller,
         max_depth,
         collect,
-        visited: HashSet::from([start_class.to_owned()]),
+        visited: HashSet::from([(start_uri.to_owned(), start_class.to_owned())]),
         items: Vec::new(),
     };
     walker.recurse(start_class, start_uri, 0);
@@ -107,7 +109,7 @@ where
     caller: CallerContext<'a>,
     max_depth: usize,
     collect: F,
-    visited: HashSet<String>,
+    visited: HashSet<(String, String)>,
     items: Vec<T>,
 }
 
@@ -121,7 +123,7 @@ where
         }
 
         for (super_name, super_uri) in supertype_targets(self.idx, class_name, class_uri) {
-            if !self.visited.insert(super_name.clone()) {
+            if !self.visited.insert((super_uri.clone(), super_name.clone())) {
                 continue;
             }
             self.items.extend((self.collect)(
@@ -953,14 +955,18 @@ fn resolve_star_imports(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
 /// 3. Search the resolved file's symbol table for `name`.
 /// 4. Recurse into that file's own supertypes (depth-limited, cycle-safe).
 fn resolve_from_class_hierarchy(idx: &Indexer, name: &str, from_uri: &Url) -> Vec<Location> {
-    walk_hierarchy(
+    let mut results = walk_hierarchy(
         idx,
         "",
         from_uri.as_str(),
         CallerContext::default(),
         4,
         |index, _, class_uri, _| find_name_in_uri(index, name, class_uri),
-    )
+    );
+    // Deduplicate: hierarchy walk may find the same definition via multiple paths
+    // (e.g. diamond inheritance). Keep traversal order (most-specific first).
+    results.dedup_by(|a, b| a.uri == b.uri && a.range == b.range);
+    results
 }
 
 /// `rg` scoped to the directory that would contain `package` sources.

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -955,7 +955,7 @@ fn resolve_star_imports(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
 /// 3. Search the resolved file's symbol table for `name`.
 /// 4. Recurse into that file's own supertypes (depth-limited, cycle-safe).
 fn resolve_from_class_hierarchy(idx: &Indexer, name: &str, from_uri: &Url) -> Vec<Location> {
-    let mut results = walk_hierarchy(
+    let results = walk_hierarchy(
         idx,
         "",
         from_uri.as_str(),
@@ -963,10 +963,19 @@ fn resolve_from_class_hierarchy(idx: &Indexer, name: &str, from_uri: &Url) -> Ve
         4,
         |index, _, class_uri, _| find_name_in_uri(index, name, class_uri),
     );
-    // Deduplicate: hierarchy walk may find the same definition via multiple paths
-    // (e.g. diamond inheritance). Keep traversal order (most-specific first).
-    results.dedup_by(|a, b| a.uri == b.uri && a.range == b.range);
+    // Stable dedup via HashSet — diamond inheritance can produce the same location
+    // via multiple paths; dedup_by only removes consecutive duplicates.
+    let mut seen = HashSet::new();
     results
+        .into_iter()
+        .filter(|loc| {
+            seen.insert((
+                loc.uri.clone(),
+                loc.range.start.line,
+                loc.range.start.character,
+            ))
+        })
+        .collect()
 }
 
 /// `rg` scoped to the directory that would contain `package` sources.

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -232,30 +232,9 @@ pub(crate) fn rg_find_definition(
         None => std::borrow::Cow::Owned(std::env::current_dir().unwrap_or_default()),
     };
 
-    let mut cmd = Command::new("rg");
-    cmd.args([
-        "--no-heading",
-        "--with-filename",
-        "--line-number",
-        "--column",
-        // NOTE: rg has no --absolute-path flag; absolute output comes from
-        // passing an absolute search root as the positional argument.
-    ]);
-    for ext in SOURCE_EXTENSIONS {
-        cmd.args(["--glob", &format!("*.{ext}")]);
-    }
-    cmd.args(["-e", &pattern]);
-    cmd.arg(search_root.as_ref());
-
-    let out = match cmd.output() {
-        Ok(o) if o.status.success() => o,
-        _ => return vec![],
-    };
-
-    let locs: Vec<Location> = String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .filter_map(|l| parse_rg_line_with_content_rooted(l, &search_root).map(|(loc, _)| loc))
-        .collect();
+    let locs = RgSearch::rooted(search_root.as_ref())
+        .with_pattern(pattern)
+        .locations();
 
     if let Some(m) = matcher {
         m.filter_locs(locs)
@@ -273,6 +252,144 @@ pub(crate) struct RgSearchRequest<'a> {
     include_decl: bool,
     from_uri: &'a Url,
     decl_files: &'a [String],
+}
+
+enum RgTarget<'a> {
+    Root(&'a Path),
+    Files(&'a [String]),
+}
+
+struct RgSearch<'a> {
+    parse_root: &'a Path,
+    target: RgTarget<'a>,
+    patterns: Vec<String>,
+    word_regexp: bool,
+    list_files: bool,
+}
+
+impl<'a> RgSearch<'a> {
+    fn rooted(root: &'a Path) -> Self {
+        Self {
+            parse_root: root,
+            target: RgTarget::Root(root),
+            patterns: Vec::new(),
+            word_regexp: false,
+            list_files: false,
+        }
+    }
+
+    fn files(files: &'a [String]) -> Self {
+        Self {
+            parse_root: Path::new("/"),
+            target: RgTarget::Files(files),
+            patterns: Vec::new(),
+            word_regexp: false,
+            list_files: false,
+        }
+    }
+
+    fn with_pattern(mut self, pattern: impl Into<String>) -> Self {
+        self.patterns.push(pattern.into());
+        self
+    }
+
+    fn with_patterns<I, S>(mut self, patterns: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.patterns.extend(patterns.into_iter().map(Into::into));
+        self
+    }
+
+    fn word_regexp(mut self) -> Self {
+        self.word_regexp = true;
+        self
+    }
+
+    fn list_files(mut self) -> Self {
+        self.list_files = true;
+        self
+    }
+
+    fn build_command(&self) -> Command {
+        let mut command = Command::new("rg");
+        if self.list_files {
+            command.arg("-l");
+        } else {
+            command.args([
+                "--no-heading",
+                "--with-filename",
+                "--line-number",
+                "--column",
+            ]);
+        }
+        if self.word_regexp {
+            command.arg("--word-regexp");
+        }
+        for ext in SOURCE_EXTENSIONS {
+            command.args(["--glob", &format!("*.{ext}")]);
+        }
+        for pattern in &self.patterns {
+            command.args(["-e", pattern]);
+        }
+        match &self.target {
+            RgTarget::Root(root) => {
+                command.arg(root);
+            }
+            RgTarget::Files(files) => {
+                command.arg("--");
+                command.args(*files);
+            }
+        }
+        command
+    }
+
+    fn output(&self) -> Option<std::process::Output> {
+        let mut command = self.build_command();
+        match command.output() {
+            Ok(output) if output.status.success() && !output.stdout.is_empty() => Some(output),
+            _ => None,
+        }
+    }
+
+    fn locations_with_content(&self) -> Vec<(Location, String)> {
+        let Some(output) = self.output() else {
+            return vec![];
+        };
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .filter_map(|line| parse_rg_line_with_content_rooted(line, self.parse_root))
+            .collect()
+    }
+
+    fn locations(&self) -> Vec<Location> {
+        self.locations_with_content()
+            .into_iter()
+            .map(|(location, _)| location)
+            .collect()
+    }
+
+    fn files_with_matches(&self) -> Vec<String> {
+        let Some(output) = self.output() else {
+            return vec![];
+        };
+        let root = match &self.target {
+            RgTarget::Root(root) => *root,
+            RgTarget::Files(_) => return vec![],
+        };
+        String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(|line| {
+                let path = Path::new(line);
+                if path.is_absolute() {
+                    line.to_owned()
+                } else {
+                    root.join(line).to_string_lossy().into_owned()
+                }
+            })
+            .collect()
+    }
 }
 
 impl<'a> RgSearchRequest<'a> {
@@ -338,27 +455,6 @@ fn build_rg_patterns(request: &RgSearchRequest<'_>) -> Vec<String> {
     }
 }
 
-fn build_rg_command(request: &RgSearchRequest<'_>, patterns: &[String]) -> Command {
-    let mut command = Command::new("rg");
-    command.args([
-        "--no-heading",
-        "--with-filename",
-        "--line-number",
-        "--column",
-    ]);
-    if request.parent_class.is_none() && request.declared_pkg.is_none() {
-        command.arg("--word-regexp");
-    }
-    for ext in SOURCE_EXTENSIONS {
-        command.args(["--glob", &format!("*.{ext}")]);
-    }
-    for pattern in patterns {
-        command.args(["-e", pattern.as_str()]);
-    }
-    command.arg(request.search_root.as_ref());
-    command
-}
-
 fn should_skip_reference(loc: &Location, content: &str, request: &RgSearchRequest<'_>) -> bool {
     let trimmed = content.trim_start();
     if trimmed.starts_with("import ") || trimmed.starts_with("package ") {
@@ -376,23 +472,19 @@ fn should_skip_reference(loc: &Location, content: &str, request: &RgSearchReques
     false
 }
 
-fn parse_rg_output(output: &[u8], request: &RgSearchRequest<'_>) -> Vec<Location> {
-    String::from_utf8_lossy(output)
-        .lines()
-        .filter_map(|line| parse_rg_line_with_content_rooted(line, request.search_root.as_ref()))
+fn run_rg_search(request: &RgSearchRequest<'_>, patterns: &[String]) -> Vec<Location> {
+    let mut search =
+        RgSearch::rooted(request.search_root.as_ref()).with_patterns(patterns.iter().cloned());
+    if request.parent_class.is_none() && request.declared_pkg.is_none() {
+        search = search.word_regexp();
+    }
+    search
+        .locations_with_content()
+        .into_iter()
         .filter_map(|(loc, content)| {
             (!should_skip_reference(&loc, &content, request)).then_some(loc)
         })
         .collect()
-}
-
-fn run_rg_search(request: &RgSearchRequest<'_>, patterns: &[String]) -> Vec<Location> {
-    let mut command = build_rg_command(request, patterns);
-    let output = match command.output() {
-        Ok(output) if output.status.success() && !output.stdout.is_empty() => output,
-        _ => return vec![],
-    };
-    parse_rg_output(&output.stdout, request)
 }
 
 fn filter_candidate_files(
@@ -541,26 +633,10 @@ pub(crate) fn rg_find_implementors(
         None => return vec![],
     };
     // Search for the name in source files.
-    let mut cmd = Command::new("rg");
-    cmd.args([
-        "--no-heading",
-        "--with-filename",
-        "--line-number",
-        "--column",
-        "-e",
-        &safe,
-    ]);
-    for ext in SOURCE_EXTENSIONS {
-        cmd.args(["--glob", &format!("*.{ext}")]);
-    }
-    cmd.arg(root);
-    let out = match cmd.output() {
-        Ok(o) if !o.stdout.is_empty() => o,
-        _ => return vec![],
-    };
-    let locs: Vec<Location> = String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .filter_map(|l| parse_rg_line_with_content_rooted(l, root))
+    let locs: Vec<Location> = RgSearch::rooted(root)
+        .with_pattern(safe)
+        .locations_with_content()
+        .into_iter()
         .filter_map(|(loc, content)| {
             let line = content.trim();
             // Heuristics: declaration-like lines
@@ -633,27 +709,10 @@ pub(crate) fn regex_escape(s: &str) -> String {
 
 /// Run `rg -l` to get the list of files matching a pattern.
 fn rg_files_with_matches(pattern: &str, root: &Path) -> Vec<String> {
-    let mut cmd = Command::new("rg");
-    cmd.arg("-l");
-    for ext in SOURCE_EXTENSIONS {
-        cmd.args(["--glob", &format!("*.{ext}")]);
-    }
-    cmd.args(["-e", pattern]).arg(root);
-    let out = match cmd.output() {
-        Ok(o) if !o.stdout.is_empty() => o,
-        _ => return vec![],
-    };
-    String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .map(|l| {
-            let p = std::path::Path::new(l);
-            if p.is_absolute() {
-                l.to_owned()
-            } else {
-                root.join(l).to_string_lossy().into_owned()
-            }
-        })
-        .collect()
+    RgSearch::rooted(root)
+        .list_files()
+        .with_pattern(pattern.to_owned())
+        .files_with_matches()
 }
 
 /// Run `rg --word-regexp NAME` restricted to specific files.
@@ -661,28 +720,10 @@ fn rg_word_in_files(safe_name: &str, files: &[String]) -> Vec<(Location, String)
     if files.is_empty() {
         return vec![];
     }
-    let out = match Command::new("rg")
-        .args([
-            "--no-heading",
-            "--with-filename",
-            "--line-number",
-            "--column",
-            "--word-regexp",
-            "-e",
-            safe_name,
-            "--",
-        ])
-        .args(files)
-        .output()
-    {
-        Ok(o) if !o.stdout.is_empty() => o,
-        _ => return vec![],
-    };
-    // Files passed to rg_word_in_files are already absolute (from rg_files_with_matches).
-    String::from_utf8_lossy(&out.stdout)
-        .lines()
-        .filter_map(|l| parse_rg_line_with_content_rooted(l, std::path::Path::new("/")))
-        .collect()
+    RgSearch::files(files)
+        .word_regexp()
+        .with_pattern(safe_name.to_owned())
+        .locations_with_content()
 }
 
 fn parse_rg_line_with_content_rooted(line: &str, root: &Path) -> Option<(Location, String)> {

--- a/src/types.rs
+++ b/src/types.rs
@@ -53,7 +53,6 @@ pub(crate) struct CursorPos {
 }
 
 /// The caller's position context, used for visibility filtering and type-param substitution.
-#[allow(dead_code)]
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct CallerContext<'a> {
     pub uri: Option<&'a str>,


### PR DESCRIPTION
## Wave 2 Architecture Refactor + PR #58 Fixes

### d299a11 — Parser shared setup helpers
- Extract `new_file_data()`, `with_parsed_tree()`, `finalize_parse()` from `parse_kotlin/java/swift`
- `LanguageParser` trait not introduced (Rule of Three not met — only 3 parsers, single dispatch site)

### 12db2f4 — Backend layer violations fixed
- Move `cst_call_info()` / `cst_cursor_is_local_var()` from `backend/handlers.rs` to `indexer/infer/`
- Add public indexer getters to replace direct DashMap access in backend
- `CursorContext` construction already centralized — no change needed

### 1c46b5e — PR #58 review fixes
- `ensure_file_data` returns `Arc<FileData>` (avoid O(n) clone on hot read paths)
- `walk_hierarchy` visited set tracks `(uri, name)` pairs (prevent same-simple-name conflation)
- `resolve_from_class_hierarchy` deduplicates results for diamond-inheritance paths
- Remove spurious `#[allow(dead_code)]` from `CallerContext`

686 tests passing, 0 clippy warnings.