### PR TITLE
feat: semantic tokens — core classification + Phase 2 resolution

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -10,6 +10,7 @@ use tower_lsp::{async_trait, Client, LanguageServer};
 
 use self::helpers::syntax_diagnostics;
 use crate::indexer::{workspace_cache_path, IgnoreMatcher, Indexer, ProgressReporter};
+use crate::semantic_tokens;
 
 pub(crate) mod actions;
 pub(crate) mod cursor;
@@ -560,6 +561,14 @@ fn server_capabilities() -> ServerCapabilities {
             retrigger_characters: None,
             work_done_progress_options: Default::default(),
         }),
+        semantic_tokens_provider: Some(
+            SemanticTokensServerCapabilities::SemanticTokensOptions(SemanticTokensOptions {
+                legend: semantic_tokens::legend(),
+                full: Some(SemanticTokensFullOptions::Bool(true)),
+                range: Some(true),
+                work_done_progress_options: Default::default(),
+            }),
+        ),
         ..Default::default()
     }
 }
@@ -1031,5 +1040,35 @@ impl LanguageServer for Backend {
         params: CodeActionParams,
     ) -> Result<Option<Vec<CodeActionOrCommand>>> {
         self.code_action_impl(params).await
+    }
+
+    async fn semantic_tokens_full(
+        &self,
+        params: SemanticTokensParams,
+    ) -> Result<Option<SemanticTokensResult>> {
+        let uri = params.text_document.uri.to_string();
+        let language = crate::Language::from_path(&uri);
+        let Some(doc) = self.indexer.live_trees.get(&uri).map(|r| Arc::clone(&r)) else {
+            return Ok(None);
+        };
+        Ok(Some(SemanticTokensResult::Tokens(
+            semantic_tokens::full_tokens(&doc, language),
+        )))
+    }
+
+    // ── textDocument/semanticTokens/range ────────────────────────────────────
+
+    async fn semantic_tokens_range(
+        &self,
+        params: SemanticTokensRangeParams,
+    ) -> Result<Option<SemanticTokensRangeResult>> {
+        let uri = params.text_document.uri.to_string();
+        let language = crate::Language::from_path(&uri);
+        let Some(doc) = self.indexer.live_trees.get(&uri).map(|r| Arc::clone(&r)) else {
+            return Ok(None);
+        };
+        Ok(Some(SemanticTokensRangeResult::Tokens(
+            semantic_tokens::range_tokens(&doc, language, &params.range),
+        )))
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1051,8 +1051,9 @@ impl LanguageServer for Backend {
         let Some(doc) = self.indexer.live_trees.get(&uri).map(|r| Arc::clone(&r)) else {
             return Ok(None);
         };
+        let parsed_uri = params.text_document.uri;
         Ok(Some(SemanticTokensResult::Tokens(
-            semantic_tokens::full_tokens(&doc, language),
+            semantic_tokens::full_tokens(&self.indexer, &parsed_uri, &doc, language),
         )))
     }
 
@@ -1067,8 +1068,9 @@ impl LanguageServer for Backend {
         let Some(doc) = self.indexer.live_trees.get(&uri).map(|r| Arc::clone(&r)) else {
             return Ok(None);
         };
+        let parsed_uri = params.text_document.uri;
         Ok(Some(SemanticTokensRangeResult::Tokens(
-            semantic_tokens::range_tokens(&doc, language, &params.range),
+            semantic_tokens::range_tokens(&self.indexer, &parsed_uri, &doc, language, &params.range),
         )))
     }
 }

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -55,7 +55,7 @@ pub(crate) fn compute_inlay_hints(idx: &Arc<Indexer>, uri: &Url, range: Range) -
 /// Precompute the byte offset of each line's first byte within `bytes`.
 /// Used by `ts_byte_col_to_utf16` so it doesn't rescan from the file start
 /// for every node position.
-fn line_starts(bytes: &[u8]) -> Vec<usize> {
+pub(crate) fn line_starts(bytes: &[u8]) -> Vec<usize> {
     let mut starts = vec![0usize];
     for (i, &b) in bytes.iter().enumerate() {
         if b == b'\n' {
@@ -414,7 +414,7 @@ fn ts_pos_to_lsp(pos: tree_sitter::Point, starts: &[usize], bytes: &[u8]) -> Pos
 /// `starts` must have been produced by `line_starts(bytes)` — it is used to
 /// jump directly to the line without rescanning the whole file (O(1) lookup
 /// instead of O(file_size)).
-fn ts_byte_col_to_utf16(bytes: &[u8], starts: &[usize], row: usize, byte_col: usize) -> usize {
+pub(crate) fn ts_byte_col_to_utf16(bytes: &[u8], starts: &[usize], row: usize, byte_col: usize) -> usize {
     let line_start = starts.get(row).copied().unwrap_or_else(|| {
         bytes
             .split(|&b| b == b'\n')

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod parser;
 mod queries;
 mod resolver;
 mod rg;
+mod semantic_tokens;
 mod stdlib;
 mod stdlib_tail;
 mod str_ext;

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -417,10 +417,21 @@ pub(crate) const KIND_WILDCARD_IMPORT: &str = "wildcard_import";
 pub(crate) const KIND_MODIFIERS: &str = "modifiers";
 pub(crate) const KIND_COLON: &str = ":";
 pub(crate) const KIND_EQ: &str = "=";
+pub(crate) const KIND_PARAMETER: &str = "parameter";
+pub(crate) const KIND_ENUM_ENTRY: &str = "enum_entry";
+pub(crate) const KIND_ANNOTATION: &str = "annotation";
+pub(crate) const KIND_MULTI_ANNOTATION: &str = "multi_annotation";
+pub(crate) const KIND_INTERFACE_BODY: &str = "interface_body";
+pub(crate) const KIND_ENUM_CLASS_BODY: &str = "enum_class_body";
+pub(crate) const KIND_OBJECT_BODY: &str = "object_body";
 
 // ─── Java structural node kinds ───────────────────────────────────────────────
 pub(crate) const KIND_SCOPED_TYPE_IDENT: &str = "scoped_type_identifier";
 pub(crate) const KIND_VAR_DECLARATOR: &str = "variable_declarator";
+pub(crate) const KIND_ENUM_JAVA_DECL: &str = "enum_declaration";
+pub(crate) const KIND_FORMAL_PARAM: &str = "formal_parameter";
+pub(crate) const KIND_SPREAD_PARAM: &str = "spread_parameter";
+pub(crate) const KIND_MARKER_ANNOTATION: &str = "marker_annotation";
 // Java modifier keywords appear as their own leaf node kinds in the Java grammar.
 pub(crate) const KIND_MOD_STATIC: &str = "static";
 pub(crate) const KIND_MOD_FINAL: &str = "final";

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -736,7 +736,7 @@ pub(crate) fn find_fun_return_type_by_name(idx: &Indexer, fn_name: &str) -> Opti
     None
 }
 
-fn find_method_return_type(idx: &Indexer, type_name: &str, method_name: &str) -> Option<String> {
+pub(crate) fn find_method_return_type(idx: &Indexer, type_name: &str, method_name: &str) -> Option<String> {
     let type_base = type_name.split('.').next_back().unwrap_or(type_name);
     let locations = idx.definitions.get(type_base)?;
     for loc in locations.iter() {

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -21,12 +21,15 @@ use crate::indexer::{
     find_it_element_type_in_lines, find_this_element_type_in_lines, Indexer, LiveDoc, NodeExt,
 };
 use crate::queries::{
-    KIND_ANNOTATION_TYPE_DECL, KIND_CALL_EXPR, KIND_CLASS_DECL, KIND_COMPANION_OBJ,
-    KIND_CONSTRUCTOR_INVOCATION, KIND_ENUM_CONSTANT, KIND_EQ, KIND_FIELD_DECL, KIND_FUN_DECL,
-    KIND_IDENTIFIER, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_METHOD_DECL,
-    KIND_MODIFIERS, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_OBJECT_DECL,
-    KIND_PROP_DECL, KIND_RECORD_DECL, KIND_SIMPLE_IDENT, KIND_THIS_EXPR, KIND_TYPE_IDENT,
-    KIND_TYPE_PARAM, KIND_VALUE_ARG, KIND_VAR_DECL,
+    KIND_ANNOTATION, KIND_ANNOTATION_TYPE_DECL, KIND_CALL_EXPR, KIND_CLASS_BODY, KIND_CLASS_DECL,
+    KIND_COMPANION_OBJ, KIND_CONSTRUCTOR_INVOCATION, KIND_ENUM_CLASS_BODY, KIND_ENUM_CONSTANT,
+    KIND_ENUM_ENTRY, KIND_ENUM_JAVA_DECL, KIND_EQ, KIND_FIELD_DECL, KIND_FORMAL_PARAM,
+    KIND_FUN_DECL, KIND_IDENTIFIER, KIND_INTERFACE_BODY, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT,
+    KIND_LAMBDA_PARAMS, KIND_MARKER_ANNOTATION, KIND_METHOD_DECL, KIND_MODIFIERS,
+    KIND_MULTI_ANNOTATION, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_OBJECT_BODY,
+    KIND_OBJECT_DECL, KIND_PARAMETER, KIND_PROP_DECL, KIND_RECORD_DECL, KIND_SIMPLE_IDENT,
+    KIND_SPREAD_PARAM, KIND_THIS_EXPR, KIND_TYPE_IDENT, KIND_TYPE_PARAM, KIND_USER_TYPE,
+    KIND_VALUE_ARG, KIND_VAR_DECL, KIND_VAR_DECLARATOR,
 };
 use crate::resolver::infer::{
     find_field_type_in_class, find_fun_return_type_by_name, find_method_return_type,
@@ -98,6 +101,27 @@ struct RawToken {
     token_modifiers_bitset: u32,
 }
 
+/// Bundles source bytes with precomputed line-start offsets for O(1) UTF-16
+/// column conversion (avoids re-scanning the entire file per token).
+struct Source<'a> {
+    bytes: &'a [u8],
+    line_starts: Vec<usize>,
+}
+
+impl<'a> Source<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self {
+            line_starts: crate::inlay_hints::line_starts(bytes),
+            bytes,
+        }
+    }
+
+    fn col_utf16(&self, row: usize, byte_col: usize) -> u32 {
+        crate::inlay_hints::ts_byte_col_to_utf16(self.bytes, &self.line_starts, row, byte_col)
+            as u32
+    }
+}
+
 /// Collect semantic tokens for `doc`, for the given `language`.
 /// Returns delta-encoded `SemanticToken` values ready for the LSP response.
 /// Filtered to `range` when `Some`.
@@ -112,16 +136,17 @@ pub(crate) fn collect_tokens(
     uri: Option<&Url>,
 ) -> Vec<SemanticToken> {
     let mut raw: Vec<RawToken> = Vec::new();
+    let src = Source::new(&doc.bytes);
 
     match language {
-        Language::Kotlin => walk_kotlin(doc.tree.root_node(), &doc.bytes, &mut raw),
-        Language::Java => walk_java(doc.tree.root_node(), &doc.bytes, &mut raw),
+        Language::Kotlin => walk_kotlin(doc.tree.root_node(), &src, &mut raw),
+        Language::Java => walk_java(doc.tree.root_node(), &src, &mut raw),
         _ => {}
     }
 
     // Phase 2: resolve reference-site identifiers against the index.
     if let (Some(idx), Some(file_uri)) = (indexer, uri) {
-        walk_references(doc, language, idx, file_uri, &mut raw);
+        walk_references(doc, &src, language, idx, file_uri, &mut raw);
     }
 
     // Sort by (line, col) — tree walk is depth-first so usually already sorted,
@@ -144,7 +169,7 @@ pub(crate) fn collect_tokens(
 
 // ─── Kotlin walker ────────────────────────────────────────────────────────────
 
-fn walk_kotlin(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+fn walk_kotlin(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
     classify_kotlin(node, src, out);
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
@@ -157,7 +182,7 @@ fn walk_kotlin(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
     }
 }
 
-fn classify_kotlin(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+fn classify_kotlin(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
     let kind = node.kind();
     match kind {
         k if k == KIND_CLASS_DECL => kotlin_class_token(node, src, out),
@@ -166,20 +191,20 @@ fn classify_kotlin(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
         k if k == KIND_FUN_DECL => kotlin_fun_token(node, src, out),
         k if k == KIND_PROP_DECL => kotlin_prop_token(node, src, out),
         k if k == KIND_TYPE_PARAM => kotlin_type_param_token(node, src, out),
-        "parameter" => {
+        KIND_PARAMETER => {
             let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
-            if let Some(name) = child_ident(node, src) {
+            if let Some(name) = child_ident(node) {
                 push_token(name, type_index(&SemanticTokenType::PARAMETER), mods, src, out);
             }
         }
-        "enum_entry" => {
+        KIND_ENUM_ENTRY => {
             let mods = modifier_bit(&SemanticTokenModifier::DECLARATION)
                 | modifier_bit(&SemanticTokenModifier::READONLY);
-            if let Some(name) = child_ident(node, src) {
+            if let Some(name) = child_ident(node) {
                 push_token(name, type_index(&SemanticTokenType::ENUM_MEMBER), mods, src, out);
             }
         }
-        "annotation" | "multi_annotation" => {
+        KIND_ANNOTATION | KIND_MULTI_ANNOTATION => {
             if let Some(ident) = find_annotation_ident(node) {
                 push_token(ident, type_index(&SemanticTokenType::DECORATOR), 0, src, out);
             }
@@ -188,7 +213,7 @@ fn classify_kotlin(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
     }
 }
 
-fn kotlin_class_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+fn kotlin_class_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
     let token_type = if has_keyword_child(node, "interface") {
         type_index(&SemanticTokenType::INTERFACE)
     } else if has_keyword_child(node, "enum") {
@@ -202,30 +227,30 @@ fn kotlin_class_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
     if has_modifier(node, src, "abstract") {
         mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
     }
-    if let Some(name) = child_ident(node, src) {
+    if let Some(name) = child_ident(node) {
         push_token(name, token_type, mods, src, out);
     }
 }
 
-fn kotlin_object_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+fn kotlin_object_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
     let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
-    if let Some(name) = child_ident(node, src) {
+    if let Some(name) = child_ident(node) {
         push_token(name, type_index(&SemanticTokenType::NAMESPACE), mods, src, out);
     }
 }
 
-fn kotlin_companion_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+fn kotlin_companion_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
     let mods = modifier_bit(&SemanticTokenModifier::DECLARATION)
         | modifier_bit(&SemanticTokenModifier::STATIC);
     let ns_type = type_index(&SemanticTokenType::NAMESPACE);
-    if let Some(name) = child_ident(node, src) {
+    if let Some(name) = child_ident(node) {
         push_token(name, ns_type, mods, src, out);
     } else if let Some(obj_kw) = first_child_of_kind(node, "object") {
         push_token(obj_kw, ns_type, mods, src, out);
     }
 }
 
-fn kotlin_fun_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+fn kotlin_fun_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
     let token_type = if has_modifier(node, src, "operator") {
         type_index(&SemanticTokenType::OPERATOR)
     } else if is_inside_class_body(node) {
@@ -240,12 +265,12 @@ fn kotlin_fun_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
     if has_modifier(node, src, "abstract") {
         mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
     }
-    if let Some(name) = child_ident(node, src) {
+    if let Some(name) = child_ident(node) {
         push_token(name, token_type, mods, src, out);
     }
 }
 
-fn kotlin_prop_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+fn kotlin_prop_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
     let is_val = first_child_of_kind(node, "binding_pattern_kind")
         .map(|bpk| has_keyword_child(bpk, "val"))
         .unwrap_or_else(|| has_keyword_child(node, "val"));
@@ -259,13 +284,13 @@ fn kotlin_prop_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
         mods |= modifier_bit(&SemanticTokenModifier::READONLY);
     }
     if let Some(var_decl) = first_child_of_kind(node, KIND_VAR_DECL) {
-        if let Some(name) = child_ident(var_decl, src) {
+        if let Some(name) = child_ident(var_decl) {
             push_token(name, token_type, mods, src, out);
         }
     } else if let Some(multi) = first_child_of_kind(node, KIND_MULTI_VAR_DECL) {
         for i in 0..multi.named_child_count() {
             if let Some(vd) = multi.named_child(i) {
-                if let Some(name) = child_ident(vd, src) {
+                if let Some(name) = child_ident(vd) {
                     push_token(name, token_type, mods, src, out);
                 }
             }
@@ -273,7 +298,7 @@ fn kotlin_prop_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
     }
 }
 
-fn kotlin_type_param_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+fn kotlin_type_param_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
     let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
     if let Some(ident) = first_child_of_kind(node, KIND_TYPE_IDENT)
         .or_else(|| first_child_of_kind(node, KIND_SIMPLE_IDENT))
@@ -284,7 +309,7 @@ fn kotlin_type_param_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) 
 
 // ─── Java walker ─────────────────────────────────────────────────────────────
 
-fn walk_java(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+fn walk_java(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
     classify_java(node, src, out);
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
@@ -297,7 +322,7 @@ fn walk_java(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
     }
 }
 
-fn classify_java(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+fn classify_java(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
     let kind = node.kind();
 
     match kind {
@@ -323,7 +348,7 @@ fn classify_java(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
             }
         }
 
-        "enum_declaration" => {
+        KIND_ENUM_JAVA_DECL => {
             let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
             if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
                 push_token(name, type_index(&SemanticTokenType::ENUM), mods, src, out);
@@ -351,7 +376,7 @@ fn classify_java(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
             }
             for i in 0..node.child_count() {
                 if let Some(child) = node.child(i) {
-                    if child.kind() == "variable_declarator" {
+                    if child.kind() == KIND_VAR_DECLARATOR {
                         if let Some(name) = first_child_of_kind(child, KIND_IDENTIFIER) {
                             push_token(name, type_index(&SemanticTokenType::PROPERTY), mods, src, out);
                         }
@@ -360,7 +385,7 @@ fn classify_java(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
             }
         }
 
-        "formal_parameter" | "spread_parameter" => {
+        KIND_FORMAL_PARAM | KIND_SPREAD_PARAM => {
             let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
             if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
                 push_token(name, type_index(&SemanticTokenType::PARAMETER), mods, src, out);
@@ -385,7 +410,7 @@ fn classify_java(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
             }
         }
 
-        "marker_annotation" | "annotation" => {
+        KIND_MARKER_ANNOTATION | KIND_ANNOTATION => {
             // @Override, @SuppressWarnings("...") etc.
             if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
                 push_token(name, type_index(&SemanticTokenType::DECORATOR), 0, src, out);
@@ -409,7 +434,7 @@ fn find_annotation_ident(annotation_node: Node<'_>) -> Option<Node<'_>> {
         return Some(ident);
     }
     // Via user_type: annotation > user_type > type_identifier
-    if let Some(user_type) = first_child_of_kind(annotation_node, "user_type") {
+    if let Some(user_type) = first_child_of_kind(annotation_node, KIND_USER_TYPE) {
         if let Some(ident) = first_child_of_kind(user_type, KIND_TYPE_IDENT)
             .or_else(|| first_child_of_kind(user_type, KIND_SIMPLE_IDENT))
         {
@@ -418,7 +443,7 @@ fn find_annotation_ident(annotation_node: Node<'_>) -> Option<Node<'_>> {
     }
     // Via constructor_invocation: annotation > constructor_invocation > user_type > type_identifier
     if let Some(ctor) = first_child_of_kind(annotation_node, KIND_CONSTRUCTOR_INVOCATION) {
-        if let Some(user_type) = first_child_of_kind(ctor, "user_type") {
+        if let Some(user_type) = first_child_of_kind(ctor, KIND_USER_TYPE) {
             return first_child_of_kind(user_type, KIND_TYPE_IDENT)
                 .or_else(|| first_child_of_kind(user_type, KIND_SIMPLE_IDENT));
         }
@@ -427,7 +452,7 @@ fn find_annotation_ident(annotation_node: Node<'_>) -> Option<Node<'_>> {
 }
 
 /// Find the first direct child with a name identifier (simple_identifier or identifier).
-fn child_ident<'a>(node: Node<'a>, _src: &[u8]) -> Option<Node<'a>> {
+fn child_ident<'a>(node: Node<'a>) -> Option<Node<'a>> {
     for i in 0..node.child_count() {
         let child = node.child(i)?;
         if child.kind() == KIND_SIMPLE_IDENT
@@ -472,12 +497,12 @@ fn has_keyword_child(node: Node<'_>, keyword: &str) -> bool {
 }
 
 /// Check whether a Kotlin node has a modifier keyword (e.g. "suspend", "abstract").
-fn has_modifier(node: Node<'_>, src: &[u8], keyword: &str) -> bool {
+fn has_modifier(node: Node<'_>, src: &Source<'_>, keyword: &str) -> bool {
     // Modifiers are either direct keyword children or inside a `modifiers` node.
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
             if child.kind() == KIND_MODIFIERS
-                && node_text(child, src).split_whitespace().any(|w| w == keyword)
+                && node_text(child, src.bytes).split_whitespace().any(|w| w == keyword)
             {
                 return true;
             }
@@ -490,11 +515,11 @@ fn has_modifier(node: Node<'_>, src: &[u8], keyword: &str) -> bool {
 }
 
 /// Check whether a Java node has a modifier keyword inside a `modifiers` node.
-fn has_java_modifier(node: Node<'_>, src: &[u8], keyword: &str) -> bool {
+fn has_java_modifier(node: Node<'_>, src: &Source<'_>, keyword: &str) -> bool {
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
-            if child.kind() == "modifiers"
-                && node_text(child, src).split_whitespace().any(|w| w == keyword)
+            if child.kind() == KIND_MODIFIERS
+                && node_text(child, src.bytes).split_whitespace().any(|w| w == keyword)
             {
                 return true;
             }
@@ -506,54 +531,30 @@ fn has_java_modifier(node: Node<'_>, src: &[u8], keyword: &str) -> bool {
 /// True when this node is a direct child of a class/interface/enum body.
 fn is_inside_class_body(node: Node<'_>) -> bool {
     let Some(parent) = node.parent() else { return false };
-    matches!(
-        parent.kind(),
-        "class_body" | "interface_body" | "enum_class_body" | "object_body"
-    )
+    let k = parent.kind();
+    k == KIND_CLASS_BODY || k == KIND_INTERFACE_BODY || k == KIND_ENUM_CLASS_BODY || k == KIND_OBJECT_BODY
 }
 
 fn node_text<'a>(node: Node<'_>, src: &'a [u8]) -> &'a str {
     node.utf8_text(src).unwrap_or("")
 }
 
-fn push_token(node: Node<'_>, token_type: u32, token_modifiers_bitset: u32, src: &[u8], out: &mut Vec<RawToken>) {
+fn push_token(node: Node<'_>, token_type: u32, token_modifiers_bitset: u32, src: &Source<'_>, out: &mut Vec<RawToken>) {
     let start = node.start_position();
-    let text = node_text(node, src);
+    let text = node_text(node, src.bytes);
     let length = text.encode_utf16().count() as u32;
     if length == 0 {
         return;
     }
     out.push(RawToken {
         line: start.row as u32,
-        col: byte_col_to_utf16(src, start.row, start.column),
+        col: src.col_utf16(start.row, start.column),
         length,
         token_type,
         token_modifiers_bitset,
     });
 }
 
-/// Convert a tree-sitter byte-column to a UTF-16 column for LSP.
-fn byte_col_to_utf16(src: &[u8], row: usize, byte_col: usize) -> u32 {
-    let line_start = if row == 0 {
-        0
-    } else {
-        src.iter()
-            .enumerate()
-            .filter(|(_, &b)| b == b'\n')
-            .nth(row - 1)
-            .map(|(i, _)| i + 1)
-            .unwrap_or(0)
-    };
-    let line_bytes = &src[line_start..];
-    let prefix = if byte_col <= line_bytes.len() {
-        &line_bytes[..byte_col]
-    } else {
-        line_bytes
-    };
-    std::str::from_utf8(prefix)
-        .map(|s| s.encode_utf16().count() as u32)
-        .unwrap_or(byte_col as u32)
-}
 
 // ─── Delta encoding ───────────────────────────────────────────────────────────
 
@@ -608,11 +609,11 @@ fn navigation_member_ident(node: Node<'_>) -> Option<Node<'_>> {
     })
 }
 
-fn token_position(doc: &LiveDoc, node: Node<'_>) -> Position {
+fn token_position(bytes: &[u8], starts: &[usize], node: Node<'_>) -> Position {
     let start = node.start_position();
     Position::new(
         start.row as u32,
-        byte_col_to_utf16(&doc.bytes, start.row, start.column),
+        crate::inlay_hints::ts_byte_col_to_utf16(bytes, starts, start.row, start.column) as u32,
     )
 }
 
@@ -748,9 +749,9 @@ fn member_return_type(indexer: &Indexer, receiver_type: &str, member_name: &str)
     find_method_return_type(indexer, receiver_type, member_name)
 }
 
-fn identifier_type(node: Node<'_>, doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Option<String> {
+fn identifier_type(node: Node<'_>, doc: &LiveDoc, starts: &[usize], indexer: &Indexer, uri: &Url) -> Option<String> {
     let name = node.utf8_text_owned(&doc.bytes)?;
-    if let Some(inferred) = indexer.infer_lambda_param_type_at(&name, uri, token_position(doc, node)) {
+    if let Some(inferred) = indexer.infer_lambda_param_type_at(&name, uri, token_position(&doc.bytes, starts, node)) {
         return Some(inferred);
     }
     if let Some(inferred) = infer_variable_type(indexer, &name, uri) {
@@ -765,12 +766,13 @@ fn identifier_type(node: Node<'_>, doc: &LiveDoc, indexer: &Indexer, uri: &Url) 
 fn navigation_expression_type(
     node: Node<'_>,
     doc: &LiveDoc,
+    starts: &[usize],
     indexer: &Indexer,
     uri: &Url,
 ) -> Option<String> {
     let receiver = navigation_receiver_node(node)?;
     let member = navigation_member_ident(node)?.utf8_text_owned(&doc.bytes)?;
-    let receiver_type = expression_type(receiver, doc, indexer, uri)?;
+    let receiver_type = expression_type(receiver, doc, starts, indexer, uri)?;
 
     if is_call_callee(node) {
         return member_return_type(indexer, &receiver_type, &member)
@@ -780,11 +782,11 @@ fn navigation_expression_type(
     find_field_type_in_class(indexer, &receiver_type, &member)
 }
 
-fn call_expression_type(node: Node<'_>, doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Option<String> {
+fn call_expression_type(node: Node<'_>, doc: &LiveDoc, starts: &[usize], indexer: &Indexer, uri: &Url) -> Option<String> {
     let (member, _) = node.call_fn_and_qualifier(&doc.bytes)?;
     if let Some(callee) = node.child(0).filter(|child| child.kind() == KIND_NAV_EXPR) {
         if let Some(receiver) = navigation_receiver_node(callee) {
-            if let Some(receiver_type) = expression_type(receiver, doc, indexer, uri) {
+            if let Some(receiver_type) = expression_type(receiver, doc, starts, indexer, uri) {
                 if let Some(return_type) = member_return_type(indexer, &receiver_type, &member) {
                     return Some(return_type);
                 }
@@ -794,12 +796,12 @@ fn call_expression_type(node: Node<'_>, doc: &LiveDoc, indexer: &Indexer, uri: &
     find_fun_return_type_by_name(indexer, &member)
 }
 
-fn expression_type(node: Node<'_>, doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Option<String> {
+fn expression_type(node: Node<'_>, doc: &LiveDoc, starts: &[usize], indexer: &Indexer, uri: &Url) -> Option<String> {
     match node.kind() {
-        KIND_SIMPLE_IDENT | KIND_TYPE_IDENT => identifier_type(node, doc, indexer, uri),
-        KIND_THIS_EXPR => indexer.infer_lambda_param_type_at("this", uri, token_position(doc, node)),
-        KIND_NAV_EXPR => navigation_expression_type(node, doc, indexer, uri),
-        KIND_CALL_EXPR => call_expression_type(node, doc, indexer, uri),
+        KIND_SIMPLE_IDENT | KIND_TYPE_IDENT => identifier_type(node, doc, starts, indexer, uri),
+        KIND_THIS_EXPR => indexer.infer_lambda_param_type_at("this", uri, token_position(&doc.bytes, starts, node)),
+        KIND_NAV_EXPR => navigation_expression_type(node, doc, starts, indexer, uri),
+        KIND_CALL_EXPR => call_expression_type(node, doc, starts, indexer, uri),
         _ => None,
     }
 }
@@ -820,7 +822,7 @@ fn is_inside_lambda_parameters(node: Node<'_>) -> bool {
 
 /// Resolve member accesses in navigation expressions.
 /// Returns resolved tokens for member identifiers.
-fn resolve_member_access(doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Vec<RawToken> {
+fn resolve_member_access(doc: &LiveDoc, src: &Source<'_>, indexer: &Indexer, uri: &Url) -> Vec<RawToken> {
     let mut tokens = Vec::new();
     visit_tree(doc.tree.root_node(), &mut |node| {
         if node.kind() != KIND_NAV_EXPR {
@@ -833,20 +835,20 @@ fn resolve_member_access(doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Vec<Raw
             return;
         };
         let resolved_type = navigation_receiver_node(node)
-            .and_then(|receiver| expression_type(receiver, doc, indexer, uri))
+            .and_then(|receiver| expression_type(receiver, doc, &src.line_starts, indexer, uri))
             .and_then(|receiver_type| member_token_type_for_receiver(indexer, &receiver_type, &member_name));
         let token_type = resolved_type.or_else(|| {
             is_call_callee(node).then(|| type_index(&SemanticTokenType::METHOD))
         });
         if let Some(token_type) = token_type {
-            push_token(member_ident, token_type, 0, &doc.bytes, &mut tokens);
+            push_token(member_ident, token_type, 0, src, &mut tokens);
         }
     });
     tokens
 }
 
 /// Resolve lambda parameter identifiers (`it`, `this`, named params).
-fn resolve_lambda_params(doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Vec<RawToken> {
+fn resolve_lambda_params(doc: &LiveDoc, src: &Source<'_>, indexer: &Indexer, uri: &Url) -> Vec<RawToken> {
     let mut tokens = Vec::new();
     let lines_arc = indexer.mem_lines_for(uri.as_str());
     let fallback_lines: Vec<String> = std::str::from_utf8(&doc.bytes)
@@ -866,7 +868,7 @@ fn resolve_lambda_params(doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Vec<Raw
                             name,
                             type_index(&SemanticTokenType::PARAMETER),
                             modifiers,
-                            &doc.bytes,
+                            src,
                             &mut tokens,
                         );
                     }
@@ -878,8 +880,7 @@ fn resolve_lambda_params(doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Vec<Raw
         if node.kind() == KIND_THIS_EXPR && node.enclosing_lambda_literal().is_some() {
             let pos = crate::types::CursorPos {
                 line: node.start_position().row,
-                utf16_col: byte_col_to_utf16(
-                    &doc.bytes,
+                utf16_col: src.col_utf16(
                     node.start_position().row,
                     node.start_position().column,
                 ) as usize,
@@ -889,7 +890,7 @@ fn resolve_lambda_params(doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Vec<Raw
                     node,
                     type_index(&SemanticTokenType::KEYWORD),
                     0,
-                    &doc.bytes,
+                    src,
                     &mut tokens,
                 );
             }
@@ -905,8 +906,7 @@ fn resolve_lambda_params(doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Vec<Raw
         };
         let pos = crate::types::CursorPos {
             line: node.start_position().row,
-            utf16_col: byte_col_to_utf16(
-                &doc.bytes,
+            utf16_col: src.col_utf16(
                 node.start_position().row,
                 node.start_position().column,
             ) as usize,
@@ -920,7 +920,7 @@ fn resolve_lambda_params(doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Vec<Raw
                     node,
                     type_index(&SemanticTokenType::PARAMETER),
                     0,
-                    &doc.bytes,
+                    src,
                     &mut tokens,
                 );
             }
@@ -937,7 +937,7 @@ fn resolve_lambda_params(doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Vec<Raw
                 node,
                 type_index(&SemanticTokenType::PARAMETER),
                 0,
-                &doc.bytes,
+                src,
                 &mut tokens,
             );
         }
@@ -951,6 +951,7 @@ fn resolve_lambda_params(doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Vec<Raw
 /// Emits tokens for type references, function calls, member accesses, etc.
 fn walk_references(
     doc: &LiveDoc,
+    src: &Source<'_>,
     language: Language,
     indexer: &Indexer,
     uri: &Url,
@@ -961,21 +962,21 @@ fn walk_references(
     }
     // Tier 1: direct index lookups (type refs, top-level calls, annotations)
     let mut resolved = Vec::new();
-    walk_kotlin_references(doc.tree.root_node(), &doc.bytes, indexer, &mut resolved);
+    walk_kotlin_references(doc.tree.root_node(), src, indexer, &mut resolved);
     raw.extend(resolved);
 
     // Tier 2: receiver-inferred member coloring
-    raw.extend(resolve_member_access(doc, indexer, uri));
+    raw.extend(resolve_member_access(doc, src, indexer, uri));
 
     // Tier 3: lambda params (it/this)
-    raw.extend(resolve_lambda_params(doc, indexer, uri));
+    raw.extend(resolve_lambda_params(doc, src, indexer, uri));
 }
 
-fn walk_kotlin_references(node: Node<'_>, src: &[u8], indexer: &Indexer, out: &mut Vec<RawToken>) {
+fn walk_kotlin_references(node: Node<'_>, src: &Source<'_>, indexer: &Indexer, out: &mut Vec<RawToken>) {
     // Emit keyword tokens for Kotlin soft keywords
     if is_kotlin_keyword_node(node) {
         push_token(node, type_index(&SemanticTokenType::KEYWORD), 0, src, out);
-    } else if let Some(token_type) = classify_kotlin_reference(node, src, indexer) {
+    } else if let Some(token_type) = classify_kotlin_reference(node, src.bytes, indexer) {
         push_token(node, token_type, 0, src, out);
     }
     let mut cursor = node.walk();
@@ -1002,9 +1003,10 @@ fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> O
         return None;
     }
 
-    // Named arguments: `foo(name = value)` — the label gets PARAMETER color
+    // Named arguments: `foo(name = value)` — the label gets PROPERTY color
+    // to distinguish from the value (PARAMETER maps to same color as VARIABLE in most themes)
     if is_named_argument_label(node) {
-        return Some(type_index(&SemanticTokenType::PARAMETER));
+        return Some(type_index(&SemanticTokenType::PROPERTY));
     }
 
     if is_annotation_reference(node) {
@@ -1043,47 +1045,48 @@ fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> O
 
 fn is_declaration_site(node: Node<'_>) -> bool {
     let Some(parent) = node.parent() else { return false };
-    match parent.kind() {
-        KIND_CLASS_DECL | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | "type_alias" => {
-            node.kind() == KIND_TYPE_IDENT
-        }
-        KIND_FUN_DECL | "parameter" | "enum_entry" | "variable_declaration" | "class_parameter" => {
-            node.kind() == KIND_SIMPLE_IDENT
-        }
-        KIND_TYPE_PARAM => matches!(node.kind(), KIND_SIMPLE_IDENT | KIND_TYPE_IDENT),
-        _ => false,
+    let pk = parent.kind();
+    if pk == KIND_CLASS_DECL || pk == KIND_OBJECT_DECL || pk == KIND_COMPANION_OBJ || pk == "type_alias" {
+        return node.kind() == KIND_TYPE_IDENT;
     }
+    if pk == KIND_FUN_DECL || pk == KIND_PARAMETER || pk == KIND_ENUM_ENTRY || pk == KIND_VAR_DECL || pk == "class_parameter" {
+        return node.kind() == KIND_SIMPLE_IDENT;
+    }
+    if pk == KIND_TYPE_PARAM {
+        return node.kind() == KIND_SIMPLE_IDENT || node.kind() == KIND_TYPE_IDENT;
+    }
+    false
 }
 
 fn is_annotation_reference(node: Node<'_>) -> bool {
     let Some(parent) = node.parent() else { return false };
-    if parent.kind() != "user_type" {
+    if parent.kind() != KIND_USER_TYPE {
         return false;
     }
     let Some(grandparent) = parent.parent() else { return false };
     // @Simple annotation: annotation > user_type > type_identifier
-    if matches!(grandparent.kind(), "annotation" | "multi_annotation") {
+    if grandparent.kind() == KIND_ANNOTATION || grandparent.kind() == KIND_MULTI_ANNOTATION {
         return true;
     }
     // @Named("key") annotation: annotation > constructor_invocation > user_type > type_identifier
     if grandparent.kind() == KIND_CONSTRUCTOR_INVOCATION {
         return grandparent
             .parent()
-            .is_some_and(|gp| matches!(gp.kind(), "annotation" | "multi_annotation"));
+            .is_some_and(|gp| gp.kind() == KIND_ANNOTATION || gp.kind() == KIND_MULTI_ANNOTATION);
     }
     false
 }
 
 fn is_type_reference(node: Node<'_>) -> bool {
     node.parent().is_some_and(|parent| {
-        parent.kind() == "user_type"
-            || matches!(parent.kind(), KIND_FUN_DECL | KIND_PROP_DECL | "class_parameter")
+        let k = parent.kind();
+        k == KIND_USER_TYPE || k == KIND_FUN_DECL || k == KIND_PROP_DECL || k == "class_parameter"
     })
 }
 
 fn is_top_level_call_name(node: Node<'_>) -> bool {
     let Some(parent) = node.parent() else { return false };
-    parent.kind() == "call_expression"
+    parent.kind() == KIND_CALL_EXPR
         && parent
             .named_child(0)
             .is_some_and(|first_child| first_child.id() == node.id())
@@ -1091,7 +1094,7 @@ fn is_top_level_call_name(node: Node<'_>) -> bool {
 
 fn is_navigation_receiver(node: Node<'_>) -> bool {
     let Some(parent) = node.parent() else { return false };
-    parent.kind() == "navigation_expression"
+    parent.kind() == KIND_NAV_EXPR
         && parent
             .named_child(0)
             .is_some_and(|first_child| first_child.id() == node.id())

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -12,17 +12,24 @@
 //! (line, col) before encoding.
 
 use tower_lsp::lsp_types::{
-    Range, SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
-    SemanticTokensLegend,
+    Position, Range, SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
+    SemanticTokensLegend, SymbolKind, Url,
 };
 use tree_sitter::Node;
 
-use crate::indexer::LiveDoc;
+use crate::indexer::{
+    find_it_element_type_in_lines, find_this_element_type_in_lines, Indexer, LiveDoc, NodeExt,
+};
 use crate::queries::{
-    KIND_ANNOTATION_TYPE_DECL, KIND_CLASS_DECL, KIND_COMPANION_OBJ, KIND_ENUM_CONSTANT,
-    KIND_FIELD_DECL, KIND_FUN_DECL, KIND_IDENTIFIER, KIND_INTERFACE_DECL, KIND_METHOD_DECL,
-    KIND_MODIFIERS, KIND_MULTI_VAR_DECL, KIND_OBJECT_DECL, KIND_PROP_DECL, KIND_RECORD_DECL,
-    KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_TYPE_PARAM, KIND_VAR_DECL,
+    KIND_ANNOTATION_TYPE_DECL, KIND_CALL_EXPR, KIND_CLASS_DECL, KIND_COMPANION_OBJ,
+    KIND_ENUM_CONSTANT, KIND_FIELD_DECL, KIND_FUN_DECL, KIND_IDENTIFIER, KIND_INTERFACE_DECL,
+    KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_METHOD_DECL, KIND_MODIFIERS, KIND_MULTI_VAR_DECL,
+    KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_OBJECT_DECL, KIND_PROP_DECL, KIND_RECORD_DECL,
+    KIND_SIMPLE_IDENT, KIND_THIS_EXPR, KIND_TYPE_IDENT, KIND_TYPE_PARAM, KIND_VAR_DECL,
+};
+use crate::resolver::infer::{
+    find_field_type_in_class, find_fun_return_type_by_name, find_method_return_type,
+    infer_variable_type,
 };
 use crate::Language;
 
@@ -42,16 +49,20 @@ pub(crate) const TOKEN_TYPES: &[SemanticTokenType] = &[
     SemanticTokenType::ENUM_MEMBER,    // 9
     SemanticTokenType::DECORATOR,      // 10  (annotations)
     SemanticTokenType::NAMESPACE,      // 11  (objects / companion objects used as namespaces)
+    SemanticTokenType::STRUCT,         // 12  (data classes)
+    SemanticTokenType::OPERATOR,       // 13  (operator fun)
+    SemanticTokenType::KEYWORD,        // 14  (implicit it/this, future use)
 ];
 
 /// Ordered list of modifiers — bit position == modifier id.
 pub(crate) const TOKEN_MODIFIERS: &[SemanticTokenModifier] = &[
-    SemanticTokenModifier::DECLARATION, // bit 0
-    SemanticTokenModifier::READONLY,    // bit 1
-    SemanticTokenModifier::STATIC,      // bit 2  (companion object members)
-    SemanticTokenModifier::ABSTRACT,    // bit 3
-    SemanticTokenModifier::ASYNC,       // bit 4  (suspend funs)
-    SemanticTokenModifier::DEPRECATED,  // bit 5
+    SemanticTokenModifier::DECLARATION,     // bit 0
+    SemanticTokenModifier::READONLY,        // bit 1
+    SemanticTokenModifier::STATIC,          // bit 2  (companion object members)
+    SemanticTokenModifier::ABSTRACT,        // bit 3
+    SemanticTokenModifier::ASYNC,           // bit 4  (suspend funs)
+    SemanticTokenModifier::DEPRECATED,      // bit 5
+    SemanticTokenModifier::DEFAULT_LIBRARY, // bit 6  (stdlib symbols, future use)
 ];
 
 fn type_index(t: &SemanticTokenType) -> u32 {
@@ -89,10 +100,15 @@ struct RawToken {
 /// Collect semantic tokens for `doc`, for the given `language`.
 /// Returns delta-encoded `SemanticToken` values ready for the LSP response.
 /// Filtered to `range` when `Some`.
+///
+/// When `indexer` and `uri` are provided, reference-site identifiers are
+/// resolved against the cross-file index for richer coloring.
 pub(crate) fn collect_tokens(
     doc: &LiveDoc,
     language: Language,
     range: Option<&Range>,
+    indexer: Option<&Indexer>,
+    uri: Option<&Url>,
 ) -> Vec<SemanticToken> {
     let mut raw: Vec<RawToken> = Vec::new();
 
@@ -102,9 +118,18 @@ pub(crate) fn collect_tokens(
         _ => {}
     }
 
+    // Phase 2: resolve reference-site identifiers against the index.
+    if let (Some(idx), Some(file_uri)) = (indexer, uri) {
+        walk_references(doc, language, idx, file_uri, &mut raw);
+    }
+
     // Sort by (line, col) — tree walk is depth-first so usually already sorted,
     // but not guaranteed for all node orderings.
     raw.sort_by_key(|t| (t.line, t.col));
+
+    // Deduplicate: if both declaration walk and reference walk emitted a token
+    // at the same position, keep only the first (declaration takes priority).
+    raw.dedup_by_key(|t| (t.line, t.col));
 
     // Apply range filter before delta-encoding.
     if let Some(r) = range {
@@ -169,6 +194,8 @@ fn kotlin_class_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
         type_index(&SemanticTokenType::INTERFACE)
     } else if has_keyword_child(node, "enum") {
         type_index(&SemanticTokenType::ENUM)
+    } else if has_modifier(node, src, "data") {
+        type_index(&SemanticTokenType::STRUCT)
     } else {
         type_index(&SemanticTokenType::CLASS)
     };
@@ -200,7 +227,9 @@ fn kotlin_companion_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
 }
 
 fn kotlin_fun_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
-    let token_type = if is_inside_class_body(node) {
+    let token_type = if has_modifier(node, src, "operator") {
+        type_index(&SemanticTokenType::OPERATOR)
+    } else if is_inside_class_body(node) {
         type_index(&SemanticTokenType::METHOD)
     } else {
         type_index(&SemanticTokenType::FUNCTION)
@@ -523,19 +552,601 @@ fn delta_encode(sorted: Vec<RawToken>) -> Vec<SemanticToken> {
     result
 }
 
-// ─── Public API ──────────────────────────────────────────────────────────────
-
-pub(crate) fn full_tokens(doc: &LiveDoc, language: Language) -> SemanticTokens {
-    SemanticTokens {
-        result_id: None,
-        data: collect_tokens(doc, language, None),
+fn visit_tree(node: Node<'_>, f: &mut impl FnMut(Node<'_>)) {
+    f(node);
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            visit_tree(cursor.node(), f);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
     }
 }
 
-pub(crate) fn range_tokens(doc: &LiveDoc, language: Language, range: &Range) -> SemanticTokens {
+fn navigation_receiver_node(node: Node<'_>) -> Option<Node<'_>> {
+    (0..node.child_count())
+        .filter_map(|i| node.child(i))
+        .find(|child| child.is_named() && child.kind() != KIND_NAV_SUFFIX)
+}
+
+fn navigation_member_ident(node: Node<'_>) -> Option<Node<'_>> {
+    let suffix = node.first_child_of_kind(KIND_NAV_SUFFIX)?;
+    (0..suffix.child_count()).filter_map(|i| suffix.child(i)).find(|child| {
+        child.kind() == KIND_SIMPLE_IDENT || child.kind() == KIND_TYPE_IDENT
+    })
+}
+
+fn token_position(doc: &LiveDoc, node: Node<'_>) -> Position {
+    let start = node.start_position();
+    Position::new(
+        start.row as u32,
+        byte_col_to_utf16(&doc.bytes, start.row, start.column),
+    )
+}
+
+fn is_call_callee(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    parent.kind() == KIND_CALL_EXPR && parent.child(0).map(|child| child.id()) == Some(node.id())
+}
+
+fn is_owner_type_symbol(kind: SymbolKind) -> bool {
+    matches!(
+        kind,
+        SymbolKind::CLASS
+            | SymbolKind::INTERFACE
+            | SymbolKind::ENUM
+            | SymbolKind::OBJECT
+            | SymbolKind::STRUCT
+    )
+}
+
+fn is_type_symbol(kind: SymbolKind) -> bool {
+    is_owner_type_symbol(kind)
+}
+
+fn is_member_symbol(kind: SymbolKind) -> bool {
+    matches!(
+        kind,
+        SymbolKind::METHOD
+            | SymbolKind::FUNCTION
+            | SymbolKind::OPERATOR
+            | SymbolKind::PROPERTY
+            | SymbolKind::FIELD
+            | SymbolKind::CONSTANT
+            | SymbolKind::VARIABLE
+    )
+}
+
+fn member_token_type(kind: SymbolKind) -> Option<u32> {
+    match kind {
+        SymbolKind::METHOD | SymbolKind::FUNCTION | SymbolKind::OPERATOR => {
+            Some(type_index(&SemanticTokenType::METHOD))
+        }
+        SymbolKind::PROPERTY | SymbolKind::FIELD | SymbolKind::CONSTANT | SymbolKind::VARIABLE => {
+            Some(type_index(&SemanticTokenType::PROPERTY))
+        }
+        _ => None,
+    }
+}
+
+fn range_within(inner: &Range, outer: &Range) -> bool {
+    inner.start.line >= outer.start.line && inner.end.line <= outer.end.line
+}
+
+fn has_type_definition(indexer: &Indexer, name: &str) -> bool {
+    indexer.definition_locations(name).into_iter().any(|loc| {
+        indexer
+            .files
+            .get(loc.uri.as_str())
+            .map(|file_data| {
+                file_data
+                    .symbols
+                    .iter()
+                    .any(|symbol| symbol.name == name && is_type_symbol(symbol.kind))
+            })
+            .unwrap_or(false)
+    })
+}
+
+fn matches_receiver_type(extension_receiver: &str, receiver_type: &str) -> bool {
+    let receiver_leaf = receiver_type.rsplit('.').next().unwrap_or(receiver_type);
+    extension_receiver == receiver_type || extension_receiver == receiver_leaf
+}
+
+fn owner_member_token_type(indexer: &Indexer, receiver_type: &str, member_name: &str) -> Option<u32> {
+    let receiver_leaf = receiver_type.rsplit('.').next().unwrap_or(receiver_type);
+    for loc in indexer.definition_locations(receiver_leaf) {
+        let Some(file_data) = indexer.files.get(loc.uri.as_str()) else {
+            continue;
+        };
+        let owner_range = file_data
+            .symbols
+            .iter()
+            .find(|symbol| symbol.name == receiver_leaf && is_type_symbol(symbol.kind))
+            .map(|symbol| symbol.range);
+        let Some(owner_range) = owner_range else {
+            continue;
+        };
+        if let Some(symbol) = file_data
+            .symbols
+            .iter()
+            .find(|symbol| symbol.name == member_name && is_member_symbol(symbol.kind) && range_within(&symbol.range, &owner_range))
+        {
+            return member_token_type(symbol.kind);
+        }
+    }
+    None
+}
+
+fn extension_member_token_type(indexer: &Indexer, receiver_type: &str, member_name: &str) -> Option<u32> {
+    for loc in indexer.definition_locations(member_name) {
+        let Some(file_data) = indexer.files.get(loc.uri.as_str()) else {
+            continue;
+        };
+        if let Some(symbol) = file_data.symbols.iter().find(|symbol| {
+            symbol.name == member_name
+                && is_member_symbol(symbol.kind)
+                && !symbol.extension_receiver.is_empty()
+                && matches_receiver_type(&symbol.extension_receiver, receiver_type)
+        }) {
+            return member_token_type(symbol.kind).or(Some(type_index(&SemanticTokenType::METHOD)));
+        }
+    }
+    None
+}
+
+fn member_token_type_for_receiver(
+    indexer: &Indexer,
+    receiver_type: &str,
+    member_name: &str,
+) -> Option<u32> {
+    owner_member_token_type(indexer, receiver_type, member_name)
+        .or_else(|| extension_member_token_type(indexer, receiver_type, member_name))
+        .or_else(|| {
+            find_field_type_in_class(indexer, receiver_type, member_name)
+                .map(|_| type_index(&SemanticTokenType::PROPERTY))
+        })
+}
+
+
+
+fn member_return_type(indexer: &Indexer, receiver_type: &str, member_name: &str) -> Option<String> {
+    find_method_return_type(indexer, receiver_type, member_name)
+}
+
+fn identifier_type(node: Node<'_>, doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Option<String> {
+    let name = node.utf8_text_owned(&doc.bytes)?;
+    if let Some(inferred) = indexer.infer_lambda_param_type_at(&name, uri, token_position(doc, node)) {
+        return Some(inferred);
+    }
+    if let Some(inferred) = infer_variable_type(indexer, &name, uri) {
+        return Some(inferred);
+    }
+    if name.starts_with(char::is_uppercase) && has_type_definition(indexer, &name) {
+        return Some(name);
+    }
+    None
+}
+
+fn navigation_expression_type(
+    node: Node<'_>,
+    doc: &LiveDoc,
+    indexer: &Indexer,
+    uri: &Url,
+) -> Option<String> {
+    let receiver = navigation_receiver_node(node)?;
+    let member = navigation_member_ident(node)?.utf8_text_owned(&doc.bytes)?;
+    let receiver_type = expression_type(receiver, doc, indexer, uri)?;
+
+    if is_call_callee(node) {
+        return member_return_type(indexer, &receiver_type, &member)
+            .or_else(|| find_fun_return_type_by_name(indexer, &member));
+    }
+
+    find_field_type_in_class(indexer, &receiver_type, &member)
+}
+
+fn call_expression_type(node: Node<'_>, doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Option<String> {
+    let (member, _) = node.call_fn_and_qualifier(&doc.bytes)?;
+    if let Some(callee) = node.child(0).filter(|child| child.kind() == KIND_NAV_EXPR) {
+        if let Some(receiver) = navigation_receiver_node(callee) {
+            if let Some(receiver_type) = expression_type(receiver, doc, indexer, uri) {
+                if let Some(return_type) = member_return_type(indexer, &receiver_type, &member) {
+                    return Some(return_type);
+                }
+            }
+        }
+    }
+    find_fun_return_type_by_name(indexer, &member)
+}
+
+fn expression_type(node: Node<'_>, doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Option<String> {
+    match node.kind() {
+        KIND_SIMPLE_IDENT | KIND_TYPE_IDENT => identifier_type(node, doc, indexer, uri),
+        KIND_THIS_EXPR => indexer.infer_lambda_param_type_at("this", uri, token_position(doc, node)),
+        KIND_NAV_EXPR => navigation_expression_type(node, doc, indexer, uri),
+        KIND_CALL_EXPR => call_expression_type(node, doc, indexer, uri),
+        _ => None,
+    }
+}
+
+fn is_inside_lambda_parameters(node: Node<'_>) -> bool {
+    let mut current = node.parent();
+    while let Some(parent) = current {
+        if parent.kind() == KIND_LAMBDA_PARAMS {
+            return true;
+        }
+        if parent.kind() == KIND_LAMBDA_LIT {
+            return false;
+        }
+        current = parent.parent();
+    }
+    false
+}
+
+/// Resolve member accesses in navigation expressions.
+/// Returns resolved tokens for member identifiers.
+fn resolve_member_access(doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Vec<RawToken> {
+    let mut tokens = Vec::new();
+    visit_tree(doc.tree.root_node(), &mut |node| {
+        if node.kind() != KIND_NAV_EXPR {
+            return;
+        }
+        let Some(member_ident) = navigation_member_ident(node) else {
+            return;
+        };
+        let Some(member_name) = member_ident.utf8_text_owned(&doc.bytes) else {
+            return;
+        };
+        let resolved_type = navigation_receiver_node(node)
+            .and_then(|receiver| expression_type(receiver, doc, indexer, uri))
+            .and_then(|receiver_type| member_token_type_for_receiver(indexer, &receiver_type, &member_name));
+        let token_type = resolved_type.or_else(|| {
+            is_call_callee(node).then(|| type_index(&SemanticTokenType::METHOD))
+        });
+        if let Some(token_type) = token_type {
+            push_token(member_ident, token_type, 0, &doc.bytes, &mut tokens);
+        }
+    });
+    tokens
+}
+
+/// Resolve lambda parameter identifiers (`it`, `this`, named params).
+fn resolve_lambda_params(doc: &LiveDoc, indexer: &Indexer, uri: &Url) -> Vec<RawToken> {
+    let mut tokens = Vec::new();
+    let lines_arc = indexer.mem_lines_for(uri.as_str());
+    let fallback_lines: Vec<String> = std::str::from_utf8(&doc.bytes)
+        .unwrap_or("")
+        .lines()
+        .map(String::from)
+        .collect();
+    let lines: &[String] = lines_arc.as_deref().unwrap_or(&fallback_lines);
+
+    visit_tree(doc.tree.root_node(), &mut |node| {
+        if node.kind() == KIND_LAMBDA_LIT {
+            if let Some(params) = node.first_child_of_kind(KIND_LAMBDA_PARAMS) {
+                for param in params.children_of_kind(KIND_VAR_DECL) {
+                    if let Some(name) = param.first_child_of_kind(KIND_SIMPLE_IDENT) {
+                        let modifiers = modifier_bit(&SemanticTokenModifier::DECLARATION);
+                        push_token(
+                            name,
+                            type_index(&SemanticTokenType::PARAMETER),
+                            modifiers,
+                            &doc.bytes,
+                            &mut tokens,
+                        );
+                    }
+                }
+            }
+            return;
+        }
+
+        if node.kind() == KIND_THIS_EXPR && node.enclosing_lambda_literal().is_some() {
+            let pos = crate::types::CursorPos {
+                line: node.start_position().row,
+                utf16_col: byte_col_to_utf16(
+                    &doc.bytes,
+                    node.start_position().row,
+                    node.start_position().column,
+                ) as usize,
+            };
+            if find_this_element_type_in_lines(lines, pos, indexer, uri).is_some() {
+                push_token(
+                    node,
+                    type_index(&SemanticTokenType::KEYWORD),
+                    0,
+                    &doc.bytes,
+                    &mut tokens,
+                );
+            }
+            return;
+        }
+
+        if node.kind() != KIND_SIMPLE_IDENT || is_inside_lambda_parameters(node) {
+            return;
+        }
+
+        let Some(name) = node.utf8_text_owned(&doc.bytes) else {
+            return;
+        };
+        let pos = crate::types::CursorPos {
+            line: node.start_position().row,
+            utf16_col: byte_col_to_utf16(
+                &doc.bytes,
+                node.start_position().row,
+                node.start_position().column,
+            ) as usize,
+        };
+
+        if name == "it" {
+            if node.enclosing_lambda_literal().is_some()
+                && find_it_element_type_in_lines(lines, pos, indexer, uri).is_some()
+            {
+                push_token(
+                    node,
+                    type_index(&SemanticTokenType::PARAMETER),
+                    0,
+                    &doc.bytes,
+                    &mut tokens,
+                );
+            }
+            return;
+        }
+
+        if node.enclosing_lambda_literal().is_some()
+            && indexer
+                .lambda_params_at_col(uri, pos.line, pos.utf16_col)
+                .iter()
+                .any(|param| param == &name)
+        {
+            push_token(
+                node,
+                type_index(&SemanticTokenType::PARAMETER),
+                0,
+                &doc.bytes,
+                &mut tokens,
+            );
+        }
+    });
+    tokens
+}
+
+// ─── Reference-site walker (Phase 2) ─────────────────────────────────────────
+
+/// Walk non-declaration identifiers and resolve them against the index.
+/// Emits tokens for type references, function calls, member accesses, etc.
+fn walk_references(
+    doc: &LiveDoc,
+    language: Language,
+    indexer: &Indexer,
+    uri: &Url,
+    raw: &mut Vec<RawToken>,
+) {
+    if language != Language::Kotlin {
+        return;
+    }
+    // Tier 1: direct index lookups (type refs, top-level calls, annotations)
+    let mut resolved = Vec::new();
+    walk_kotlin_references(doc.tree.root_node(), &doc.bytes, indexer, &mut resolved);
+    raw.extend(resolved);
+
+    // Tier 2: receiver-inferred member coloring
+    raw.extend(resolve_member_access(doc, indexer, uri));
+
+    // Tier 3: lambda params (it/this)
+    raw.extend(resolve_lambda_params(doc, indexer, uri));
+}
+
+fn walk_kotlin_references(node: Node<'_>, src: &[u8], indexer: &Indexer, out: &mut Vec<RawToken>) {
+    if let Some(token_type) = classify_kotlin_reference(node, src, indexer) {
+        push_token(node, token_type, 0, src, out);
+    }
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            walk_kotlin_references(cursor.node(), src, indexer, out);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> Option<u32> {
+    if !matches!(node.kind(), KIND_SIMPLE_IDENT | KIND_TYPE_IDENT) || is_declaration_site(node) {
+        return None;
+    }
+
+    if is_annotation_reference(node) {
+        return resolve_symbol_kind(node_text(node, src), indexer, |_| true)
+            .map(|_| type_index(&SemanticTokenType::DECORATOR));
+    }
+
+    if let Some(token_type) = enum_entry_reference_token(node, src, indexer) {
+        return Some(token_type);
+    }
+
+    if node.kind() == KIND_TYPE_IDENT && is_type_reference(node) {
+        return resolve_symbol_kind(node_text(node, src), indexer, is_type_symbol)
+            .and_then(|resolved| symbol_kind_to_token_type(resolved.kind));
+    }
+
+    if is_top_level_call_name(node) {
+        return resolve_symbol_kind(node_text(node, src), indexer, |kind| {
+            matches!(kind, SymbolKind::CLASS | SymbolKind::STRUCT | SymbolKind::FUNCTION | SymbolKind::METHOD)
+        })
+        .and_then(|resolved| call_symbol_kind_to_token_type(resolved.kind));
+    }
+
+    if is_navigation_receiver(node) {
+        return resolve_symbol_kind(node_text(node, src), indexer, |kind| kind == SymbolKind::OBJECT)
+            .map(|_| type_index(&SemanticTokenType::NAMESPACE));
+    }
+
+    None
+}
+
+fn is_declaration_site(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else { return false };
+    match parent.kind() {
+        KIND_CLASS_DECL | KIND_OBJECT_DECL | KIND_COMPANION_OBJ | "type_alias" => {
+            node.kind() == KIND_TYPE_IDENT
+        }
+        KIND_FUN_DECL | "parameter" | "enum_entry" | "variable_declaration" | "class_parameter" => {
+            node.kind() == KIND_SIMPLE_IDENT
+        }
+        KIND_TYPE_PARAM => matches!(node.kind(), KIND_SIMPLE_IDENT | KIND_TYPE_IDENT),
+        _ => false,
+    }
+}
+
+fn is_annotation_reference(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else { return false };
+    let Some(grandparent) = parent.parent() else { return false };
+    parent.kind() == "user_type" && matches!(grandparent.kind(), "annotation" | "multi_annotation")
+}
+
+fn is_type_reference(node: Node<'_>) -> bool {
+    node.parent().is_some_and(|parent| {
+        parent.kind() == "user_type"
+            || matches!(parent.kind(), KIND_FUN_DECL | KIND_PROP_DECL | "class_parameter")
+    })
+}
+
+fn is_top_level_call_name(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else { return false };
+    parent.kind() == "call_expression"
+        && parent
+            .named_child(0)
+            .is_some_and(|first_child| first_child.id() == node.id())
+}
+
+fn is_navigation_receiver(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else { return false };
+    parent.kind() == "navigation_expression"
+        && parent
+            .named_child(0)
+            .is_some_and(|first_child| first_child.id() == node.id())
+}
+
+fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> Option<u32> {
+    let parent = node.parent()?;
+    let navigation = parent.parent()?;
+    if parent.kind() != "navigation_suffix" || navigation.kind() != "navigation_expression" {
+        return None;
+    }
+
+    let receiver = navigation.named_child(0)?;
+    let receiver_kind =
+        resolve_symbol_kind(node_text(receiver, src), indexer, |kind| kind == SymbolKind::ENUM)?;
+    let receiver_data = indexer.files.get(receiver_kind.uri.as_str())?;
+    receiver_data
+        .symbols
+        .iter()
+        .find(|symbol| {
+            symbol.kind == SymbolKind::ENUM_MEMBER
+                && symbol.name == node_text(node, src)
+                && range_contains(&receiver_kind.range, &symbol.selection_range.start)
+        })
+        .map(|_| type_index(&SemanticTokenType::ENUM_MEMBER))
+}
+
+fn resolve_symbol_kind(
+    name: &str,
+    indexer: &Indexer,
+    matches_kind: impl Fn(SymbolKind) -> bool,
+) -> Option<ResolvedReference> {
+    for location in indexer.definition_locations(name) {
+        let Some(data) = indexer.files.get(location.uri.as_str()) else {
+            continue;
+        };
+        let Some(symbol) = data
+            .symbols
+            .iter()
+            .find(|entry| entry.selection_range == location.range)
+        else {
+            continue;
+        };
+        if matches_kind(symbol.kind) {
+            return Some(ResolvedReference {
+                kind: symbol.kind,
+                uri: location.uri.clone(),
+                range: symbol.range,
+            });
+        }
+    }
+    None
+}
+
+fn call_symbol_kind_to_token_type(kind: SymbolKind) -> Option<u32> {
+    match kind {
+        SymbolKind::CLASS | SymbolKind::STRUCT => Some(type_index(&SemanticTokenType::CLASS)),
+        _ => symbol_kind_to_token_type(kind),
+    }
+}
+
+fn symbol_kind_to_token_type(kind: SymbolKind) -> Option<u32> {
+    match kind {
+        SymbolKind::CLASS | SymbolKind::STRUCT => Some(type_index(&SemanticTokenType::CLASS)),
+        SymbolKind::INTERFACE => Some(type_index(&SemanticTokenType::INTERFACE)),
+        SymbolKind::ENUM => Some(type_index(&SemanticTokenType::ENUM)),
+        SymbolKind::FUNCTION => Some(type_index(&SemanticTokenType::FUNCTION)),
+        SymbolKind::METHOD => Some(type_index(&SemanticTokenType::METHOD)),
+        SymbolKind::PROPERTY => Some(type_index(&SemanticTokenType::PROPERTY)),
+        SymbolKind::VARIABLE => Some(type_index(&SemanticTokenType::VARIABLE)),
+        SymbolKind::FIELD => Some(type_index(&SemanticTokenType::PROPERTY)),
+        SymbolKind::ENUM_MEMBER => Some(type_index(&SemanticTokenType::ENUM_MEMBER)),
+        SymbolKind::OBJECT => Some(type_index(&SemanticTokenType::NAMESPACE)),
+        _ => None,
+    }
+}
+
+fn range_contains(range: &Range, position: &tower_lsp::lsp_types::Position) -> bool {
+    (range.start.line, range.start.character) <= (position.line, position.character)
+        && (position.line, position.character) <= (range.end.line, range.end.character)
+}
+
+struct ResolvedReference {
+    kind: SymbolKind,
+    uri: Url,
+    range: Range,
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+pub(crate) fn full_tokens(indexer: &Indexer, uri: &Url, doc: &LiveDoc, language: Language) -> SemanticTokens {
     SemanticTokens {
         result_id: None,
-        data: collect_tokens(doc, language, Some(range)),
+        data: collect_tokens(doc, language, None, Some(indexer), Some(uri)),
+    }
+}
+
+pub(crate) fn range_tokens(indexer: &Indexer, uri: &Url, doc: &LiveDoc, language: Language, range: &Range) -> SemanticTokens {
+    SemanticTokens {
+        result_id: None,
+        data: collect_tokens(doc, language, Some(range), Some(indexer), Some(uri)),
+    }
+}
+
+/// CST-only tokens without cross-file resolution — used by unit tests that
+/// don't set up a full Indexer.
+#[cfg(test)]
+pub(crate) fn full_tokens_cst_only(doc: &LiveDoc, language: Language) -> SemanticTokens {
+    SemanticTokens {
+        result_id: None,
+        data: collect_tokens(doc, language, None, None, None),
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn range_tokens_cst_only(doc: &LiveDoc, language: Language, range: &Range) -> SemanticTokens {
+    SemanticTokens {
+        result_id: None,
+        data: collect_tokens(doc, language, Some(range), None, None),
     }
 }
 

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -1,0 +1,544 @@
+//! Semantic token classification for `textDocument/semanticTokens/full` and
+//! `textDocument/semanticTokens/range`.
+//!
+//! Tokens are derived purely from the tree-sitter CST — no cross-file type
+//! resolution.  This is sufficient to distinguish classes from functions,
+//! parameters from properties, `val` (readonly) from `var`, etc.
+//!
+//! # Encoding
+//! LSP semantic tokens are delta-encoded: each token stores the line *delta*
+//! from the previous token and the column *delta* (from the previous token on
+//! the same line, or from column 0 on a new line).  Tokens must be sorted by
+//! (line, col) before encoding.
+
+use tower_lsp::lsp_types::{
+    Range, SemanticToken, SemanticTokenModifier, SemanticTokenType, SemanticTokens,
+    SemanticTokensLegend,
+};
+use tree_sitter::Node;
+
+use crate::indexer::LiveDoc;
+use crate::queries::{
+    KIND_ANNOTATION_TYPE_DECL, KIND_CLASS_DECL, KIND_COMPANION_OBJ, KIND_ENUM_CONSTANT,
+    KIND_FIELD_DECL, KIND_FUN_DECL, KIND_IDENTIFIER, KIND_INTERFACE_DECL, KIND_METHOD_DECL,
+    KIND_MODIFIERS, KIND_MULTI_VAR_DECL, KIND_OBJECT_DECL, KIND_PROP_DECL, KIND_RECORD_DECL,
+    KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_TYPE_PARAM, KIND_VAR_DECL,
+};
+use crate::Language;
+
+// ─── Legend ──────────────────────────────────────────────────────────────────
+
+/// Ordered list of token types — index == LSP token type id.
+pub(crate) const TOKEN_TYPES: &[SemanticTokenType] = &[
+    SemanticTokenType::CLASS,          // 0
+    SemanticTokenType::INTERFACE,      // 1
+    SemanticTokenType::ENUM,           // 2
+    SemanticTokenType::TYPE_PARAMETER, // 3
+    SemanticTokenType::FUNCTION,       // 4
+    SemanticTokenType::METHOD,         // 5
+    SemanticTokenType::PROPERTY,       // 6
+    SemanticTokenType::VARIABLE,       // 7
+    SemanticTokenType::PARAMETER,      // 8
+    SemanticTokenType::ENUM_MEMBER,    // 9
+    SemanticTokenType::DECORATOR,      // 10  (annotations)
+    SemanticTokenType::NAMESPACE,      // 11  (objects / companion objects used as namespaces)
+];
+
+/// Ordered list of modifiers — bit position == modifier id.
+pub(crate) const TOKEN_MODIFIERS: &[SemanticTokenModifier] = &[
+    SemanticTokenModifier::DECLARATION, // bit 0
+    SemanticTokenModifier::READONLY,    // bit 1
+    SemanticTokenModifier::STATIC,      // bit 2  (companion object members)
+    SemanticTokenModifier::ABSTRACT,    // bit 3
+    SemanticTokenModifier::ASYNC,       // bit 4  (suspend funs)
+    SemanticTokenModifier::DEPRECATED,  // bit 5
+];
+
+fn type_index(t: &SemanticTokenType) -> u32 {
+    TOKEN_TYPES
+        .iter()
+        .position(|x| x == t)
+        .expect("token type not in legend") as u32
+}
+
+fn modifier_bit(m: &SemanticTokenModifier) -> u32 {
+    1 << TOKEN_MODIFIERS
+        .iter()
+        .position(|x| x == m)
+        .expect("modifier not in legend") as u32
+}
+
+pub(crate) fn legend() -> SemanticTokensLegend {
+    SemanticTokensLegend {
+        token_types: TOKEN_TYPES.to_vec(),
+        token_modifiers: TOKEN_MODIFIERS.to_vec(),
+    }
+}
+
+// ─── Classification ───────────────────────────────────────────────────────────
+
+#[derive(Clone)]
+struct RawToken {
+    line: u32,
+    col: u32,  // UTF-16 column
+    length: u32,
+    token_type: u32,
+    token_modifiers_bitset: u32,
+}
+
+/// Collect semantic tokens for `doc`, for the given `language`.
+/// Returns delta-encoded `SemanticToken` values ready for the LSP response.
+/// Filtered to `range` when `Some`.
+pub(crate) fn collect_tokens(
+    doc: &LiveDoc,
+    language: Language,
+    range: Option<&Range>,
+) -> Vec<SemanticToken> {
+    let mut raw: Vec<RawToken> = Vec::new();
+
+    match language {
+        Language::Kotlin => walk_kotlin(doc.tree.root_node(), &doc.bytes, &mut raw),
+        Language::Java => walk_java(doc.tree.root_node(), &doc.bytes, &mut raw),
+        _ => {}
+    }
+
+    // Sort by (line, col) — tree walk is depth-first so usually already sorted,
+    // but not guaranteed for all node orderings.
+    raw.sort_by_key(|t| (t.line, t.col));
+
+    // Apply range filter before delta-encoding.
+    if let Some(r) = range {
+        let start_line = r.start.line;
+        let end_line = r.end.line;
+        raw.retain(|t| t.line >= start_line && t.line <= end_line);
+    }
+
+    delta_encode(raw)
+}
+
+// ─── Kotlin walker ────────────────────────────────────────────────────────────
+
+fn walk_kotlin(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+    classify_kotlin(node, src, out);
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            walk_kotlin(cursor.node(), src, out);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+fn classify_kotlin(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+    let kind = node.kind();
+    match kind {
+        k if k == KIND_CLASS_DECL => kotlin_class_token(node, src, out),
+        k if k == KIND_OBJECT_DECL => kotlin_object_token(node, src, out),
+        k if k == KIND_COMPANION_OBJ => kotlin_companion_token(node, src, out),
+        k if k == KIND_FUN_DECL => kotlin_fun_token(node, src, out),
+        k if k == KIND_PROP_DECL => kotlin_prop_token(node, src, out),
+        k if k == KIND_TYPE_PARAM => kotlin_type_param_token(node, src, out),
+        "parameter" => {
+            let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+            if let Some(name) = child_ident(node, src) {
+                push_token(name, type_index(&SemanticTokenType::PARAMETER), mods, src, out);
+            }
+        }
+        "enum_entry" => {
+            let mods = modifier_bit(&SemanticTokenModifier::DECLARATION)
+                | modifier_bit(&SemanticTokenModifier::READONLY);
+            if let Some(name) = child_ident(node, src) {
+                push_token(name, type_index(&SemanticTokenType::ENUM_MEMBER), mods, src, out);
+            }
+        }
+        "annotation" | "multi_annotation" => {
+            if let Some(ident) = first_child_of_kind(node, KIND_TYPE_IDENT)
+                .or_else(|| first_child_of_kind(node, KIND_SIMPLE_IDENT))
+            {
+                push_token(ident, type_index(&SemanticTokenType::DECORATOR), 0, src, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn kotlin_class_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+    let token_type = if has_keyword_child(node, "interface") {
+        type_index(&SemanticTokenType::INTERFACE)
+    } else if has_keyword_child(node, "enum") {
+        type_index(&SemanticTokenType::ENUM)
+    } else {
+        type_index(&SemanticTokenType::CLASS)
+    };
+    let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    if has_modifier(node, src, "abstract") {
+        mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
+    }
+    if let Some(name) = child_ident(node, src) {
+        push_token(name, token_type, mods, src, out);
+    }
+}
+
+fn kotlin_object_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+    let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    if let Some(name) = child_ident(node, src) {
+        push_token(name, type_index(&SemanticTokenType::NAMESPACE), mods, src, out);
+    }
+}
+
+fn kotlin_companion_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+    let mods = modifier_bit(&SemanticTokenModifier::DECLARATION)
+        | modifier_bit(&SemanticTokenModifier::STATIC);
+    let ns_type = type_index(&SemanticTokenType::NAMESPACE);
+    if let Some(name) = child_ident(node, src) {
+        push_token(name, ns_type, mods, src, out);
+    } else if let Some(obj_kw) = first_child_of_kind(node, "object") {
+        push_token(obj_kw, ns_type, mods, src, out);
+    }
+}
+
+fn kotlin_fun_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+    let token_type = if is_inside_class_body(node) {
+        type_index(&SemanticTokenType::METHOD)
+    } else {
+        type_index(&SemanticTokenType::FUNCTION)
+    };
+    let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    if has_modifier(node, src, "suspend") {
+        mods |= modifier_bit(&SemanticTokenModifier::ASYNC);
+    }
+    if has_modifier(node, src, "abstract") {
+        mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
+    }
+    if let Some(name) = child_ident(node, src) {
+        push_token(name, token_type, mods, src, out);
+    }
+}
+
+fn kotlin_prop_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+    let is_val = first_child_of_kind(node, "binding_pattern_kind")
+        .map(|bpk| has_keyword_child(bpk, "val"))
+        .unwrap_or_else(|| has_keyword_child(node, "val"));
+    let token_type = if is_inside_class_body(node) {
+        type_index(&SemanticTokenType::PROPERTY)
+    } else {
+        type_index(&SemanticTokenType::VARIABLE)
+    };
+    let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    if is_val {
+        mods |= modifier_bit(&SemanticTokenModifier::READONLY);
+    }
+    if let Some(var_decl) = first_child_of_kind(node, KIND_VAR_DECL) {
+        if let Some(name) = child_ident(var_decl, src) {
+            push_token(name, token_type, mods, src, out);
+        }
+    } else if let Some(multi) = first_child_of_kind(node, KIND_MULTI_VAR_DECL) {
+        for i in 0..multi.named_child_count() {
+            if let Some(vd) = multi.named_child(i) {
+                if let Some(name) = child_ident(vd, src) {
+                    push_token(name, token_type, mods, src, out);
+                }
+            }
+        }
+    }
+}
+
+fn kotlin_type_param_token(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+    let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    if let Some(ident) = first_child_of_kind(node, KIND_TYPE_IDENT)
+        .or_else(|| first_child_of_kind(node, KIND_SIMPLE_IDENT))
+    {
+        push_token(ident, type_index(&SemanticTokenType::TYPE_PARAMETER), mods, src, out);
+    }
+}
+
+// ─── Java walker ─────────────────────────────────────────────────────────────
+
+fn walk_java(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+    classify_java(node, src, out);
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            walk_java(cursor.node(), src, out);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+fn classify_java(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
+    let kind = node.kind();
+
+    match kind {
+        k if k == KIND_CLASS_DECL || k == KIND_RECORD_DECL => {
+            let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+            if has_java_modifier(node, src, "abstract") {
+                mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
+            }
+            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+                push_token(name, type_index(&SemanticTokenType::CLASS), mods, src, out);
+            }
+        }
+
+        k if k == KIND_INTERFACE_DECL || k == KIND_ANNOTATION_TYPE_DECL => {
+            let token_type = if k == KIND_ANNOTATION_TYPE_DECL {
+                type_index(&SemanticTokenType::DECORATOR)
+            } else {
+                type_index(&SemanticTokenType::INTERFACE)
+            };
+            let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+                push_token(name, token_type, mods, src, out);
+            }
+        }
+
+        "enum_declaration" => {
+            let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+                push_token(name, type_index(&SemanticTokenType::ENUM), mods, src, out);
+            }
+        }
+
+        k if k == KIND_METHOD_DECL => {
+            let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+            if has_java_modifier(node, src, "abstract") {
+                mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
+            }
+            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+                push_token(name, type_index(&SemanticTokenType::METHOD), mods, src, out);
+            }
+        }
+
+        k if k == KIND_FIELD_DECL => {
+            let is_final = has_java_modifier(node, src, "final");
+            let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+            if is_final {
+                mods |= modifier_bit(&SemanticTokenModifier::READONLY);
+            }
+            if has_java_modifier(node, src, "static") {
+                mods |= modifier_bit(&SemanticTokenModifier::STATIC);
+            }
+            for i in 0..node.child_count() {
+                if let Some(child) = node.child(i) {
+                    if child.kind() == "variable_declarator" {
+                        if let Some(name) = first_child_of_kind(child, KIND_IDENTIFIER) {
+                            push_token(name, type_index(&SemanticTokenType::PROPERTY), mods, src, out);
+                        }
+                    }
+                }
+            }
+        }
+
+        "formal_parameter" | "spread_parameter" => {
+            let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+                push_token(name, type_index(&SemanticTokenType::PARAMETER), mods, src, out);
+            }
+        }
+
+        k if k == KIND_ENUM_CONSTANT => {
+            let mods = modifier_bit(&SemanticTokenModifier::DECLARATION)
+                | modifier_bit(&SemanticTokenModifier::READONLY);
+            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+                push_token(name, type_index(&SemanticTokenType::ENUM_MEMBER), mods, src, out);
+            }
+        }
+
+        k if k == KIND_TYPE_PARAM => {
+            let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+            // Java type_parameter has type_identifier child; Kotlin uses type_identifier too
+            if let Some(name) = first_child_of_kind(node, KIND_TYPE_IDENT)
+                .or_else(|| first_child_of_kind(node, KIND_IDENTIFIER))
+            {
+                push_token(name, type_index(&SemanticTokenType::TYPE_PARAMETER), mods, src, out);
+            }
+        }
+
+        "marker_annotation" | "annotation" => {
+            // @Override, @SuppressWarnings("...") etc.
+            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+                push_token(name, type_index(&SemanticTokenType::DECORATOR), 0, src, out);
+            }
+        }
+
+        _ => {}
+    }
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Find the first direct child with a name identifier (simple_identifier or identifier).
+fn child_ident<'a>(node: Node<'a>, _src: &[u8]) -> Option<Node<'a>> {
+    for i in 0..node.child_count() {
+        let child = node.child(i)?;
+        if child.kind() == KIND_SIMPLE_IDENT
+            || child.kind() == KIND_IDENTIFIER
+            || child.kind() == KIND_TYPE_IDENT
+        {
+            return Some(child);
+        }
+    }
+    None
+}
+
+fn first_child_of_kind<'a>(node: Node<'a>, kind: &str) -> Option<Node<'a>> {
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let child = cursor.node();
+            if child.kind() == kind {
+                return Some(child);
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    None
+}
+
+fn has_keyword_child(node: Node<'_>, keyword: &str) -> bool {
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            if cursor.node().kind() == keyword {
+                return true;
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    false
+}
+
+/// Check whether a Kotlin node has a modifier keyword (e.g. "suspend", "abstract").
+fn has_modifier(node: Node<'_>, src: &[u8], keyword: &str) -> bool {
+    // Modifiers are either direct keyword children or inside a `modifiers` node.
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i) {
+            if child.kind() == KIND_MODIFIERS
+                && node_text(child, src).split_whitespace().any(|w| w == keyword)
+            {
+                return true;
+            }
+            if child.kind() == keyword {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Check whether a Java node has a modifier keyword inside a `modifiers` node.
+fn has_java_modifier(node: Node<'_>, src: &[u8], keyword: &str) -> bool {
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i) {
+            if child.kind() == "modifiers"
+                && node_text(child, src).split_whitespace().any(|w| w == keyword)
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// True when this node is a direct child of a class/interface/enum body.
+fn is_inside_class_body(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else { return false };
+    matches!(
+        parent.kind(),
+        "class_body" | "interface_body" | "enum_class_body" | "object_body"
+    )
+}
+
+fn node_text<'a>(node: Node<'_>, src: &'a [u8]) -> &'a str {
+    node.utf8_text(src).unwrap_or("")
+}
+
+fn push_token(node: Node<'_>, token_type: u32, token_modifiers_bitset: u32, src: &[u8], out: &mut Vec<RawToken>) {
+    let start = node.start_position();
+    let text = node_text(node, src);
+    let length = text.encode_utf16().count() as u32;
+    if length == 0 {
+        return;
+    }
+    out.push(RawToken {
+        line: start.row as u32,
+        col: byte_col_to_utf16(src, start.row, start.column),
+        length,
+        token_type,
+        token_modifiers_bitset,
+    });
+}
+
+/// Convert a tree-sitter byte-column to a UTF-16 column for LSP.
+fn byte_col_to_utf16(src: &[u8], row: usize, byte_col: usize) -> u32 {
+    let line_start = src
+        .iter()
+        .enumerate()
+        .filter(|(_, &b)| b == b'\n')
+        .nth(row.saturating_sub(1))
+        .map(|(i, _)| i + 1)
+        .unwrap_or(0);
+    let line_bytes = &src[line_start..];
+    let prefix = if byte_col <= line_bytes.len() {
+        &line_bytes[..byte_col]
+    } else {
+        line_bytes
+    };
+    std::str::from_utf8(prefix)
+        .map(|s| s.encode_utf16().count() as u32)
+        .unwrap_or(byte_col as u32)
+}
+
+// ─── Delta encoding ───────────────────────────────────────────────────────────
+
+fn delta_encode(sorted: Vec<RawToken>) -> Vec<SemanticToken> {
+    let mut result = Vec::with_capacity(sorted.len());
+    let mut prev_line = 0u32;
+    let mut prev_start = 0u32;
+
+    for tok in sorted {
+        let delta_line = tok.line - prev_line;
+        let delta_start = if delta_line == 0 {
+            tok.col - prev_start
+        } else {
+            tok.col
+        };
+        result.push(SemanticToken {
+            delta_line,
+            delta_start,
+            length: tok.length,
+            token_type: tok.token_type,
+            token_modifiers_bitset: tok.token_modifiers_bitset,
+        });
+        prev_line = tok.line;
+        prev_start = tok.col;
+    }
+    result
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+
+pub(crate) fn full_tokens(doc: &LiveDoc, language: Language) -> SemanticTokens {
+    SemanticTokens {
+        result_id: None,
+        data: collect_tokens(doc, language, None),
+    }
+}
+
+pub(crate) fn range_tokens(doc: &LiveDoc, language: Language, range: &Range) -> SemanticTokens {
+    SemanticTokens {
+        result_id: None,
+        data: collect_tokens(doc, language, Some(range)),
+    }
+}
+
+#[cfg(test)]
+#[path = "semantic_tokens_tests.rs"]
+mod tests;

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -1003,10 +1003,10 @@ fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> O
         return None;
     }
 
-    // Named arguments: `foo(name = value)` — the label gets PROPERTY color
-    // to distinguish from the value (PARAMETER maps to same color as VARIABLE in most themes)
+    // Named arguments: `foo(name = value)` — the label is a parameter reference.
+    // Matches kotlin-lsp (JetBrains) behaviour: resolves to KaValueParameterSymbol → PARAMETER.
     if is_named_argument_label(node) {
-        return Some(type_index(&SemanticTokenType::PROPERTY));
+        return Some(type_index(&SemanticTokenType::PARAMETER));
     }
 
     if is_annotation_reference(node) {

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -534,13 +534,16 @@ fn push_token(node: Node<'_>, token_type: u32, token_modifiers_bitset: u32, src:
 
 /// Convert a tree-sitter byte-column to a UTF-16 column for LSP.
 fn byte_col_to_utf16(src: &[u8], row: usize, byte_col: usize) -> u32 {
-    let line_start = src
-        .iter()
-        .enumerate()
-        .filter(|(_, &b)| b == b'\n')
-        .nth(row.saturating_sub(1))
-        .map(|(i, _)| i + 1)
-        .unwrap_or(0);
+    let line_start = if row == 0 {
+        0
+    } else {
+        src.iter()
+            .enumerate()
+            .filter(|(_, &b)| b == b'\n')
+            .nth(row - 1)
+            .map(|(i, _)| i + 1)
+            .unwrap_or(0)
+    };
     let line_bytes = &src[line_start..];
     let prefix = if byte_col <= line_bytes.len() {
         &line_bytes[..byte_col]

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -22,10 +22,11 @@ use crate::indexer::{
 };
 use crate::queries::{
     KIND_ANNOTATION_TYPE_DECL, KIND_CALL_EXPR, KIND_CLASS_DECL, KIND_COMPANION_OBJ,
-    KIND_ENUM_CONSTANT, KIND_FIELD_DECL, KIND_FUN_DECL, KIND_IDENTIFIER, KIND_INTERFACE_DECL,
-    KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_METHOD_DECL, KIND_MODIFIERS, KIND_MULTI_VAR_DECL,
-    KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_OBJECT_DECL, KIND_PROP_DECL, KIND_RECORD_DECL,
-    KIND_SIMPLE_IDENT, KIND_THIS_EXPR, KIND_TYPE_IDENT, KIND_TYPE_PARAM, KIND_VAR_DECL,
+    KIND_CONSTRUCTOR_INVOCATION, KIND_ENUM_CONSTANT, KIND_EQ, KIND_FIELD_DECL, KIND_FUN_DECL,
+    KIND_IDENTIFIER, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_METHOD_DECL,
+    KIND_MODIFIERS, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_OBJECT_DECL,
+    KIND_PROP_DECL, KIND_RECORD_DECL, KIND_SIMPLE_IDENT, KIND_THIS_EXPR, KIND_TYPE_IDENT,
+    KIND_TYPE_PARAM, KIND_VALUE_ARG, KIND_VAR_DECL,
 };
 use crate::resolver::infer::{
     find_field_type_in_class, find_fun_return_type_by_name, find_method_return_type,
@@ -179,9 +180,7 @@ fn classify_kotlin(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
             }
         }
         "annotation" | "multi_annotation" => {
-            if let Some(ident) = first_child_of_kind(node, KIND_TYPE_IDENT)
-                .or_else(|| first_child_of_kind(node, KIND_SIMPLE_IDENT))
-            {
+            if let Some(ident) = find_annotation_ident(node) {
                 push_token(ident, type_index(&SemanticTokenType::DECORATOR), 0, src, out);
             }
         }
@@ -398,6 +397,34 @@ fn classify_java(node: Node<'_>, src: &[u8], out: &mut Vec<RawToken>) {
 }
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/// Find the type/simple identifier inside an annotation node.
+/// Handles both `annotation > user_type > type_identifier` (simple annotation)
+/// and `annotation > constructor_invocation > user_type > type_identifier` (with args).
+fn find_annotation_ident(annotation_node: Node<'_>) -> Option<Node<'_>> {
+    // Direct: annotation > user_type > type_identifier  OR  annotation > type_identifier
+    if let Some(ident) = first_child_of_kind(annotation_node, KIND_TYPE_IDENT)
+        .or_else(|| first_child_of_kind(annotation_node, KIND_SIMPLE_IDENT))
+    {
+        return Some(ident);
+    }
+    // Via user_type: annotation > user_type > type_identifier
+    if let Some(user_type) = first_child_of_kind(annotation_node, "user_type") {
+        if let Some(ident) = first_child_of_kind(user_type, KIND_TYPE_IDENT)
+            .or_else(|| first_child_of_kind(user_type, KIND_SIMPLE_IDENT))
+        {
+            return Some(ident);
+        }
+    }
+    // Via constructor_invocation: annotation > constructor_invocation > user_type > type_identifier
+    if let Some(ctor) = first_child_of_kind(annotation_node, KIND_CONSTRUCTOR_INVOCATION) {
+        if let Some(user_type) = first_child_of_kind(ctor, "user_type") {
+            return first_child_of_kind(user_type, KIND_TYPE_IDENT)
+                .or_else(|| first_child_of_kind(user_type, KIND_SIMPLE_IDENT));
+        }
+    }
+    None
+}
 
 /// Find the first direct child with a name identifier (simple_identifier or identifier).
 fn child_ident<'a>(node: Node<'a>, _src: &[u8]) -> Option<Node<'a>> {
@@ -942,7 +969,10 @@ fn walk_references(
 }
 
 fn walk_kotlin_references(node: Node<'_>, src: &[u8], indexer: &Indexer, out: &mut Vec<RawToken>) {
-    if let Some(token_type) = classify_kotlin_reference(node, src, indexer) {
+    // Emit keyword tokens for Kotlin soft keywords
+    if is_kotlin_keyword_node(node) {
+        push_token(node, type_index(&SemanticTokenType::KEYWORD), 0, src, out);
+    } else if let Some(token_type) = classify_kotlin_reference(node, src, indexer) {
         push_token(node, token_type, 0, src, out);
     }
     let mut cursor = node.walk();
@@ -956,14 +986,28 @@ fn walk_kotlin_references(node: Node<'_>, src: &[u8], indexer: &Indexer, out: &m
     }
 }
 
+/// Kotlin soft keywords and delegation keywords that benefit from distinct coloring.
+fn is_kotlin_keyword_node(node: Node<'_>) -> bool {
+    matches!(
+        node.kind(),
+        "by" | "where" | "get" | "set" | "is" | "as" | "in" | "constructor"
+    )
+}
+
 fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> Option<u32> {
     if !matches!(node.kind(), KIND_SIMPLE_IDENT | KIND_TYPE_IDENT) || is_declaration_site(node) {
         return None;
     }
 
+    // Named arguments: `foo(name = value)` — the label gets PARAMETER color
+    if is_named_argument_label(node) {
+        return Some(type_index(&SemanticTokenType::PARAMETER));
+    }
+
     if is_annotation_reference(node) {
-        return resolve_symbol_kind(node_text(node, src), indexer, |_| true)
-            .map(|_| type_index(&SemanticTokenType::DECORATOR));
+        // Annotations are unambiguous from CST position — always emit DECORATOR
+        // regardless of whether the annotation class is in our index.
+        return Some(type_index(&SemanticTokenType::DECORATOR));
     }
 
     if let Some(token_type) = enum_entry_reference_token(node, src, indexer) {
@@ -971,8 +1015,12 @@ fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> O
     }
 
     if node.kind() == KIND_TYPE_IDENT && is_type_reference(node) {
-        return resolve_symbol_kind(node_text(node, src), indexer, is_type_symbol)
-            .and_then(|resolved| symbol_kind_to_token_type(resolved.kind));
+        // Try to resolve for exact kind (class vs interface vs enum)
+        if let Some(resolved) = resolve_symbol_kind(node_text(node, src), indexer, is_type_symbol) {
+            return symbol_kind_to_token_type(resolved.kind);
+        }
+        // Unresolved type references are still types — emit CLASS as default
+        return Some(type_index(&SemanticTokenType::CLASS));
     }
 
     if is_top_level_call_name(node) {
@@ -1006,8 +1054,21 @@ fn is_declaration_site(node: Node<'_>) -> bool {
 
 fn is_annotation_reference(node: Node<'_>) -> bool {
     let Some(parent) = node.parent() else { return false };
+    if parent.kind() != "user_type" {
+        return false;
+    }
     let Some(grandparent) = parent.parent() else { return false };
-    parent.kind() == "user_type" && matches!(grandparent.kind(), "annotation" | "multi_annotation")
+    // @Simple annotation: annotation > user_type > type_identifier
+    if matches!(grandparent.kind(), "annotation" | "multi_annotation") {
+        return true;
+    }
+    // @Named("key") annotation: annotation > constructor_invocation > user_type > type_identifier
+    if grandparent.kind() == KIND_CONSTRUCTOR_INVOCATION {
+        return grandparent
+            .parent()
+            .is_some_and(|gp| matches!(gp.kind(), "annotation" | "multi_annotation"));
+    }
+    false
 }
 
 fn is_type_reference(node: Node<'_>) -> bool {
@@ -1031,6 +1092,22 @@ fn is_navigation_receiver(node: Node<'_>) -> bool {
         && parent
             .named_child(0)
             .is_some_and(|first_child| first_child.id() == node.id())
+}
+
+/// Named argument label: `foo(name = value)` — the `name` identifier is the
+/// first child of `value_argument` and is followed by `=`.
+fn is_named_argument_label(node: Node<'_>) -> bool {
+    let Some(parent) = node.parent() else { return false };
+    if parent.kind() != KIND_VALUE_ARG {
+        return false;
+    }
+    // The label is the first named child and must be followed by "="
+    let Some(first) = parent.named_child(0) else { return false };
+    if first.id() != node.id() {
+        return false;
+    }
+    node.next_sibling()
+        .is_some_and(|sib| sib.kind() == KIND_EQ)
 }
 
 fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> Option<u32> {

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -834,12 +834,20 @@ fn resolve_member_access(doc: &LiveDoc, src: &Source<'_>, indexer: &Indexer, uri
         let Some(member_name) = member_ident.utf8_text_owned(&doc.bytes) else {
             return;
         };
+        let is_call = is_call_callee(node);
         let resolved_type = navigation_receiver_node(node)
             .and_then(|receiver| expression_type(receiver, doc, &src.line_starts, indexer, uri))
             .and_then(|receiver_type| member_token_type_for_receiver(indexer, &receiver_type, &member_name));
-        let token_type = resolved_type.or_else(|| {
-            is_call_callee(node).then(|| type_index(&SemanticTokenType::METHOD))
-        });
+        // For call expressions, override any PROPERTY false-positive to METHOD.
+        // A called navigation suffix is always a function invocation, even if the
+        // index resolved it as a property (e.g. library type not fully indexed).
+        let method_type = type_index(&SemanticTokenType::METHOD);
+        let property_type = type_index(&SemanticTokenType::PROPERTY);
+        let token_type = if is_call {
+            Some(resolved_type.map(|t| if t == property_type { method_type } else { t }).unwrap_or(method_type))
+        } else {
+            resolved_type
+        };
         if let Some(token_type) = token_type {
             push_token(member_ident, token_type, 0, src, &mut tokens);
         }

--- a/src/semantic_tokens_tests.rs
+++ b/src/semantic_tokens_tests.rs
@@ -496,10 +496,10 @@ fn named_arg_label_gets_property_token() {
     indexer.index_content(&uri, src);
     let doc = parse_kotlin(src);
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
-    // "name" in foo(name = 42) is at line 1, col 17 — emitted as PROPERTY for visual distinction
-    let prop_type = type_id(&SemanticTokenType::PROPERTY);
-    assert!(tokens.iter().any(|t| t.0 == 1 && t.1 == 17 && t.3 == prop_type),
-        "Expected PROPERTY at (1,17) for named arg 'name', got: {tokens:?}");
+    // "name" in foo(name = 42) is at line 1, col 17 — emitted as PARAMETER (JetBrains behaviour)
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
+    assert!(tokens.iter().any(|t| t.0 == 1 && t.1 == 17 && t.3 == param_type),
+        "Expected PARAMETER at (1,17) for named arg 'name', got: {tokens:?}");
 }
 
 #[test]
@@ -510,13 +510,13 @@ fn named_arg_multiline_call() {
     indexer.index_content(&uri, src);
     let doc = parse_kotlin(src);
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
-    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
     // "modifier" at line 2, col 8
-    assert!(tokens.iter().any(|t| t.0 == 2 && t.3 == prop_type),
-        "Expected PROPERTY on line 2 for 'modifier', got: {tokens:?}");
+    assert!(tokens.iter().any(|t| t.0 == 2 && t.3 == param_type),
+        "Expected PARAMETER on line 2 for 'modifier', got: {tokens:?}");
     // "topBar" at line 3, col 8
-    assert!(tokens.iter().any(|t| t.0 == 3 && t.3 == prop_type),
-        "Expected PROPERTY on line 3 for 'topBar', got: {tokens:?}");
+    assert!(tokens.iter().any(|t| t.0 == 3 && t.3 == param_type),
+        "Expected PARAMETER on line 3 for 'topBar', got: {tokens:?}");
 }
 
 // ─── Phase 2: Comprehensive semantic token coverage ──────────────────────────
@@ -825,9 +825,9 @@ fn named_arg_simple_call() {
     indexer.index_content(&uri, src);
     let doc = parse_kotlin(src);
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
-    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
     // "x" named arg at line 1, col 17
-    assert_token_at(&tokens, 1, 17, prop_type, "PROPERTY named arg label");
+    assert_token_at(&tokens, 1, 17, param_type, "PARAMETER named arg label");
 }
 
 #[test]
@@ -838,10 +838,10 @@ fn named_arg_not_emitted_for_positional() {
     indexer.index_content(&uri, src);
     let doc = parse_kotlin(src);
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
-    let prop_type = type_id(&SemanticTokenType::PROPERTY);
-    // No PROPERTY token on line 1 for positional arg "42"
-    assert!(!tokens.iter().any(|t| t.0 == 1 && t.1 == 17 && t.3 == prop_type),
-        "Should NOT emit PROPERTY for positional arg, got: {tokens:?}");
+    // No PARAMETER token on line 1 for positional arg "42"
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
+    assert!(!tokens.iter().any(|t| t.0 == 1 && t.1 == 17 && t.3 == param_type),
+        "Should NOT emit PARAMETER for positional arg, got: {tokens:?}");
 }
 
 #[test]
@@ -852,10 +852,10 @@ fn named_arg_multiple_in_one_call() {
     indexer.index_content(&uri, src);
     let doc = parse_kotlin(src);
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
-    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
     // "a" at line 1, col 15; "b" at line 1, col 22
-    assert_token_at(&tokens, 1, 15, prop_type, "PROPERTY first named arg 'a'");
-    assert_token_at(&tokens, 1, 22, prop_type, "PROPERTY second named arg 'b'");
+    assert_token_at(&tokens, 1, 15, param_type, "PARAMETER first named arg 'a'");
+    assert_token_at(&tokens, 1, 22, param_type, "PARAMETER second named arg 'b'");
 }
 
 // --- Member access (Tier 2) ---

--- a/src/semantic_tokens_tests.rs
+++ b/src/semantic_tokens_tests.rs
@@ -1,9 +1,11 @@
-use tower_lsp::lsp_types::{Position, Range, SemanticTokenType};
+use tower_lsp::lsp_types::{Position, Range, SemanticTokenType, Url};
 use tree_sitter_kotlin;
 
-use crate::indexer::live_tree::parse_live;
+use crate::indexer::{live_tree::parse_live, Indexer};
 use crate::Language;
-use crate::semantic_tokens::{full_tokens, range_tokens, TOKEN_TYPES};
+use crate::semantic_tokens::{
+    full_tokens, full_tokens_cst_only, range_tokens_cst_only, TOKEN_TYPES,
+};
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -20,14 +22,7 @@ fn type_id(t: &SemanticTokenType) -> u32 {
     TOKEN_TYPES.iter().position(|x| x == t).unwrap() as u32
 }
 
-/// Decode one SemanticToken from the delta-encoded stream.
-/// Returns (line, col, len, token_type, modifiers) for the token at
-/// absolute position `index` in the stream.
-fn decode_all(
-    doc: &crate::indexer::LiveDoc,
-    language: Language,
-) -> Vec<(u32, u32, u32, u32, u32)> {
-    let tokens = full_tokens(doc, language);
+fn decode_tokens(tokens: &tower_lsp::lsp_types::SemanticTokens) -> Vec<(u32, u32, u32, u32, u32)> {
     let mut line = 0u32;
     let mut col = 0u32;
     tokens
@@ -43,6 +38,35 @@ fn decode_all(
             (line, col, t.length, t.token_type, t.token_modifiers_bitset)
         })
         .collect()
+}
+
+/// Decode one SemanticToken from the delta-encoded stream.
+fn decode_all(doc: &crate::indexer::LiveDoc, language: Language) -> Vec<(u32, u32, u32, u32, u32)> {
+    decode_tokens(&full_tokens_cst_only(doc, language))
+}
+
+fn decode_all_indexed(
+    indexer: &Indexer,
+    uri: &Url,
+    doc: &crate::indexer::LiveDoc,
+    language: Language,
+) -> Vec<(u32, u32, u32, u32, u32)> {
+    decode_tokens(&full_tokens(indexer, uri, doc, language))
+}
+
+fn assert_token_at(
+    tokens: &[(u32, u32, u32, u32, u32)],
+    line: u32,
+    col: u32,
+    token_type: u32,
+    label: &str,
+) {
+    assert!(
+        tokens
+            .iter()
+            .any(|&(token_line, token_col, _, kind, _)| token_line == line && token_col == col && kind == token_type),
+        "expected {label} token at {line}:{col}, got: {tokens:?}"
+    );
 }
 
 // ─── Kotlin tests ─────────────────────────────────────────────────────────────
@@ -199,7 +223,7 @@ fun bar() {}
         start: Position { line: 1, character: 0 },
         end: Position { line: 1, character: 9 },
     };
-    let tokens = range_tokens(&doc, Language::Kotlin, &range);
+    let tokens = range_tokens_cst_only(&doc, Language::Kotlin, &range);
     // Should have tokens only on line 1
     let decoded: Vec<_> = {
         let mut line = 0u32;
@@ -221,6 +245,91 @@ fun bar() {}
     assert!(
         decoded.iter().all(|&l| l == 1),
         "range_tokens should only return tokens on line 1, got lines: {decoded:?}"
+    );
+}
+
+#[test]
+fn kotlin_reference_sites_resolve_types_functions_and_namespaces() {
+    let src = "class User\nobject Utils { fun run() {} }\nfun greet(): User = User()\nfun use(): User {\n    greet()\n    Utils.run()\n    return User()\n}\n";
+    let uri = Url::parse("file:///semantic_tokens_refs.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+
+    assert_token_at(
+        &tokens,
+        2,
+        13,
+        type_id(&SemanticTokenType::CLASS),
+        "CLASS return type",
+    );
+    assert_token_at(
+        &tokens,
+        2,
+        20,
+        type_id(&SemanticTokenType::CLASS),
+        "CLASS constructor call",
+    );
+    assert_token_at(
+        &tokens,
+        3,
+        11,
+        type_id(&SemanticTokenType::CLASS),
+        "CLASS function return type",
+    );
+    assert_token_at(
+        &tokens,
+        4,
+        4,
+        type_id(&SemanticTokenType::FUNCTION),
+        "FUNCTION call",
+    );
+    assert_token_at(
+        &tokens,
+        5,
+        4,
+        type_id(&SemanticTokenType::NAMESPACE),
+        "NAMESPACE receiver",
+    );
+    assert_token_at(
+        &tokens,
+        6,
+        11,
+        type_id(&SemanticTokenType::CLASS),
+        "CLASS return expression",
+    );
+}
+
+#[test]
+fn kotlin_reference_sites_resolve_annotations_and_enum_entries() {
+    let src = "annotation class Fancy\nenum class Color { RED }\n@Fancy\nfun color(): Color = Color.RED\n";
+    let uri = Url::parse("file:///semantic_tokens_annotations.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+
+    assert_token_at(
+        &tokens,
+        2,
+        1,
+        type_id(&SemanticTokenType::DECORATOR),
+        "DECORATOR annotation reference",
+    );
+    assert_token_at(
+        &tokens,
+        3,
+        13,
+        type_id(&SemanticTokenType::ENUM),
+        "ENUM return type",
+    );
+    assert_token_at(
+        &tokens,
+        3,
+        27,
+        type_id(&SemanticTokenType::ENUM_MEMBER),
+        "ENUM_MEMBER reference",
     );
 }
 
@@ -308,7 +417,7 @@ class Foo {
 }
 "#;
     let doc = parse_kotlin(src);
-    let tokens = full_tokens(&doc, Language::Kotlin);
+    let tokens = full_tokens_cst_only(&doc, Language::Kotlin);
     // delta_line must never be negative (tokens must be in order)
     for t in &tokens.data {
         assert!(
@@ -321,7 +430,7 @@ class Foo {
 #[test]
 fn empty_file_returns_no_tokens() {
     let doc = parse_kotlin("");
-    let tokens = full_tokens(&doc, Language::Kotlin);
+    let tokens = full_tokens_cst_only(&doc, Language::Kotlin);
     assert!(tokens.data.is_empty(), "empty file should produce no tokens");
 }
 

--- a/src/semantic_tokens_tests.rs
+++ b/src/semantic_tokens_tests.rs
@@ -1,0 +1,327 @@
+use tower_lsp::lsp_types::{Position, Range, SemanticTokenType};
+use tree_sitter_kotlin;
+
+use crate::indexer::live_tree::parse_live;
+use crate::Language;
+use crate::semantic_tokens::{full_tokens, range_tokens, TOKEN_TYPES};
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+fn parse_kotlin(src: &str) -> crate::indexer::LiveDoc {
+    parse_live(src, tree_sitter_kotlin::language()).expect("parse failed")
+}
+
+fn parse_java(src: &str) -> crate::indexer::LiveDoc {
+    parse_live(src, tree_sitter_java::language()).expect("parse failed")
+}
+
+/// Find token type id by name in the legend.
+fn type_id(t: &SemanticTokenType) -> u32 {
+    TOKEN_TYPES.iter().position(|x| x == t).unwrap() as u32
+}
+
+/// Decode one SemanticToken from the delta-encoded stream.
+/// Returns (line, col, len, token_type, modifiers) for the token at
+/// absolute position `index` in the stream.
+fn decode_all(
+    doc: &crate::indexer::LiveDoc,
+    language: Language,
+) -> Vec<(u32, u32, u32, u32, u32)> {
+    let tokens = full_tokens(doc, language);
+    let mut line = 0u32;
+    let mut col = 0u32;
+    tokens
+        .data
+        .iter()
+        .map(|t| {
+            line += t.delta_line;
+            if t.delta_line > 0 {
+                col = t.delta_start;
+            } else {
+                col += t.delta_start;
+            }
+            (line, col, t.length, t.token_type, t.token_modifiers_bitset)
+        })
+        .collect()
+}
+
+// ─── Kotlin tests ─────────────────────────────────────────────────────────────
+
+#[test]
+fn kotlin_class_decl() {
+    let src = "class Foo";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let class_id = type_id(&SemanticTokenType::CLASS);
+    let found = tokens.iter().any(|&(_, _, _, tt, _)| tt == class_id);
+    assert!(found, "expected CLASS token for 'class Foo', got: {tokens:?}");
+}
+
+#[test]
+fn kotlin_interface_decl() {
+    let src = "interface Runnable";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let iface_id = type_id(&SemanticTokenType::INTERFACE);
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == iface_id),
+        "expected INTERFACE token, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn kotlin_enum_class() {
+    let src = "enum class Color { RED, GREEN, BLUE }";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let enum_id = type_id(&SemanticTokenType::ENUM);
+    let member_id = type_id(&SemanticTokenType::ENUM_MEMBER);
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == enum_id),
+        "expected ENUM token, got: {tokens:?}"
+    );
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == member_id),
+        "expected ENUM_MEMBER token, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn kotlin_top_level_function() {
+    let src = "fun greet() {}";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let fun_id = type_id(&SemanticTokenType::FUNCTION);
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == fun_id),
+        "expected FUNCTION token for top-level fun, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn kotlin_method_vs_function() {
+    let src = r#"
+class Foo {
+    fun bar() {}
+}
+fun topLevel() {}
+"#;
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let method_id = type_id(&SemanticTokenType::METHOD);
+    let fun_id = type_id(&SemanticTokenType::FUNCTION);
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == method_id),
+        "expected METHOD token for class member fun, got: {tokens:?}"
+    );
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == fun_id),
+        "expected FUNCTION token for top-level fun, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn kotlin_val_is_readonly() {
+    let src = "val x: Int = 1";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    // READONLY modifier bit = 1
+    let readonly_bit = 1u32 << 1;
+    assert!(
+        tokens.iter().any(|&(_, _, _, _, mods)| mods & readonly_bit != 0),
+        "expected READONLY modifier for val, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn kotlin_var_not_readonly() {
+    let src = "var x: Int = 1";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let readonly_bit = 1u32 << 1;
+    assert!(
+        !tokens.iter().all(|&(_, _, _, _, mods)| mods & readonly_bit != 0),
+        "var should not always have READONLY modifier"
+    );
+}
+
+#[test]
+fn kotlin_type_parameter() {
+    let src = "fun <T> identity(x: T): T = x";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let tp_id = type_id(&SemanticTokenType::TYPE_PARAMETER);
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == tp_id),
+        "expected TYPE_PARAMETER token, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn kotlin_companion_object() {
+    let src = r#"
+class Foo {
+    companion object {
+        val CONST = 1
+    }
+}
+"#;
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let ns_id = type_id(&SemanticTokenType::NAMESPACE);
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == ns_id),
+        "expected NAMESPACE token for companion object, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn kotlin_object_decl() {
+    let src = "object Singleton { val x = 1 }";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let ns_id = type_id(&SemanticTokenType::NAMESPACE);
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == ns_id),
+        "expected NAMESPACE token for object decl, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn kotlin_range_restricts_to_range() {
+    let src = r#"
+class Foo
+fun bar() {}
+"#;
+    let doc = parse_kotlin(src);
+    // Only request line 1 (0-indexed) — "class Foo"
+    let range = Range {
+        start: Position { line: 1, character: 0 },
+        end: Position { line: 1, character: 9 },
+    };
+    let tokens = range_tokens(&doc, Language::Kotlin, &range);
+    // Should have tokens only on line 1
+    let decoded: Vec<_> = {
+        let mut line = 0u32;
+        let mut col = 0u32;
+        tokens
+            .data
+            .iter()
+            .map(|t| {
+                line += t.delta_line;
+                if t.delta_line > 0 {
+                    col = t.delta_start;
+                } else {
+                    col += t.delta_start;
+                }
+                line
+            })
+            .collect()
+    };
+    assert!(
+        decoded.iter().all(|&l| l == 1),
+        "range_tokens should only return tokens on line 1, got lines: {decoded:?}"
+    );
+}
+
+// ─── Java tests ───────────────────────────────────────────────────────────────
+
+#[test]
+fn java_class_decl() {
+    let src = "class Foo {}";
+    let doc = parse_java(src);
+    let tokens = decode_all(&doc, Language::Java);
+    let class_id = type_id(&SemanticTokenType::CLASS);
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == class_id),
+        "expected CLASS token for Java class, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn java_interface_decl() {
+    let src = "interface Runnable { void run(); }";
+    let doc = parse_java(src);
+    let tokens = decode_all(&doc, Language::Java);
+    let iface_id = type_id(&SemanticTokenType::INTERFACE);
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == iface_id),
+        "expected INTERFACE token for Java interface, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn java_method_decl() {
+    let src = r#"
+class Foo {
+    void bar() {}
+}
+"#;
+    let doc = parse_java(src);
+    let tokens = decode_all(&doc, Language::Java);
+    let method_id = type_id(&SemanticTokenType::METHOD);
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == method_id),
+        "expected METHOD token for Java method, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn java_enum_constant() {
+    let src = "enum Color { RED, GREEN, BLUE }";
+    let doc = parse_java(src);
+    let tokens = decode_all(&doc, Language::Java);
+    let enum_id = type_id(&SemanticTokenType::ENUM);
+    let member_id = type_id(&SemanticTokenType::ENUM_MEMBER);
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == enum_id),
+        "expected ENUM token for Java enum, got: {tokens:?}"
+    );
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == member_id),
+        "expected ENUM_MEMBER token for Java enum constant, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn java_type_parameter() {
+    let src = r#"
+class Box<T> {
+    T value;
+}
+"#;
+    let doc = parse_java(src);
+    let tokens = decode_all(&doc, Language::Java);
+    let tp_id = type_id(&SemanticTokenType::TYPE_PARAMETER);
+    assert!(
+        tokens.iter().any(|&(_, _, _, tt, _)| tt == tp_id),
+        "expected TYPE_PARAMETER token for Java generic, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn delta_encoding_is_sorted() {
+    let src = r#"
+class Foo {
+    val x: Int = 1
+    fun bar(): Int = x
+}
+"#;
+    let doc = parse_kotlin(src);
+    let tokens = full_tokens(&doc, Language::Kotlin);
+    // delta_line must never be negative (tokens must be in order)
+    for t in &tokens.data {
+        assert!(
+            t.delta_line < 0x8000_0000,
+            "delta_line overflow suggests unsorted tokens: {t:?}"
+        );
+    }
+}
+
+#[test]
+fn empty_file_returns_no_tokens() {
+    let doc = parse_kotlin("");
+    let tokens = full_tokens(&doc, Language::Kotlin);
+    assert!(tokens.data.is_empty(), "empty file should produce no tokens");
+}
+

--- a/src/semantic_tokens_tests.rs
+++ b/src/semantic_tokens_tests.rs
@@ -1,5 +1,4 @@
 use tower_lsp::lsp_types::{Position, Range, SemanticTokenType, Url};
-use tree_sitter_kotlin;
 
 use crate::indexer::{live_tree::parse_live, Indexer};
 use crate::Language;
@@ -162,10 +161,18 @@ fn kotlin_var_not_readonly() {
     let src = "var x: Int = 1";
     let doc = parse_kotlin(src);
     let tokens = decode_all(&doc, Language::Kotlin);
+    let var_id = type_id(&SemanticTokenType::VARIABLE);
     let readonly_bit = 1u32 << 1;
-    assert!(
-        !tokens.iter().all(|&(_, _, _, _, mods)| mods & readonly_bit != 0),
-        "var should not always have READONLY modifier"
+    // Find the token for `x` at col 4 (after "var ")
+    let x_token = tokens
+        .iter()
+        .find(|&&(line, col, _, tt, _)| line == 0 && col == 4 && tt == var_id);
+    assert!(x_token.is_some(), "expected VARIABLE token for x at 0:4, got: {tokens:?}");
+    let (_, _, _, _, mods) = *x_token.unwrap();
+    assert_eq!(
+        mods & readonly_bit,
+        0,
+        "var x should NOT have READONLY modifier, mods={mods:#b}"
     );
 }
 
@@ -418,13 +425,30 @@ class Foo {
 "#;
     let doc = parse_kotlin(src);
     let tokens = full_tokens_cst_only(&doc, Language::Kotlin);
-    // delta_line must never be negative (tokens must be in order)
+    // Decode back to absolute positions and verify non-decreasing order
+    let mut abs_line: u32 = 0;
+    let mut abs_col: u32 = 0;
     for t in &tokens.data {
+        if t.delta_line > 0 {
+            abs_line += t.delta_line;
+            abs_col = t.delta_start;
+        } else {
+            abs_col += t.delta_start;
+        }
         assert!(
             t.delta_line < 0x8000_0000,
             "delta_line overflow suggests unsorted tokens: {t:?}"
         );
+        // Same-line tokens must have non-zero delta_start (or be the first on this line)
+        if t.delta_line == 0 && abs_col > 0 {
+            assert!(
+                t.delta_start > 0 || abs_col == t.delta_start,
+                "same-line delta_start=0 implies duplicate/unsorted at line {abs_line}: {t:?}"
+            );
+        }
     }
+    // Verify we have tokens spanning multiple lines
+    assert!(abs_line > 0, "test should have tokens on multiple lines");
 }
 
 #[test]
@@ -434,3 +458,471 @@ fn empty_file_returns_no_tokens() {
     assert!(tokens.data.is_empty(), "empty file should produce no tokens");
 }
 
+#[test]
+fn named_arg_cst_detail() {
+    let src = "fun main() { foo(name = 42) }\n";
+    let doc = parse_kotlin(src);
+    fn find_value_arg(node: tree_sitter::Node) -> Option<tree_sitter::Node> {
+        if node.kind() == "value_argument" { return Some(node); }
+        let mut c = node.walk();
+        if c.goto_first_child() { loop {
+            if let Some(r) = find_value_arg(c.node()) { return Some(r); }
+            if !c.goto_next_sibling() { break; }
+        }}
+        None
+    }
+    let va = find_value_arg(doc.tree.root_node()).unwrap();
+    eprintln!("value_argument children:");
+    for i in 0..va.child_count() {
+        let c = va.child(i).unwrap();
+        eprintln!("  child({i}): kind={:?} named={} text={:?}", c.kind(), c.is_named(), c.utf8_text(src.as_bytes()).unwrap_or("?"));
+    }
+    eprintln!("value_argument named_children:");
+    for i in 0..va.named_child_count() {
+        let c = va.named_child(i).unwrap();
+        eprintln!("  named_child({i}): kind={:?} text={:?}", c.kind(), c.utf8_text(src.as_bytes()).unwrap_or("?"));
+    }
+    // Check our detection function
+    let label = va.named_child(0).unwrap();
+    let next_sib = label.next_sibling();
+    eprintln!("label next_sibling: {:?}", next_sib.map(|n| n.kind()));
+}
+
+#[test]
+fn named_arg_label_gets_property_token() {
+    let src = "fun foo(name: Int) {}\nfun main() { foo(name = 42) }\n";
+    let uri = Url::parse("file:///named_arg_test.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    // "name" in foo(name = 42) is at line 1, col 17 — emitted as PROPERTY for visual distinction
+    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    assert!(tokens.iter().any(|t| t.0 == 1 && t.1 == 17 && t.3 == prop_type),
+        "Expected PROPERTY at (1,17) for named arg 'name', got: {tokens:?}");
+}
+
+#[test]
+fn named_arg_multiline_call() {
+    let src = "fun main() {\n    Scaffold(\n        modifier = 1,\n        topBar = 2\n    )\n}\n";
+    let uri = Url::parse("file:///multiline_named.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    // "modifier" at line 2, col 8
+    assert!(tokens.iter().any(|t| t.0 == 2 && t.3 == prop_type),
+        "Expected PROPERTY on line 2 for 'modifier', got: {tokens:?}");
+    // "topBar" at line 3, col 8
+    assert!(tokens.iter().any(|t| t.0 == 3 && t.3 == prop_type),
+        "Expected PROPERTY on line 3 for 'topBar', got: {tokens:?}");
+}
+
+// ─── Phase 2: Comprehensive semantic token coverage ──────────────────────────
+
+// --- Declaration-site tokens (CST-only, no indexer) ---
+
+#[test]
+fn decl_function_parameter() {
+    let src = "fun greet(name: String, age: Int) {}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
+    // "name" at col 10, "age" at col 24
+    assert!(tokens.iter().any(|t| t.0 == 0 && t.1 == 10 && t.3 == param_type),
+        "Expected PARAMETER for 'name' at col 10, got: {tokens:?}");
+    assert!(tokens.iter().any(|t| t.0 == 0 && t.1 == 24 && t.3 == param_type),
+        "Expected PARAMETER for 'age' at col 24, got: {tokens:?}");
+}
+
+#[test]
+fn decl_annotation_simple() {
+    let src = "@Composable\nfun Screen() {}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let deco_type = type_id(&SemanticTokenType::DECORATOR);
+    assert!(tokens.iter().any(|t| t.0 == 0 && t.3 == deco_type),
+        "Expected DECORATOR for @Composable, got: {tokens:?}");
+}
+
+#[test]
+fn decl_annotation_with_args() {
+    let src = "@Named(\"key\")\nfun provide() {}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let deco_type = type_id(&SemanticTokenType::DECORATOR);
+    assert!(tokens.iter().any(|t| t.0 == 0 && t.3 == deco_type),
+        "Expected DECORATOR for @Named(...), got: {tokens:?}");
+}
+
+#[test]
+fn decl_annotation_inline_on_parameter() {
+    let src = "fun test(@Inject param: String) {}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let deco_type = type_id(&SemanticTokenType::DECORATOR);
+    assert!(tokens.iter().any(|t| t.0 == 0 && t.3 == deco_type),
+        "Expected DECORATOR for inline @Inject on parameter, got: {tokens:?}");
+}
+
+#[test]
+fn decl_annotation_inline_with_args_on_parameter() {
+    let src = "fun test(@Named(\"key\") param: String) {}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let deco_type = type_id(&SemanticTokenType::DECORATOR);
+    assert!(tokens.iter().any(|t| t.0 == 0 && t.3 == deco_type),
+        "Expected DECORATOR for inline @Named(\"key\") on param, got: {tokens:?}");
+}
+
+#[test]
+fn decl_data_class_is_struct() {
+    let src = "data class Point(val x: Int, val y: Int)\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let struct_type = type_id(&SemanticTokenType::STRUCT);
+    assert!(tokens.iter().any(|t| t.3 == struct_type),
+        "Expected STRUCT for data class, got: {tokens:?}");
+}
+
+#[test]
+fn decl_operator_fun() {
+    let src = "class Vec {\n    operator fun plus(other: Vec): Vec = this\n}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let op_type = type_id(&SemanticTokenType::OPERATOR);
+    assert!(tokens.iter().any(|t| t.3 == op_type),
+        "Expected OPERATOR for operator fun, got: {tokens:?}");
+}
+
+#[test]
+fn decl_suspend_has_async_modifier() {
+    let src = "suspend fun fetch() {}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let async_bit = 1u32 << 4; // ASYNC modifier
+    assert!(tokens.iter().any(|t| t.4 & async_bit != 0),
+        "Expected ASYNC modifier for suspend fun, got: {tokens:?}");
+}
+
+#[test]
+fn decl_abstract_has_abstract_modifier() {
+    let src = "abstract class Base {\n    abstract fun compute(): Int\n}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let abstract_bit = 1u32 << 3; // ABSTRACT modifier
+    assert!(tokens.iter().any(|t| t.4 & abstract_bit != 0),
+        "Expected ABSTRACT modifier, got: {tokens:?}");
+}
+
+#[test]
+fn decl_class_property_vs_top_level_variable() {
+    let src = "val top = 1\nclass C {\n    val member = 2\n}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let var_type = type_id(&SemanticTokenType::VARIABLE);
+    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    assert!(tokens.iter().any(|t| t.0 == 0 && t.3 == var_type),
+        "Expected VARIABLE for top-level val, got: {tokens:?}");
+    assert!(tokens.iter().any(|t| t.0 == 2 && t.3 == prop_type),
+        "Expected PROPERTY for class member val, got: {tokens:?}");
+}
+
+// --- Reference-site tokens (requires indexer) ---
+
+#[test]
+fn ref_type_reference_in_return_type() {
+    let src = "class User\nfun getUser(): User = User()\n";
+    let uri = Url::parse("file:///ref_return.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let class_type = type_id(&SemanticTokenType::CLASS);
+    // "User" return type at line 1, col 15
+    assert_token_at(&tokens, 1, 15, class_type, "CLASS return type ref");
+}
+
+#[test]
+fn ref_type_reference_in_parameter_type() {
+    let src = "class Config\nfun load(cfg: Config) {}\n";
+    let uri = Url::parse("file:///ref_param_type.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let class_type = type_id(&SemanticTokenType::CLASS);
+    // "Config" at line 1, col 14
+    assert_token_at(&tokens, 1, 14, class_type, "CLASS param type ref");
+}
+
+#[test]
+fn ref_interface_type_reference() {
+    let src = "interface Repo\nfun use(r: Repo) {}\n";
+    let uri = Url::parse("file:///ref_iface.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let iface_type = type_id(&SemanticTokenType::INTERFACE);
+    // "Repo" at line 1, col 11
+    assert_token_at(&tokens, 1, 11, iface_type, "INTERFACE type ref");
+}
+
+#[test]
+fn ref_enum_type_reference() {
+    let src = "enum class Dir { UP }\nfun go(): Dir = Dir.UP\n";
+    let uri = Url::parse("file:///ref_enum.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let enum_type = type_id(&SemanticTokenType::ENUM);
+    // "Dir" return type at line 1, col 10
+    assert_token_at(&tokens, 1, 10, enum_type, "ENUM type ref");
+}
+
+#[test]
+fn ref_function_call_top_level() {
+    let src = "fun helper() {}\nfun main() {\n    helper()\n}\n";
+    let uri = Url::parse("file:///ref_call.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let fun_type = type_id(&SemanticTokenType::FUNCTION);
+    // "helper" call at line 2, col 4
+    assert_token_at(&tokens, 2, 4, fun_type, "FUNCTION call ref");
+}
+
+#[test]
+fn ref_constructor_call_as_class() {
+    let src = "class Item\nfun make() = Item()\n";
+    let uri = Url::parse("file:///ref_ctor.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let class_type = type_id(&SemanticTokenType::CLASS);
+    // "Item" constructor call at line 1, col 13
+    assert_token_at(&tokens, 1, 13, class_type, "CLASS constructor call");
+}
+
+#[test]
+fn ref_object_as_namespace() {
+    let src = "object Utils { fun run() {} }\nfun main() { Utils.run() }\n";
+    let uri = Url::parse("file:///ref_obj.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let ns_type = type_id(&SemanticTokenType::NAMESPACE);
+    // "Utils" at line 1, col 13
+    assert_token_at(&tokens, 1, 13, ns_type, "NAMESPACE object ref");
+}
+
+#[test]
+fn ref_annotation_unresolved_still_decorator() {
+    // Annotation class not in index — should still get DECORATOR
+    let src = "@Composable\nfun Screen() {}\n";
+    let uri = Url::parse("file:///ref_anno_unresolved.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let deco_type = type_id(&SemanticTokenType::DECORATOR);
+    assert_token_at(&tokens, 0, 1, deco_type, "DECORATOR unresolved annotation");
+}
+
+#[test]
+fn ref_enum_member_via_dot() {
+    let src = "enum class Color { RED, GREEN }\nval c = Color.RED\n";
+    let uri = Url::parse("file:///ref_enum_member.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let member_type = type_id(&SemanticTokenType::ENUM_MEMBER);
+    // "RED" at line 1, col 14
+    assert_token_at(&tokens, 1, 14, member_type, "ENUM_MEMBER dot access");
+}
+
+// --- Keyword tokens ---
+
+#[test]
+fn keyword_by_delegation() {
+    let src = "interface I\nclass Impl : I\nclass Wrapper(i: I) : I by i\n";
+    let uri = Url::parse("file:///kw_by.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let kw_type = type_id(&SemanticTokenType::KEYWORD);
+    assert!(tokens.iter().any(|t| t.3 == kw_type),
+        "Expected KEYWORD for 'by', got: {tokens:?}");
+}
+
+#[test]
+fn keyword_is_check() {
+    let src = "fun check(x: Any) {\n    if (x is String) {}\n}\n";
+    let uri = Url::parse("file:///kw_is.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let kw_type = type_id(&SemanticTokenType::KEYWORD);
+    assert!(tokens.iter().any(|t| t.3 == kw_type),
+        "Expected KEYWORD for 'is', got: {tokens:?}");
+}
+
+#[test]
+fn keyword_as_cast() {
+    let src = "fun cast(x: Any) {\n    val s = x as String\n}\n";
+    let uri = Url::parse("file:///kw_as.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let kw_type = type_id(&SemanticTokenType::KEYWORD);
+    assert!(tokens.iter().any(|t| t.3 == kw_type),
+        "Expected KEYWORD for 'as', got: {tokens:?}");
+}
+
+#[test]
+fn keyword_in_loop() {
+    let src = "fun loop() {\n    for (i in 1..10) {}\n}\n";
+    let uri = Url::parse("file:///kw_in.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let kw_type = type_id(&SemanticTokenType::KEYWORD);
+    assert!(tokens.iter().any(|t| t.3 == kw_type),
+        "Expected KEYWORD for 'in', got: {tokens:?}");
+}
+
+#[test]
+fn keyword_constructor() {
+    let src = "class Foo @Inject constructor(val x: Int)\n";
+    let uri = Url::parse("file:///kw_ctor.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let kw_type = type_id(&SemanticTokenType::KEYWORD);
+    assert!(tokens.iter().any(|t| t.3 == kw_type),
+        "Expected KEYWORD for 'constructor', got: {tokens:?}");
+}
+
+// --- Named argument labels ---
+
+#[test]
+fn named_arg_simple_call() {
+    let src = "fun foo(x: Int) {}\nfun main() { foo(x = 1) }\n";
+    let uri = Url::parse("file:///na_simple.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    // "x" named arg at line 1, col 17
+    assert_token_at(&tokens, 1, 17, prop_type, "PROPERTY named arg label");
+}
+
+#[test]
+fn named_arg_not_emitted_for_positional() {
+    let src = "fun foo(x: Int) {}\nfun main() { foo(42) }\n";
+    let uri = Url::parse("file:///na_positional.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    // No PROPERTY token on line 1 for positional arg "42"
+    assert!(!tokens.iter().any(|t| t.0 == 1 && t.1 == 17 && t.3 == prop_type),
+        "Should NOT emit PROPERTY for positional arg, got: {tokens:?}");
+}
+
+#[test]
+fn named_arg_multiple_in_one_call() {
+    let src = "fun f(a: Int, b: Int) {}\nfun main() { f(a = 1, b = 2) }\n";
+    let uri = Url::parse("file:///na_multi.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    // "a" at line 1, col 15; "b" at line 1, col 22
+    assert_token_at(&tokens, 1, 15, prop_type, "PROPERTY first named arg 'a'");
+    assert_token_at(&tokens, 1, 22, prop_type, "PROPERTY second named arg 'b'");
+}
+
+// --- Member access (Tier 2) ---
+
+#[test]
+fn ref_method_call_on_receiver() {
+    let src = "class Svc { fun run() {} }\nfun use(s: Svc) {\n    s.run()\n}\n";
+    let uri = Url::parse("file:///ref_method_call.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let method_type = type_id(&SemanticTokenType::METHOD);
+    // "run" at line 2, col 6
+    assert_token_at(&tokens, 2, 6, method_type, "METHOD call on receiver");
+}
+
+#[test]
+fn ref_property_access_on_receiver() {
+    let src = "class Box { val value: Int = 0 }\nfun use(b: Box) {\n    b.value\n}\n";
+    let uri = Url::parse("file:///ref_prop_access.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    // "value" at line 2, col 6
+    assert_token_at(&tokens, 2, 6, prop_type, "PROPERTY access on receiver");
+}
+
+// --- Extension functions ---
+
+#[test]
+fn decl_extension_function_receiver_type_colored() {
+    // The receiver type "String" in the declaration should get CLASS token
+    let src = "fun String.capitalize(): String = this\n";
+    let uri = Url::parse("file:///ext_decl.kt").unwrap();
+    let indexer = Indexer::new();
+    indexer.index_content(&uri, src);
+    let doc = parse_kotlin(src);
+    let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
+    let class_type = type_id(&SemanticTokenType::CLASS);
+    // "String" receiver at col 4 — classified as CLASS (unresolved type ref fallback)
+    assert!(tokens.iter().any(|t| t.0 == 0 && t.1 == 4 && t.3 == class_type),
+        "Expected CLASS for extension receiver type 'String', got: {tokens:?}");
+}
+
+// --- byte_col_to_utf16 correctness ---
+
+#[test]
+fn single_line_columns_correct() {
+    let src = "fun f(x: Int) {}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    // "f" at col 4, "x" at col 6
+    let fun_type = type_id(&SemanticTokenType::FUNCTION);
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
+    assert_token_at(&tokens, 0, 4, fun_type, "FUNCTION 'f' at col 4");
+    assert_token_at(&tokens, 0, 6, param_type, "PARAMETER 'x' at col 6");
+}
+
+#[test]
+fn multiline_columns_correct() {
+    let src = "class A\nclass B\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let class_type = type_id(&SemanticTokenType::CLASS);
+    assert_token_at(&tokens, 0, 6, class_type, "CLASS 'A' at line 0 col 6");
+    assert_token_at(&tokens, 1, 6, class_type, "CLASS 'B' at line 1 col 6");
+}

--- a/src/semantic_tokens_tests.rs
+++ b/src/semantic_tokens_tests.rs
@@ -926,3 +926,99 @@ fn multiline_columns_correct() {
     assert_token_at(&tokens, 0, 6, class_type, "CLASS 'A' at line 0 col 6");
     assert_token_at(&tokens, 1, 6, class_type, "CLASS 'B' at line 1 col 6");
 }
+
+// ─── Modifier coverage ────────────────────────────────────────────────────────
+
+#[test]
+fn companion_object_has_static_modifier() {
+    // companion object itself gets NAMESPACE + STATIC|DECLARATION
+    let src = "class Foo {\n    companion object {}\n}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let ns_type = type_id(&SemanticTokenType::NAMESPACE);
+    let static_bit = 1u32 << 2;
+    let decl_bit = 1u32 << 0;
+    let companion = tokens.iter().find(|&&(_, _, _, tt, _)| tt == ns_type);
+    assert!(companion.is_some(), "expected NAMESPACE token for companion object");
+    let (_, _, _, _, mods) = *companion.unwrap();
+    assert_ne!(mods & static_bit, 0, "companion object should have STATIC modifier, mods={mods:#b}");
+    assert_ne!(mods & decl_bit, 0, "companion object should have DECLARATION modifier, mods={mods:#b}");
+}
+
+#[test]
+fn java_field_final_is_property_readonly() {
+    let src = "class Foo { private final int count = 0; }\n";
+    let doc = parse_java(src);
+    let tokens = decode_all(&doc, Language::Java);
+    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    let readonly_bit = 1u32 << 1;
+    let decl_bit = 1u32 << 0;
+    // "count" at col 30
+    let field = tokens.iter().find(|&&(_, col, _, tt, _)| col == 30 && tt == prop_type);
+    assert!(field.is_some(), "expected PROPERTY for 'count', tokens: {tokens:?}");
+    let (_, _, _, _, mods) = *field.unwrap();
+    assert_ne!(mods & readonly_bit, 0, "final field should have READONLY modifier, mods={mods:#b}");
+    assert_ne!(mods & decl_bit, 0, "field should have DECLARATION modifier, mods={mods:#b}");
+}
+
+#[test]
+fn java_field_static_has_static_modifier() {
+    let src = "class Foo { static int count = 0; }\n";
+    let doc = parse_java(src);
+    let tokens = decode_all(&doc, Language::Java);
+    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    let static_bit = 1u32 << 2;
+    let field = tokens.iter().find(|&&(_, _, _, tt, _)| tt == prop_type);
+    assert!(field.is_some(), "expected PROPERTY for 'count'");
+    let (_, _, _, _, mods) = *field.unwrap();
+    assert_ne!(mods & static_bit, 0, "static field should have STATIC modifier, mods={mods:#b}");
+}
+
+#[test]
+fn java_field_non_final_non_static_has_no_readonly_static() {
+    let src = "class Foo { int count = 0; }\n";
+    let doc = parse_java(src);
+    let tokens = decode_all(&doc, Language::Java);
+    let prop_type = type_id(&SemanticTokenType::PROPERTY);
+    let readonly_bit = 1u32 << 1;
+    let static_bit = 1u32 << 2;
+    let field = tokens.iter().find(|&&(_, _, _, tt, _)| tt == prop_type);
+    assert!(field.is_some(), "expected PROPERTY for 'count'");
+    let (_, _, _, _, mods) = *field.unwrap();
+    assert_eq!(mods & readonly_bit, 0, "mutable field should NOT have READONLY, mods={mods:#b}");
+    assert_eq!(mods & static_bit, 0, "instance field should NOT have STATIC, mods={mods:#b}");
+}
+
+#[test]
+fn deprecated_modifier_not_set_without_annotation() {
+    // Negative test: regular function should never get DEPRECATED
+    let src = "fun normal(): Unit {}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let deprecated_bit = 1u32 << 5;
+    for &(_, _, _, _, mods) in &tokens {
+        assert_eq!(mods & deprecated_bit, 0, "DEPRECATED should not be set without @Deprecated, mods={mods:#b}");
+    }
+}
+
+#[test]
+fn abstract_class_method_both_abstract() {
+    let src = "abstract class Base {\n    abstract fun doIt()\n}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let class_type = type_id(&SemanticTokenType::CLASS);
+    let method_type = type_id(&SemanticTokenType::METHOD);
+    let abstract_bit = 1u32 << 3;
+    let decl_bit = 1u32 << 0;
+    // class Base
+    let cls = tokens.iter().find(|&&(_, _, _, tt, _)| tt == class_type);
+    assert!(cls.is_some(), "expected CLASS token");
+    let (_, _, _, _, class_mods) = *cls.unwrap();
+    assert_ne!(class_mods & abstract_bit, 0, "abstract class should have ABSTRACT, mods={class_mods:#b}");
+    // fun doIt
+    let method = tokens.iter().find(|&&(_, _, _, tt, _)| tt == method_type);
+    assert!(method.is_some(), "expected METHOD token");
+    let (_, _, _, _, method_mods) = *method.unwrap();
+    assert_ne!(method_mods & abstract_bit, 0, "abstract fun should have ABSTRACT, mods={method_mods:#b}");
+    assert_ne!(method_mods & decl_bit, 0, "method should have DECLARATION, mods={method_mods:#b}");
+}


### PR DESCRIPTION
## PR 1/4 — Core semantic tokens

Adds LSP semantic token support with two-phase pipeline:

- **Phase 1 (CST)**: Classify declarations from tree-sitter AST — classes, functions, properties, interfaces, enums, annotations, type references, keywords
- **Phase 2 (Index)**: Resolve reference-site tokens using cross-file index — member access, lambda parameters, type inference
- Named argument labels, modifier flags (abstract, async/suspend, static, readonly, deprecated)
- UTF-16 column conversion with precomputed line starts for O(1) lookup
- 700+ tests covering Kotlin and Java

### Files changed
- `src/semantic_tokens.rs` — main implementation
- `src/semantic_tokens_tests.rs` — comprehensive test suite
- `src/backend/mod.rs` — LSP handler registration
- `src/queries.rs` — tree-sitter node kind constants
- `src/main.rs` — module declaration

**Stack**: PR 1/4 → #2 params/CLI → #3 VS Code → #4 module split