### PR TITLE
feat: parameter use-sites, CLI debug commands, annotation spans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -633,7 +633,7 @@ dependencies = [
 
 [[package]]
 name = "kotlin-lsp"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "bincode",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["."]
 
 [package]
 name        = "kotlin-lsp"
-version = "0.10.0"
+version = "0.10.1"
 edition     = "2021"
 description = "Fast, low-memory LSP server for Kotlin, Java, and Swift. Instant startup, dot-completion, go-to-definition, hover — no JVM required."
 license     = "MIT"

--- a/catch_shadow.kt
+++ b/catch_shadow.kt
@@ -1,0 +1,1 @@
+fun f(x: Int) { try { println(x) } catch (x: Exception) { println(x) }; println(x) }

--- a/class_param.kt
+++ b/class_param.kt
@@ -1,0 +1,1 @@
+class Foo(x: Int) { init { println(x) }; val y = x }

--- a/destructure_shadow.kt
+++ b/destructure_shadow.kt
@@ -1,0 +1,1 @@
+fun f(x: Int) { val (x, y) = pair; println(x); println(y) }

--- a/for_shadow.kt
+++ b/for_shadow.kt
@@ -1,0 +1,1 @@
+fun f(x: Int) { for (x in xs) println(x); println(x) }

--- a/lambda_shadow.kt
+++ b/lambda_shadow.kt
@@ -1,0 +1,1 @@
+fun f(x: Int) { list.forEach { x -> println(x) }; println(x) }

--- a/shadow_sample.kt
+++ b/shadow_sample.kt
@@ -1,0 +1,1 @@
+fun f(x: Int) { val x = x + 1; println(x) }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -561,14 +561,14 @@ fn server_capabilities() -> ServerCapabilities {
             retrigger_characters: None,
             work_done_progress_options: Default::default(),
         }),
-        semantic_tokens_provider: Some(
-            SemanticTokensServerCapabilities::SemanticTokensOptions(SemanticTokensOptions {
+        semantic_tokens_provider: Some(SemanticTokensServerCapabilities::SemanticTokensOptions(
+            SemanticTokensOptions {
                 legend: semantic_tokens::legend(),
                 full: Some(SemanticTokensFullOptions::Bool(true)),
                 range: Some(true),
                 work_done_progress_options: Default::default(),
-            }),
-        ),
+            },
+        )),
         ..Default::default()
     }
 }
@@ -1048,7 +1048,7 @@ impl LanguageServer for Backend {
     ) -> Result<Option<SemanticTokensResult>> {
         let uri = params.text_document.uri.to_string();
         let language = crate::Language::from_path(&uri);
-        let Some(doc) = self.indexer.live_trees.get(&uri).map(|r| Arc::clone(&r)) else {
+        let Some(doc) = self.indexer.live_doc(&params.text_document.uri) else {
             return Ok(None);
         };
         let parsed_uri = params.text_document.uri;
@@ -1065,12 +1065,18 @@ impl LanguageServer for Backend {
     ) -> Result<Option<SemanticTokensRangeResult>> {
         let uri = params.text_document.uri.to_string();
         let language = crate::Language::from_path(&uri);
-        let Some(doc) = self.indexer.live_trees.get(&uri).map(|r| Arc::clone(&r)) else {
+        let Some(doc) = self.indexer.live_doc(&params.text_document.uri) else {
             return Ok(None);
         };
         let parsed_uri = params.text_document.uri;
         Ok(Some(SemanticTokensRangeResult::Tokens(
-            semantic_tokens::range_tokens(&self.indexer, &parsed_uri, &doc, language, &params.range),
+            semantic_tokens::range_tokens(
+                &self.indexer,
+                &parsed_uri,
+                &doc,
+                language,
+                &params.range,
+            ),
         )))
     }
 }

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -21,6 +21,8 @@ pub(crate) enum Subcommand {
         file: PathBuf,
         /// Use CST classification only; skip cross-file index resolution.
         cst_only: bool,
+        /// Show per-phase token breakdown before dedup.
+        phases: bool,
         /// Also print the tree-sitter parse tree after tokens.
         show_tree: bool,
     },
@@ -68,6 +70,7 @@ impl CliArgs {
             &subcommand,
             parsed.positionals,
             parsed.cst_only,
+            parsed.phases,
             parsed.show_tree,
         )?;
         Ok(Some(Self {
@@ -85,6 +88,7 @@ struct ParsedCliFlags {
     root: Option<PathBuf>,
     positionals: Vec<String>,
     cst_only: bool,
+    phases: bool,
     show_tree: bool,
 }
 
@@ -123,6 +127,7 @@ fn parse_cli_flags(args: &mut lexopt::Parser) -> Result<ParsedCliFlags, String> 
         root: None,
         positionals: Vec::new(),
         cst_only: false,
+        phases: false,
         show_tree: false,
     };
 
@@ -133,6 +138,7 @@ fn parse_cli_flags(args: &mut lexopt::Parser) -> Result<ParsedCliFlags, String> 
             Some(lexopt::Arg::Long("smart")) => parsed.mode = Mode::Smart,
             Some(lexopt::Arg::Long("json")) => parsed.fmt = OutputFmt::Json,
             Some(lexopt::Arg::Long("cst-only")) => parsed.cst_only = true,
+            Some(lexopt::Arg::Long("phases")) => parsed.phases = true,
             Some(lexopt::Arg::Long("tree")) => parsed.show_tree = true,
             Some(lexopt::Arg::Long("root")) => {
                 let value = args.value().map_err(|e| e.to_string())?;
@@ -159,6 +165,7 @@ fn build_subcommand(
     subcommand: &str,
     positionals: Vec<String>,
     cst_only: bool,
+    phases: bool,
     show_tree: bool,
 ) -> Result<Subcommand, String> {
     match subcommand {
@@ -176,6 +183,7 @@ fn build_subcommand(
                 "tokens requires a FILE argument",
             )?),
             cst_only,
+            phases,
             show_tree,
         }),
         "tree" => Ok(Subcommand::Tree {
@@ -262,6 +270,7 @@ OPTIONS:
     --json          Output results as JSON array
     --root <dir>    Workspace root (default: nearest .git dir or cwd)
     --cst-only      (tokens) Skip index; CST classification only
+    --phases        (tokens) Show per-phase token breakdown with dedup markers
     --tree          (tokens) Also print the parse tree after tokens
     -h, --help      Print this help
     -V, --version   Print version

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -4,9 +4,17 @@ use std::path::PathBuf;
 
 #[derive(Debug)]
 pub(crate) enum Subcommand {
-    Find { name: String },
-    Refs { name: String },
-    Hover { file: PathBuf, line: u32, col: u32 },
+    Find {
+        name: String,
+    },
+    Refs {
+        name: String,
+    },
+    Hover {
+        file: PathBuf,
+        line: u32,
+        col: u32,
+    },
     Index,
     /// Dump semantic tokens for a file (debug).
     Tokens {
@@ -17,7 +25,9 @@ pub(crate) enum Subcommand {
         show_tree: bool,
     },
     /// Dump the tree-sitter parse tree for a file (debug).
-    Tree { file: PathBuf },
+    Tree {
+        file: PathBuf,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -47,13 +57,87 @@ pub(crate) struct CliArgs {
 impl CliArgs {
     pub(crate) fn parse() -> Result<Option<Self>, String> {
         let mut args = lexopt::Parser::from_env();
+        let Some(first) = parse_first_argument(&mut args)? else {
+            return Ok(None);
+        };
+        let Some(subcommand) = parse_subcommand_name(first)? else {
+            return Ok(None);
+        };
+        let parsed = parse_cli_flags(&mut args)?;
+        let subcommand = build_subcommand(
+            &subcommand,
+            parsed.positionals,
+            parsed.cst_only,
+            parsed.show_tree,
+        )?;
+        Ok(Some(Self {
+            subcommand,
+            mode: parsed.mode,
+            fmt: parsed.fmt,
+            root: parsed.root,
+        }))
+    }
+}
 
-        // Peek at first positional to decide if this is a CLI subcommand
-        // or an LSP invocation.  LSP mode has no positional args (just flags
-        // like --port or --index-only).
-        let first = match args.next().map_err(|e| e.to_string())? {
-            None => return Ok(None), // no args → LSP stdio mode
-            Some(lexopt::Arg::Value(v)) => v,
+struct ParsedCliFlags {
+    mode: Mode,
+    fmt: OutputFmt,
+    root: Option<PathBuf>,
+    positionals: Vec<String>,
+    cst_only: bool,
+    show_tree: bool,
+}
+
+fn parse_first_argument(args: &mut lexopt::Parser) -> Result<Option<std::ffi::OsString>, String> {
+    match args.next().map_err(|e| e.to_string())? {
+        None => Ok(None),
+        Some(lexopt::Arg::Value(value)) => Ok(Some(value)),
+        Some(lexopt::Arg::Short('h') | lexopt::Arg::Long("help")) => {
+            print_help();
+            std::process::exit(0);
+        }
+        Some(lexopt::Arg::Short('V') | lexopt::Arg::Long("version")) => {
+            print_version();
+            std::process::exit(0);
+        }
+        Some(lexopt::Arg::Long(flag)) if is_subcommand(flag) => Err(format!(
+            "'{flag}' is a subcommand, not a flag — use `kotlin-lsp {flag}` (without --)"
+        )),
+        Some(lexopt::Arg::Short(_) | lexopt::Arg::Long(_)) => Ok(None),
+    }
+}
+
+fn parse_subcommand_name(first: std::ffi::OsString) -> Result<Option<String>, String> {
+    let subcommand = first.to_string_lossy().into_owned();
+    if is_subcommand(&subcommand) {
+        Ok(Some(subcommand))
+    } else {
+        Ok(None)
+    }
+}
+
+fn parse_cli_flags(args: &mut lexopt::Parser) -> Result<ParsedCliFlags, String> {
+    let mut parsed = ParsedCliFlags {
+        mode: Mode::Auto,
+        fmt: OutputFmt::Text,
+        root: None,
+        positionals: Vec::new(),
+        cst_only: false,
+        show_tree: false,
+    };
+
+    loop {
+        match args.next().map_err(|e| e.to_string())? {
+            None => return Ok(parsed),
+            Some(lexopt::Arg::Long("fast")) => parsed.mode = Mode::Fast,
+            Some(lexopt::Arg::Long("smart")) => parsed.mode = Mode::Smart,
+            Some(lexopt::Arg::Long("json")) => parsed.fmt = OutputFmt::Json,
+            Some(lexopt::Arg::Long("cst-only")) => parsed.cst_only = true,
+            Some(lexopt::Arg::Long("tree")) => parsed.show_tree = true,
+            Some(lexopt::Arg::Long("root")) => {
+                let value = args.value().map_err(|e| e.to_string())?;
+                parsed.root = Some(PathBuf::from(value.to_string_lossy().as_ref()));
+            }
             Some(lexopt::Arg::Short('h') | lexopt::Arg::Long("help")) => {
                 print_help();
                 std::process::exit(0);
@@ -62,122 +146,94 @@ impl CliArgs {
                 print_version();
                 std::process::exit(0);
             }
-            Some(lexopt::Arg::Long(flag))
-                if matches!(flag, "find" | "refs" | "hover" | "index" | "tokens" | "tree") =>
-            {
-                return Err(format!(
-                    "'{flag}' is a subcommand, not a flag — use `kotlin-lsp {flag}` (without --)"
-                ));
-            }
-            Some(lexopt::Arg::Short(_) | lexopt::Arg::Long(_)) => {
-                // Other flag before subcommand → LSP mode
-                return Ok(None);
-            }        };
-
-        let subcmd_str = first.to_string_lossy();
-        let subcommand = match subcmd_str.as_ref() {
-            "find" | "refs" | "hover" | "index" | "tokens" | "tree" => subcmd_str.into_owned(),
-            _ => return Ok(None), // unknown first positional → LSP mode
-        };
-
-        let mut mode = Mode::Auto;
-        let mut fmt = OutputFmt::Text;
-        let mut root: Option<PathBuf> = None;
-        let mut positionals: Vec<String> = Vec::new();
-        let mut cst_only = false;
-        let mut show_tree = false;
-
-        loop {
-            match args.next().map_err(|e| e.to_string())? {
-                None => break,
-                Some(lexopt::Arg::Long("fast")) => mode = Mode::Fast,
-                Some(lexopt::Arg::Long("smart")) => mode = Mode::Smart,
-                Some(lexopt::Arg::Long("json")) => fmt = OutputFmt::Json,
-                Some(lexopt::Arg::Long("cst-only")) => cst_only = true,
-                Some(lexopt::Arg::Long("tree")) => show_tree = true,
-                Some(lexopt::Arg::Long("root")) => {
-                    let val = args.value().map_err(|e| e.to_string())?;
-                    root = Some(PathBuf::from(val.to_string_lossy().as_ref()));
-                }
-                Some(lexopt::Arg::Short('h') | lexopt::Arg::Long("help")) => {
-                    print_help();
-                    std::process::exit(0);
-                }
-                Some(lexopt::Arg::Short('V') | lexopt::Arg::Long("version")) => {
-                    print_version();
-                    std::process::exit(0);
-                }
-                Some(lexopt::Arg::Value(v)) => positionals.push(v.to_string_lossy().into_owned()),
-                Some(lexopt::Arg::Short(c)) => {
-                    return Err(format!("Unknown short flag: -{c}"));
-                }
-                Some(lexopt::Arg::Long(l)) => {
-                    return Err(format!("Unknown flag: --{l}"));
-                }
-            }
+            Some(lexopt::Arg::Value(value)) => parsed
+                .positionals
+                .push(value.to_string_lossy().into_owned()),
+            Some(lexopt::Arg::Short(flag)) => return Err(format!("Unknown short flag: -{flag}")),
+            Some(lexopt::Arg::Long(flag)) => return Err(format!("Unknown flag: --{flag}")),
         }
-
-        let sub = match subcommand.as_str() {
-            "find" => {
-                let name = positionals
-                    .into_iter()
-                    .next()
-                    .ok_or("find requires a NAME argument")?;
-                Subcommand::Find { name }
-            }
-            "refs" => {
-                let name = positionals
-                    .into_iter()
-                    .next()
-                    .ok_or("refs requires a NAME argument")?;
-                Subcommand::Refs { name }
-            }
-            "hover" => {
-                let mut it = positionals.into_iter();
-                let file = PathBuf::from(
-                    it.next().ok_or("hover requires FILE LINE COL arguments")?,
-                );
-                let line: u32 = it
-                    .next()
-                    .ok_or("hover requires LINE argument")?
-                    .parse()
-                    .map_err(|_| "LINE must be a positive integer")?;
-                let col: u32 = it
-                    .next()
-                    .ok_or("hover requires COL argument")?
-                    .parse()
-                    .map_err(|_| "COL must be a positive integer")?;
-                Subcommand::Hover { file, line, col }
-            }
-            "index" => Subcommand::Index,
-            "tokens" => {
-                let file = PathBuf::from(
-                    positionals
-                        .into_iter()
-                        .next()
-                        .ok_or("tokens requires a FILE argument")?,
-                );
-                Subcommand::Tokens { file, cst_only, show_tree }
-            }
-            "tree" => {
-                let file = PathBuf::from(
-                    positionals
-                        .into_iter()
-                        .next()
-                        .ok_or("tree requires a FILE argument")?,
-                );
-                Subcommand::Tree { file }
-            }
-            _ => unreachable!(),
-        };
-
-        Ok(Some(Self {
-            subcommand: sub,
-            mode,
-            fmt,
-            root,
-        }))
     }
+}
+
+fn build_subcommand(
+    subcommand: &str,
+    positionals: Vec<String>,
+    cst_only: bool,
+    show_tree: bool,
+) -> Result<Subcommand, String> {
+    match subcommand {
+        "find" => Ok(Subcommand::Find {
+            name: first_positional(positionals, "find requires a NAME argument")?,
+        }),
+        "refs" => Ok(Subcommand::Refs {
+            name: first_positional(positionals, "refs requires a NAME argument")?,
+        }),
+        "hover" => build_hover_subcommand(positionals),
+        "index" => Ok(Subcommand::Index),
+        "tokens" => Ok(Subcommand::Tokens {
+            file: PathBuf::from(first_positional(
+                positionals,
+                "tokens requires a FILE argument",
+            )?),
+            cst_only,
+            show_tree,
+        }),
+        "tree" => Ok(Subcommand::Tree {
+            file: PathBuf::from(first_positional(
+                positionals,
+                "tree requires a FILE argument",
+            )?),
+        }),
+        _ => unreachable!(),
+    }
+}
+
+fn build_hover_subcommand(positionals: Vec<String>) -> Result<Subcommand, String> {
+    let mut positionals = positionals.into_iter();
+    let file = PathBuf::from(
+        positionals
+            .next()
+            .ok_or("hover requires FILE LINE COL arguments")?,
+    );
+    let line = parse_position_arg(
+        positionals.next(),
+        "hover requires LINE argument",
+        "LINE must be a positive integer",
+    )?;
+    let col = parse_position_arg(
+        positionals.next(),
+        "hover requires COL argument",
+        "COL must be a positive integer",
+    )?;
+    Ok(Subcommand::Hover { file, line, col })
+}
+
+fn parse_position_arg(
+    value: Option<String>,
+    missing_message: &'static str,
+    invalid_message: &'static str,
+) -> Result<u32, String> {
+    value
+        .ok_or(missing_message)?
+        .parse()
+        .map_err(|_| invalid_message.to_string())
+}
+
+fn first_positional(
+    positionals: Vec<String>,
+    missing_message: &'static str,
+) -> Result<String, String> {
+    positionals
+        .into_iter()
+        .next()
+        .ok_or_else(|| missing_message.to_string())
+}
+
+fn is_subcommand(value: &str) -> bool {
+    matches!(
+        value,
+        "find" | "refs" | "hover" | "index" | "tokens" | "tree"
+    )
 }
 
 fn print_version() {

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -8,6 +8,16 @@ pub(crate) enum Subcommand {
     Refs { name: String },
     Hover { file: PathBuf, line: u32, col: u32 },
     Index,
+    /// Dump semantic tokens for a file (debug).
+    Tokens {
+        file: PathBuf,
+        /// Use CST classification only; skip cross-file index resolution.
+        cst_only: bool,
+        /// Also print the tree-sitter parse tree after tokens.
+        show_tree: bool,
+    },
+    /// Dump the tree-sitter parse tree for a file (debug).
+    Tree { file: PathBuf },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -53,7 +63,7 @@ impl CliArgs {
                 std::process::exit(0);
             }
             Some(lexopt::Arg::Long(flag))
-                if matches!(flag, "find" | "refs" | "hover" | "index") =>
+                if matches!(flag, "find" | "refs" | "hover" | "index" | "tokens" | "tree") =>
             {
                 return Err(format!(
                     "'{flag}' is a subcommand, not a flag — use `kotlin-lsp {flag}` (without --)"
@@ -66,7 +76,7 @@ impl CliArgs {
 
         let subcmd_str = first.to_string_lossy();
         let subcommand = match subcmd_str.as_ref() {
-            "find" | "refs" | "hover" | "index" => subcmd_str.into_owned(),
+            "find" | "refs" | "hover" | "index" | "tokens" | "tree" => subcmd_str.into_owned(),
             _ => return Ok(None), // unknown first positional → LSP mode
         };
 
@@ -74,6 +84,8 @@ impl CliArgs {
         let mut fmt = OutputFmt::Text;
         let mut root: Option<PathBuf> = None;
         let mut positionals: Vec<String> = Vec::new();
+        let mut cst_only = false;
+        let mut show_tree = false;
 
         loop {
             match args.next().map_err(|e| e.to_string())? {
@@ -81,6 +93,8 @@ impl CliArgs {
                 Some(lexopt::Arg::Long("fast")) => mode = Mode::Fast,
                 Some(lexopt::Arg::Long("smart")) => mode = Mode::Smart,
                 Some(lexopt::Arg::Long("json")) => fmt = OutputFmt::Json,
+                Some(lexopt::Arg::Long("cst-only")) => cst_only = true,
+                Some(lexopt::Arg::Long("tree")) => show_tree = true,
                 Some(lexopt::Arg::Long("root")) => {
                     let val = args.value().map_err(|e| e.to_string())?;
                     root = Some(PathBuf::from(val.to_string_lossy().as_ref()));
@@ -136,6 +150,24 @@ impl CliArgs {
                 Subcommand::Hover { file, line, col }
             }
             "index" => Subcommand::Index,
+            "tokens" => {
+                let file = PathBuf::from(
+                    positionals
+                        .into_iter()
+                        .next()
+                        .ok_or("tokens requires a FILE argument")?,
+                );
+                Subcommand::Tokens { file, cst_only, show_tree }
+            }
+            "tree" => {
+                let file = PathBuf::from(
+                    positionals
+                        .into_iter()
+                        .next()
+                        .ok_or("tree requires a FILE argument")?,
+                );
+                Subcommand::Tree { file }
+            }
             _ => unreachable!(),
         };
 
@@ -161,16 +193,20 @@ USAGE:
     kotlin-lsp                            # start LSP server (stdio)
 
 SUBCOMMANDS:
-    find  <name>              Find declarations of a symbol
-    refs  <name>              Find all references to a symbol
-    hover <file> <line> <col> Show type/doc info at a position
-    index                     Build and cache the workspace index
+    find   <name>              Find declarations of a symbol
+    refs   <name>              Find all references to a symbol
+    hover  <file> <line> <col> Show type/doc info at a position
+    index                      Build and cache the workspace index
+    tokens <file>              Dump semantic tokens (debug)
+    tree   <file>              Dump tree-sitter parse tree (debug)
 
 OPTIONS:
     --fast          Use rg/fd only; never load index (default when no cache)
     --smart         Require index; build it if missing
     --json          Output results as JSON array
     --root <dir>    Workspace root (default: nearest .git dir or cwd)
+    --cst-only      (tokens) Skip index; CST classification only
+    --tree          (tokens) Also print the parse tree after tokens
     -h, --help      Print this help
     -V, --version   Print version
 
@@ -178,7 +214,10 @@ EXAMPLES:
     kotlin-lsp find MyViewModel
     kotlin-lsp refs --fast MyViewModel --root ./android
     kotlin-lsp hover src/Foo.kt 42 10 --json
-    kotlin-lsp index --root ./android",
+    kotlin-lsp index --root ./android
+    kotlin-lsp tokens --cst-only src/Foo.kt
+    kotlin-lsp tokens src/Foo.kt --tree
+    kotlin-lsp tree src/Foo.kt",
         env!("CARGO_PKG_VERSION")
     );
 }

--- a/src/cli/hover.rs
+++ b/src/cli/hover.rs
@@ -10,15 +10,8 @@ use crate::indexer::Indexer;
 
 /// Return a hover string for `file:line:col` using the pre-built index.
 /// Line and col are 1-based (human-friendly) and converted internally to 0-based.
-pub(crate) fn hover_at(
-    indexer: &Arc<Indexer>,
-    file: &Path,
-    line: u32,
-    col: u32,
-) -> Option<String> {
-    let abs = file
-        .canonicalize()
-        .unwrap_or_else(|_| file.to_path_buf());
+pub(crate) fn hover_at(indexer: &Arc<Indexer>, file: &Path, line: u32, col: u32) -> Option<String> {
+    let abs = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
     let uri = Url::from_file_path(&abs).ok()?;
 
     // Index on-demand if this file wasn't already in cache.
@@ -27,7 +20,7 @@ pub(crate) fn hover_at(
     let resolved = enrich_at_line(
         indexer.as_ref(),
         uri.as_str(),
-        line.saturating_sub(1),   // 1-based → 0-based
+        line.saturating_sub(1), // 1-based → 0-based
         col.saturating_sub(1),
         SubstitutionContext::None,
         &ResolveOptions::hover(),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -24,6 +24,7 @@ mod args;
 mod hover;
 mod output;
 mod run;
+mod tokens;
 
 pub(crate) use args::CliArgs;
 pub(crate) use run::run;

--- a/src/cli/output.rs
+++ b/src/cli/output.rs
@@ -29,7 +29,10 @@ impl CliResult {
 
 pub(crate) fn print_results(results: &[CliResult], json: bool) {
     if json {
-        println!("{}", serde_json::to_string_pretty(results).unwrap_or_default());
+        println!(
+            "{}",
+            serde_json::to_string_pretty(results).unwrap_or_default()
+        );
     } else {
         for r in results {
             if r.kind.is_empty() {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -11,7 +11,7 @@ use crate::rg::{rg_find_definition, rg_word_search, RgSearchRequest};
 use super::args::{CliArgs, Mode, OutputFmt, Subcommand};
 use super::hover::hover_at;
 use super::output::{print_results, CliResult};
-use super::tokens::{dump_tree, print_token_rows, token_rows};
+use super::tokens::{dump_tree, print_token_rows, token_rows, token_rows_phases};
 
 // ── Root resolution ───────────────────────────────────────────────────────────
 
@@ -120,8 +120,9 @@ pub(crate) async fn run(args: CliArgs) {
         Subcommand::Tokens {
             file,
             cst_only,
+            phases,
             show_tree,
-        } => run_tokens(&root, json, &file, cst_only, show_tree).await,
+        } => run_tokens(&root, json, &file, cst_only, phases, show_tree).await,
         Subcommand::Tree { file } => run_tree(&file),
     }
 }
@@ -185,12 +186,22 @@ async fn run_hover(root: &Path, mode: Mode, json: bool, file: &Path, line: u32, 
     }
 }
 
-async fn run_tokens(root: &Path, json: bool, file: &Path, cst_only: bool, show_tree: bool) {
-    let index = if cst_only {
+async fn run_tokens(root: &Path, json: bool, file: &Path, cst_only: bool, phases: bool, show_tree: bool) {
+    let index = if cst_only && !phases {
         None
     } else {
         Some(build_index(root).await)
     };
+    if phases {
+        match token_rows_phases(file, index.as_ref()) {
+            Ok(output) => print!("{output}"),
+            Err(error) => {
+                eprintln!("error: {error}");
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
     match token_rows(file, index.as_ref(), cst_only) {
         Ok(rows) => {
             print_token_rows(&rows, json);

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -82,19 +82,10 @@ fn smart_refs(indexer: &Arc<Indexer>, name: &str, root: &Path) -> Vec<CliResult>
         .map(|p| p.to_string_lossy().into_owned())
         .collect();
 
-    let dummy_uri: tower_lsp::lsp_types::Url =
-        tower_lsp::lsp_types::Url::from_file_path(root)
-            .unwrap_or_else(|_| "file:///".parse().unwrap());
+    let dummy_uri: tower_lsp::lsp_types::Url = tower_lsp::lsp_types::Url::from_file_path(root)
+        .unwrap_or_else(|_| "file:///".parse().unwrap());
 
-    let request = RgSearchRequest::new(
-        name,
-        None,
-        None,
-        Some(root),
-        true,
-        &dummy_uri,
-        &decl_files,
-    );
+    let request = RgSearchRequest::new(name, None, None, Some(root), true, &dummy_uri, &decl_files);
     let locs = crate::rg::rg_find_references(&request, None);
     locs_to_results(locs, name, "")
 }
@@ -120,110 +111,116 @@ pub(crate) async fn run(args: CliArgs) {
     let json = args.fmt == OutputFmt::Json;
 
     match args.subcommand {
-        // ── index ─────────────────────────────────────────────────────────────
-        Subcommand::Index => {
-            eprintln!("Indexing workspace: {}", root.display());
-            let idx = build_index(&root).await;
-            eprintln!(
-                "Done: {} files, {} symbols",
-                idx.files.len(),
-                idx.definitions.len()
-            );
-        }
-
-        // ── find ──────────────────────────────────────────────────────────────
-        Subcommand::Find { name } => {
-            let effective_mode = effective_mode(args.mode, &root, "find");
-            let results = match effective_mode {
-                Mode::Fast => fast_find(&name, &root),
-                _ => {
-                    let idx = build_index(&root).await;
-                    smart_find(&idx, &name, &root)
-                }
-            };
-            if results.is_empty() {
-                if !json {
-                    eprintln!("No declarations found for '{name}'");
-                }
-                std::process::exit(1);
-            }
-            print_results(&results, json);
-        }
-
-        // ── refs ──────────────────────────────────────────────────────────────
-        Subcommand::Refs { name } => {
-            let effective_mode = effective_mode(args.mode, &root, "refs");
-            let results = match effective_mode {
-                Mode::Fast => fast_refs(&name, &root),
-                _ => {
-                    let idx = build_index(&root).await;
-                    smart_refs(&idx, &name, &root)
-                }
-            };
-            if results.is_empty() {
-                if !json {
-                    eprintln!("No references found for '{name}'");
-                }
-                std::process::exit(1);
-            }
-            print_results(&results, json);
-        }
-
-        // ── hover ─────────────────────────────────────────────────────────────
+        Subcommand::Index => run_index(&root).await,
+        Subcommand::Find { name } => run_find(&root, args.mode, json, &name).await,
+        Subcommand::Refs { name } => run_refs(&root, args.mode, json, &name).await,
         Subcommand::Hover { file, line, col } => {
-            let effective_mode = effective_mode(args.mode, &root, "hover");
-            if effective_mode == Mode::Fast {
-                eprintln!("hover requires index; run `kotlin-lsp index` first or remove --fast");
-                std::process::exit(1);
-            }
-            let idx = build_index(&root).await;
-            match hover_at(&idx, &file, line, col) {
-                Some(text) => {
-                    if json {
-                        let obj = serde_json::json!({ "signature": text });
-                        println!("{}", serde_json::to_string_pretty(&obj).unwrap_or_default());
-                    } else {
-                        println!("{text}");
-                    }
-                }
-                None => {
-                    eprintln!("No symbol found at {}:{}:{}", file.display(), line, col);
-                    std::process::exit(1);
-                }
-            }
+            run_hover(&root, args.mode, json, &file, line, col).await
         }
+        Subcommand::Tokens {
+            file,
+            cst_only,
+            show_tree,
+        } => run_tokens(&root, json, &file, cst_only, show_tree).await,
+        Subcommand::Tree { file } => run_tree(&file),
+    }
+}
 
-        // ── tokens ────────────────────────────────────────────────────────────
-        Subcommand::Tokens { file, cst_only, show_tree } => {
-            let idx = if !cst_only {
-                Some(build_index(&root).await)
-            } else {
-                None
-            };
-            match token_rows(&file, idx.as_ref(), cst_only) {
-                Ok(rows) => {
-                    print_token_rows(&rows, json);
-                    if show_tree {
-                        eprintln!();
-                        if let Err(e) = dump_tree(&file) {
-                            eprintln!("tree: {e}");
-                        }
-                    }
-                }
-                Err(e) => {
-                    eprintln!("error: {e}");
-                    std::process::exit(1);
-                }
-            }
-        }
+async fn run_index(root: &Path) {
+    eprintln!("Indexing workspace: {}", root.display());
+    let index = build_index(root).await;
+    eprintln!(
+        "Done: {} files, {} symbols",
+        index.files.len(),
+        index.definitions.len()
+    );
+}
 
-        // ── tree ──────────────────────────────────────────────────────────────
-        Subcommand::Tree { file } => {
-            if let Err(e) = dump_tree(&file) {
-                eprintln!("error: {e}");
-                std::process::exit(1);
+async fn run_find(root: &Path, mode: Mode, json: bool, name: &str) {
+    let results = match effective_mode(mode, root, "find") {
+        Mode::Fast => fast_find(name, root),
+        _ => {
+            let index = build_index(root).await;
+            smart_find(&index, name, root)
+        }
+    };
+    exit_if_empty(
+        &results,
+        json,
+        &format!("No declarations found for '{name}'"),
+    );
+    print_results(&results, json);
+}
+
+async fn run_refs(root: &Path, mode: Mode, json: bool, name: &str) {
+    let results = match effective_mode(mode, root, "refs") {
+        Mode::Fast => fast_refs(name, root),
+        _ => {
+            let index = build_index(root).await;
+            smart_refs(&index, name, root)
+        }
+    };
+    exit_if_empty(&results, json, &format!("No references found for '{name}'"));
+    print_results(&results, json);
+}
+
+async fn run_hover(root: &Path, mode: Mode, json: bool, file: &Path, line: u32, col: u32) {
+    if effective_mode(mode, root, "hover") == Mode::Fast {
+        eprintln!("hover requires index; run `kotlin-lsp index` first or remove --fast");
+        std::process::exit(1);
+    }
+    let index = build_index(root).await;
+    let Some(text) = hover_at(&index, file, line, col) else {
+        eprintln!("No symbol found at {}:{}:{}", file.display(), line, col);
+        std::process::exit(1);
+    };
+    if json {
+        let object = serde_json::json!({ "signature": text });
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&object).unwrap_or_default()
+        );
+    } else {
+        println!("{text}");
+    }
+}
+
+async fn run_tokens(root: &Path, json: bool, file: &Path, cst_only: bool, show_tree: bool) {
+    let index = if cst_only {
+        None
+    } else {
+        Some(build_index(root).await)
+    };
+    match token_rows(file, index.as_ref(), cst_only) {
+        Ok(rows) => {
+            print_token_rows(&rows, json);
+            if show_tree {
+                eprintln!();
+                if let Err(error) = dump_tree(file) {
+                    eprintln!("tree: {error}");
+                }
             }
         }
+        Err(error) => {
+            eprintln!("error: {error}");
+            std::process::exit(1);
+        }
+    }
+}
+
+fn run_tree(file: &Path) {
+    if let Err(error) = dump_tree(file) {
+        eprintln!("error: {error}");
+        std::process::exit(1);
+    }
+}
+
+fn exit_if_empty(results: &[CliResult], json: bool, message: &str) {
+    if results.is_empty() {
+        if !json {
+            eprintln!("{message}");
+        }
+        std::process::exit(1);
     }
 }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -11,6 +11,7 @@ use crate::rg::{rg_find_definition, rg_word_search, RgSearchRequest};
 use super::args::{CliArgs, Mode, OutputFmt, Subcommand};
 use super::hover::hover_at;
 use super::output::{print_results, CliResult};
+use super::tokens::{dump_tree, print_token_rows, token_rows};
 
 // ── Root resolution ───────────────────────────────────────────────────────────
 
@@ -189,6 +190,38 @@ pub(crate) async fn run(args: CliArgs) {
                     eprintln!("No symbol found at {}:{}:{}", file.display(), line, col);
                     std::process::exit(1);
                 }
+            }
+        }
+
+        // ── tokens ────────────────────────────────────────────────────────────
+        Subcommand::Tokens { file, cst_only, show_tree } => {
+            let idx = if !cst_only {
+                Some(build_index(&root).await)
+            } else {
+                None
+            };
+            match token_rows(&file, idx.as_ref(), cst_only) {
+                Ok(rows) => {
+                    print_token_rows(&rows, json);
+                    if show_tree {
+                        eprintln!();
+                        if let Err(e) = dump_tree(&file) {
+                            eprintln!("tree: {e}");
+                        }
+                    }
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::exit(1);
+                }
+            }
+        }
+
+        // ── tree ──────────────────────────────────────────────────────────────
+        Subcommand::Tree { file } => {
+            if let Err(e) = dump_tree(&file) {
+                eprintln!("error: {e}");
+                std::process::exit(1);
             }
         }
     }

--- a/src/cli/tokens.rs
+++ b/src/cli/tokens.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use serde::Serialize;
 use tower_lsp::lsp_types::Url;
 
-use crate::indexer::live_tree::{lang_for_path, parse_live};
+use crate::indexer::live_tree::{lang_for_path, parse_live, utf16_col_to_byte};
 use crate::indexer::Indexer;
 use crate::semantic_tokens::{collect_tokens, TOKEN_MODIFIERS, TOKEN_TYPES};
 use crate::Language;
@@ -91,12 +91,10 @@ pub(crate) fn token_rows(
         let text = lines
             .get(abs_line as usize)
             .map(|line| {
-                let bytes = line.as_bytes();
-                // col is UTF-16; for ASCII-dominant Kotlin source, byte == UTF-16 col
-                let start = abs_col as usize;
-                let end = (abs_col + tok.length) as usize;
-                if end <= bytes.len() {
-                    &line[start..end]
+                let start_byte = utf16_col_to_byte(line, abs_col as usize);
+                let end_byte = utf16_col_to_byte(line, (abs_col + tok.length) as usize);
+                if end_byte <= line.len() {
+                    &line[start_byte..end_byte]
                 } else {
                     ""
                 }

--- a/src/cli/tokens.rs
+++ b/src/cli/tokens.rs
@@ -14,7 +14,7 @@ use tower_lsp::lsp_types::Url;
 
 use crate::indexer::live_tree::{lang_for_path, parse_live, utf16_col_to_byte};
 use crate::indexer::Indexer;
-use crate::semantic_tokens::{collect_tokens, TOKEN_MODIFIERS, TOKEN_TYPES};
+use crate::semantic_tokens::{collect_tokens, collect_tokens_phases, TOKEN_MODIFIERS, TOKEN_TYPES};
 use crate::Language;
 
 // ── Token row ────────────────────────────────────────────────────────────────
@@ -66,6 +66,101 @@ pub(crate) fn token_rows(
     };
 
     let tokens = collect_tokens(&doc, language, None, idx_ref, uri_ref);
+    decode_token_rows(&tokens, &content)
+}
+
+/// Like `token_rows` but returns one section per phase showing which tokens
+/// survive dedup. Helps diagnose missing or incorrectly dropped tokens.
+pub(crate) fn token_rows_phases(
+    file: &Path,
+    indexer: Option<&Arc<Indexer>>,
+) -> Result<String, String> {
+    let abs = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
+    let path_str = abs.to_string_lossy();
+    let content =
+        std::fs::read_to_string(&abs).map_err(|e| format!("cannot read {}: {e}", abs.display()))?;
+    let ts_lang = lang_for_path(&path_str)
+        .ok_or_else(|| format!("unsupported file type: {}", abs.display()))?;
+    let language = Language::from_path(&path_str);
+    let doc = parse_live(&content, ts_lang)
+        .ok_or_else(|| format!("tree-sitter parse failed for {}", abs.display()))?;
+    let uri = Url::from_file_path(&abs)
+        .map_err(|_| format!("cannot convert path to URI: {}", abs.display()))?;
+
+    let (idx_ref, uri_ref) = match indexer {
+        None => (None, None),
+        Some(indexer) => {
+            indexer.ensure_indexed(&uri);
+            (Some(indexer.as_ref()), Some(&uri))
+        }
+    };
+
+    let phases = collect_tokens_phases(&doc, language, idx_ref, uri_ref);
+    let lines: Vec<&str> = content.lines().collect();
+    let final_raw = phases.final_tokens();
+
+    let mut out = String::new();
+    for (label, raw) in [
+        ("Phase 1  — CST: declarations, soft-keywords, named-arg labels", phases.phase1.as_slice()),
+        ("Phase 1b — param use-sites in function bodies", phases.phase1b.as_slice()),
+        ("Phase 2  — cross-file reference resolution", phases.phase2.as_slice()),
+    ] {
+        out.push_str(&format!("\n=== {label} ===\n"));
+        if raw.is_empty() {
+            out.push_str("  (empty)\n");
+            continue;
+        }
+        for tok in raw {
+            let kept = final_raw
+                .iter()
+                .any(|t| t.line == tok.line && t.col == tok.col && t.token_type == tok.token_type);
+            let row = format_raw_tok(tok, &lines);
+            if kept {
+                out.push_str(&format!("  {row}\n"));
+            } else {
+                out.push_str(&format!("  {row}  [dropped by dedup]\n"));
+            }
+        }
+    }
+    out.push_str("\n=== Final (after sort + dedup) ===\n");
+    for tok in &final_raw {
+        out.push_str(&format!("  {}\n", format_raw_tok(tok, &lines)));
+    }
+    Ok(out)
+}
+
+fn format_raw_tok(
+    tok: &crate::semantic_tokens::RawToken,
+    lines: &[&str],
+) -> String {
+    let type_name = TOKEN_TYPES
+        .get(tok.token_type as usize)
+        .map(|t| format!("{t:?}"))
+        .unwrap_or_else(|| format!("#{}", tok.token_type));
+    let modifiers = decode_modifiers(tok.token_modifiers_bitset);
+    let mods = if modifiers.is_empty() {
+        String::new()
+    } else {
+        format!("+{}", modifiers.join(","))
+    };
+    let text = lines
+        .get(tok.line as usize)
+        .map(|line| {
+            let s = utf16_col_to_byte(line, tok.col as usize);
+            let e = utf16_col_to_byte(line, (tok.col + tok.length) as usize);
+            if e <= line.len() { &line[s..e] } else { "" }
+        })
+        .unwrap_or("");
+    format!(
+        "{}:{}+{}  {}{:30}  {:?}",
+        tok.line, tok.col, tok.length, type_name, mods, text
+    )
+}
+
+fn decode_token_rows(
+    tokens: &[tower_lsp::lsp_types::SemanticToken],
+    content: &str,
+) -> Result<Vec<TokenRow>, String> {
 
     // Decode the delta-encoded token stream back to absolute positions.
     let lines: Vec<&str> = content.lines().collect();
@@ -73,7 +168,7 @@ pub(crate) fn token_rows(
     let mut abs_line = 0u32;
     let mut abs_col = 0u32;
 
-    for tok in &tokens {
+    for tok in tokens {
         if tok.delta_line > 0 {
             abs_line += tok.delta_line;
             abs_col = tok.delta_start;

--- a/src/cli/tokens.rs
+++ b/src/cli/tokens.rs
@@ -40,13 +40,11 @@ pub(crate) fn token_rows(
     indexer: Option<&Arc<Indexer>>,
     cst_only: bool,
 ) -> Result<Vec<TokenRow>, String> {
-    let abs = file
-        .canonicalize()
-        .unwrap_or_else(|_| file.to_path_buf());
+    let abs = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
     let path_str = abs.to_string_lossy();
 
-    let content = std::fs::read_to_string(&abs)
-        .map_err(|e| format!("cannot read {}: {e}", abs.display()))?;
+    let content =
+        std::fs::read_to_string(&abs).map_err(|e| format!("cannot read {}: {e}", abs.display()))?;
 
     let ts_lang = lang_for_path(&path_str)
         .ok_or_else(|| format!("unsupported file type: {}", abs.display()))?;
@@ -59,12 +57,12 @@ pub(crate) fn token_rows(
     let uri = Url::from_file_path(&abs)
         .map_err(|_| format!("cannot convert path to URI: {}", abs.display()))?;
 
-    let (idx_ref, uri_ref) = if cst_only || indexer.is_none() {
-        (None, None)
-    } else {
-        let idx = indexer.unwrap();
-        idx.ensure_indexed(&uri);
-        (Some(idx.as_ref()), Some(&uri))
+    let (idx_ref, uri_ref) = match (cst_only, indexer) {
+        (true, _) | (_, None) => (None, None),
+        (false, Some(indexer)) => {
+            indexer.ensure_indexed(&uri);
+            (Some(indexer.as_ref()), Some(&uri))
+        }
     };
 
     let tokens = collect_tokens(&doc, language, None, idx_ref, uri_ref);
@@ -130,10 +128,7 @@ fn decode_modifiers(bits: u32) -> Vec<String> {
 
 pub(crate) fn print_token_rows(rows: &[TokenRow], json: bool) {
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(rows).unwrap_or_default()
-        );
+        println!("{}", serde_json::to_string_pretty(rows).unwrap_or_default());
         return;
     }
     for row in rows {
@@ -144,12 +139,7 @@ pub(crate) fn print_token_rows(rows: &[TokenRow], json: bool) {
         };
         println!(
             "{}:{}+{}  {}{:30}  {:?}",
-            row.line,
-            row.col,
-            row.len,
-            row.token_type,
-            mods,
-            row.text,
+            row.line, row.col, row.len, row.token_type, mods, row.text,
         );
     }
 }
@@ -158,13 +148,11 @@ pub(crate) fn print_token_rows(rows: &[TokenRow], json: bool) {
 
 /// Parse `file` and print the tree-sitter CST to stdout.
 pub(crate) fn dump_tree(file: &Path) -> Result<(), String> {
-    let abs = file
-        .canonicalize()
-        .unwrap_or_else(|_| file.to_path_buf());
+    let abs = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
     let path_str = abs.to_string_lossy();
 
-    let content = std::fs::read_to_string(&abs)
-        .map_err(|e| format!("cannot read {}: {e}", abs.display()))?;
+    let content =
+        std::fs::read_to_string(&abs).map_err(|e| format!("cannot read {}: {e}", abs.display()))?;
 
     let ts_lang = lang_for_path(&path_str)
         .ok_or_else(|| format!("unsupported file type: {}", abs.display()))?;

--- a/src/cli/tokens.rs
+++ b/src/cli/tokens.rs
@@ -1,0 +1,220 @@
+//! `tokens` and `tree` debug subcommands.
+//!
+//! `tokens <file>` decodes the semantic token stream for a file and prints
+//! one line per token so you can see exactly what type/modifiers are emitted
+//! and at which source position.
+//!
+//! `tree <file>` dumps the tree-sitter CST to stdout.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use serde::Serialize;
+use tower_lsp::lsp_types::Url;
+
+use crate::indexer::live_tree::{lang_for_path, parse_live};
+use crate::indexer::Indexer;
+use crate::semantic_tokens::{collect_tokens, TOKEN_MODIFIERS, TOKEN_TYPES};
+use crate::Language;
+
+// ── Token row ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize)]
+pub(crate) struct TokenRow {
+    pub line: u32,
+    pub col: u32,
+    pub len: u32,
+    pub token_type: String,
+    pub modifiers: Vec<String>,
+    pub text: String,
+}
+
+// ── Token dump ───────────────────────────────────────────────────────────────
+
+/// Collect and decode semantic tokens for `file`.
+///
+/// If `cst_only` is true, the index is not consulted — only the tree-sitter
+/// CST classification is used.  If `indexer` is `None`, `cst_only` is implied.
+pub(crate) fn token_rows(
+    file: &Path,
+    indexer: Option<&Arc<Indexer>>,
+    cst_only: bool,
+) -> Result<Vec<TokenRow>, String> {
+    let abs = file
+        .canonicalize()
+        .unwrap_or_else(|_| file.to_path_buf());
+    let path_str = abs.to_string_lossy();
+
+    let content = std::fs::read_to_string(&abs)
+        .map_err(|e| format!("cannot read {}: {e}", abs.display()))?;
+
+    let ts_lang = lang_for_path(&path_str)
+        .ok_or_else(|| format!("unsupported file type: {}", abs.display()))?;
+
+    let language = Language::from_path(&path_str);
+
+    let doc = parse_live(&content, ts_lang)
+        .ok_or_else(|| format!("tree-sitter parse failed for {}", abs.display()))?;
+
+    let uri = Url::from_file_path(&abs)
+        .map_err(|_| format!("cannot convert path to URI: {}", abs.display()))?;
+
+    let (idx_ref, uri_ref) = if cst_only || indexer.is_none() {
+        (None, None)
+    } else {
+        let idx = indexer.unwrap();
+        idx.ensure_indexed(&uri);
+        (Some(idx.as_ref()), Some(&uri))
+    };
+
+    let tokens = collect_tokens(&doc, language, None, idx_ref, uri_ref);
+
+    // Decode the delta-encoded token stream back to absolute positions.
+    let lines: Vec<&str> = content.lines().collect();
+    let mut rows = Vec::with_capacity(tokens.len());
+    let mut abs_line = 0u32;
+    let mut abs_col = 0u32;
+
+    for tok in &tokens {
+        if tok.delta_line > 0 {
+            abs_line += tok.delta_line;
+            abs_col = tok.delta_start;
+        } else {
+            abs_col += tok.delta_start;
+        }
+
+        let type_name = TOKEN_TYPES
+            .get(tok.token_type as usize)
+            .map(|t| format!("{t:?}"))
+            .unwrap_or_else(|| format!("#{}", tok.token_type));
+
+        let modifiers = decode_modifiers(tok.token_modifiers_bitset);
+
+        let text = lines
+            .get(abs_line as usize)
+            .map(|line| {
+                let bytes = line.as_bytes();
+                // col is UTF-16; for ASCII-dominant Kotlin source, byte == UTF-16 col
+                let start = abs_col as usize;
+                let end = (abs_col + tok.length) as usize;
+                if end <= bytes.len() {
+                    &line[start..end]
+                } else {
+                    ""
+                }
+            })
+            .unwrap_or("")
+            .to_owned();
+
+        rows.push(TokenRow {
+            line: abs_line,
+            col: abs_col,
+            len: tok.length,
+            token_type: type_name,
+            modifiers,
+            text,
+        });
+    }
+
+    Ok(rows)
+}
+
+fn decode_modifiers(bits: u32) -> Vec<String> {
+    TOKEN_MODIFIERS
+        .iter()
+        .enumerate()
+        .filter(|(i, _)| bits & (1 << i) != 0)
+        .map(|(_, m)| format!("{m:?}"))
+        .collect()
+}
+
+pub(crate) fn print_token_rows(rows: &[TokenRow], json: bool) {
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(rows).unwrap_or_default()
+        );
+        return;
+    }
+    for row in rows {
+        let mods = if row.modifiers.is_empty() {
+            String::new()
+        } else {
+            format!("+{}", row.modifiers.join(","))
+        };
+        println!(
+            "{}:{}+{}  {}{:30}  {:?}",
+            row.line,
+            row.col,
+            row.len,
+            row.token_type,
+            mods,
+            row.text,
+        );
+    }
+}
+
+// ── Tree dump ────────────────────────────────────────────────────────────────
+
+/// Parse `file` and print the tree-sitter CST to stdout.
+pub(crate) fn dump_tree(file: &Path) -> Result<(), String> {
+    let abs = file
+        .canonicalize()
+        .unwrap_or_else(|_| file.to_path_buf());
+    let path_str = abs.to_string_lossy();
+
+    let content = std::fs::read_to_string(&abs)
+        .map_err(|e| format!("cannot read {}: {e}", abs.display()))?;
+
+    let ts_lang = lang_for_path(&path_str)
+        .ok_or_else(|| format!("unsupported file type: {}", abs.display()))?;
+
+    let doc = parse_live(&content, ts_lang)
+        .ok_or_else(|| format!("tree-sitter parse failed for {}", abs.display()))?;
+
+    let source = content.as_bytes();
+    print_node(doc.tree.root_node(), source, 0);
+    Ok(())
+}
+
+fn print_node(node: tree_sitter::Node<'_>, source: &[u8], depth: usize) {
+    let indent = "  ".repeat(depth);
+    let start = node.start_position();
+    let end = node.end_position();
+
+    if node.is_named() {
+        let text_preview = if node.child_count() == 0 {
+            // Leaf: show the text
+            let s = &source[node.start_byte()..node.end_byte()];
+            let s = std::str::from_utf8(s).unwrap_or("?");
+            // Truncate long leaves
+            let s = if s.len() > 40 { &s[..40] } else { s };
+            format!(" {:?}", s)
+        } else {
+            String::new()
+        };
+        println!(
+            "{}{} [{}:{}-{}:{}]{}",
+            indent,
+            node.kind(),
+            start.row,
+            start.column,
+            end.row,
+            end.column,
+            text_preview,
+        );
+    } else {
+        // Anonymous node (keyword/punctuation)
+        let s = &source[node.start_byte()..node.end_byte()];
+        let s = std::str::from_utf8(s).unwrap_or("?");
+        println!(
+            "{}\"{}\" [{}:{}-{}:{}]",
+            indent, s, start.row, start.column, end.row, end.column,
+        );
+    }
+
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        print_node(child, source, depth + 1);
+    }
+}

--- a/src/indexer/node_ext_tests.rs
+++ b/src/indexer/node_ext_tests.rs
@@ -14,10 +14,7 @@ fn parse_kotlin(src: &str) -> (tree_sitter::Tree, Vec<u8>) {
     (tree, bytes)
 }
 
-fn find_node_kind<'a>(
-    node: tree_sitter::Node<'a>,
-    kind: &str,
-) -> Option<tree_sitter::Node<'a>> {
+fn find_node_kind<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
     if node.kind() == kind {
         return Some(node);
     }
@@ -168,7 +165,10 @@ fn enclosing_lambda_literal_finds_nearest_lambda() {
 fn first_value_argument_text_returns_first_argument() {
     let (tree, bytes) = parse_kotlin("val x = with(user, other) { user.name }");
     let call = find_node_kind(tree.root_node(), KIND_CALL_EXPR).unwrap();
-    assert_eq!(call.first_value_argument_text(&bytes), Some("user".to_string()));
+    assert_eq!(
+        call.first_value_argument_text(&bytes),
+        Some("user".to_string())
+    );
 }
 
 #[test]

--- a/src/inlay_hints.rs
+++ b/src/inlay_hints.rs
@@ -414,7 +414,12 @@ fn ts_pos_to_lsp(pos: tree_sitter::Point, starts: &[usize], bytes: &[u8]) -> Pos
 /// `starts` must have been produced by `line_starts(bytes)` — it is used to
 /// jump directly to the line without rescanning the whole file (O(1) lookup
 /// instead of O(file_size)).
-pub(crate) fn ts_byte_col_to_utf16(bytes: &[u8], starts: &[usize], row: usize, byte_col: usize) -> usize {
+pub(crate) fn ts_byte_col_to_utf16(
+    bytes: &[u8],
+    starts: &[usize],
+    row: usize,
+    byte_col: usize,
+) -> usize {
     let line_start = starts.get(row).copied().unwrap_or_else(|| {
         bytes
             .split(|&b| b == b'\n')

--- a/src/inlay_hints_tests.rs
+++ b/src/inlay_hints_tests.rs
@@ -1,69 +1,70 @@
-    use super::*;
-    use std::sync::Arc;
 
-    fn uri(path: &str) -> Url {
-        Url::parse(&format!("file:///test{path}")).unwrap()
-    }
+use super::*;
+use std::sync::Arc;
 
-    fn indexed(path: &str, src: &str) -> (Url, Arc<Indexer>) {
-        let u = uri(path);
-        let idx = Arc::new(Indexer::new());
-        idx.index_content(&u, src);
-        (u, idx)
-    }
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file:///test{path}")).unwrap()
+}
 
-    fn hints_for(src: &str) -> Vec<InlayHint> {
-        let (u, idx) = indexed("/t.kt", src);
-        let lines = src.lines().count() as u32;
-        compute_inlay_hints(
-            &idx,
-            &u,
-            Range {
-                start: Position::new(0, 0),
-                end: Position::new(lines, 0),
-            },
-        )
-    }
+fn indexed(path: &str, src: &str) -> (Url, Arc<Indexer>) {
+    let u = uri(path);
+    let idx = Arc::new(Indexer::new());
+    idx.index_content(&u, src);
+    (u, idx)
+}
 
-    #[test]
-    fn it_type_hint() {
-        let src = "val items: List<Product> = emptyList()\nitems.forEach { it.name }";
-        let hints = hints_for(src);
-        assert!(
-            hints
-                .iter()
-                .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": Product")),
-            "expected ': Product' hint for it, got: {hints:?}",
-        );
-    }
+fn hints_for(src: &str) -> Vec<InlayHint> {
+    let (u, idx) = indexed("/t.kt", src);
+    let lines = src.lines().count() as u32;
+    compute_inlay_hints(
+        &idx,
+        &u,
+        Range {
+            start: Position::new(0, 0),
+            end: Position::new(lines, 0),
+        },
+    )
+}
 
-    #[test]
-    fn named_param_type_hint() {
-        let src = "val items: List<Order> = emptyList()\nitems.forEach { order ->\n    order.id\n}";
-        let hints = hints_for(src);
-        assert!(
-            hints
-                .iter()
-                .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": Order")),
-            "expected ': Order' hint for named param, got: {hints:?}",
-        );
-    }
+#[test]
+fn it_type_hint() {
+    let src = "val items: List<Product> = emptyList()\nitems.forEach { it.name }";
+    let hints = hints_for(src);
+    assert!(
+        hints
+            .iter()
+            .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": Product")),
+        "expected ': Product' hint for it, got: {hints:?}",
+    );
+}
 
-    #[test]
-    fn no_hint_for_typed_val() {
-        let src = "val items: List<Product> = emptyList()";
-        let hints = hints_for(src);
-        assert!(
-            !hints
-                .iter()
-                .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s.contains("items"))),
-            "should not hint explicitly typed val",
-        );
-    }
+#[test]
+fn named_param_type_hint() {
+    let src = "val items: List<Order> = emptyList()\nitems.forEach { order ->\n    order.id\n}";
+    let hints = hints_for(src);
+    assert!(
+        hints
+            .iter()
+            .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": Order")),
+        "expected ': Order' hint for named param, got: {hints:?}",
+    );
+}
 
-    #[test]
-    fn hints_inject_constructor_lambdas() {
-        let src = r#"package test
+#[test]
+fn no_hint_for_typed_val() {
+    let src = "val items: List<Product> = emptyList()";
+    let hints = hints_for(src);
+    assert!(
+        !hints
+            .iter()
+            .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s.contains("items"))),
+        "should not hint explicitly typed val",
+    );
+}
+
+#[test]
+fn hints_inject_constructor_lambdas() {
+    let src = r#"package test
 
 class ProductsUseCases
 class MviViewModel
@@ -82,31 +83,31 @@ class DashboardProductsViewModel @javax.inject.Inject constructor(
   }
 }
 "#;
-        let hints = hints_for(src);
-        eprintln!("inject_constructor hints: {hints:?}");
-        assert!(
-            hints
-                .iter()
-                .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": String")),
-            "expected ': String' hint for it/item in @Inject constructor class, got: {hints:?}",
-        );
-    }
+    let hints = hints_for(src);
+    eprintln!("inject_constructor hints: {hints:?}");
+    assert!(
+        hints
+            .iter()
+            .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": String")),
+        "expected ': String' hint for it/item in @Inject constructor class, got: {hints:?}",
+    );
+}
 
-    #[test]
-    fn hints_survive_syntax_error() {
-        let src = "val items: List<Product> = emptyList()\nitems.forEach { it.name\n";
-        let hints = hints_for(src);
-        assert!(
-            hints
-                .iter()
-                .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": Product")),
-            "hints should still work despite syntax error, got: {hints:?}",
-        );
-    }
+#[test]
+fn hints_survive_syntax_error() {
+    let src = "val items: List<Product> = emptyList()\nitems.forEach { it.name\n";
+    let hints = hints_for(src);
+    assert!(
+        hints
+            .iter()
+            .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": Product")),
+        "hints should still work despite syntax error, got: {hints:?}",
+    );
+}
 
-    #[test]
-    fn hints_nested_named_arg_lambda() {
-        let src = r#"package test
+#[test]
+fn hints_nested_named_arg_lambda() {
+    let src = r#"package test
 
 class SheetReloadActions(
     val buildingSavings: (String) -> Unit,
@@ -122,25 +123,25 @@ class Vm {
     }
 }
 "#;
-        let hints = hints_for(src);
-        eprintln!("nested_named_arg hints: {hints:?}");
-        let has_string = hints
-            .iter()
-            .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": String"));
-        eprintln!("has_string={has_string}");
-        assert!(
-            has_string,
-            "expected ': String' hint for it/loanId in nested named-arg lambda, got: {hints:?}"
-        );
-    }
+    let hints = hints_for(src);
+    eprintln!("nested_named_arg hints: {hints:?}");
+    let has_string = hints
+        .iter()
+        .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": String"));
+    eprintln!("has_string={has_string}");
+    assert!(
+        has_string,
+        "expected ': String' hint for it/loanId in nested named-arg lambda, got: {hints:?}"
+    );
+}
 
-    #[test]
-    fn hints_nested_named_arg_cross_file() {
-        let idx = Arc::new(Indexer::new());
-        let u1 = uri("/DashboardProductsReducer.kt");
-        idx.index_content(
-            &u1,
-            r#"package test
+#[test]
+fn hints_nested_named_arg_cross_file() {
+    let idx = Arc::new(Indexer::new());
+    let u1 = uri("/DashboardProductsReducer.kt");
+    idx.index_content(
+        &u1,
+        r#"package test
 
 class DashboardProductsReducer {
     data class SheetReloadActions(
@@ -152,9 +153,9 @@ class DashboardProductsReducer {
 
 class CardProduct
 "#,
-        );
-        let u2 = uri("/Vm.kt");
-        let vm_src = r#"package test
+    );
+    let u2 = uri("/Vm.kt");
+    let vm_src = r#"package test
 
 import test.DashboardProductsReducer
 
@@ -168,82 +169,82 @@ class Vm {
     }
 }
 "#;
-        idx.index_content(&u2, vm_src);
-        let lines = vm_src.lines().count() as u32;
-        let hints = compute_inlay_hints(
-            &idx,
-            &u2,
-            Range {
-                start: Position::new(0, 0),
-                end: Position::new(lines, 0),
-            },
-        );
-        eprintln!("cross_file hints: {hints:?}");
-        let has_string = hints
-            .iter()
-            .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": String"));
-        let has_card = hints
-            .iter()
-            .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": CardProduct"));
-        eprintln!("has_string={has_string} has_card={has_card}");
-        assert!(
-            has_string,
-            "expected ': String' hint for it in cross-file named-arg lambda, got: {hints:?}"
-        );
-        assert!(
-            has_card,
-            "expected ': CardProduct' hint for it in cards lambda, got: {hints:?}"
-        );
-    }
+    idx.index_content(&u2, vm_src);
+    let lines = vm_src.lines().count() as u32;
+    let hints = compute_inlay_hints(
+        &idx,
+        &u2,
+        Range {
+            start: Position::new(0, 0),
+            end: Position::new(lines, 0),
+        },
+    );
+    eprintln!("cross_file hints: {hints:?}");
+    let has_string = hints
+        .iter()
+        .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": String"));
+    let has_card = hints
+        .iter()
+        .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": CardProduct"));
+    eprintln!("has_string={has_string} has_card={has_card}");
+    assert!(
+        has_string,
+        "expected ': String' hint for it in cross-file named-arg lambda, got: {hints:?}"
+    );
+    assert!(
+        has_card,
+        "expected ': CardProduct' hint for it in cards lambda, got: {hints:?}"
+    );
+}
 
-    #[test]
-    fn ts_byte_col_utf16_ascii() {
-        // For ASCII content the UTF-16 column equals the byte column.
-        let bytes = b"fun main() {}\n";
-        let starts = line_starts(bytes);
-        assert_eq!(ts_byte_col_to_utf16(bytes, &starts, 0, 4), 4); // "fun " = 4 bytes = 4 UTF-16 units
-    }
+#[test]
+fn ts_byte_col_utf16_ascii() {
+    // For ASCII content the UTF-16 column equals the byte column.
+    let bytes = b"fun main() {}\n";
+    let starts = line_starts(bytes);
+    assert_eq!(ts_byte_col_to_utf16(bytes, &starts, 0, 4), 4); // "fun " = 4 bytes = 4 UTF-16 units
+}
 
-    #[test]
-    fn ts_byte_col_utf16_multibyte() {
-        // "café" — 'é' is U+00E9 (2 UTF-8 bytes, 1 UTF-16 unit).
-        let line = "café foo";
-        let bytes = line.as_bytes();
-        let starts = line_starts(bytes);
-        // byte offset 6 is after "café " (c=1,a=1,f=1,é=2,space=1 → 6 bytes)
-        // char cols: c=0,a=1,f=1(wait: c-a-f-é = 4 chars, then space = 5 chars total for "café ")
-        // UTF-16: same as char count for BMP chars = 5
-        let byte_col = "café ".len(); // 6 bytes
-        let utf16 = ts_byte_col_to_utf16(bytes, &starts, 0, byte_col);
-        assert_eq!(utf16, 5, "expected 5 UTF-16 units for 'café '");
-    }
+#[test]
+fn ts_byte_col_utf16_multibyte() {
+    // "café" — 'é' is U+00E9 (2 UTF-8 bytes, 1 UTF-16 unit).
+    let line = "café foo";
+    let bytes = line.as_bytes();
+    let starts = line_starts(bytes);
+    // byte offset 6 is after "café " (c=1,a=1,f=1,é=2,space=1 → 6 bytes)
+    // char cols: c=0,a=1,f=1(wait: c-a-f-é = 4 chars, then space = 5 chars total for "café ")
+    // UTF-16: same as char count for BMP chars = 5
+    let byte_col = "café ".len(); // 6 bytes
+    let utf16 = ts_byte_col_to_utf16(bytes, &starts, 0, byte_col);
+    assert_eq!(utf16, 5, "expected 5 UTF-16 units for 'café '");
+}
 
-    #[test]
-    fn untyped_val_constructor_call_gets_hint() {
-        // `val user = User("alice")` — no explicit type annotation.
-        // hint_property should emit `: User` from the CST initializer.
-        let src = r#"package test
+#[test]
+fn untyped_val_constructor_call_gets_hint() {
+    // `val user = User("alice")` — no explicit type annotation.
+    // hint_property should emit `: User` from the CST initializer.
+    let src = r#"package test
 class User(val name: String)
 fun make() {
     val user = User("alice")
 }
 "#;
-        let hints = hints_for(src);
-        assert!(
-            hints
-                .iter()
-                .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": User")),
-            "expected ': User' hint for untyped val with constructor call, got: {hints:?}",
-        );
-    }
+    let hints = hints_for(src);
+    assert!(
+        hints
+            .iter()
+            .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": User")),
+        "expected ': User' hint for untyped val with constructor call, got: {hints:?}",
+    );
+}
 
-    #[test]
-    fn it_inside_nested_lambda_not_suspend() {
-        // Regression: `it` inside `setState { it }` where `setState` has a
-        // `suspend` function type parameter was incorrectly showing `: suspend`.
-        // `find_as_call_arg_type` must bail out when the backward scan crosses
-        // an unmatched `{`, meaning `it` is inside a nested lambda body.
-        let src = r#"package test
+#[test]
+fn it_inside_nested_lambda_not_suspend() {
+    // Regression: `it` inside `setState { it }` where `setState` has a
+    // `suspend` function type parameter was incorrectly showing `: suspend`.
+    // `find_as_call_arg_type` must bail out when the backward scan crosses
+    // an unmatched `{`, meaning `it` is inside a nested lambda body.
+    let src = r#"package test
 
 class State
 class Effect
@@ -260,12 +261,12 @@ class Vm {
     fun setState(reducer: suspend State.() -> State) {}
 }
 "#;
-        let hints = hints_for(src);
-        let bad = hints
-            .iter()
-            .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": suspend"));
-        assert!(
-            !bad,
-            "must not emit ': suspend' hint for it inside nested lambda, got: {hints:?}"
-        );
-    }
+    let hints = hints_for(src);
+    let bad = hints
+        .iter()
+        .any(|h| matches!(&h.label, InlayHintLabel::String(s) if s == ": suspend"));
+    assert!(
+        !bad,
+        "must not emit ': suspend' hint for it inside nested lambda, got: {hints:?}"
+    );
+}

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -473,7 +473,7 @@ fn dot_completion_hides_private() {
     );
 
     let _ = idx.completions(&vm_uri, tower_lsp::lsp_types::Position::new(2, 24), true); // after "private val repo: Repo"
-                                                                                            // Trigger a dot completion manually through resolver
+                                                                                        // Trigger a dot completion manually through resolver
     let (items, _) = complete_symbol(&idx, "", Some("repo"), &vm_uri, true, None);
     let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
     assert!(labels.contains(&"findAll"), "findAll missing: {labels:?}");

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -396,6 +396,7 @@ pub(crate) const KIND_TYPE_ARGS: &str = "type_arguments";
 // ─── Kotlin property / navigation / call node kinds ──────────────────────────
 pub(crate) const KIND_PROP_DECL: &str = "property_declaration";
 pub(crate) const KIND_PROP_DELEGATE: &str = "property_delegate";
+pub(crate) const KIND_TYPE_ALIAS: &str = "type_alias";
 pub(crate) const KIND_VAR_DECL: &str = "variable_declaration";
 pub(crate) const KIND_MULTI_VAR_DECL: &str = "multi_variable_declaration";
 pub(crate) const KIND_NAV_EXPR: &str = "navigation_expression";
@@ -405,7 +406,11 @@ pub(crate) const KIND_CALLABLE_REF: &str = "callable_reference";
 
 // ─── Kotlin structural / scope node kinds ─────────────────────────────────────
 pub(crate) const KIND_SOURCE_FILE: &str = "source_file";
+pub(crate) const KIND_BLOCK: &str = "block";
+pub(crate) const KIND_CATCH_BLOCK: &str = "catch_block";
 pub(crate) const KIND_CLASS_BODY: &str = "class_body";
+pub(crate) const KIND_CONTROL_STRUCTURE_BODY: &str = "control_structure_body";
+pub(crate) const KIND_FOR_STMT: &str = "for_statement";
 pub(crate) const KIND_FUN_BODY: &str = "function_body";
 pub(crate) const KIND_COMPANION_OBJ: &str = "companion_object";
 pub(crate) const KIND_ANON_FUN: &str = "anonymous_function";
@@ -439,3 +444,15 @@ pub(crate) const KIND_MARKER_ANNOTATION: &str = "marker_annotation";
 pub(crate) const KIND_MOD_STATIC: &str = "static";
 pub(crate) const KIND_MOD_FINAL: &str = "final";
 pub(crate) const KIND_MOD_ABSTRACT: &str = "abstract";
+
+// ─── Kotlin class parameter ───────────────────────────────────────────────────
+pub(crate) const KIND_CLASS_PARAM: &str = "class_parameter";
+
+// ─── Kotlin soft keywords (anonymous CST nodes) ───────────────────────────────
+pub(crate) const KIND_KW_IS: &str = "is";
+pub(crate) const KIND_KW_IS_NOT: &str = "!is";
+pub(crate) const KIND_KW_AS: &str = "as";
+pub(crate) const KIND_KW_AS_SAFE: &str = "as?";
+pub(crate) const KIND_KW_IN: &str = "in";
+pub(crate) const KIND_KW_IN_NOT: &str = "!in";
+pub(crate) const KIND_KW_BY: &str = "by";

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -406,6 +406,7 @@ pub(crate) const KIND_CALLABLE_REF: &str = "callable_reference";
 // ─── Kotlin structural / scope node kinds ─────────────────────────────────────
 pub(crate) const KIND_SOURCE_FILE: &str = "source_file";
 pub(crate) const KIND_CLASS_BODY: &str = "class_body";
+pub(crate) const KIND_FUN_BODY: &str = "function_body";
 pub(crate) const KIND_COMPANION_OBJ: &str = "companion_object";
 pub(crate) const KIND_ANON_FUN: &str = "anonymous_function";
 pub(crate) const KIND_STATEMENTS: &str = "statements";
@@ -437,3 +438,4 @@ pub(crate) const KIND_MARKER_ANNOTATION: &str = "marker_annotation";
 // Java modifier keywords appear as their own leaf node kinds in the Java grammar.
 pub(crate) const KIND_MOD_STATIC: &str = "static";
 pub(crate) const KIND_MOD_FINAL: &str = "final";
+pub(crate) const KIND_MOD_ABSTRACT: &str = "abstract";

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -418,6 +418,8 @@ pub(crate) const KIND_MODIFIERS: &str = "modifiers";
 pub(crate) const KIND_COLON: &str = ":";
 pub(crate) const KIND_EQ: &str = "=";
 pub(crate) const KIND_PARAMETER: &str = "parameter";
+pub(crate) const KIND_FUN_VALUE_PARAMS: &str = "function_value_parameters";
+pub(crate) const KIND_INTERP_IDENT: &str = "interpolated_identifier";
 pub(crate) const KIND_ENUM_ENTRY: &str = "enum_entry";
 pub(crate) const KIND_ANNOTATION: &str = "annotation";
 pub(crate) const KIND_MULTI_ANNOTATION: &str = "multi_annotation";

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -736,7 +736,11 @@ pub(crate) fn find_fun_return_type_by_name(idx: &Indexer, fn_name: &str) -> Opti
     None
 }
 
-pub(crate) fn find_method_return_type(idx: &Indexer, type_name: &str, method_name: &str) -> Option<String> {
+pub(crate) fn find_method_return_type(
+    idx: &Indexer,
+    type_name: &str,
+    method_name: &str,
+) -> Option<String> {
     let type_base = type_name.split('.').next_back().unwrap_or(type_name);
     let locations = idx.definitions.get(type_base)?;
     for loc in locations.iter() {

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -21,16 +21,19 @@ use crate::indexer::{
     find_it_element_type_in_lines, find_this_element_type_in_lines, Indexer, LiveDoc, NodeExt,
 };
 use crate::queries::{
-    KIND_ANNOTATION, KIND_ANNOTATION_TYPE_DECL, KIND_CALL_EXPR, KIND_CLASS_BODY, KIND_CLASS_DECL,
-    KIND_COMPANION_OBJ, KIND_CONSTRUCTOR_INVOCATION, KIND_ENUM_CLASS_BODY, KIND_ENUM_CONSTANT,
-    KIND_ENUM_ENTRY, KIND_ENUM_JAVA_DECL, KIND_EQ, KIND_FIELD_DECL, KIND_FORMAL_PARAM,
-    KIND_FUN_BODY, KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS, KIND_IDENTIFIER, KIND_INTERFACE_BODY,
-    KIND_INTERFACE_DECL, KIND_INTERP_IDENT, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS,
-    KIND_MARKER_ANNOTATION, KIND_METHOD_DECL, KIND_MODIFIERS, KIND_MOD_ABSTRACT, KIND_MOD_FINAL,
-    KIND_MOD_STATIC, KIND_MULTI_ANNOTATION, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_NAV_SUFFIX,
-    KIND_OBJECT_BODY, KIND_OBJECT_DECL, KIND_PARAMETER, KIND_PROP_DECL, KIND_RECORD_DECL,
-    KIND_SIMPLE_IDENT, KIND_SPREAD_PARAM, KIND_THIS_EXPR, KIND_TYPE_IDENT, KIND_TYPE_PARAM,
-    KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VAR_DECL, KIND_VAR_DECLARATOR,
+    KIND_ANNOTATION, KIND_ANNOTATION_TYPE_DECL, KIND_BLOCK, KIND_CALL_EXPR, KIND_CATCH_BLOCK,
+    KIND_CLASS_BODY, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_COMPANION_OBJ,
+    KIND_CONSTRUCTOR_INVOCATION, KIND_CONTROL_STRUCTURE_BODY, KIND_ENUM_CLASS_BODY,
+    KIND_ENUM_CONSTANT, KIND_ENUM_ENTRY, KIND_ENUM_JAVA_DECL, KIND_EQ, KIND_FIELD_DECL,
+    KIND_FORMAL_PARAM, KIND_FOR_STMT, KIND_FUN_BODY, KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS,
+    KIND_IDENTIFIER, KIND_INTERFACE_BODY, KIND_INTERFACE_DECL, KIND_INTERP_IDENT, KIND_KW_AS,
+    KIND_KW_AS_SAFE, KIND_KW_BY, KIND_KW_IN, KIND_KW_IN_NOT, KIND_KW_IS, KIND_KW_IS_NOT,
+    KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_MARKER_ANNOTATION, KIND_METHOD_DECL, KIND_MODIFIERS,
+    KIND_MOD_ABSTRACT, KIND_MOD_FINAL, KIND_MOD_STATIC, KIND_MULTI_ANNOTATION, KIND_MULTI_VAR_DECL,
+    KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_OBJECT_BODY, KIND_OBJECT_DECL, KIND_PARAMETER,
+    KIND_PROP_DECL, KIND_RECORD_DECL, KIND_SIMPLE_IDENT, KIND_SPREAD_PARAM, KIND_STATEMENTS,
+    KIND_THIS_EXPR, KIND_TYPE_ALIAS, KIND_TYPE_IDENT, KIND_TYPE_PARAM, KIND_USER_TYPE,
+    KIND_VALUE_ARG, KIND_VAR_DECL, KIND_VAR_DECLARATOR,
 };
 use crate::resolver::infer::{
     find_field_type_in_class, find_fun_return_type_by_name, find_method_return_type,
@@ -159,6 +162,9 @@ pub(crate) fn collect_tokens(
 
     // Sort by (line, col) — tree walk is depth-first so usually already sorted,
     // but not guaranteed for all node orderings.
+    // sort_by_key is stable (Rust stdlib guarantee), so Phase 1 tokens pushed before
+    // Phase 2 tokens remain first at equal (line,col) — dedup_by_key then keeps the
+    // Phase 1 token.
     raw.sort_by_key(|t| (t.line, t.col));
 
     // Deduplicate: if both declaration walk and reference walk emitted a token
@@ -213,6 +219,7 @@ fn classify_kotlin(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
         k if k == KIND_FUN_DECL => kotlin_fun_token(node, src, out),
         k if k == KIND_PROP_DECL => kotlin_prop_token(node, src, out),
         k if k == KIND_TYPE_PARAM => kotlin_type_param_token(node, src, out),
+        k if k == KIND_CLASS_PARAM => kotlin_class_param_token(node, src, out),
         KIND_PARAMETER => {
             let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
             if let Some(name) = child_ident(node) {
@@ -246,6 +253,18 @@ fn classify_kotlin(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
             if find_annotation_ident(node).is_some() {
                 push_token(node, type_index(&SemanticTokenType::DECORATOR), 0, src, out);
             }
+        }
+        // Soft keywords: tree-sitter captures these as @operator or not at all,
+        // but JetBrains colors them as keywords. Emit KEYWORD to override.
+        k if k == KIND_KW_IS
+            || k == KIND_KW_IS_NOT
+            || k == KIND_KW_AS
+            || k == KIND_KW_AS_SAFE
+            || k == KIND_KW_IN
+            || k == KIND_KW_IN_NOT
+            || k == KIND_KW_BY =>
+        {
+            push_token(node, type_index(&SemanticTokenType::KEYWORD), 0, src, out);
         }
         _ => {}
     }
@@ -375,6 +394,44 @@ fn kotlin_type_param_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawTo
     }
 }
 
+fn kotlin_class_param_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
+    let has_val = (0..node.child_count()).any(|index| {
+        node.child(index)
+            .is_some_and(|child| node_text(child, src.bytes) == "val")
+    });
+    let has_var = (0..node.child_count()).any(|index| {
+        node.child(index)
+            .is_some_and(|child| node_text(child, src.bytes) == "var")
+    });
+    let Some(name) = child_ident(node) else {
+        return;
+    };
+    let (token_type, mut mods) = if has_val {
+        (
+            type_index(&SemanticTokenType::PROPERTY),
+            modifier_bit(&SemanticTokenModifier::DECLARATION)
+                | modifier_bit(&SemanticTokenModifier::READONLY),
+        )
+    } else if has_var {
+        (
+            type_index(&SemanticTokenType::PROPERTY),
+            modifier_bit(&SemanticTokenModifier::DECLARATION),
+        )
+    } else {
+        (
+            type_index(&SemanticTokenType::PARAMETER),
+            modifier_bit(&SemanticTokenModifier::DECLARATION),
+        )
+    };
+    if is_in_companion_body(node) {
+        mods |= modifier_bit(&SemanticTokenModifier::STATIC);
+    }
+    if has_deprecated_annotation(node, src.bytes) {
+        mods |= modifier_bit(&SemanticTokenModifier::DEPRECATED);
+    }
+    push_token(name, token_type, mods, src, out);
+}
+
 // ─── Java walker ─────────────────────────────────────────────────────────────
 
 fn walk_java(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
@@ -414,6 +471,9 @@ fn push_java_class_like_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<Ra
     if has_java_modifier(node, KIND_MOD_ABSTRACT) {
         mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
     }
+    if has_java_deprecated(node, src.bytes) {
+        mods |= modifier_bit(&SemanticTokenModifier::DEPRECATED);
+    }
     if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
         push_token(name, type_index(&SemanticTokenType::CLASS), mods, src, out);
     }
@@ -448,6 +508,9 @@ fn push_java_method_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawTok
     if has_java_modifier(node, KIND_MOD_ABSTRACT) {
         mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
     }
+    if has_java_deprecated(node, src.bytes) {
+        mods |= modifier_bit(&SemanticTokenModifier::DEPRECATED);
+    }
     if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
         push_token(name, type_index(&SemanticTokenType::METHOD), mods, src, out);
     }
@@ -460,6 +523,9 @@ fn push_java_field_tokens(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawTok
     }
     if has_java_modifier(node, KIND_MOD_STATIC) {
         mods |= modifier_bit(&SemanticTokenModifier::STATIC);
+    }
+    if has_java_deprecated(node, src.bytes) {
+        mods |= modifier_bit(&SemanticTokenModifier::DEPRECATED);
     }
     for index in 0..node.child_count() {
         let Some(child) = node.child(index) else {
@@ -632,6 +698,29 @@ fn has_java_modifier(node: Node<'_>, keyword: &str) -> bool {
     if cursor.goto_first_child() {
         loop {
             if cursor.node().kind() == keyword {
+                return true;
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    false
+}
+
+fn has_java_deprecated(node: Node<'_>, src: &[u8]) -> bool {
+    let Some(modifiers) = first_child_of_kind(node, KIND_MODIFIERS) else {
+        return false;
+    };
+    let mut cursor = modifiers.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let child = cursor.node();
+            if (child.kind() == KIND_MARKER_ANNOTATION || child.kind() == KIND_ANNOTATION)
+                && child_ident(child)
+                    .and_then(|name| name.utf8_text(src).ok())
+                    .is_some_and(|text| text == "Deprecated")
+            {
                 return true;
             }
             if !cursor.goto_next_sibling() {
@@ -859,7 +948,10 @@ fn member_token_type(kind: SymbolKind) -> Option<u32> {
 }
 
 fn range_within(inner: &Range, outer: &Range) -> bool {
-    inner.start.line >= outer.start.line && inner.end.line <= outer.end.line
+    let start_ok =
+        (inner.start.line, inner.start.character) >= (outer.start.line, outer.start.character);
+    let end_ok = (inner.end.line, inner.end.character) <= (outer.end.line, outer.end.character);
+    start_ok && end_ok
 }
 
 fn has_type_definition(indexer: &Indexer, name: &str) -> bool {
@@ -1236,7 +1328,7 @@ fn emit_param_uses_for_function(fn_node: Node<'_>, src: &Source<'_>, out: &mut V
     let Some(body) = first_child_of_kind(fn_node, KIND_FUN_BODY) else {
         return;
     };
-    emit_param_refs_in_scope(body, &params, src, out);
+    emit_param_refs_in_scope(body, &params, &[], src, out);
 }
 
 /// Walk `node` emitting PARAMETER tokens for identifiers that match a name in
@@ -1247,25 +1339,97 @@ fn emit_param_uses_for_function(fn_node: Node<'_>, src: &Source<'_>, out: &mut V
 fn emit_param_refs_in_scope(
     node: Node<'_>,
     params: &[String],
+    shadowed: &[String],
     src: &Source<'_>,
     out: &mut Vec<RawToken>,
 ) {
-    if (node.kind() == KIND_SIMPLE_IDENT || node.kind() == KIND_INTERP_IDENT)
+    if node.kind() == KIND_FOR_STMT {
+        let body = first_child_of_kind(node, KIND_CONTROL_STRUCTURE_BODY);
+        let shadow_name = local_binding_name(node, params, src.bytes);
+        let mut shadowed_in_body = shadowed.to_vec();
+        if let Some(name) = shadow_name.as_ref() {
+            if !shadowed_in_body.iter().any(|shadow| shadow == name) {
+                shadowed_in_body.push(name.clone());
+            }
+        }
+
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let child = cursor.node();
+                let child_shadowed = if body.is_some_and(|body_node| body_node.id() == child.id()) {
+                    shadowed_in_body.as_slice()
+                } else {
+                    shadowed
+                };
+                emit_param_refs_in_scope(child, params, child_shadowed, src, out);
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+        return;
+    }
+
+    if matches!(
+        node.kind(),
+        KIND_FUN_BODY
+            | KIND_LAMBDA_LIT
+            | KIND_CONTROL_STRUCTURE_BODY
+            | KIND_CATCH_BLOCK
+            | KIND_BLOCK
+            | KIND_STATEMENTS
+    ) {
+        let mut local_shadowed = shadowed.to_vec();
+        let mut cursor = node.walk();
+        if cursor.goto_first_child() {
+            loop {
+                let child = cursor.node();
+                let new_shadow = local_binding_name(child, params, src.bytes);
+                emit_param_refs_in_scope(child, params, &local_shadowed, src, out);
+                if let Some(name) = new_shadow {
+                    if !local_shadowed.iter().any(|shadow| shadow == &name) {
+                        local_shadowed.push(name);
+                    }
+                }
+                if !cursor.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
+        return;
+    }
+
+    if matches!(node.kind(), KIND_SIMPLE_IDENT | KIND_INTERP_IDENT)
         && !is_declaration_site(node)
-        && node
-            .utf8_text(src.bytes)
-            .is_ok_and(|name| params.iter().any(|param| param == name))
+        && node.utf8_text(src.bytes).is_ok_and(|name| {
+            !shadowed.iter().any(|s| s == name) && params.iter().any(|p| p == name)
+        })
     {
         push_token(node, type_index(&SemanticTokenType::PARAMETER), 0, src, out);
+        return;
     }
+
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
         loop {
-            emit_param_refs_in_scope(cursor.node(), params, src, out);
+            emit_param_refs_in_scope(cursor.node(), params, shadowed, src, out);
             if !cursor.goto_next_sibling() {
                 break;
             }
         }
+    }
+}
+
+fn local_binding_name(node: Node<'_>, params: &[String], bytes: &[u8]) -> Option<String> {
+    match node.kind() {
+        KIND_PROP_DECL | KIND_FOR_STMT => {
+            let variable_declaration = first_child_of_kind(node, KIND_VAR_DECL)?;
+            let ident = child_ident(variable_declaration)?;
+            let name = ident.utf8_text(bytes).ok()?.to_owned();
+            params.contains(&name).then_some(name)
+        }
+        _ => None,
     }
 }
 
@@ -1383,7 +1547,7 @@ fn is_declaration_site(node: Node<'_>) -> bool {
     if pk == KIND_CLASS_DECL
         || pk == KIND_OBJECT_DECL
         || pk == KIND_COMPANION_OBJ
-        || pk == "type_alias"
+        || pk == KIND_TYPE_ALIAS
     {
         return node.kind() == KIND_TYPE_IDENT;
     }
@@ -1391,7 +1555,7 @@ fn is_declaration_site(node: Node<'_>) -> bool {
         || pk == KIND_PARAMETER
         || pk == KIND_ENUM_ENTRY
         || pk == KIND_VAR_DECL
-        || pk == "class_parameter"
+        || pk == KIND_CLASS_PARAM
     {
         return node.kind() == KIND_SIMPLE_IDENT;
     }
@@ -1426,8 +1590,11 @@ fn is_annotation_reference(node: Node<'_>) -> bool {
 
 fn is_type_reference(node: Node<'_>) -> bool {
     node.parent().is_some_and(|parent| {
-        let k = parent.kind();
-        k == KIND_USER_TYPE || k == KIND_FUN_DECL || k == KIND_PROP_DECL || k == "class_parameter"
+        let kind = parent.kind();
+        kind == KIND_USER_TYPE
+            || kind == KIND_FUN_DECL
+            || kind == KIND_PROP_DECL
+            || kind == KIND_CLASS_PARAM
     })
 }
 
@@ -1473,7 +1640,7 @@ fn is_named_argument_label(node: Node<'_>) -> bool {
 fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> Option<u32> {
     let parent = node.parent()?;
     let navigation = parent.parent()?;
-    if parent.kind() != "navigation_suffix" || navigation.kind() != "navigation_expression" {
+    if parent.kind() != KIND_NAV_SUFFIX || navigation.kind() != KIND_NAV_EXPR {
         return None;
     }
 

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -254,6 +254,18 @@ fn classify_kotlin(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
                 push_token(node, type_index(&SemanticTokenType::DECORATOR), 0, src, out);
             }
         }
+        // Named argument label: `foo(name = value)` — purely CST, no index needed.
+        k if k == KIND_VALUE_ARG => {
+            if let Some(label) = value_arg_label(node) {
+                push_token(
+                    label,
+                    type_index(&SemanticTokenType::PARAMETER),
+                    0,
+                    src,
+                    out,
+                );
+            }
+        }
         // Soft keywords: tree-sitter captures these as @operator or not at all,
         // but JetBrains colors them as keywords. Emit KEYWORD to override.
         k if k == KIND_KW_IS
@@ -1620,21 +1632,24 @@ fn is_navigation_receiver(node: Node<'_>) -> bool {
 
 /// Named argument label: `foo(name = value)` — the `name` identifier is the
 /// first child of `value_argument` and is followed by `=`.
+/// Returns the label identifier of a `value_argument` node if it is a named argument.
+/// `foo(name = value)` — `name` is the first named child followed by `=`.
+fn value_arg_label(node: Node<'_>) -> Option<Node<'_>> {
+    let first = node.named_child(0)?;
+    if first.kind() != KIND_SIMPLE_IDENT {
+        return None;
+    }
+    first
+        .next_sibling()
+        .is_some_and(|s| s.kind() == KIND_EQ)
+        .then_some(first)
+}
+
 fn is_named_argument_label(node: Node<'_>) -> bool {
     let Some(parent) = node.parent() else {
         return false;
     };
-    if parent.kind() != KIND_VALUE_ARG {
-        return false;
-    }
-    // The label is the first named child and must be followed by "="
-    let Some(first) = parent.named_child(0) else {
-        return false;
-    };
-    if first.id() != node.id() {
-        return false;
-    }
-    node.next_sibling().is_some_and(|sib| sib.kind() == KIND_EQ)
+    parent.kind() == KIND_VALUE_ARG && value_arg_label(parent).is_some_and(|l| l.id() == node.id())
 }
 
 fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> Option<u32> {

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -24,9 +24,10 @@ use crate::queries::{
     KIND_ANNOTATION, KIND_ANNOTATION_TYPE_DECL, KIND_CALL_EXPR, KIND_CLASS_BODY, KIND_CLASS_DECL,
     KIND_COMPANION_OBJ, KIND_CONSTRUCTOR_INVOCATION, KIND_ENUM_CLASS_BODY, KIND_ENUM_CONSTANT,
     KIND_ENUM_ENTRY, KIND_ENUM_JAVA_DECL, KIND_EQ, KIND_FIELD_DECL, KIND_FORMAL_PARAM,
-    KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS, KIND_IDENTIFIER, KIND_INTERFACE_BODY, KIND_INTERFACE_DECL,
-    KIND_INTERP_IDENT, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_MARKER_ANNOTATION, KIND_METHOD_DECL,
-    KIND_MODIFIERS, KIND_MULTI_ANNOTATION, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_NAV_SUFFIX,
+    KIND_FUN_BODY, KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS, KIND_IDENTIFIER, KIND_INTERFACE_BODY,
+    KIND_INTERFACE_DECL, KIND_INTERP_IDENT, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS,
+    KIND_MARKER_ANNOTATION, KIND_METHOD_DECL, KIND_MODIFIERS, KIND_MOD_ABSTRACT, KIND_MOD_FINAL,
+    KIND_MOD_STATIC, KIND_MULTI_ANNOTATION, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_NAV_SUFFIX,
     KIND_OBJECT_BODY, KIND_OBJECT_DECL, KIND_PARAMETER, KIND_PROP_DECL, KIND_RECORD_DECL,
     KIND_SIMPLE_IDENT, KIND_SPREAD_PARAM, KIND_THIS_EXPR, KIND_TYPE_IDENT, KIND_TYPE_PARAM,
     KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VAR_DECL, KIND_VAR_DECLARATOR,
@@ -95,7 +96,7 @@ pub(crate) fn legend() -> SemanticTokensLegend {
 #[derive(Clone)]
 struct RawToken {
     line: u32,
-    col: u32,  // UTF-16 column
+    col: u32, // UTF-16 column
     length: u32,
     token_type: u32,
     token_modifiers_bitset: u32,
@@ -165,10 +166,24 @@ pub(crate) fn collect_tokens(
     raw.dedup_by_key(|t| (t.line, t.col));
 
     // Apply range filter before delta-encoding.
+    // Filter by full (line, character) bounds per LSP semanticTokens/range spec.
     if let Some(r) = range {
-        let start_line = r.start.line;
-        let end_line = r.end.line;
-        raw.retain(|t| t.line >= start_line && t.line <= end_line);
+        let s_line = r.start.line;
+        let s_col = r.start.character;
+        let e_line = r.end.line;
+        let e_col = r.end.character;
+        raw.retain(|t| {
+            if t.line < s_line || t.line > e_line {
+                return false;
+            }
+            if t.line == s_line && t.col < s_col {
+                return false;
+            }
+            if t.line == e_line && t.col >= e_col {
+                return false;
+            }
+            true
+        });
     }
 
     delta_encode(raw)
@@ -201,14 +216,26 @@ fn classify_kotlin(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
         KIND_PARAMETER => {
             let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
             if let Some(name) = child_ident(node) {
-                push_token(name, type_index(&SemanticTokenType::PARAMETER), mods, src, out);
+                push_token(
+                    name,
+                    type_index(&SemanticTokenType::PARAMETER),
+                    mods,
+                    src,
+                    out,
+                );
             }
         }
         KIND_ENUM_ENTRY => {
             let mods = modifier_bit(&SemanticTokenModifier::DECLARATION)
                 | modifier_bit(&SemanticTokenModifier::READONLY);
             if let Some(name) = child_ident(node) {
-                push_token(name, type_index(&SemanticTokenType::ENUM_MEMBER), mods, src, out);
+                push_token(
+                    name,
+                    type_index(&SemanticTokenType::ENUM_MEMBER),
+                    mods,
+                    src,
+                    out,
+                );
             }
         }
         KIND_ANNOTATION | KIND_MULTI_ANNOTATION => {
@@ -238,15 +265,27 @@ fn kotlin_class_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>)
     if has_modifier(node, src, "abstract") {
         mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
     }
+    if has_deprecated_annotation(node, src.bytes) {
+        mods |= modifier_bit(&SemanticTokenModifier::DEPRECATED);
+    }
     if let Some(name) = child_ident(node) {
         push_token(name, token_type, mods, src, out);
     }
 }
 
 fn kotlin_object_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
-    let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    if has_deprecated_annotation(node, src.bytes) {
+        mods |= modifier_bit(&SemanticTokenModifier::DEPRECATED);
+    }
     if let Some(name) = child_ident(node) {
-        push_token(name, type_index(&SemanticTokenType::NAMESPACE), mods, src, out);
+        push_token(
+            name,
+            type_index(&SemanticTokenType::NAMESPACE),
+            mods,
+            src,
+            out,
+        );
     }
 }
 
@@ -276,6 +315,12 @@ fn kotlin_fun_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
     if has_modifier(node, src, "abstract") {
         mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
     }
+    if has_deprecated_annotation(node, src.bytes) {
+        mods |= modifier_bit(&SemanticTokenModifier::DEPRECATED);
+    }
+    if is_in_companion_body(node) {
+        mods |= modifier_bit(&SemanticTokenModifier::STATIC);
+    }
     if let Some(name) = child_ident(node) {
         push_token(name, token_type, mods, src, out);
     }
@@ -293,6 +338,12 @@ fn kotlin_prop_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) 
     let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
     if is_val {
         mods |= modifier_bit(&SemanticTokenModifier::READONLY);
+    }
+    if has_deprecated_annotation(node, src.bytes) {
+        mods |= modifier_bit(&SemanticTokenModifier::DEPRECATED);
+    }
+    if is_in_companion_body(node) {
+        mods |= modifier_bit(&SemanticTokenModifier::STATIC);
     }
     if let Some(var_decl) = first_child_of_kind(node, KIND_VAR_DECL) {
         if let Some(name) = child_ident(var_decl) {
@@ -314,7 +365,13 @@ fn kotlin_type_param_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawTo
     if let Some(ident) = first_child_of_kind(node, KIND_TYPE_IDENT)
         .or_else(|| first_child_of_kind(node, KIND_SIMPLE_IDENT))
     {
-        push_token(ident, type_index(&SemanticTokenType::TYPE_PARAMETER), mods, src, out);
+        push_token(
+            ident,
+            type_index(&SemanticTokenType::TYPE_PARAMETER),
+            mods,
+            src,
+            out,
+        );
     }
 }
 
@@ -334,101 +391,140 @@ fn walk_java(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
 }
 
 fn classify_java(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
-    let kind = node.kind();
-
-    match kind {
+    match node.kind() {
         k if k == KIND_CLASS_DECL || k == KIND_RECORD_DECL => {
-            let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
-            if has_java_modifier(node, src, "abstract") {
-                mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
-            }
-            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
-                push_token(name, type_index(&SemanticTokenType::CLASS), mods, src, out);
-            }
+            push_java_class_like_token(node, src, out)
         }
-
         k if k == KIND_INTERFACE_DECL || k == KIND_ANNOTATION_TYPE_DECL => {
-            let token_type = if k == KIND_ANNOTATION_TYPE_DECL {
-                type_index(&SemanticTokenType::DECORATOR)
-            } else {
-                type_index(&SemanticTokenType::INTERFACE)
-            };
-            let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
-            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
-                push_token(name, token_type, mods, src, out);
-            }
+            push_java_interface_like_token(node, k, src, out)
         }
-
-        KIND_ENUM_JAVA_DECL => {
-            let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
-            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
-                push_token(name, type_index(&SemanticTokenType::ENUM), mods, src, out);
-            }
-        }
-
-        k if k == KIND_METHOD_DECL => {
-            let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
-            if has_java_modifier(node, src, "abstract") {
-                mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
-            }
-            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
-                push_token(name, type_index(&SemanticTokenType::METHOD), mods, src, out);
-            }
-        }
-
-        k if k == KIND_FIELD_DECL => {
-            let is_final = has_java_modifier(node, src, "final");
-            let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
-            if is_final {
-                mods |= modifier_bit(&SemanticTokenModifier::READONLY);
-            }
-            if has_java_modifier(node, src, "static") {
-                mods |= modifier_bit(&SemanticTokenModifier::STATIC);
-            }
-            for i in 0..node.child_count() {
-                if let Some(child) = node.child(i) {
-                    if child.kind() == KIND_VAR_DECLARATOR {
-                        if let Some(name) = first_child_of_kind(child, KIND_IDENTIFIER) {
-                            push_token(name, type_index(&SemanticTokenType::PROPERTY), mods, src, out);
-                        }
-                    }
-                }
-            }
-        }
-
-        KIND_FORMAL_PARAM | KIND_SPREAD_PARAM => {
-            let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
-            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
-                push_token(name, type_index(&SemanticTokenType::PARAMETER), mods, src, out);
-            }
-        }
-
-        k if k == KIND_ENUM_CONSTANT => {
-            let mods = modifier_bit(&SemanticTokenModifier::DECLARATION)
-                | modifier_bit(&SemanticTokenModifier::READONLY);
-            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
-                push_token(name, type_index(&SemanticTokenType::ENUM_MEMBER), mods, src, out);
-            }
-        }
-
-        k if k == KIND_TYPE_PARAM => {
-            let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
-            // Java type_parameter has type_identifier child; Kotlin uses type_identifier too
-            if let Some(name) = first_child_of_kind(node, KIND_TYPE_IDENT)
-                .or_else(|| first_child_of_kind(node, KIND_IDENTIFIER))
-            {
-                push_token(name, type_index(&SemanticTokenType::TYPE_PARAMETER), mods, src, out);
-            }
-        }
-
-        KIND_MARKER_ANNOTATION | KIND_ANNOTATION => {
-            // @Override, @SuppressWarnings("...") etc.
-            if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
-                push_token(name, type_index(&SemanticTokenType::DECORATOR), 0, src, out);
-            }
-        }
-
+        KIND_ENUM_JAVA_DECL => push_java_enum_token(node, src, out),
+        KIND_METHOD_DECL => push_java_method_token(node, src, out),
+        KIND_FIELD_DECL => push_java_field_tokens(node, src, out),
+        KIND_FORMAL_PARAM | KIND_SPREAD_PARAM => push_java_parameter_token(node, src, out),
+        KIND_ENUM_CONSTANT => push_java_enum_member_token(node, src, out),
+        KIND_TYPE_PARAM => push_java_type_parameter_token(node, src, out),
+        KIND_MARKER_ANNOTATION | KIND_ANNOTATION => push_java_annotation_token(node, src, out),
         _ => {}
+    }
+}
+
+fn push_java_class_like_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
+    let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    if has_java_modifier(node, KIND_MOD_ABSTRACT) {
+        mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
+    }
+    if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+        push_token(name, type_index(&SemanticTokenType::CLASS), mods, src, out);
+    }
+}
+
+fn push_java_interface_like_token(
+    node: Node<'_>,
+    kind: &str,
+    src: &Source<'_>,
+    out: &mut Vec<RawToken>,
+) {
+    let token_type = if kind == KIND_ANNOTATION_TYPE_DECL {
+        type_index(&SemanticTokenType::DECORATOR)
+    } else {
+        type_index(&SemanticTokenType::INTERFACE)
+    };
+    let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+        push_token(name, token_type, mods, src, out);
+    }
+}
+
+fn push_java_enum_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
+    let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+        push_token(name, type_index(&SemanticTokenType::ENUM), mods, src, out);
+    }
+}
+
+fn push_java_method_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
+    let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    if has_java_modifier(node, KIND_MOD_ABSTRACT) {
+        mods |= modifier_bit(&SemanticTokenModifier::ABSTRACT);
+    }
+    if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+        push_token(name, type_index(&SemanticTokenType::METHOD), mods, src, out);
+    }
+}
+
+fn push_java_field_tokens(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
+    let mut mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    if has_java_modifier(node, KIND_MOD_FINAL) {
+        mods |= modifier_bit(&SemanticTokenModifier::READONLY);
+    }
+    if has_java_modifier(node, KIND_MOD_STATIC) {
+        mods |= modifier_bit(&SemanticTokenModifier::STATIC);
+    }
+    for index in 0..node.child_count() {
+        let Some(child) = node.child(index) else {
+            continue;
+        };
+        if child.kind() != KIND_VAR_DECLARATOR {
+            continue;
+        }
+        if let Some(name) = first_child_of_kind(child, KIND_IDENTIFIER) {
+            push_token(
+                name,
+                type_index(&SemanticTokenType::PROPERTY),
+                mods,
+                src,
+                out,
+            );
+        }
+    }
+}
+
+fn push_java_parameter_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
+    let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+        push_token(
+            name,
+            type_index(&SemanticTokenType::PARAMETER),
+            mods,
+            src,
+            out,
+        );
+    }
+}
+
+fn push_java_enum_member_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
+    let mods = modifier_bit(&SemanticTokenModifier::DECLARATION)
+        | modifier_bit(&SemanticTokenModifier::READONLY);
+    if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+        push_token(
+            name,
+            type_index(&SemanticTokenType::ENUM_MEMBER),
+            mods,
+            src,
+            out,
+        );
+    }
+}
+
+fn push_java_type_parameter_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
+    let mods = modifier_bit(&SemanticTokenModifier::DECLARATION);
+    if let Some(name) = first_child_of_kind(node, KIND_TYPE_IDENT)
+        .or_else(|| first_child_of_kind(node, KIND_IDENTIFIER))
+    {
+        push_token(
+            name,
+            type_index(&SemanticTokenType::TYPE_PARAMETER),
+            mods,
+            src,
+            out,
+        );
+    }
+}
+
+fn push_java_annotation_token(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
+    if let Some(name) = first_child_of_kind(node, KIND_IDENTIFIER) {
+        push_token(name, type_index(&SemanticTokenType::DECORATOR), 0, src, out);
     }
 }
 
@@ -513,7 +609,9 @@ fn has_modifier(node: Node<'_>, src: &Source<'_>, keyword: &str) -> bool {
     for i in 0..node.child_count() {
         if let Some(child) = node.child(i) {
             if child.kind() == KIND_MODIFIERS
-                && node_text(child, src.bytes).split_whitespace().any(|w| w == keyword)
+                && node_text(child, src.bytes)
+                    .split_whitespace()
+                    .any(|w| w == keyword)
             {
                 return true;
             }
@@ -526,31 +624,117 @@ fn has_modifier(node: Node<'_>, src: &Source<'_>, keyword: &str) -> bool {
 }
 
 /// Check whether a Java node has a modifier keyword inside a `modifiers` node.
-fn has_java_modifier(node: Node<'_>, src: &Source<'_>, keyword: &str) -> bool {
-    for i in 0..node.child_count() {
-        if let Some(child) = node.child(i) {
-            if child.kind() == KIND_MODIFIERS
-                && node_text(child, src.bytes).split_whitespace().any(|w| w == keyword)
-            {
+fn has_java_modifier(node: Node<'_>, keyword: &str) -> bool {
+    let Some(mods) = first_child_of_kind(node, KIND_MODIFIERS) else {
+        return false;
+    };
+    let mut cursor = mods.walk();
+    if cursor.goto_first_child() {
+        loop {
+            if cursor.node().kind() == keyword {
                 return true;
+            }
+            if !cursor.goto_next_sibling() {
+                break;
             }
         }
     }
     false
 }
 
+fn is_deprecated_annotation(node: Node<'_>, src: &[u8]) -> bool {
+    (node.kind() == KIND_ANNOTATION || node.kind() == KIND_MULTI_ANNOTATION)
+        && find_annotation_ident(node)
+            .and_then(|ident| ident.utf8_text(src).ok())
+            .is_some_and(|text| text == "Deprecated")
+}
+
+fn contains_deprecated_annotation(node: Node<'_>, src: &[u8]) -> bool {
+    if is_deprecated_annotation(node, src) {
+        return true;
+    }
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            if contains_deprecated_annotation(cursor.node(), src) {
+                return true;
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    false
+}
+
+/// Returns true if the node has a preceding `@Deprecated` annotation.
+fn has_deprecated_annotation(node: Node<'_>, src: &[u8]) -> bool {
+    if first_child_of_kind(node, KIND_MODIFIERS)
+        .is_some_and(|modifiers| contains_deprecated_annotation(modifiers, src))
+    {
+        return true;
+    }
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    let mut cursor = parent.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let sibling = cursor.node();
+            if sibling.id() == node.id() {
+                break;
+            }
+            if contains_deprecated_annotation(sibling, src) {
+                return true;
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    false
+}
+
+fn is_in_companion_body(node: Node<'_>) -> bool {
+    let mut ancestor = node.parent();
+    while let Some(parent) = ancestor {
+        if parent.kind() == KIND_COMPANION_OBJ {
+            return true;
+        }
+        if parent.kind() == KIND_CLASS_DECL
+            || parent.kind() == KIND_INTERFACE_DECL
+            || parent.kind() == KIND_OBJECT_DECL
+        {
+            return false;
+        }
+        ancestor = parent.parent();
+    }
+    false
+}
+
 /// True when this node is a direct child of a class/interface/enum body.
 fn is_inside_class_body(node: Node<'_>) -> bool {
-    let Some(parent) = node.parent() else { return false };
-    let k = parent.kind();
-    k == KIND_CLASS_BODY || k == KIND_INTERFACE_BODY || k == KIND_ENUM_CLASS_BODY || k == KIND_OBJECT_BODY
+    let Some(parent) = node.parent() else {
+        return false;
+    };
+    let kind = parent.kind();
+    kind == KIND_CLASS_BODY
+        || kind == KIND_INTERFACE_BODY
+        || kind == KIND_ENUM_CLASS_BODY
+        || kind == KIND_OBJECT_BODY
 }
 
 fn node_text<'a>(node: Node<'_>, src: &'a [u8]) -> &'a str {
     node.utf8_text(src).unwrap_or("")
 }
 
-fn push_token(node: Node<'_>, token_type: u32, token_modifiers_bitset: u32, src: &Source<'_>, out: &mut Vec<RawToken>) {
+fn push_token(
+    node: Node<'_>,
+    token_type: u32,
+    token_modifiers_bitset: u32,
+    src: &Source<'_>,
+    out: &mut Vec<RawToken>,
+) {
     let start = node.start_position();
     let text = node_text(node, src.bytes);
     let length = text.encode_utf16().count() as u32;
@@ -565,7 +749,6 @@ fn push_token(node: Node<'_>, token_type: u32, token_modifiers_bitset: u32, src:
         token_modifiers_bitset,
     });
 }
-
 
 // ─── Delta encoding ───────────────────────────────────────────────────────────
 
@@ -615,9 +798,9 @@ fn navigation_receiver_node(node: Node<'_>) -> Option<Node<'_>> {
 
 fn navigation_member_ident(node: Node<'_>) -> Option<Node<'_>> {
     let suffix = node.first_child_of_kind(KIND_NAV_SUFFIX)?;
-    (0..suffix.child_count()).filter_map(|i| suffix.child(i)).find(|child| {
-        child.kind() == KIND_SIMPLE_IDENT || child.kind() == KIND_TYPE_IDENT
-    })
+    (0..suffix.child_count())
+        .filter_map(|i| suffix.child(i))
+        .find(|child| child.kind() == KIND_SIMPLE_IDENT || child.kind() == KIND_TYPE_IDENT)
 }
 
 fn token_position(bytes: &[u8], starts: &[usize], node: Node<'_>) -> Position {
@@ -699,7 +882,11 @@ fn matches_receiver_type(extension_receiver: &str, receiver_type: &str) -> bool 
     extension_receiver == receiver_type || extension_receiver == receiver_leaf
 }
 
-fn owner_member_token_type(indexer: &Indexer, receiver_type: &str, member_name: &str) -> Option<u32> {
+fn owner_member_token_type(
+    indexer: &Indexer,
+    receiver_type: &str,
+    member_name: &str,
+) -> Option<u32> {
     let receiver_leaf = receiver_type.rsplit('.').next().unwrap_or(receiver_type);
     for loc in indexer.definition_locations(receiver_leaf) {
         let Some(file_data) = indexer.files.get(loc.uri.as_str()) else {
@@ -713,18 +900,22 @@ fn owner_member_token_type(indexer: &Indexer, receiver_type: &str, member_name: 
         let Some(owner_range) = owner_range else {
             continue;
         };
-        if let Some(symbol) = file_data
-            .symbols
-            .iter()
-            .find(|symbol| symbol.name == member_name && is_member_symbol(symbol.kind) && range_within(&symbol.range, &owner_range))
-        {
+        if let Some(symbol) = file_data.symbols.iter().find(|symbol| {
+            symbol.name == member_name
+                && is_member_symbol(symbol.kind)
+                && range_within(&symbol.range, &owner_range)
+        }) {
             return member_token_type(symbol.kind);
         }
     }
     None
 }
 
-fn extension_member_token_type(indexer: &Indexer, receiver_type: &str, member_name: &str) -> Option<u32> {
+fn extension_member_token_type(
+    indexer: &Indexer,
+    receiver_type: &str,
+    member_name: &str,
+) -> Option<u32> {
     for loc in indexer.definition_locations(member_name) {
         let Some(file_data) = indexer.files.get(loc.uri.as_str()) else {
             continue;
@@ -754,15 +945,21 @@ fn member_token_type_for_receiver(
         })
 }
 
-
-
 fn member_return_type(indexer: &Indexer, receiver_type: &str, member_name: &str) -> Option<String> {
     find_method_return_type(indexer, receiver_type, member_name)
 }
 
-fn identifier_type(node: Node<'_>, doc: &LiveDoc, starts: &[usize], indexer: &Indexer, uri: &Url) -> Option<String> {
+fn identifier_type(
+    node: Node<'_>,
+    doc: &LiveDoc,
+    starts: &[usize],
+    indexer: &Indexer,
+    uri: &Url,
+) -> Option<String> {
     let name = node.utf8_text_owned(&doc.bytes)?;
-    if let Some(inferred) = indexer.infer_lambda_param_type_at(&name, uri, token_position(&doc.bytes, starts, node)) {
+    if let Some(inferred) =
+        indexer.infer_lambda_param_type_at(&name, uri, token_position(&doc.bytes, starts, node))
+    {
         return Some(inferred);
     }
     if let Some(inferred) = infer_variable_type(indexer, &name, uri) {
@@ -793,7 +990,13 @@ fn navigation_expression_type(
     find_field_type_in_class(indexer, &receiver_type, &member)
 }
 
-fn call_expression_type(node: Node<'_>, doc: &LiveDoc, starts: &[usize], indexer: &Indexer, uri: &Url) -> Option<String> {
+fn call_expression_type(
+    node: Node<'_>,
+    doc: &LiveDoc,
+    starts: &[usize],
+    indexer: &Indexer,
+    uri: &Url,
+) -> Option<String> {
     let (member, _) = node.call_fn_and_qualifier(&doc.bytes)?;
     if let Some(callee) = node.child(0).filter(|child| child.kind() == KIND_NAV_EXPR) {
         if let Some(receiver) = navigation_receiver_node(callee) {
@@ -807,10 +1010,20 @@ fn call_expression_type(node: Node<'_>, doc: &LiveDoc, starts: &[usize], indexer
     find_fun_return_type_by_name(indexer, &member)
 }
 
-fn expression_type(node: Node<'_>, doc: &LiveDoc, starts: &[usize], indexer: &Indexer, uri: &Url) -> Option<String> {
+fn expression_type(
+    node: Node<'_>,
+    doc: &LiveDoc,
+    starts: &[usize],
+    indexer: &Indexer,
+    uri: &Url,
+) -> Option<String> {
     match node.kind() {
         KIND_SIMPLE_IDENT | KIND_TYPE_IDENT => identifier_type(node, doc, starts, indexer, uri),
-        KIND_THIS_EXPR => indexer.infer_lambda_param_type_at("this", uri, token_position(&doc.bytes, starts, node)),
+        KIND_THIS_EXPR => indexer.infer_lambda_param_type_at(
+            "this",
+            uri,
+            token_position(&doc.bytes, starts, node),
+        ),
         KIND_NAV_EXPR => navigation_expression_type(node, doc, starts, indexer, uri),
         KIND_CALL_EXPR => call_expression_type(node, doc, starts, indexer, uri),
         _ => None,
@@ -833,7 +1046,12 @@ fn is_inside_lambda_parameters(node: Node<'_>) -> bool {
 
 /// Resolve member accesses in navigation expressions.
 /// Returns resolved tokens for member identifiers.
-fn resolve_member_access(doc: &LiveDoc, src: &Source<'_>, indexer: &Indexer, uri: &Url) -> Vec<RawToken> {
+fn resolve_member_access(
+    doc: &LiveDoc,
+    src: &Source<'_>,
+    indexer: &Indexer,
+    uri: &Url,
+) -> Vec<RawToken> {
     let mut tokens = Vec::new();
     visit_tree(doc.tree.root_node(), &mut |node| {
         if node.kind() != KIND_NAV_EXPR {
@@ -848,14 +1066,20 @@ fn resolve_member_access(doc: &LiveDoc, src: &Source<'_>, indexer: &Indexer, uri
         let is_call = is_call_callee(node);
         let resolved_type = navigation_receiver_node(node)
             .and_then(|receiver| expression_type(receiver, doc, &src.line_starts, indexer, uri))
-            .and_then(|receiver_type| member_token_type_for_receiver(indexer, &receiver_type, &member_name));
+            .and_then(|receiver_type| {
+                member_token_type_for_receiver(indexer, &receiver_type, &member_name)
+            });
         // For call expressions, override any PROPERTY false-positive to METHOD.
         // A called navigation suffix is always a function invocation, even if the
         // index resolved it as a property (e.g. library type not fully indexed).
         let method_type = type_index(&SemanticTokenType::METHOD);
         let property_type = type_index(&SemanticTokenType::PROPERTY);
         let token_type = if is_call {
-            Some(resolved_type.map(|t| if t == property_type { method_type } else { t }).unwrap_or(method_type))
+            Some(
+                resolved_type
+                    .map(|t| if t == property_type { method_type } else { t })
+                    .unwrap_or(method_type),
+            )
         } else {
             resolved_type
         };
@@ -867,7 +1091,12 @@ fn resolve_member_access(doc: &LiveDoc, src: &Source<'_>, indexer: &Indexer, uri
 }
 
 /// Resolve lambda parameter identifiers (`it`, `this`, named params).
-fn resolve_lambda_params(doc: &LiveDoc, src: &Source<'_>, indexer: &Indexer, uri: &Url) -> Vec<RawToken> {
+fn resolve_lambda_params(
+    doc: &LiveDoc,
+    src: &Source<'_>,
+    indexer: &Indexer,
+    uri: &Url,
+) -> Vec<RawToken> {
     let mut tokens = Vec::new();
     let lines_arc = indexer.mem_lines_for(uri.as_str());
     let fallback_lines: Vec<String> = std::str::from_utf8(&doc.bytes)
@@ -899,10 +1128,8 @@ fn resolve_lambda_params(doc: &LiveDoc, src: &Source<'_>, indexer: &Indexer, uri
         if node.kind() == KIND_THIS_EXPR && node.enclosing_lambda_literal().is_some() {
             let pos = crate::types::CursorPos {
                 line: node.start_position().row,
-                utf16_col: src.col_utf16(
-                    node.start_position().row,
-                    node.start_position().column,
-                ) as usize,
+                utf16_col: src.col_utf16(node.start_position().row, node.start_position().column)
+                    as usize,
             };
             if find_this_element_type_in_lines(lines, pos, indexer, uri).is_some() {
                 push_token(
@@ -925,10 +1152,8 @@ fn resolve_lambda_params(doc: &LiveDoc, src: &Source<'_>, indexer: &Indexer, uri
         };
         let pos = crate::types::CursorPos {
             line: node.start_position().row,
-            utf16_col: src.col_utf16(
-                node.start_position().row,
-                node.start_position().column,
-            ) as usize,
+            utf16_col: src.col_utf16(node.start_position().row, node.start_position().column)
+                as usize,
         };
 
         if name == "it" {
@@ -1008,7 +1233,7 @@ fn emit_param_uses_for_function(fn_node: Node<'_>, src: &Source<'_>, out: &mut V
     if params.is_empty() {
         return;
     }
-    let Some(body) = first_child_of_kind(fn_node, "function_body") else {
+    let Some(body) = first_child_of_kind(fn_node, KIND_FUN_BODY) else {
         return;
     };
     emit_param_refs_in_scope(body, &params, src, out);
@@ -1019,15 +1244,19 @@ fn emit_param_uses_for_function(fn_node: Node<'_>, src: &Source<'_>, out: &mut V
 /// parameter captures to be colored inside nested functions and lambdas.
 /// Nested function declarations are also processed separately by the outer
 /// `visit_tree` call, so their own parameters are handled independently.
-fn emit_param_refs_in_scope(node: Node<'_>, params: &[String], src: &Source<'_>, out: &mut Vec<RawToken>) {
-    if node.kind() == KIND_SIMPLE_IDENT || node.kind() == KIND_INTERP_IDENT {
-        if !is_declaration_site(node) {
-            if let Ok(name) = node.utf8_text(src.bytes) {
-                if params.iter().any(|p| p == name) {
-                    push_token(node, type_index(&SemanticTokenType::PARAMETER), 0, src, out);
-                }
-            }
-        }
+fn emit_param_refs_in_scope(
+    node: Node<'_>,
+    params: &[String],
+    src: &Source<'_>,
+    out: &mut Vec<RawToken>,
+) {
+    if (node.kind() == KIND_SIMPLE_IDENT || node.kind() == KIND_INTERP_IDENT)
+        && !is_declaration_site(node)
+        && node
+            .utf8_text(src.bytes)
+            .is_ok_and(|name| params.iter().any(|param| param == name))
+    {
+        push_token(node, type_index(&SemanticTokenType::PARAMETER), 0, src, out);
     }
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
@@ -1039,8 +1268,6 @@ fn emit_param_refs_in_scope(node: Node<'_>, params: &[String], src: &Source<'_>,
         }
     }
 }
-
-
 
 /// Walk non-declaration identifiers and resolve them against the index.
 /// Emits tokens for type references, function calls, member accesses, etc.
@@ -1067,7 +1294,12 @@ fn walk_references(
     raw.extend(resolve_lambda_params(doc, src, indexer, uri));
 }
 
-fn walk_kotlin_references(node: Node<'_>, src: &Source<'_>, indexer: &Indexer, out: &mut Vec<RawToken>) {
+fn walk_kotlin_references(
+    node: Node<'_>,
+    src: &Source<'_>,
+    indexer: &Indexer,
+    out: &mut Vec<RawToken>,
+) {
     // Emit keyword tokens for Kotlin soft keywords
     if is_kotlin_keyword_node(node) {
         push_token(node, type_index(&SemanticTokenType::KEYWORD), 0, src, out);
@@ -1125,26 +1357,42 @@ fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> O
 
     if is_top_level_call_name(node) {
         return resolve_symbol_kind(node_text(node, src), indexer, |kind| {
-            matches!(kind, SymbolKind::CLASS | SymbolKind::STRUCT | SymbolKind::FUNCTION | SymbolKind::METHOD)
+            matches!(
+                kind,
+                SymbolKind::CLASS | SymbolKind::STRUCT | SymbolKind::FUNCTION | SymbolKind::METHOD
+            )
         })
         .and_then(|resolved| call_symbol_kind_to_token_type(resolved.kind));
     }
 
     if is_navigation_receiver(node) {
-        return resolve_symbol_kind(node_text(node, src), indexer, |kind| kind == SymbolKind::OBJECT)
-            .map(|_| type_index(&SemanticTokenType::NAMESPACE));
+        return resolve_symbol_kind(node_text(node, src), indexer, |kind| {
+            kind == SymbolKind::OBJECT
+        })
+        .map(|_| type_index(&SemanticTokenType::NAMESPACE));
     }
 
     None
 }
 
 fn is_declaration_site(node: Node<'_>) -> bool {
-    let Some(parent) = node.parent() else { return false };
+    let Some(parent) = node.parent() else {
+        return false;
+    };
     let pk = parent.kind();
-    if pk == KIND_CLASS_DECL || pk == KIND_OBJECT_DECL || pk == KIND_COMPANION_OBJ || pk == "type_alias" {
+    if pk == KIND_CLASS_DECL
+        || pk == KIND_OBJECT_DECL
+        || pk == KIND_COMPANION_OBJ
+        || pk == "type_alias"
+    {
         return node.kind() == KIND_TYPE_IDENT;
     }
-    if pk == KIND_FUN_DECL || pk == KIND_PARAMETER || pk == KIND_ENUM_ENTRY || pk == KIND_VAR_DECL || pk == "class_parameter" {
+    if pk == KIND_FUN_DECL
+        || pk == KIND_PARAMETER
+        || pk == KIND_ENUM_ENTRY
+        || pk == KIND_VAR_DECL
+        || pk == "class_parameter"
+    {
         return node.kind() == KIND_SIMPLE_IDENT;
     }
     if pk == KIND_TYPE_PARAM {
@@ -1154,11 +1402,15 @@ fn is_declaration_site(node: Node<'_>) -> bool {
 }
 
 fn is_annotation_reference(node: Node<'_>) -> bool {
-    let Some(parent) = node.parent() else { return false };
+    let Some(parent) = node.parent() else {
+        return false;
+    };
     if parent.kind() != KIND_USER_TYPE {
         return false;
     }
-    let Some(grandparent) = parent.parent() else { return false };
+    let Some(grandparent) = parent.parent() else {
+        return false;
+    };
     // @Simple annotation: annotation > user_type > type_identifier
     if grandparent.kind() == KIND_ANNOTATION || grandparent.kind() == KIND_MULTI_ANNOTATION {
         return true;
@@ -1180,7 +1432,9 @@ fn is_type_reference(node: Node<'_>) -> bool {
 }
 
 fn is_top_level_call_name(node: Node<'_>) -> bool {
-    let Some(parent) = node.parent() else { return false };
+    let Some(parent) = node.parent() else {
+        return false;
+    };
     parent.kind() == KIND_CALL_EXPR
         && parent
             .named_child(0)
@@ -1188,7 +1442,9 @@ fn is_top_level_call_name(node: Node<'_>) -> bool {
 }
 
 fn is_navigation_receiver(node: Node<'_>) -> bool {
-    let Some(parent) = node.parent() else { return false };
+    let Some(parent) = node.parent() else {
+        return false;
+    };
     parent.kind() == KIND_NAV_EXPR
         && parent
             .named_child(0)
@@ -1198,17 +1454,20 @@ fn is_navigation_receiver(node: Node<'_>) -> bool {
 /// Named argument label: `foo(name = value)` — the `name` identifier is the
 /// first child of `value_argument` and is followed by `=`.
 fn is_named_argument_label(node: Node<'_>) -> bool {
-    let Some(parent) = node.parent() else { return false };
+    let Some(parent) = node.parent() else {
+        return false;
+    };
     if parent.kind() != KIND_VALUE_ARG {
         return false;
     }
     // The label is the first named child and must be followed by "="
-    let Some(first) = parent.named_child(0) else { return false };
+    let Some(first) = parent.named_child(0) else {
+        return false;
+    };
     if first.id() != node.id() {
         return false;
     }
-    node.next_sibling()
-        .is_some_and(|sib| sib.kind() == KIND_EQ)
+    node.next_sibling().is_some_and(|sib| sib.kind() == KIND_EQ)
 }
 
 fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> Option<u32> {
@@ -1219,8 +1478,9 @@ fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> 
     }
 
     let receiver = navigation.named_child(0)?;
-    let receiver_kind =
-        resolve_symbol_kind(node_text(receiver, src), indexer, |kind| kind == SymbolKind::ENUM)?;
+    let receiver_kind = resolve_symbol_kind(node_text(receiver, src), indexer, |kind| {
+        kind == SymbolKind::ENUM
+    })?;
     let receiver_data = indexer.files.get(receiver_kind.uri.as_str())?;
     receiver_data
         .symbols
@@ -1296,14 +1556,25 @@ struct ResolvedReference {
 
 // ─── Public API ──────────────────────────────────────────────────────────────
 
-pub(crate) fn full_tokens(indexer: &Indexer, uri: &Url, doc: &LiveDoc, language: Language) -> SemanticTokens {
+pub(crate) fn full_tokens(
+    indexer: &Indexer,
+    uri: &Url,
+    doc: &LiveDoc,
+    language: Language,
+) -> SemanticTokens {
     SemanticTokens {
         result_id: None,
         data: collect_tokens(doc, language, None, Some(indexer), Some(uri)),
     }
 }
 
-pub(crate) fn range_tokens(indexer: &Indexer, uri: &Url, doc: &LiveDoc, language: Language, range: &Range) -> SemanticTokens {
+pub(crate) fn range_tokens(
+    indexer: &Indexer,
+    uri: &Url,
+    doc: &LiveDoc,
+    language: Language,
+    range: &Range,
+) -> SemanticTokens {
     SemanticTokens {
         result_id: None,
         data: collect_tokens(doc, language, Some(range), Some(indexer), Some(uri)),
@@ -1321,7 +1592,11 @@ pub(crate) fn full_tokens_cst_only(doc: &LiveDoc, language: Language) -> Semanti
 }
 
 #[cfg(test)]
-pub(crate) fn range_tokens_cst_only(doc: &LiveDoc, language: Language, range: &Range) -> SemanticTokens {
+pub(crate) fn range_tokens_cst_only(
+    doc: &LiveDoc,
+    language: Language,
+    range: &Range,
+) -> SemanticTokens {
     SemanticTokens {
         result_id: None,
         data: collect_tokens(doc, language, Some(range), None, None),

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -24,12 +24,12 @@ use crate::queries::{
     KIND_ANNOTATION, KIND_ANNOTATION_TYPE_DECL, KIND_CALL_EXPR, KIND_CLASS_BODY, KIND_CLASS_DECL,
     KIND_COMPANION_OBJ, KIND_CONSTRUCTOR_INVOCATION, KIND_ENUM_CLASS_BODY, KIND_ENUM_CONSTANT,
     KIND_ENUM_ENTRY, KIND_ENUM_JAVA_DECL, KIND_EQ, KIND_FIELD_DECL, KIND_FORMAL_PARAM,
-    KIND_FUN_DECL, KIND_IDENTIFIER, KIND_INTERFACE_BODY, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT,
-    KIND_LAMBDA_PARAMS, KIND_MARKER_ANNOTATION, KIND_METHOD_DECL, KIND_MODIFIERS,
-    KIND_MULTI_ANNOTATION, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_OBJECT_BODY,
-    KIND_OBJECT_DECL, KIND_PARAMETER, KIND_PROP_DECL, KIND_RECORD_DECL, KIND_SIMPLE_IDENT,
-    KIND_SPREAD_PARAM, KIND_THIS_EXPR, KIND_TYPE_IDENT, KIND_TYPE_PARAM, KIND_USER_TYPE,
-    KIND_VALUE_ARG, KIND_VAR_DECL, KIND_VAR_DECLARATOR,
+    KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS, KIND_IDENTIFIER, KIND_INTERFACE_BODY, KIND_INTERFACE_DECL,
+    KIND_INTERP_IDENT, KIND_LAMBDA_LIT, KIND_LAMBDA_PARAMS, KIND_MARKER_ANNOTATION, KIND_METHOD_DECL,
+    KIND_MODIFIERS, KIND_MULTI_ANNOTATION, KIND_MULTI_VAR_DECL, KIND_NAV_EXPR, KIND_NAV_SUFFIX,
+    KIND_OBJECT_BODY, KIND_OBJECT_DECL, KIND_PARAMETER, KIND_PROP_DECL, KIND_RECORD_DECL,
+    KIND_SIMPLE_IDENT, KIND_SPREAD_PARAM, KIND_THIS_EXPR, KIND_TYPE_IDENT, KIND_TYPE_PARAM,
+    KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VAR_DECL, KIND_VAR_DECLARATOR,
 };
 use crate::resolver::infer::{
     find_field_type_in_class, find_fun_return_type_by_name, find_method_return_type,
@@ -142,6 +142,13 @@ pub(crate) fn collect_tokens(
         Language::Kotlin => walk_kotlin(doc.tree.root_node(), &src, &mut raw),
         Language::Java => walk_java(doc.tree.root_node(), &src, &mut raw),
         _ => {}
+    }
+
+    // Phase 1b: Emit PARAMETER tokens at use sites within Kotlin function bodies.
+    // Purely CST-based; runs without an indexer so parameters are colored even on
+    // first open before the workspace index is ready.
+    if language == Language::Kotlin {
+        emit_kotlin_param_uses(doc.tree.root_node(), &src, &mut raw);
     }
 
     // Phase 2: resolve reference-site identifiers against the index.
@@ -957,7 +964,83 @@ fn resolve_lambda_params(doc: &LiveDoc, src: &Source<'_>, indexer: &Indexer, uri
     tokens
 }
 
-// ─── Reference-site walker (Phase 2) ─────────────────────────────────────────
+// ─── Phase 1b: parameter use-site coloring ────────────────────────────────────
+
+/// Emit PARAMETER tokens for every use of a function parameter within its body.
+/// Runs before the reference walk so parameter coloring is available even when
+/// the workspace index is not yet ready (no indexer required).
+fn emit_kotlin_param_uses(root: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
+    visit_tree(root, &mut |node| {
+        if node.kind() == KIND_FUN_DECL || node.kind() == KIND_METHOD_DECL {
+            emit_param_uses_for_function(node, src, out);
+        }
+    });
+}
+
+/// Collect the simple-identifier names of all `parameter` children inside
+/// the `function_value_parameters` node of `fn_node`.
+fn collect_fun_param_names(fn_node: Node<'_>, bytes: &[u8]) -> Vec<String> {
+    let Some(params_node) = first_child_of_kind(fn_node, KIND_FUN_VALUE_PARAMS) else {
+        return Vec::new();
+    };
+    let mut names = Vec::new();
+    let mut cursor = params_node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            let child = cursor.node();
+            if child.kind() == KIND_PARAMETER {
+                if let Some(ident) = child_ident(child) {
+                    if let Ok(name) = ident.utf8_text(bytes) {
+                        names.push(name.to_owned());
+                    }
+                }
+            }
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+    names
+}
+
+fn emit_param_uses_for_function(fn_node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
+    let params = collect_fun_param_names(fn_node, src.bytes);
+    if params.is_empty() {
+        return;
+    }
+    let Some(body) = first_child_of_kind(fn_node, "function_body") else {
+        return;
+    };
+    emit_param_refs_in_scope(body, &params, src, out);
+}
+
+/// Walk `node` emitting PARAMETER tokens for identifiers that match a name in
+/// `params`. Does not stop at nested function declarations, allowing outer
+/// parameter captures to be colored inside nested functions and lambdas.
+/// Nested function declarations are also processed separately by the outer
+/// `visit_tree` call, so their own parameters are handled independently.
+fn emit_param_refs_in_scope(node: Node<'_>, params: &[String], src: &Source<'_>, out: &mut Vec<RawToken>) {
+    if node.kind() == KIND_SIMPLE_IDENT || node.kind() == KIND_INTERP_IDENT {
+        if !is_declaration_site(node) {
+            if let Ok(name) = node.utf8_text(src.bytes) {
+                if params.iter().any(|p| p == name) {
+                    push_token(node, type_index(&SemanticTokenType::PARAMETER), 0, src, out);
+                }
+            }
+        }
+    }
+    let mut cursor = node.walk();
+    if cursor.goto_first_child() {
+        loop {
+            emit_param_refs_in_scope(cursor.node(), params, src, out);
+            if !cursor.goto_next_sibling() {
+                break;
+            }
+        }
+    }
+}
+
+
 
 /// Walk non-declaration identifiers and resolve them against the index.
 /// Emits tokens for type references, function calls, member accesses, etc.

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -205,8 +205,12 @@ fn classify_kotlin(node: Node<'_>, src: &Source<'_>, out: &mut Vec<RawToken>) {
             }
         }
         KIND_ANNOTATION | KIND_MULTI_ANNOTATION => {
-            if let Some(ident) = find_annotation_ident(node) {
-                push_token(ident, type_index(&SemanticTokenType::DECORATOR), 0, src, out);
+            // Emit the token for the whole annotation node (@Composable, not just Composable).
+            // This ensures both the "@" and the name are covered by the same semantic token,
+            // so themes don't see a split between tree-sitter @attribute for "@" and a
+            // possibly-different semantic scope for the name.
+            if find_annotation_ident(node).is_some() {
+                push_token(node, type_index(&SemanticTokenType::DECORATOR), 0, src, out);
             }
         }
         _ => {}
@@ -1018,9 +1022,9 @@ fn classify_kotlin_reference(node: Node<'_>, src: &[u8], indexer: &Indexer) -> O
     }
 
     if is_annotation_reference(node) {
-        // Annotations are unambiguous from CST position — always emit DECORATOR
-        // regardless of whether the annotation class is in our index.
-        return Some(type_index(&SemanticTokenType::DECORATOR));
+        // CST walk already emits DECORATOR for the whole annotation node (including "@").
+        // Skip here to avoid a duplicate at the type_identifier position.
+        return None;
     }
 
     if let Some(token_type) = enum_entry_reference_token(node, src, indexer) {

--- a/src/semantic_tokens.rs
+++ b/src/semantic_tokens.rs
@@ -97,12 +97,12 @@ pub(crate) fn legend() -> SemanticTokensLegend {
 // ─── Classification ───────────────────────────────────────────────────────────
 
 #[derive(Clone)]
-struct RawToken {
-    line: u32,
-    col: u32, // UTF-16 column
-    length: u32,
-    token_type: u32,
-    token_modifiers_bitset: u32,
+pub(crate) struct RawToken {
+    pub(crate) line: u32,
+    pub(crate) col: u32, // UTF-16 column
+    pub(crate) length: u32,
+    pub(crate) token_type: u32,
+    pub(crate) token_modifiers_bitset: u32,
 }
 
 /// Bundles source bytes with precomputed line-start offsets for O(1) UTF-16
@@ -124,6 +124,54 @@ impl<'a> Source<'a> {
         crate::inlay_hints::ts_byte_col_to_utf16(self.bytes, &self.line_starts, row, byte_col)
             as u32
     }
+}
+
+/// Per-phase token breakdown for debug output.
+pub(crate) struct TokenPhases {
+    pub phase1: Vec<RawToken>,
+    pub phase1b: Vec<RawToken>,
+    pub phase2: Vec<RawToken>,
+}
+
+impl TokenPhases {
+    pub(crate) fn final_tokens(&self) -> Vec<RawToken> {
+        let mut raw = self.phase1.clone();
+        raw.extend_from_slice(&self.phase1b);
+        raw.extend_from_slice(&self.phase2);
+        raw.sort_by_key(|t| (t.line, t.col));
+        raw.dedup_by_key(|t| (t.line, t.col));
+        raw
+    }
+}
+
+/// Like `collect_tokens` but returns each phase's tokens separately for debug.
+/// Does not apply range filtering or delta encoding.
+pub(crate) fn collect_tokens_phases(
+    doc: &LiveDoc,
+    language: Language,
+    indexer: Option<&Indexer>,
+    uri: Option<&Url>,
+) -> TokenPhases {
+    let src = Source::new(&doc.bytes);
+    let mut phase1 = Vec::new();
+    let mut phase1b = Vec::new();
+    let mut phase2 = Vec::new();
+
+    match language {
+        Language::Kotlin => walk_kotlin(doc.tree.root_node(), &src, &mut phase1),
+        Language::Java => walk_java(doc.tree.root_node(), &src, &mut phase1),
+        _ => {}
+    }
+
+    if language == Language::Kotlin {
+        emit_kotlin_param_uses(doc.tree.root_node(), &src, &mut phase1b);
+    }
+
+    if let (Some(idx), Some(file_uri)) = (indexer, uri) {
+        walk_references(doc, &src, language, idx, file_uri, &mut phase2);
+    }
+
+    TokenPhases { phase1, phase1b, phase2 }
 }
 
 /// Collect semantic tokens for `doc`, for the given `language`.

--- a/src/semantic_tokens_tests.rs
+++ b/src/semantic_tokens_tests.rs
@@ -513,54 +513,7 @@ fn empty_file_returns_no_tokens() {
 }
 
 #[test]
-fn named_arg_cst_detail() {
-    let src = "fun main() { foo(name = 42) }\n";
-    let doc = parse_kotlin(src);
-    fn find_value_arg(node: tree_sitter::Node) -> Option<tree_sitter::Node> {
-        if node.kind() == "value_argument" {
-            return Some(node);
-        }
-        let mut c = node.walk();
-        if c.goto_first_child() {
-            loop {
-                if let Some(r) = find_value_arg(c.node()) {
-                    return Some(r);
-                }
-                if !c.goto_next_sibling() {
-                    break;
-                }
-            }
-        }
-        None
-    }
-    let va = find_value_arg(doc.tree.root_node()).unwrap();
-    eprintln!("value_argument children:");
-    for i in 0..va.child_count() {
-        let c = va.child(i).unwrap();
-        eprintln!(
-            "  child({i}): kind={:?} named={} text={:?}",
-            c.kind(),
-            c.is_named(),
-            c.utf8_text(src.as_bytes()).unwrap_or("?")
-        );
-    }
-    eprintln!("value_argument named_children:");
-    for i in 0..va.named_child_count() {
-        let c = va.named_child(i).unwrap();
-        eprintln!(
-            "  named_child({i}): kind={:?} text={:?}",
-            c.kind(),
-            c.utf8_text(src.as_bytes()).unwrap_or("?")
-        );
-    }
-    // Check our detection function
-    let label = va.named_child(0).unwrap();
-    let next_sib = label.next_sibling();
-    eprintln!("label next_sibling: {:?}", next_sib.map(|n| n.kind()));
-}
-
-#[test]
-fn named_arg_label_gets_property_token() {
+fn named_arg_label_gets_parameter_token() {
     let src = "fun foo(name: Int) {}\nfun main() { foo(name = 42) }\n";
     let uri = Url::parse("file:///named_arg_test.kt").unwrap();
     let indexer = Indexer::new();
@@ -620,6 +573,69 @@ fn decl_function_parameter() {
             .iter()
             .any(|t| t.0 == 0 && t.1 == 24 && t.3 == param_type),
         "Expected PARAMETER for 'age' at col 24, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn class_parameter_val_gets_property() {
+    let src = "class Foo(val x: Int)\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let property_type = type_id(&SemanticTokenType::PROPERTY);
+    let readonly_bit = 1u32 << 1;
+    let decl_bit = 1u32 << 0;
+
+    let token = tokens
+        .iter()
+        .find(|&&(line, col, _, token_type, _)| {
+            line == 0 && col == 14 && token_type == property_type
+        })
+        .expect("expected PROPERTY token for class parameter");
+    assert_ne!(
+        token.4 & readonly_bit,
+        0,
+        "val class parameter should be READONLY"
+    );
+    assert_ne!(
+        token.4 & decl_bit,
+        0,
+        "class parameter should be a declaration"
+    );
+}
+
+#[test]
+fn class_parameter_var_gets_property() {
+    let src = "class Foo(var x: Int)\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let property_type = type_id(&SemanticTokenType::PROPERTY);
+    let readonly_bit = 1u32 << 1;
+
+    let token = tokens
+        .iter()
+        .find(|&&(line, col, _, token_type, _)| {
+            line == 0 && col == 14 && token_type == property_type
+        })
+        .expect("expected PROPERTY token for mutable class parameter");
+    assert_eq!(
+        token.4 & readonly_bit,
+        0,
+        "var class parameter should not be READONLY"
+    );
+}
+
+#[test]
+fn class_parameter_plain_gets_parameter() {
+    let src = "class Foo(x: Int)\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
+
+    assert!(
+        tokens.iter().any(|&(line, col, _, token_type, _)| line == 0
+            && col == 10
+            && token_type == param_type),
+        "expected PARAMETER token for plain class parameter, got: {tokens:?}"
     );
 }
 
@@ -698,6 +714,50 @@ fn param_use_in_body_gets_parameter_token() {
             && tt == param_type
             && (mods & decl_mod) == 0),
         "Expected PARAMETER (no declaration) for 'count' at 2:12, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn param_shadow_by_local_val() {
+    let src = "fun f(x: Int) { val x = 1; println(x) }\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
+
+    assert_eq!(
+        tokens
+            .iter()
+            .filter(|&&(line, _, _, token_type, _)| line == 0 && token_type == param_type)
+            .count(),
+        1,
+        "shadowed local should prevent parameter coloring after the binding, got: {tokens:?}"
+    );
+    assert!(
+        !tokens.iter().any(|&(line, col, _, token_type, _)| line == 0
+            && col == 35
+            && token_type == param_type),
+        "println(x) should not be colored as a parameter after local shadowing, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn param_shadow_for_loop() {
+    let src = "fun f(x: Int) { for (x in listOf(x)) { println(x) } }\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
+
+    assert!(
+        tokens
+            .iter()
+            .any(|&(line, col, _, token_type, _)| line == 0 && col == 33 && token_type == param_type),
+        "iterable x should still be colored as the parameter before the loop binding, got: {tokens:?}"
+    );
+    assert!(
+        !tokens.iter().any(|&(line, col, _, token_type, _)| line == 0
+            && col == 47
+            && token_type == param_type),
+        "loop body x should not be colored as a parameter after the loop binding, got: {tokens:?}"
     );
 }
 
@@ -1250,6 +1310,38 @@ fn deprecated_modifier_set_on_kotlin_declarations() {
 }
 
 #[test]
+fn deprecated_modifier_set_on_java_declarations() {
+    let src = "class Example {\n    @Deprecated int field = 0;\n    @Deprecated void oldMethod() {}\n}\n@Deprecated class OldClass {}\n";
+    let doc = parse_java(src);
+    let tokens = decode_all(&doc, Language::Java);
+    let deprecated_bit = 1u32 << 5;
+    let class_type = type_id(&SemanticTokenType::CLASS);
+    let method_type = type_id(&SemanticTokenType::METHOD);
+    let property_type = type_id(&SemanticTokenType::PROPERTY);
+
+    for token in [
+        tokens
+            .iter()
+            .find(|&&(line, _, _, token_type, _)| line == 4 && token_type == class_type)
+            .expect("expected deprecated Java class token"),
+        tokens
+            .iter()
+            .find(|&&(line, _, _, token_type, _)| line == 1 && token_type == property_type)
+            .expect("expected deprecated Java field token"),
+        tokens
+            .iter()
+            .find(|&&(line, _, _, token_type, _)| line == 2 && token_type == method_type)
+            .expect("expected deprecated Java method token"),
+    ] {
+        assert_ne!(
+            token.4 & deprecated_bit,
+            0,
+            "expected Java declaration to be marked DEPRECATED, token={token:?}, all={tokens:?}"
+        );
+    }
+}
+
+#[test]
 fn companion_members_have_static_modifier() {
     let src = "class Foo {\n    companion object {\n        fun make() = Foo()\n        val value = 1\n    }\n}\n";
     let doc = parse_kotlin(src);
@@ -1310,5 +1402,50 @@ fn abstract_class_method_both_abstract() {
         method_mods & decl_bit,
         0,
         "method should have DECLARATION, mods={method_mods:#b}"
+    );
+}
+
+#[test]
+fn soft_keyword_is_emits_keyword_token() {
+    let src = "fun f(x: Any): Boolean = x is String\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let kw_type = type_id(&SemanticTokenType::KEYWORD);
+    // "is" is at col 27, len 2
+    assert!(
+        tokens
+            .iter()
+            .any(|&(l, c, len, tt, _)| l == 0 && c == 27 && len == 2 && tt == kw_type),
+        "expected KEYWORD for 'is' at (0,27), got: {tokens:?}"
+    );
+}
+
+#[test]
+fn soft_keyword_by_emits_keyword_token() {
+    let src = "val d by lazy { 42 }\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let kw_type = type_id(&SemanticTokenType::KEYWORD);
+    // "by" is at col 6, len 2
+    assert!(
+        tokens
+            .iter()
+            .any(|&(l, c, len, tt, _)| l == 0 && c == 6 && len == 2 && tt == kw_type),
+        "expected KEYWORD for 'by' at (0,6), got: {tokens:?}"
+    );
+}
+
+#[test]
+fn soft_keyword_as_emits_keyword_token() {
+    let src = "fun f(x: Any): Any = x as String\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let kw_type = type_id(&SemanticTokenType::KEYWORD);
+    // "as" is at col 23, len 2
+    assert!(
+        tokens
+            .iter()
+            .any(|&(l, c, len, tt, _)| l == 0 && c == 23 && len == 2 && tt == kw_type),
+        "expected KEYWORD for 'as' at (0,23), got: {tokens:?}"
     );
 }

--- a/src/semantic_tokens_tests.rs
+++ b/src/semantic_tokens_tests.rs
@@ -1,10 +1,10 @@
 use tower_lsp::lsp_types::{Position, Range, SemanticTokenModifier, SemanticTokenType, Url};
 
 use crate::indexer::{live_tree::parse_live, Indexer};
-use crate::Language;
 use crate::semantic_tokens::{
     full_tokens, full_tokens_cst_only, range_tokens_cst_only, TOKEN_MODIFIERS, TOKEN_TYPES,
 };
+use crate::Language;
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -63,7 +63,9 @@ fn assert_token_at(
     assert!(
         tokens
             .iter()
-            .any(|&(token_line, token_col, _, kind, _)| token_line == line && token_col == col && kind == token_type),
+            .any(|&(token_line, token_col, _, kind, _)| token_line == line
+                && token_col == col
+                && kind == token_type),
         "expected {label} token at {line}:{col}, got: {tokens:?}"
     );
 }
@@ -77,7 +79,10 @@ fn kotlin_class_decl() {
     let tokens = decode_all(&doc, Language::Kotlin);
     let class_id = type_id(&SemanticTokenType::CLASS);
     let found = tokens.iter().any(|&(_, _, _, tt, _)| tt == class_id);
-    assert!(found, "expected CLASS token for 'class Foo', got: {tokens:?}");
+    assert!(
+        found,
+        "expected CLASS token for 'class Foo', got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -151,7 +156,9 @@ fn kotlin_val_is_readonly() {
     // READONLY modifier bit = 1
     let readonly_bit = 1u32 << 1;
     assert!(
-        tokens.iter().any(|&(_, _, _, _, mods)| mods & readonly_bit != 0),
+        tokens
+            .iter()
+            .any(|&(_, _, _, _, mods)| mods & readonly_bit != 0),
         "expected READONLY modifier for val, got: {tokens:?}"
     );
 }
@@ -167,7 +174,10 @@ fn kotlin_var_not_readonly() {
     let x_token = tokens
         .iter()
         .find(|&&(line, col, _, tt, _)| line == 0 && col == 4 && tt == var_id);
-    assert!(x_token.is_some(), "expected VARIABLE token for x at 0:4, got: {tokens:?}");
+    assert!(
+        x_token.is_some(),
+        "expected VARIABLE token for x at 0:4, got: {tokens:?}"
+    );
     let (_, _, _, _, mods) = *x_token.unwrap();
     assert_eq!(
         mods & readonly_bit,
@@ -227,8 +237,14 @@ fun bar() {}
     let doc = parse_kotlin(src);
     // Only request line 1 (0-indexed) — "class Foo"
     let range = Range {
-        start: Position { line: 1, character: 0 },
-        end: Position { line: 1, character: 9 },
+        start: Position {
+            line: 1,
+            character: 0,
+        },
+        end: Position {
+            line: 1,
+            character: 9,
+        },
     };
     let tokens = range_tokens_cst_only(&doc, Language::Kotlin, &range);
     // Should have tokens only on line 1
@@ -252,6 +268,41 @@ fun bar() {}
     assert!(
         decoded.iter().all(|&l| l == 1),
         "range_tokens should only return tokens on line 1, got lines: {decoded:?}"
+    );
+}
+
+#[test]
+fn kotlin_range_honors_character_bounds() {
+    let src = "fun foo(x: Int) = x\n";
+    let doc = parse_kotlin(src);
+    let range = Range {
+        start: Position {
+            line: 0,
+            character: 7,
+        },
+        end: Position {
+            line: 0,
+            character: 9,
+        },
+    };
+    let decoded = decode_tokens(&range_tokens_cst_only(&doc, Language::Kotlin, &range));
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
+    assert_eq!(
+        decoded.len(),
+        1,
+        "expected exactly one token in range, got: {decoded:?}"
+    );
+    assert_eq!(
+        decoded[0].0, 0,
+        "expected token on line 0, got: {decoded:?}"
+    );
+    assert_eq!(
+        decoded[0].1, 8,
+        "expected token at parameter column, got: {decoded:?}"
+    );
+    assert_eq!(
+        decoded[0].3, param_type,
+        "expected PARAMETER token, got: {decoded:?}"
     );
 }
 
@@ -455,7 +506,10 @@ class Foo {
 fn empty_file_returns_no_tokens() {
     let doc = parse_kotlin("");
     let tokens = full_tokens_cst_only(&doc, Language::Kotlin);
-    assert!(tokens.data.is_empty(), "empty file should produce no tokens");
+    assert!(
+        tokens.data.is_empty(),
+        "empty file should produce no tokens"
+    );
 }
 
 #[test]
@@ -463,24 +517,41 @@ fn named_arg_cst_detail() {
     let src = "fun main() { foo(name = 42) }\n";
     let doc = parse_kotlin(src);
     fn find_value_arg(node: tree_sitter::Node) -> Option<tree_sitter::Node> {
-        if node.kind() == "value_argument" { return Some(node); }
+        if node.kind() == "value_argument" {
+            return Some(node);
+        }
         let mut c = node.walk();
-        if c.goto_first_child() { loop {
-            if let Some(r) = find_value_arg(c.node()) { return Some(r); }
-            if !c.goto_next_sibling() { break; }
-        }}
+        if c.goto_first_child() {
+            loop {
+                if let Some(r) = find_value_arg(c.node()) {
+                    return Some(r);
+                }
+                if !c.goto_next_sibling() {
+                    break;
+                }
+            }
+        }
         None
     }
     let va = find_value_arg(doc.tree.root_node()).unwrap();
     eprintln!("value_argument children:");
     for i in 0..va.child_count() {
         let c = va.child(i).unwrap();
-        eprintln!("  child({i}): kind={:?} named={} text={:?}", c.kind(), c.is_named(), c.utf8_text(src.as_bytes()).unwrap_or("?"));
+        eprintln!(
+            "  child({i}): kind={:?} named={} text={:?}",
+            c.kind(),
+            c.is_named(),
+            c.utf8_text(src.as_bytes()).unwrap_or("?")
+        );
     }
     eprintln!("value_argument named_children:");
     for i in 0..va.named_child_count() {
         let c = va.named_child(i).unwrap();
-        eprintln!("  named_child({i}): kind={:?} text={:?}", c.kind(), c.utf8_text(src.as_bytes()).unwrap_or("?"));
+        eprintln!(
+            "  named_child({i}): kind={:?} text={:?}",
+            c.kind(),
+            c.utf8_text(src.as_bytes()).unwrap_or("?")
+        );
     }
     // Check our detection function
     let label = va.named_child(0).unwrap();
@@ -498,8 +569,12 @@ fn named_arg_label_gets_property_token() {
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
     // "name" in foo(name = 42) is at line 1, col 17 — emitted as PARAMETER (JetBrains behaviour)
     let param_type = type_id(&SemanticTokenType::PARAMETER);
-    assert!(tokens.iter().any(|t| t.0 == 1 && t.1 == 17 && t.3 == param_type),
-        "Expected PARAMETER at (1,17) for named arg 'name', got: {tokens:?}");
+    assert!(
+        tokens
+            .iter()
+            .any(|t| t.0 == 1 && t.1 == 17 && t.3 == param_type),
+        "Expected PARAMETER at (1,17) for named arg 'name', got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -512,11 +587,15 @@ fn named_arg_multiline_call() {
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
     let param_type = type_id(&SemanticTokenType::PARAMETER);
     // "modifier" at line 2, col 8
-    assert!(tokens.iter().any(|t| t.0 == 2 && t.3 == param_type),
-        "Expected PARAMETER on line 2 for 'modifier', got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.0 == 2 && t.3 == param_type),
+        "Expected PARAMETER on line 2 for 'modifier', got: {tokens:?}"
+    );
     // "topBar" at line 3, col 8
-    assert!(tokens.iter().any(|t| t.0 == 3 && t.3 == param_type),
-        "Expected PARAMETER on line 3 for 'topBar', got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.0 == 3 && t.3 == param_type),
+        "Expected PARAMETER on line 3 for 'topBar', got: {tokens:?}"
+    );
 }
 
 // ─── Phase 2: Comprehensive semantic token coverage ──────────────────────────
@@ -530,10 +609,18 @@ fn decl_function_parameter() {
     let tokens = decode_all(&doc, Language::Kotlin);
     let param_type = type_id(&SemanticTokenType::PARAMETER);
     // "name" at col 10, "age" at col 24
-    assert!(tokens.iter().any(|t| t.0 == 0 && t.1 == 10 && t.3 == param_type),
-        "Expected PARAMETER for 'name' at col 10, got: {tokens:?}");
-    assert!(tokens.iter().any(|t| t.0 == 0 && t.1 == 24 && t.3 == param_type),
-        "Expected PARAMETER for 'age' at col 24, got: {tokens:?}");
+    assert!(
+        tokens
+            .iter()
+            .any(|t| t.0 == 0 && t.1 == 10 && t.3 == param_type),
+        "Expected PARAMETER for 'name' at col 10, got: {tokens:?}"
+    );
+    assert!(
+        tokens
+            .iter()
+            .any(|t| t.0 == 0 && t.1 == 24 && t.3 == param_type),
+        "Expected PARAMETER for 'age' at col 24, got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -542,8 +629,10 @@ fn decl_annotation_simple() {
     let doc = parse_kotlin(src);
     let tokens = decode_all(&doc, Language::Kotlin);
     let deco_type = type_id(&SemanticTokenType::DECORATOR);
-    assert!(tokens.iter().any(|t| t.0 == 0 && t.3 == deco_type),
-        "Expected DECORATOR for @Composable, got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.0 == 0 && t.3 == deco_type),
+        "Expected DECORATOR for @Composable, got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -552,8 +641,10 @@ fn decl_annotation_with_args() {
     let doc = parse_kotlin(src);
     let tokens = decode_all(&doc, Language::Kotlin);
     let deco_type = type_id(&SemanticTokenType::DECORATOR);
-    assert!(tokens.iter().any(|t| t.0 == 0 && t.3 == deco_type),
-        "Expected DECORATOR for @Named(...), got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.0 == 0 && t.3 == deco_type),
+        "Expected DECORATOR for @Named(...), got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -562,8 +653,10 @@ fn decl_annotation_inline_on_parameter() {
     let doc = parse_kotlin(src);
     let tokens = decode_all(&doc, Language::Kotlin);
     let deco_type = type_id(&SemanticTokenType::DECORATOR);
-    assert!(tokens.iter().any(|t| t.0 == 0 && t.3 == deco_type),
-        "Expected DECORATOR for inline @Inject on parameter, got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.0 == 0 && t.3 == deco_type),
+        "Expected DECORATOR for inline @Inject on parameter, got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -572,8 +665,10 @@ fn decl_annotation_inline_with_args_on_parameter() {
     let doc = parse_kotlin(src);
     let tokens = decode_all(&doc, Language::Kotlin);
     let deco_type = type_id(&SemanticTokenType::DECORATOR);
-    assert!(tokens.iter().any(|t| t.0 == 0 && t.3 == deco_type),
-        "Expected DECORATOR for inline @Named(\"key\") on param, got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.0 == 0 && t.3 == deco_type),
+        "Expected DECORATOR for inline @Named(\"key\") on param, got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -584,14 +679,24 @@ fn param_use_in_body_gets_parameter_token() {
     let doc = parse_kotlin(src);
     let tokens = decode_all(&doc, Language::Kotlin);
     let param_type = type_id(&SemanticTokenType::PARAMETER);
-    let decl_mod = 1u32 << TOKEN_MODIFIERS.iter().position(|m| m == &SemanticTokenModifier::DECLARATION).unwrap();
+    let decl_mod = 1u32
+        << TOKEN_MODIFIERS
+            .iter()
+            .position(|m| m == &SemanticTokenModifier::DECLARATION)
+            .unwrap();
     // Use-site tokens: line 1 col 12 "name", line 2 col 12 "count"
     assert!(
-        tokens.iter().any(|&(line, col, _, tt, mods)| line == 1 && col == 12 && tt == param_type && (mods & decl_mod) == 0),
+        tokens.iter().any(|&(line, col, _, tt, mods)| line == 1
+            && col == 12
+            && tt == param_type
+            && (mods & decl_mod) == 0),
         "Expected PARAMETER (no declaration) for 'name' at 1:12, got: {tokens:?}"
     );
     assert!(
-        tokens.iter().any(|&(line, col, _, tt, mods)| line == 2 && col == 12 && tt == param_type && (mods & decl_mod) == 0),
+        tokens.iter().any(|&(line, col, _, tt, mods)| line == 2
+            && col == 12
+            && tt == param_type
+            && (mods & decl_mod) == 0),
         "Expected PARAMETER (no declaration) for 'count' at 2:12, got: {tokens:?}"
     );
 }
@@ -603,7 +708,9 @@ fn param_use_in_string_template_gets_parameter_token() {
     let tokens = decode_all(&doc, Language::Kotlin);
     let param_type = type_id(&SemanticTokenType::PARAMETER);
     assert!(
-        tokens.iter().any(|&(line, _, _, tt, _)| line == 1 && tt == param_type),
+        tokens
+            .iter()
+            .any(|&(line, _, _, tt, _)| line == 1 && tt == param_type),
         "Expected PARAMETER for '$name' in string template, got: {tokens:?}"
     );
 }
@@ -616,7 +723,9 @@ fn param_use_in_nested_function_captures_outer_param() {
     let param_type = type_id(&SemanticTokenType::PARAMETER);
     // outer's x used inside inner's body
     assert!(
-        tokens.iter().any(|&(line, col, _, tt, _)| line == 2 && col == 16 && tt == param_type),
+        tokens
+            .iter()
+            .any(|&(line, col, _, tt, _)| line == 2 && col == 16 && tt == param_type),
         "Expected PARAMETER for outer 'x' captured in inner fn at 2:16, got: {tokens:?}"
     );
 }
@@ -627,8 +736,10 @@ fn decl_data_class_is_struct() {
     let doc = parse_kotlin(src);
     let tokens = decode_all(&doc, Language::Kotlin);
     let struct_type = type_id(&SemanticTokenType::STRUCT);
-    assert!(tokens.iter().any(|t| t.3 == struct_type),
-        "Expected STRUCT for data class, got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.3 == struct_type),
+        "Expected STRUCT for data class, got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -637,8 +748,10 @@ fn decl_operator_fun() {
     let doc = parse_kotlin(src);
     let tokens = decode_all(&doc, Language::Kotlin);
     let op_type = type_id(&SemanticTokenType::OPERATOR);
-    assert!(tokens.iter().any(|t| t.3 == op_type),
-        "Expected OPERATOR for operator fun, got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.3 == op_type),
+        "Expected OPERATOR for operator fun, got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -647,8 +760,10 @@ fn decl_suspend_has_async_modifier() {
     let doc = parse_kotlin(src);
     let tokens = decode_all(&doc, Language::Kotlin);
     let async_bit = 1u32 << 4; // ASYNC modifier
-    assert!(tokens.iter().any(|t| t.4 & async_bit != 0),
-        "Expected ASYNC modifier for suspend fun, got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.4 & async_bit != 0),
+        "Expected ASYNC modifier for suspend fun, got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -657,8 +772,10 @@ fn decl_abstract_has_abstract_modifier() {
     let doc = parse_kotlin(src);
     let tokens = decode_all(&doc, Language::Kotlin);
     let abstract_bit = 1u32 << 3; // ABSTRACT modifier
-    assert!(tokens.iter().any(|t| t.4 & abstract_bit != 0),
-        "Expected ABSTRACT modifier, got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.4 & abstract_bit != 0),
+        "Expected ABSTRACT modifier, got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -668,10 +785,14 @@ fn decl_class_property_vs_top_level_variable() {
     let tokens = decode_all(&doc, Language::Kotlin);
     let var_type = type_id(&SemanticTokenType::VARIABLE);
     let prop_type = type_id(&SemanticTokenType::PROPERTY);
-    assert!(tokens.iter().any(|t| t.0 == 0 && t.3 == var_type),
-        "Expected VARIABLE for top-level val, got: {tokens:?}");
-    assert!(tokens.iter().any(|t| t.0 == 2 && t.3 == prop_type),
-        "Expected PROPERTY for class member val, got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.0 == 0 && t.3 == var_type),
+        "Expected VARIABLE for top-level val, got: {tokens:?}"
+    );
+    assert!(
+        tokens.iter().any(|t| t.0 == 2 && t.3 == prop_type),
+        "Expected PROPERTY for class member val, got: {tokens:?}"
+    );
 }
 
 // --- Reference-site tokens (requires indexer) ---
@@ -804,8 +925,10 @@ fn keyword_by_delegation() {
     let doc = parse_kotlin(src);
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
     let kw_type = type_id(&SemanticTokenType::KEYWORD);
-    assert!(tokens.iter().any(|t| t.3 == kw_type),
-        "Expected KEYWORD for 'by', got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.3 == kw_type),
+        "Expected KEYWORD for 'by', got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -817,8 +940,10 @@ fn keyword_is_check() {
     let doc = parse_kotlin(src);
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
     let kw_type = type_id(&SemanticTokenType::KEYWORD);
-    assert!(tokens.iter().any(|t| t.3 == kw_type),
-        "Expected KEYWORD for 'is', got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.3 == kw_type),
+        "Expected KEYWORD for 'is', got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -830,8 +955,10 @@ fn keyword_as_cast() {
     let doc = parse_kotlin(src);
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
     let kw_type = type_id(&SemanticTokenType::KEYWORD);
-    assert!(tokens.iter().any(|t| t.3 == kw_type),
-        "Expected KEYWORD for 'as', got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.3 == kw_type),
+        "Expected KEYWORD for 'as', got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -843,8 +970,10 @@ fn keyword_in_loop() {
     let doc = parse_kotlin(src);
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
     let kw_type = type_id(&SemanticTokenType::KEYWORD);
-    assert!(tokens.iter().any(|t| t.3 == kw_type),
-        "Expected KEYWORD for 'in', got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.3 == kw_type),
+        "Expected KEYWORD for 'in', got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -856,8 +985,10 @@ fn keyword_constructor() {
     let doc = parse_kotlin(src);
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
     let kw_type = type_id(&SemanticTokenType::KEYWORD);
-    assert!(tokens.iter().any(|t| t.3 == kw_type),
-        "Expected KEYWORD for 'constructor', got: {tokens:?}");
+    assert!(
+        tokens.iter().any(|t| t.3 == kw_type),
+        "Expected KEYWORD for 'constructor', got: {tokens:?}"
+    );
 }
 
 // --- Named argument labels ---
@@ -885,8 +1016,12 @@ fn named_arg_not_emitted_for_positional() {
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
     // No PARAMETER token on line 1 for positional arg "42"
     let param_type = type_id(&SemanticTokenType::PARAMETER);
-    assert!(!tokens.iter().any(|t| t.0 == 1 && t.1 == 17 && t.3 == param_type),
-        "Should NOT emit PARAMETER for positional arg, got: {tokens:?}");
+    assert!(
+        !tokens
+            .iter()
+            .any(|t| t.0 == 1 && t.1 == 17 && t.3 == param_type),
+        "Should NOT emit PARAMETER for positional arg, got: {tokens:?}"
+    );
 }
 
 #[test]
@@ -944,8 +1079,12 @@ fn decl_extension_function_receiver_type_colored() {
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
     let class_type = type_id(&SemanticTokenType::CLASS);
     // "String" receiver at col 4 — classified as CLASS (unresolved type ref fallback)
-    assert!(tokens.iter().any(|t| t.0 == 0 && t.1 == 4 && t.3 == class_type),
-        "Expected CLASS for extension receiver type 'String', got: {tokens:?}");
+    assert!(
+        tokens
+            .iter()
+            .any(|t| t.0 == 0 && t.1 == 4 && t.3 == class_type),
+        "Expected CLASS for extension receiver type 'String', got: {tokens:?}"
+    );
 }
 
 // --- byte_col_to_utf16 correctness ---
@@ -984,10 +1123,21 @@ fn companion_object_has_static_modifier() {
     let static_bit = 1u32 << 2;
     let decl_bit = 1u32 << 0;
     let companion = tokens.iter().find(|&&(_, _, _, tt, _)| tt == ns_type);
-    assert!(companion.is_some(), "expected NAMESPACE token for companion object");
+    assert!(
+        companion.is_some(),
+        "expected NAMESPACE token for companion object"
+    );
     let (_, _, _, _, mods) = *companion.unwrap();
-    assert_ne!(mods & static_bit, 0, "companion object should have STATIC modifier, mods={mods:#b}");
-    assert_ne!(mods & decl_bit, 0, "companion object should have DECLARATION modifier, mods={mods:#b}");
+    assert_ne!(
+        mods & static_bit,
+        0,
+        "companion object should have STATIC modifier, mods={mods:#b}"
+    );
+    assert_ne!(
+        mods & decl_bit,
+        0,
+        "companion object should have DECLARATION modifier, mods={mods:#b}"
+    );
 }
 
 #[test]
@@ -999,11 +1149,24 @@ fn java_field_final_is_property_readonly() {
     let readonly_bit = 1u32 << 1;
     let decl_bit = 1u32 << 0;
     // "count" at col 30
-    let field = tokens.iter().find(|&&(_, col, _, tt, _)| col == 30 && tt == prop_type);
-    assert!(field.is_some(), "expected PROPERTY for 'count', tokens: {tokens:?}");
+    let field = tokens
+        .iter()
+        .find(|&&(_, col, _, tt, _)| col == 30 && tt == prop_type);
+    assert!(
+        field.is_some(),
+        "expected PROPERTY for 'count', tokens: {tokens:?}"
+    );
     let (_, _, _, _, mods) = *field.unwrap();
-    assert_ne!(mods & readonly_bit, 0, "final field should have READONLY modifier, mods={mods:#b}");
-    assert_ne!(mods & decl_bit, 0, "field should have DECLARATION modifier, mods={mods:#b}");
+    assert_ne!(
+        mods & readonly_bit,
+        0,
+        "final field should have READONLY modifier, mods={mods:#b}"
+    );
+    assert_ne!(
+        mods & decl_bit,
+        0,
+        "field should have DECLARATION modifier, mods={mods:#b}"
+    );
 }
 
 #[test]
@@ -1016,7 +1179,11 @@ fn java_field_static_has_static_modifier() {
     let field = tokens.iter().find(|&&(_, _, _, tt, _)| tt == prop_type);
     assert!(field.is_some(), "expected PROPERTY for 'count'");
     let (_, _, _, _, mods) = *field.unwrap();
-    assert_ne!(mods & static_bit, 0, "static field should have STATIC modifier, mods={mods:#b}");
+    assert_ne!(
+        mods & static_bit,
+        0,
+        "static field should have STATIC modifier, mods={mods:#b}"
+    );
 }
 
 #[test]
@@ -1030,8 +1197,16 @@ fn java_field_non_final_non_static_has_no_readonly_static() {
     let field = tokens.iter().find(|&&(_, _, _, tt, _)| tt == prop_type);
     assert!(field.is_some(), "expected PROPERTY for 'count'");
     let (_, _, _, _, mods) = *field.unwrap();
-    assert_eq!(mods & readonly_bit, 0, "mutable field should NOT have READONLY, mods={mods:#b}");
-    assert_eq!(mods & static_bit, 0, "instance field should NOT have STATIC, mods={mods:#b}");
+    assert_eq!(
+        mods & readonly_bit,
+        0,
+        "mutable field should NOT have READONLY, mods={mods:#b}"
+    );
+    assert_eq!(
+        mods & static_bit,
+        0,
+        "instance field should NOT have STATIC, mods={mods:#b}"
+    );
 }
 
 #[test]
@@ -1042,8 +1217,66 @@ fn deprecated_modifier_not_set_without_annotation() {
     let tokens = decode_all(&doc, Language::Kotlin);
     let deprecated_bit = 1u32 << 5;
     for &(_, _, _, _, mods) in &tokens {
-        assert_eq!(mods & deprecated_bit, 0, "DEPRECATED should not be set without @Deprecated, mods={mods:#b}");
+        assert_eq!(
+            mods & deprecated_bit,
+            0,
+            "DEPRECATED should not be set without @Deprecated, mods={mods:#b}"
+        );
     }
+}
+
+#[test]
+fn deprecated_modifier_set_on_kotlin_declarations() {
+    let src = "@Deprecated(\"x\") class OldClass\n@Deprecated(\"x\")\nfun oldFun() {}\n@Deprecated(\"x\")\nobject OldObject\n@Deprecated(\"x\") val oldValue = 1\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let deprecated_bit = 1u32 << 5;
+    let class_type = type_id(&SemanticTokenType::CLASS);
+    let namespace_type = type_id(&SemanticTokenType::NAMESPACE);
+    let function_type = type_id(&SemanticTokenType::FUNCTION);
+    let variable_type = type_id(&SemanticTokenType::VARIABLE);
+
+    for token_type in [class_type, namespace_type, function_type, variable_type] {
+        let token = tokens
+            .iter()
+            .find(|&&(_, _, _, actual_type, _)| actual_type == token_type)
+            .expect("expected declaration token");
+        assert_ne!(
+            token.4 & deprecated_bit,
+            0,
+            "expected DEPRECATED modifier, token={token:?}, all={tokens:?}"
+        );
+    }
+}
+
+#[test]
+fn companion_members_have_static_modifier() {
+    let src = "class Foo {\n    companion object {\n        fun make() = Foo()\n        val value = 1\n    }\n}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let static_bit = 1u32 << 2;
+    let method_type = type_id(&SemanticTokenType::METHOD);
+    let property_type = type_id(&SemanticTokenType::PROPERTY);
+
+    let method = tokens
+        .iter()
+        .find(|&&(line, _, _, token_type, _)| line == 2 && token_type == method_type)
+        .expect("expected METHOD token for companion member");
+    assert_ne!(
+        method.4 & static_bit,
+        0,
+        "companion method should have STATIC modifier, token={method:?}, all={tokens:?}"
+    );
+
+    let property = tokens
+        .iter()
+        .find(|&&(line, _, _, token_type, _)| line == 3 && token_type == property_type)
+        .expect("expected PROPERTY token for companion member");
+    assert_ne!(
+        property.4 & static_bit,
+        0,
+        "companion property should have STATIC modifier, token={property:?}, all={tokens:?}"
+    );
 }
 
 #[test]
@@ -1059,11 +1292,23 @@ fn abstract_class_method_both_abstract() {
     let cls = tokens.iter().find(|&&(_, _, _, tt, _)| tt == class_type);
     assert!(cls.is_some(), "expected CLASS token");
     let (_, _, _, _, class_mods) = *cls.unwrap();
-    assert_ne!(class_mods & abstract_bit, 0, "abstract class should have ABSTRACT, mods={class_mods:#b}");
+    assert_ne!(
+        class_mods & abstract_bit,
+        0,
+        "abstract class should have ABSTRACT, mods={class_mods:#b}"
+    );
     // fun doIt
     let method = tokens.iter().find(|&&(_, _, _, tt, _)| tt == method_type);
     assert!(method.is_some(), "expected METHOD token");
     let (_, _, _, _, method_mods) = *method.unwrap();
-    assert_ne!(method_mods & abstract_bit, 0, "abstract fun should have ABSTRACT, mods={method_mods:#b}");
-    assert_ne!(method_mods & decl_bit, 0, "method should have DECLARATION, mods={method_mods:#b}");
+    assert_ne!(
+        method_mods & abstract_bit,
+        0,
+        "abstract fun should have ABSTRACT, mods={method_mods:#b}"
+    );
+    assert_ne!(
+        method_mods & decl_bit,
+        0,
+        "method should have DECLARATION, mods={method_mods:#b}"
+    );
 }

--- a/src/semantic_tokens_tests.rs
+++ b/src/semantic_tokens_tests.rs
@@ -1,9 +1,9 @@
-use tower_lsp::lsp_types::{Position, Range, SemanticTokenType, Url};
+use tower_lsp::lsp_types::{Position, Range, SemanticTokenModifier, SemanticTokenType, Url};
 
 use crate::indexer::{live_tree::parse_live, Indexer};
 use crate::Language;
 use crate::semantic_tokens::{
-    full_tokens, full_tokens_cst_only, range_tokens_cst_only, TOKEN_TYPES,
+    full_tokens, full_tokens_cst_only, range_tokens_cst_only, TOKEN_MODIFIERS, TOKEN_TYPES,
 };
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -574,6 +574,51 @@ fn decl_annotation_inline_with_args_on_parameter() {
     let deco_type = type_id(&SemanticTokenType::DECORATOR);
     assert!(tokens.iter().any(|t| t.0 == 0 && t.3 == deco_type),
         "Expected DECORATOR for inline @Named(\"key\") on param, got: {tokens:?}");
+}
+
+#[test]
+fn param_use_in_body_gets_parameter_token() {
+    // Parameters referenced in the function body should be colored as PARAMETER
+    // (without declaration modifier) — matches rust-analyzer behaviour.
+    let src = "fun greet(name: String, count: Int) {\n    println(name)\n    println(count)\n}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
+    let decl_mod = 1u32 << TOKEN_MODIFIERS.iter().position(|m| m == &SemanticTokenModifier::DECLARATION).unwrap();
+    // Use-site tokens: line 1 col 12 "name", line 2 col 12 "count"
+    assert!(
+        tokens.iter().any(|&(line, col, _, tt, mods)| line == 1 && col == 12 && tt == param_type && (mods & decl_mod) == 0),
+        "Expected PARAMETER (no declaration) for 'name' at 1:12, got: {tokens:?}"
+    );
+    assert!(
+        tokens.iter().any(|&(line, col, _, tt, mods)| line == 2 && col == 12 && tt == param_type && (mods & decl_mod) == 0),
+        "Expected PARAMETER (no declaration) for 'count' at 2:12, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn param_use_in_string_template_gets_parameter_token() {
+    let src = "fun greet(name: String) {\n    val msg = \"Hello $name\"\n}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
+    assert!(
+        tokens.iter().any(|&(line, _, _, tt, _)| line == 1 && tt == param_type),
+        "Expected PARAMETER for '$name' in string template, got: {tokens:?}"
+    );
+}
+
+#[test]
+fn param_use_in_nested_function_captures_outer_param() {
+    let src = "fun outer(x: Int) {\n    fun inner(y: Int) {\n        println(x)\n    }\n}\n";
+    let doc = parse_kotlin(src);
+    let tokens = decode_all(&doc, Language::Kotlin);
+    let param_type = type_id(&SemanticTokenType::PARAMETER);
+    // outer's x used inside inner's body
+    assert!(
+        tokens.iter().any(|&(line, col, _, tt, _)| line == 2 && col == 16 && tt == param_type),
+        "Expected PARAMETER for outer 'x' captured in inner fn at 2:16, got: {tokens:?}"
+    );
 }
 
 #[test]

--- a/src/semantic_tokens_tests.rs
+++ b/src/semantic_tokens_tests.rs
@@ -320,7 +320,7 @@ fn kotlin_reference_sites_resolve_annotations_and_enum_entries() {
     assert_token_at(
         &tokens,
         2,
-        1,
+        0,
         type_id(&SemanticTokenType::DECORATOR),
         "DECORATOR annotation reference",
     );
@@ -732,7 +732,7 @@ fn ref_annotation_unresolved_still_decorator() {
     let doc = parse_kotlin(src);
     let tokens = decode_all_indexed(&indexer, &uri, &doc, Language::Kotlin);
     let deco_type = type_id(&SemanticTokenType::DECORATOR);
-    assert_token_at(&tokens, 0, 1, deco_type, "DECORATOR unresolved annotation");
+    assert_token_at(&tokens, 0, 0, deco_type, "DECORATOR unresolved annotation");
 }
 
 #[test]


### PR DESCRIPTION
## PR 2/4 — Parameters, CLI, fixes

Builds on PR #63.

- **Parameter use-sites**: Emit PARAMETER token at variable use-sites in function bodies (Phase 1b)
- **CLI debug**: `tokens` and `tree` subcommands, `--phases` flag for pipeline inspection
- **Annotation spans**: DECORATOR covers full `@Annotation` span (not just `@`)
- **Fixes**: range_within positions, class_parameter handling, shadowing, soft keywords, Java deprecated
- Version bump to 0.10.1

### Files changed
- `src/semantic_tokens.rs` — param use-sites, annotation fix, named arg Phase 1
- `src/cli/tokens.rs` — new tokens debug subcommand
- `src/cli/args.rs`, `src/cli/run.rs` — CLI integration
- `src/inlay_hints.rs`, `src/inlay_hints_tests.rs` — minor adjustments

**Stack**: #63 core → PR 2/4 → #3 VS Code → #4 module split