### PR TITLE
feat: self-contained VS Code extension

### DIFF
--- a/contrib/vscode/.gitignore
+++ b/contrib/vscode/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/contrib/vscode/extension.js
+++ b/contrib/vscode/extension.js
@@ -1,0 +1,29 @@
+const { LanguageClient, TransportKind } = require("vscode-languageclient/node");
+const vscode = require("vscode");
+
+let client;
+
+function activate(context) {
+  const command = vscode.workspace.getConfiguration("kotlinLsp").get("path", "kotlin-lsp");
+
+  const serverOptions = {
+    command,
+    transport: TransportKind.stdio,
+  };
+
+  const clientOptions = {
+    documentSelector: [
+      { scheme: "file", language: "kotlin" },
+      { scheme: "file", language: "java" },
+    ],
+  };
+
+  client = new LanguageClient("kotlin-lsp", "Kotlin LSP", serverOptions, clientOptions);
+  client.start();
+}
+
+function deactivate() {
+  return client?.stop();
+}
+
+module.exports = { activate, deactivate };

--- a/contrib/vscode/kotlin-language-configuration.json
+++ b/contrib/vscode/kotlin-language-configuration.json
@@ -1,0 +1,15 @@
+{
+  "comments": { "lineComment": "//", "blockComment": ["/*", "*/"] },
+  "brackets": [
+    ["{", "}"],
+    ["[", "]"],
+    ["(", ")"]
+  ],
+  "autoClosingPairs": [
+    { "open": "{", "close": "}" },
+    { "open": "[", "close": "]" },
+    { "open": "(", "close": ")" },
+    { "open": "\"", "close": "\"", "notIn": ["string"] },
+    { "open": "'", "close": "'", "notIn": ["string", "comment"] }
+  ]
+}

--- a/contrib/vscode/package.json
+++ b/contrib/vscode/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "kotlin-lsp-client",
+  "publisher": "kotlin-lsp",
+  "displayName": "Kotlin LSP (kotlin-lsp)",
+  "description": "VSCode client for kotlin-lsp",
+  "version": "0.0.1",
+  "engines": { "vscode": "^1.75.0" },
+  "activationEvents": ["onLanguage:kotlin", "onLanguage:java"],
+  "main": "./extension.js",
+  "contributes": {
+    "languages": [
+      {
+        "id": "kotlin",
+        "aliases": ["Kotlin"],
+        "extensions": [".kt", ".kts"],
+        "configuration": "./kotlin-language-configuration.json"
+      }
+    ],
+    "grammars": [
+      {
+        "language": "kotlin",
+        "scopeName": "source.kotlin",
+        "path": "./syntaxes/kotlin.tmLanguage.json"
+      }
+    ],
+    "configuration": {
+      "title": "Kotlin LSP",
+      "properties": {
+        "kotlinLsp.path": {
+          "type": "string",
+          "default": "kotlin-lsp",
+          "description": "Path to kotlin-lsp binary"
+        }
+      }
+    }
+  },
+  "dependencies": {
+    "vscode-languageclient": "^9.0.1"
+  }
+}

--- a/contrib/vscode/syntaxes/kotlin.tmLanguage.json
+++ b/contrib/vscode/syntaxes/kotlin.tmLanguage.json
@@ -1,0 +1,580 @@
+{
+    "$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
+    "name": "Kotlin",
+    "scopeName": "source.kotlin",
+    "patterns": [
+        {
+            "include": "#import"
+        },
+        {
+            "include": "#package"
+        },
+        {
+            "include": "#code"
+        }
+    ],
+    "fileTypes": [
+        "kt",
+        "kts"
+    ],
+    "repository": {
+        "import": {
+            "begin": "\\b(import)\\b\\s*",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.soft.kotlin"
+                }
+            },
+            "end": ";|$",
+            "name": "meta.import.kotlin",
+            "contentName": "entity.name.package.kotlin",
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#hard-keywords"
+                },
+                {
+                    "match": "\\*",
+                    "name": "variable.language.wildcard.kotlin"
+                }
+            ]
+        },
+        "package": {
+            "begin": "\\b(package)\\b\\s*",
+            "beginCaptures": {
+                "1": {
+                    "name": "keyword.hard.package.kotlin"
+                }
+            },
+            "end": ";|$",
+            "name": "meta.package.kotlin",
+            "contentName": "entity.name.package.kotlin",
+            "patterns": [
+                {
+                    "include": "#comments"
+                }
+            ]
+        },
+        "code": {
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#keywords"
+                },
+                {
+                    "include": "#annotation-simple"
+                },
+                {
+                    "include": "#annotation-site-list"
+                },
+                {
+                    "include": "#annotation-site"
+                },
+                {
+                    "include": "#class-declaration"
+                },
+                {
+                    "include": "#object"
+                },
+                {
+                    "include": "#type-alias"
+                },
+                {
+                    "include": "#function"
+                },
+                {
+                    "include": "#variable-declaration"
+                },
+                {
+                    "include": "#type-constraint"
+                },
+                {
+                    "include": "#type-annotation"
+                },
+                {
+                    "include": "#function-call"
+                },
+                {
+                    "include": "#method-reference"
+                },
+                {
+                    "include": "#key"
+                },
+                {
+                    "include": "#string"
+                },
+                {
+                    "include": "#string-empty"
+                },
+                {
+                    "include": "#string-multiline"
+                },
+                {
+                    "include": "#character"
+                },
+                {
+                    "include": "#lambda-arrow"
+                },
+                {
+                    "include": "#operators"
+                },
+                {
+                    "include": "#self-reference"
+                },
+                {
+                    "include": "#decimal-literal"
+                },
+                {
+                    "include": "#hex-literal"
+                },
+                {
+                    "include": "#binary-literal"
+                },
+                {
+                    "include": "#boolean-literal"
+                },
+                {
+                    "include": "#null-literal"
+                }
+            ]
+        },
+        "comments": {
+            "patterns": [
+                {
+                    "include": "#comment-line"
+                },
+                {
+                    "include": "#comment-block"
+                },
+                {
+                    "include": "#comment-javadoc"
+                }
+            ]
+        },
+        "comment-line": {
+            "begin": "//",
+            "end": "$",
+            "name": "comment.line.double-slash.kotlin"
+        },
+        "comment-block": {
+            "begin": "/\\*(?!\\*)",
+            "end": "\\*/",
+            "name": "comment.block.kotlin"
+        },
+        "comment-javadoc": {
+            "patterns": [
+                {
+                    "begin": "/\\*\\*",
+                    "end": "\\*/",
+                    "name": "comment.block.javadoc.kotlin",
+                    "patterns": [
+                        {
+                            "match": "@(return|constructor|receiver|sample|see|author|since|suppress)\\b",
+                            "name": "keyword.other.documentation.javadoc.kotlin"
+                        },
+                        {
+                            "match": "(@param|@property)\\s+(\\S+)",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.other.documentation.javadoc.kotlin"
+                                },
+                                "2": {
+                                    "name": "variable.parameter.kotlin"
+                                }
+                            }
+                        },
+                        {
+                            "match": "(@param)\\[(\\S+)\\]",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.other.documentation.javadoc.kotlin"
+                                },
+                                "2": {
+                                    "name": "variable.parameter.kotlin"
+                                }
+                            }
+                        },
+                        {
+                            "match": "(@(?:exception|throws))\\s+(\\S+)",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.other.documentation.javadoc.kotlin"
+                                },
+                                "2": {
+                                    "name": "entity.name.type.class.kotlin"
+                                }
+                            }
+                        },
+                        {
+                            "match": "{(@link)\\s+(\\S+)?#([\\w$]+\\s*\\([^\\(\\)]*\\)).*}",
+                            "captures": {
+                                "1": {
+                                    "name": "keyword.other.documentation.javadoc.kotlin"
+                                },
+                                "2": {
+                                    "name": "entity.name.type.class.kotlin"
+                                },
+                                "3": {
+                                    "name": "variable.parameter.kotlin"
+                                }
+                            }
+                        }
+                    ]
+                }
+            ]
+        },
+        "keywords": {
+            "patterns": [
+                {
+                    "include": "#prefix-modifiers"
+                },
+                {
+                    "include": "#postfix-modifiers"
+                },
+                {
+                    "include": "#soft-keywords"
+                },
+                {
+                    "include": "#hard-keywords"
+                },
+                {
+                    "include": "#control-keywords"
+                }
+            ]
+        },
+        "prefix-modifiers": {
+            "match": "\\b(abstract|final|enum|open|annotation|sealed|data|override|final|lateinit|private|protected|public|internal|inner|companion|noinline|crossinline|vararg|reified|tailrec|operator|infix|inline|external|const|suspend|value)\\b",
+            "name": "storage.modifier.other.kotlin"
+        },
+        "postfix-modifiers": {
+            "match": "\\b(where|by|get|set)\\b",
+            "name": "storage.modifier.other.kotlin"
+        },
+        "soft-keywords": {
+            "match": "\\b(init|catch|finally|field)\\b",
+            "name": "keyword.soft.kotlin"
+        },
+        "hard-keywords": {
+            "match": "\\b(as|typeof|is|in)\\b",
+            "name": "keyword.hard.kotlin"
+        },
+        "control-keywords": {
+            "match": "\\b(if|else|while|do|when|try|throw|break|continue|return|for)\\b",
+            "name": "keyword.control.kotlin"
+        },
+        "annotation-simple": {
+            "match": "(?<!\\w)@[\\w\\.]+\\b(?!:)",
+            "name": "entity.name.type.annotation.kotlin"
+        },
+        "annotation-site-list": {
+            "begin": "(?<!\\w)(@\\w+):\\s*\\[",
+            "end": "\\]",
+            "beginCaptures": {
+                "1": {
+                    "name": "entity.name.type.annotation-site.kotlin"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#unescaped-annotation"
+                }
+            ]
+        },
+        "annotation-site": {
+            "begin": "(?<!\\w)(@\\w+):\\s*(?!\\[)",
+            "end": "$",
+            "beginCaptures": {
+                "1": {
+                    "name": "entity.name.type.annotation-site.kotlin"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#unescaped-annotation"
+                }
+            ]
+        },
+        "unescaped-annotation": {
+            "match": "\\b[\\w\\.]+\\b",
+            "name": "entity.name.type.annotation.kotlin"
+        },
+        "class-declaration": {
+            "match": "\\b(class|(?:fun\\s+)?interface)\\s+(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?",
+            "captures": {
+                "1": {
+                    "name": "keyword.hard.class.kotlin"
+                },
+                "2": {
+                    "name": "entity.name.type.class.kotlin"
+                },
+                "3": {
+                    "patterns": [
+                        {
+                            "include": "#type-parameter"
+                        }
+                    ]
+                }
+            }
+        },
+        "object": {
+            "match": "\\b(object)(?:\\s+(\\b\\w+\\b|`[^`]+`))?",
+            "captures": {
+                "1": {
+                    "name": "keyword.hard.object.kotlin"
+                },
+                "2": {
+                    "name": "entity.name.type.object.kotlin"
+                }
+            }
+        },
+        "type-alias": {
+            "match": "\\b(typealias)\\s+(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?",
+            "captures": {
+                "1": {
+                    "name": "keyword.hard.typealias.kotlin"
+                },
+                "2": {
+                    "name": "entity.name.type.kotlin"
+                },
+                "3": {
+                    "patterns": [
+                        {
+                            "include": "#type-parameter"
+                        }
+                    ]
+                }
+            }
+        },
+        "function": {
+            "match": "\\b(fun)\\b\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?\\s*(?:(?:(\\w+)\\.)?(\\b\\w+\\b|`[^`]+`))?",
+            "captures": {
+                "1": {
+                    "name": "keyword.hard.fun.kotlin"
+                },
+                "2": {
+                    "patterns": [
+                        {
+                            "include": "#type-parameter"
+                        }
+                    ]
+                },
+                "4": {
+                    "name": "entity.name.type.class.extension.kotlin"
+                },
+                "5": {
+                    "name": "entity.name.function.declaration.kotlin"
+                }
+            }
+        },
+        "variable-declaration": {
+            "match": "\\b(val|var)\\b\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?",
+            "captures": {
+                "1": {
+                    "name": "keyword.hard.kotlin"
+                },
+                "2": {
+                    "patterns": [
+                        {
+                            "include": "#type-parameter"
+                        }
+                    ]
+                }
+            }
+        },
+        "type-parameter": {
+            "patterns": [
+                {
+                    "match": "\\b\\w+\\b",
+                    "name": "entity.name.type.kotlin"
+                },
+                {
+                    "match": "\\b(in|out)\\b",
+                    "name": "storage.modifier.kotlin"
+                }
+            ]
+        },
+        "type-annotation": {
+            "match": "(?<![:?]):\\s*(\\w|\\?|\\s|->|(?<GROUP>[<(]([^<>()\"']|\\g<GROUP>)+[)>]))+",
+            "captures": {
+                "0": {
+                    "patterns": [
+                        {
+                            "include": "#type-parameter"
+                        }
+                    ]
+                }
+            }
+        },
+        "function-call": {
+            "match": "\\??\\.?(\\b\\w+\\b|`[^`]+`)\\s*(?<GROUP><([^<>]|\\g<GROUP>)+>)?\\s*(?=[({])",
+            "captures": {
+                "1": {
+                    "name": "entity.name.function.call.kotlin"
+                },
+                "2": {
+                    "patterns": [
+                        {
+                            "include": "#type-parameter"
+                        }
+                    ]
+                }
+            }
+        },
+        "method-reference": {
+            "match": "\\??::(\\b\\w+\\b|`[^`]+`)",
+            "captures": {
+                "1": {
+                    "name": "entity.name.function.reference.kotlin"
+                }
+            }
+        },
+        "key": {
+            "match": "\\b(\\w=)\\s*(=)",
+            "captures": {
+                "1": {
+                    "name": "variable.parameter.kotlin"
+                },
+                "2": {
+                    "name": "keyword.operator.assignment.kotlin"
+                }
+            }
+        },
+        "string-empty": {
+            "match": "(?<!\")\"\"(?!\")",
+            "name": "string.quoted.double.kotlin"
+        },
+        "string": {
+            "begin": "(?<!\")\"(?!\")",
+            "end": "\"",
+            "name": "string.quoted.double.kotlin",
+            "patterns": [
+                {
+                    "match": "\\\\.",
+                    "name": "constant.character.escape.kotlin"
+                },
+                {
+                    "include": "#string-escape-simple"
+                },
+                {
+                    "include": "#string-escape-bracketed"
+                }
+            ]
+        },
+        "string-multiline": {
+            "begin": "\"\"\"",
+            "end": "\"\"\"",
+            "name": "string.quoted.double.kotlin",
+            "patterns": [
+                {
+                    "match": "\\\\.",
+                    "name": "constant.character.escape.kotlin"
+                },
+                {
+                    "include": "#string-escape-simple"
+                },
+                {
+                    "include": "#string-escape-bracketed"
+                }
+            ]
+        },
+        "string-escape-simple": {
+            "match": "(?<!\\\\)\\$\\w+\\b",
+            "name": "variable.string-escape.kotlin"
+        },
+        "string-escape-bracketed": {
+            "begin": "(?<!\\\\)(\\$\\{)",
+            "end": "(\\})",
+            "name": "meta.template.expression.kotlin",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.template-expression.begin"
+                }
+            },
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.template-expression.end"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#code"
+                }
+            ]
+        },
+        "character": {
+            "begin": "'",
+            "end": "'",
+            "name": "string.quoted.single.kotlin",
+            "patterns": [
+                {
+                    "match": "\\\\.",
+                    "name": "constant.character.escape.kotlin"
+                }
+            ]
+        },
+        "decimal-literal": {
+            "match": "\\b\\d[\\d_]*(\\.[\\d_]+)?((e|E)\\d+)?(u|U)?(L|F|f)?\\b",
+            "name": "constant.numeric.decimal.kotlin"
+        },
+        "hex-literal": {
+            "match": "0(x|X)[A-Fa-f0-9][A-Fa-f0-9_]*(u|U)?",
+            "name": "constant.numeric.hex.kotlin"
+        },
+        "binary-literal": {
+            "match": "0(b|B)[01][01_]*",
+            "name": "constant.numeric.binary.kotlin"
+        },
+        "boolean-literal": {
+            "match": "\\b(true|false)\\b",
+            "name": "constant.language.boolean.kotlin"
+        },
+        "null-literal": {
+            "match": "\\bnull\\b",
+            "name": "constant.language.null.kotlin"
+        },
+        "lambda-arrow": {
+            "match": "->",
+            "name": "storage.type.function.arrow.kotlin"
+        },
+        "operators": {
+            "patterns": [
+                {
+                    "match": "(===?|\\!==?|<=|>=|<|>)",
+                    "name": "keyword.operator.comparison.kotlin"
+                },
+                {
+                    "match": "([+*/%-]=)",
+                    "name": "keyword.operator.assignment.arithmetic.kotlin"
+                },
+                {
+                    "match": "(=)",
+                    "name": "keyword.operator.assignment.kotlin"
+                },
+                {
+                    "match": "([+*/%-])",
+                    "name": "keyword.operator.arithmetic.kotlin"
+                },
+                {
+                    "match": "(!|&&|\\|\\|)",
+                    "name": "keyword.operator.logical.kotlin"
+                },
+                {
+                    "match": "(--|\\+\\+)",
+                    "name": "keyword.operator.increment-decrement.kotlin"
+                },
+                {
+                    "match": "(\\.\\.)",
+                    "name": "keyword.operator.range.kotlin"
+                }
+            ]
+        },
+        "self-reference": {
+            "match": "\\b(this|super)(@\\w+)?\\b",
+            "name": "variable.language.this.kotlin"
+        }
+    }
+}

--- a/docs/editors.md
+++ b/docs/editors.md
@@ -66,24 +66,37 @@ require('cmp').setup {
 
 ## VS Code
 
-VS Code does not support arbitrary LSP binaries natively. Use the
-[**Custom Language Server**](https://marketplace.visualstudio.com/items?itemName=cesium.custom-language-server)
-extension, then add to `.vscode/settings.json`:
+A self-contained extension is included in `contrib/vscode/`. It registers the Kotlin language, provides syntax highlighting, and launches kotlin-lsp as the language server — no other Kotlin plugins needed.
+
+**Install:**
+
+```bash
+cd contrib/vscode && npm install
+```
+
+Then symlink into your VS Code extensions directory:
+
+```bash
+# VS Code
+ln -s "$(pwd)/contrib/vscode" ~/.vscode/extensions/kotlin-lsp.kotlin-lsp-client-0.0.1
+
+# VS Code OSS / Code
+ln -s "$(pwd)/contrib/vscode" ~/.vscode-oss/extensions/kotlin-lsp.kotlin-lsp-client-0.0.1
+```
+
+Restart VS Code. The extension activates automatically for `.kt` and `.java` files.
+
+> **Tip:** Disable other Kotlin extensions (`fwcd.kotlin`, `jetbrains.kotlin`) to avoid conflicts — kotlin-lsp handles language registration, syntax highlighting, and LSP on its own.
+
+**Configuration** (optional) — in `.vscode/settings.json`:
 
 ```json
 {
-  "custom-language-server.servers": [
-    {
-      "name": "kotlin-lsp",
-      "command": "/path/to/kotlin-lsp",
-      "filetypes": ["kotlin", "java", "swift"]
-    }
-  ]
+  "kotlinLsp.path": "/path/to/kotlin-lsp"
 }
 ```
 
-> **Note:** The [Kotlin language plugin](https://marketplace.visualstudio.com/items?itemName=mathiasfrohlich.Kotlin) must be installed so VS Code recognises `.kt` files as `kotlin`.  
-> For a production-grade Kotlin experience in VS Code, consider [Kotlin Language Server](https://github.com/fwcd/kotlin-language-server) alongside this one (they can coexist on different capabilities).
+Default: `kotlin-lsp` (looks on `$PATH`).
 
 ## Zed
 


### PR DESCRIPTION
## PR 3/4 — VS Code extension

Builds on PR #64.

Adds a self-contained VS Code extension in `contrib/vscode/` — no external plugins needed.

- LSP client using `vscode-languageclient`
- Kotlin language registration, TextMate grammar, language configuration
- Updated `docs/editors.md` with setup instructions

### Files
- `contrib/vscode/extension.js` — LSP client
- `contrib/vscode/package.json` — extension manifest
- `contrib/vscode/syntaxes/kotlin.tmLanguage.json` — TextMate grammar
- `contrib/vscode/kotlin-language-configuration.json` — brackets, comments
- `docs/editors.md` — updated VS Code section

**Stack**: #63 core → #64 params/CLI → PR 3/4 → #4 module split