### PR TITLE
feat: zero-config source root discovery (workspace.json + build layout + CLI)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -41,6 +41,17 @@ parsing only (no type resolution):
 | `textDocument/onTypeFormatting` | Low | Auto-indent / brace matching as you type. |
 | `textDocument/formatting` | Low | Delegate to `ktfmt` / `google-java-format` subprocess if available on `$PATH`. |
 
+## Known UX gaps (scouted from JetBrains kotlin-lsp, 2026-05)
+
+Small improvements identified by comparing against the JetBrains reference implementation. None require type resolution.
+
+| Area | What to change | Effort |
+|---|---|---|
+| **Hover — backtick identifiers** | Change ` ```kotlin ` to ` ````kotlin ` (quadruple backtick fence) in `src/backend/format.rs`. Kotlin identifiers can contain backticks (`` `my fun` ``); a triple-backtick fence breaks the Markdown block. | Trivial |
+| **Completion item kind — METHOD** | `symbol_kind_to_completion` in `src/resolver/complete.rs` maps both `SymbolKind::FUNCTION` and `SymbolKind::METHOD` to `CompletionItemKind::FUNCTION`. Should map METHOD → `CompletionItemKind::METHOD` so editors show the correct icon. | Trivial |
+| **FoldingRange — import block** | Detect `import` blocks (consecutive lines starting with `import`) and emit `FoldingRangeKind::Imports` instead of `Region`. Currently all folds are `Region`. (`src/backend/handlers.rs`) | Low |
+| **FoldingRange — block comments** | Detect `/* … */` multi-line comments and fold with `FoldingRangeKind::Comment`. Currently only `//` line-comment blocks are folded. | Low |
+| **FoldingRange — collapsedText** | Set `collapsed_text` on every fold range (e.g. `"..."` for blocks, `"imports"` for import folds). Improves editor display when a region is collapsed. | Trivial |
 
 
 ## What gets indexed

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -277,10 +277,21 @@ impl Backend {
 
         // Auto-discover source roots from workspace.json (JetBrains Gradle/Maven format).
         // Discovered paths are merged with any user-configured sourcePaths.
-        for path in crate::workspace_json::load_source_paths(workspace_root) {
+        let workspace_json_paths = crate::workspace_json::load_source_paths(workspace_root);
+        for path in &workspace_json_paths {
             let path_str = path.to_string_lossy().into_owned();
             if !all_source_paths.contains(&path_str) {
                 all_source_paths.push(path_str);
+            }
+        }
+
+        // Fallback: if workspace.json wasn't present, probe standard Maven/Gradle layouts.
+        if workspace_json_paths.is_empty() {
+            for path in crate::workspace_json::detect_build_layout_source_paths(workspace_root) {
+                let path_str = path.to_string_lossy().into_owned();
+                if !all_source_paths.contains(&path_str) {
+                    all_source_paths.push(path_str);
+                }
             }
         }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -271,13 +271,24 @@ impl Backend {
             }
         }
 
-        if let Some(source_paths) =
+        let mut all_source_paths: Vec<String> =
             Self::collect_indexing_option_strings(initialization_options, "sourcePaths")
-        {
-            log::info!("sourcePaths: {:?}", source_paths);
+                .unwrap_or_default();
+
+        // Auto-discover source roots from workspace.json (JetBrains Gradle/Maven format).
+        // Discovered paths are merged with any user-configured sourcePaths.
+        for path in crate::workspace_json::load_source_paths(workspace_root) {
+            let path_str = path.to_string_lossy().into_owned();
+            if !all_source_paths.contains(&path_str) {
+                all_source_paths.push(path_str);
+            }
+        }
+
+        if !all_source_paths.is_empty() {
+            log::info!("sourcePaths (combined): {:?}", all_source_paths);
             match self.indexer.source_paths_raw.write() {
                 Ok(mut source_paths_raw) => {
-                    *source_paths_raw = source_paths;
+                    *source_paths_raw = all_source_paths;
                 }
                 Err(error) => {
                     log::warn!("Failed to update source paths: {error}");

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -32,6 +32,8 @@ pub(crate) enum Subcommand {
     Tree {
         file: PathBuf,
     },
+    /// List auto-discovered source roots for the workspace.
+    Sources,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -205,6 +207,7 @@ fn build_subcommand(
                 "tree requires a FILE argument",
             )?),
         }),
+        "sources" => Ok(Subcommand::Sources),
         _ => unreachable!(),
     }
 }
@@ -253,7 +256,7 @@ fn first_positional(
 fn is_subcommand(value: &str) -> bool {
     matches!(
         value,
-        "find" | "refs" | "hover" | "index" | "tokens" | "tree"
+        "find" | "refs" | "hover" | "index" | "tokens" | "tree" | "sources"
     )
 }
 
@@ -270,12 +273,13 @@ USAGE:
     kotlin-lsp                            # start LSP server (stdio)
 
 SUBCOMMANDS:
-    find   <name>              Find declarations of a symbol
-    refs   <name>              Find all references to a symbol
-    hover  <file> <line> <col> Show type/doc info at a position
-    index                      Build and cache the workspace index
-    tokens <file>              Dump semantic tokens (debug)
-    tree   <file>              Dump tree-sitter parse tree (debug)
+    find    <name>              Find declarations of a symbol
+    refs    <name>              Find all references to a symbol
+    hover   <file> <line> <col> Show type/doc info at a position
+    index                       Build and cache the workspace index
+    sources                     List auto-discovered source roots
+    tokens  <file>              Dump semantic tokens (debug)
+    tree    <file>              Dump tree-sitter parse tree (debug)
 
 OPTIONS:
     --fast          Use rg/fd only; never load index (default when no cache)
@@ -295,6 +299,8 @@ EXAMPLES:
     kotlin-lsp refs --fast MyViewModel --root ./android
     kotlin-lsp hover src/Foo.kt 42 10 --json
     kotlin-lsp index --root ./android
+    kotlin-lsp sources --root ./android
+    kotlin-lsp sources --json
     kotlin-lsp tokens src/Foo.kt
     kotlin-lsp tokens --resolve src/Foo.kt
     kotlin-lsp tokens src/Foo.kt --tree

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -24,6 +24,7 @@ mod args;
 mod hover;
 mod output;
 mod run;
+mod sources;
 mod tokens;
 
 pub(crate) use args::CliArgs;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -137,6 +137,7 @@ pub(crate) async fn run(args: CliArgs) {
             run_tokens(json, &file, index.as_ref(), cst_only, phases, show_tree)
         }
         Subcommand::Tree { file } => run_tree(&file),
+        Subcommand::Sources => super::sources::run_sources(&root, json),
     }
 }
 

--- a/src/cli/sources.rs
+++ b/src/cli/sources.rs
@@ -5,13 +5,13 @@
 //! where each path was found. Useful for verifying project setup without
 //! starting the LSP server.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use serde::Serialize;
 
 #[derive(Debug, Serialize)]
 pub(crate) struct SourceRoot {
-    pub path: PathBuf,
+    pub path: String, // lossy-UTF8; always serializable
     pub origin: &'static str, // "workspace.json" | "build-layout"
     pub exists: bool,
 }
@@ -23,8 +23,8 @@ pub(crate) fn discover(workspace_root: &Path) -> Vec<SourceRoot> {
     let json_paths = crate::workspace_json::load_source_paths(workspace_root);
     for path in &json_paths {
         roots.push(SourceRoot {
-            exists: path.exists(),
-            path: path.clone(),
+            exists: path.is_dir(),
+            path: path.to_string_lossy().into_owned(),
             origin: "workspace.json",
         });
     }
@@ -32,8 +32,8 @@ pub(crate) fn discover(workspace_root: &Path) -> Vec<SourceRoot> {
     if json_paths.is_empty() {
         for path in crate::workspace_json::detect_build_layout_source_paths(workspace_root) {
             roots.push(SourceRoot {
-                exists: path.exists(),
-                path,
+                exists: path.is_dir(),
+                path: path.to_string_lossy().into_owned(),
                 origin: "build-layout",
             });
         }
@@ -57,10 +57,13 @@ pub(crate) fn run_sources(workspace_root: &Path, json: bool) {
     }
 
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&roots).unwrap_or_default()
-        );
+        match serde_json::to_string_pretty(&roots) {
+            Ok(json_str) => println!("{json_str}"),
+            Err(e) => {
+                eprintln!("error: failed to serialize sources: {e}");
+                std::process::exit(1);
+            }
+        }
         return;
     }
 
@@ -72,7 +75,7 @@ pub(crate) fn run_sources(workspace_root: &Path, json: bool) {
             last_origin = root.origin;
         }
         let marker = if root.exists { "  ✓" } else { "  ✗" };
-        println!("{} {}", marker, root.path.display());
+        println!("{} {}", marker, root.path);
     }
 
     let missing = roots.iter().filter(|r| !r.exists).count();

--- a/src/cli/sources.rs
+++ b/src/cli/sources.rs
@@ -1,0 +1,82 @@
+//! CLI `sources` subcommand — list auto-discovered source roots.
+//!
+//! Shows what `workspace.json` and/or standard build layout detection
+//! would contribute as source roots, which paths actually exist, and
+//! where each path was found. Useful for verifying project setup without
+//! starting the LSP server.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+pub(crate) struct SourceRoot {
+    pub path: PathBuf,
+    pub origin: &'static str, // "workspace.json" | "build-layout"
+    pub exists: bool,
+}
+
+/// Collect all auto-discovered source roots for the given workspace root.
+pub(crate) fn discover(workspace_root: &Path) -> Vec<SourceRoot> {
+    let mut roots: Vec<SourceRoot> = Vec::new();
+
+    let json_paths = crate::workspace_json::load_source_paths(workspace_root);
+    for path in &json_paths {
+        roots.push(SourceRoot {
+            exists: path.exists(),
+            path: path.clone(),
+            origin: "workspace.json",
+        });
+    }
+
+    if json_paths.is_empty() {
+        for path in crate::workspace_json::detect_build_layout_source_paths(workspace_root) {
+            roots.push(SourceRoot {
+                exists: path.exists(),
+                path,
+                origin: "build-layout",
+            });
+        }
+    }
+
+    roots
+}
+
+pub(crate) fn run_sources(workspace_root: &Path, json: bool) {
+    let roots = discover(workspace_root);
+
+    if roots.is_empty() {
+        if !json {
+            eprintln!(
+                "No source roots found. Add a workspace.json or a build.gradle.kts / pom.xml."
+            );
+        } else {
+            println!("[]");
+        }
+        std::process::exit(1);
+    }
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&roots).unwrap_or_default()
+        );
+        return;
+    }
+
+    // Text output — group by origin, mark missing paths.
+    let mut last_origin = "";
+    for root in &roots {
+        if root.origin != last_origin {
+            println!("\n[{}]", root.origin);
+            last_origin = root.origin;
+        }
+        let marker = if root.exists { "  ✓" } else { "  ✗" };
+        println!("{} {}", marker, root.path.display());
+    }
+
+    let missing = roots.iter().filter(|r| !r.exists).count();
+    if missing > 0 {
+        eprintln!("\n{missing} path(s) marked ✗ do not exist on disk.");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod stdlib_tail;
 mod str_ext;
 mod task_runner;
 mod types;
+mod workspace_json;
 
 pub(crate) use lines_ext::LinesExt;
 pub(crate) use str_ext::StrExt;

--- a/src/workspace_json.rs
+++ b/src/workspace_json.rs
@@ -1,0 +1,102 @@
+//! Auto-discovery of source roots from `workspace.json`.
+//!
+//! `workspace.json` is produced by JetBrains Gradle/Maven plugins and describes
+//! project structure (modules, content roots, source directories). When the file
+//! exists at the workspace root we extract every non-resource source root so the
+//! indexer covers them without manual `sourcePaths` configuration.
+//!
+//! Placeholder substitution:
+//! - `<WORKSPACE>` → absolute workspace root path
+//! - `<MAVEN_REPO>` → `~/.m2/repository` (library jars, currently skipped)
+//!
+//! Source root types we index:
+//! - `"java-source"` — production Kotlin/Java sources
+//! - `"java-test"` — test Kotlin/Java sources
+
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+const SOURCE_TYPES: &[&str] = &["java-source", "java-test"];
+const WORKSPACE_PLACEHOLDER: &str = "<WORKSPACE>";
+
+#[derive(Deserialize)]
+struct WorkspaceData {
+    #[serde(default)]
+    modules: Vec<ModuleData>,
+}
+
+#[derive(Deserialize)]
+struct ModuleData {
+    #[serde(default, rename = "contentRoots")]
+    content_roots: Vec<ContentRootData>,
+}
+
+#[derive(Deserialize)]
+struct ContentRootData {
+    #[serde(default, rename = "sourceRoots")]
+    source_roots: Vec<SourceRootData>,
+}
+
+#[derive(Deserialize)]
+struct SourceRootData {
+    path: String,
+    #[serde(rename = "type", default)]
+    root_type: String,
+}
+
+/// Reads `<workspace_root>/workspace.json` and returns source root paths.
+///
+/// Returns an empty `Vec` (with a log warning) if the file is missing, malformed,
+/// or contains no eligible source roots — never panics.
+pub(crate) fn load_source_paths(workspace_root: &Path) -> Vec<PathBuf> {
+    let json_path = workspace_root.join("workspace.json");
+    if !json_path.exists() {
+        return Vec::new();
+    }
+
+    let content = match std::fs::read_to_string(&json_path) {
+        Ok(c) => c,
+        Err(error) => {
+            log::warn!("workspace.json: failed to read: {error}");
+            return Vec::new();
+        }
+    };
+
+    let data: WorkspaceData = match serde_json::from_str(&content) {
+        Ok(d) => d,
+        Err(error) => {
+            log::warn!("workspace.json: failed to parse: {error}");
+            return Vec::new();
+        }
+    };
+
+    let workspace_str = workspace_root.to_string_lossy();
+    let mut paths: Vec<PathBuf> = Vec::new();
+
+    for module in &data.modules {
+        for content_root in &module.content_roots {
+            for source_root in &content_root.source_roots {
+                if !SOURCE_TYPES.contains(&source_root.root_type.as_str()) {
+                    continue;
+                }
+                let resolved = source_root
+                    .path
+                    .replace(WORKSPACE_PLACEHOLDER, &workspace_str);
+                let path = PathBuf::from(resolved);
+                if !paths.contains(&path) {
+                    paths.push(path);
+                }
+            }
+        }
+    }
+
+    log::info!(
+        "workspace.json: auto-discovered {} source roots",
+        paths.len()
+    );
+    paths
+}
+
+#[cfg(test)]
+#[path = "workspace_json_tests.rs"]
+mod tests;

--- a/src/workspace_json.rs
+++ b/src/workspace_json.rs
@@ -7,7 +7,7 @@
 //!
 //! Placeholder substitution:
 //! - `<WORKSPACE>` → absolute workspace root path
-//! - `<MAVEN_REPO>` → `~/.m2/repository` (library jars, currently skipped)
+//! - `<MAVEN_REPO>` → skipped (library jars are not indexed)
 //!
 //! Source root types we index:
 //! - `"java-source"` — production Kotlin/Java sources
@@ -154,7 +154,7 @@ pub(crate) fn detect_build_layout_source_paths(workspace_root: &Path) -> Vec<Pat
     for dir in &all_dirs {
         for candidate in &source_candidates {
             let path = dir.join(candidate);
-            if path.exists() && !roots.contains(&path) {
+            if path.is_dir() && !roots.contains(&path) {
                 roots.push(path);
             }
         }
@@ -187,29 +187,32 @@ fn settings_subprojects(workspace_root: &Path) -> Vec<String> {
 }
 
 /// Parses `include("...", "...")` calls and returns directory paths.
+///
+/// Handles both double- and single-quoted project names, and both Kotlin DSL
+/// (`include(":app")`) and Groovy (`include ':app'`) styles. Lines starting
+/// with `includeBuild` or `includeFlat` are intentionally ignored.
 fn parse_include_calls(content: &str) -> Vec<String> {
     let mut result = Vec::new();
     for line in content.lines() {
         let trimmed = line.trim();
-        if !trimmed.starts_with("include") {
+        // Only match `include(` — reject `includeBuild(`, `includeFlat(`, etc.
+        if !trimmed.starts_with("include(") {
             continue;
         }
-        // Extract all quoted strings on this line.
-        let mut pos = 0;
-        while let Some(start) = trimmed[pos..].find('"') {
-            let start = pos + start + 1;
-            let Some(end) = trimmed[start..].find('"') else {
-                break;
-            };
-            let token = &trimmed[start..start + end];
-            // ":app" → "app", ":feature:login" → "feature/login"
-            let dir = token
-                .trim_start_matches(':')
-                .replace(':', std::path::MAIN_SEPARATOR_STR);
-            if !dir.is_empty() && !result.contains(&dir) {
-                result.push(dir);
+        // Extract all single- or double-quoted strings on this line.
+        let mut chars = trimmed.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '"' || c == '\'' {
+                let quote = c;
+                let token: String = chars.by_ref().take_while(|&d| d != quote).collect();
+                // ":app" → "app", ":feature:login" → "feature/login"
+                let dir = token
+                    .trim_start_matches(':')
+                    .replace(':', std::path::MAIN_SEPARATOR_STR);
+                if !dir.is_empty() && !result.contains(&dir) {
+                    result.push(dir);
+                }
             }
-            pos = start + end + 1;
         }
     }
     result

--- a/src/workspace_json.rs
+++ b/src/workspace_json.rs
@@ -97,6 +97,124 @@ pub(crate) fn load_source_paths(workspace_root: &Path) -> Vec<PathBuf> {
     paths
 }
 
+/// Detects standard Maven/Gradle source layouts without requiring `workspace.json`.
+///
+/// Activates when a build file (`build.gradle.kts`, `build.gradle`, `pom.xml`, …) exists
+/// at the workspace root. Probes well-known source directories; returns only those that
+/// actually exist on disk so the indexer never spins on empty paths.
+///
+/// Multi-module Gradle: `settings.gradle(.kts)` is parsed for `include(":module")` calls;
+/// each listed module is treated as a subproject and its standard source dirs are probed.
+///
+/// These paths are typically already covered by the workspace root scan, but listing them
+/// explicitly ensures consistent indexing when the workspace root is set to a parent dir.
+pub(crate) fn detect_build_layout_source_paths(workspace_root: &Path) -> Vec<PathBuf> {
+    let has_gradle = ["build.gradle.kts", "build.gradle"]
+        .iter()
+        .any(|f| workspace_root.join(f).exists());
+    let has_settings = ["settings.gradle.kts", "settings.gradle"]
+        .iter()
+        .any(|f| workspace_root.join(f).exists());
+    let has_maven = workspace_root.join("pom.xml").exists();
+
+    if !has_gradle && !has_settings && !has_maven {
+        return Vec::new();
+    }
+
+    let mut roots: Vec<PathBuf> = Vec::new();
+
+    // Subproject dirs from settings.gradle(.kts)
+    let subprojects = settings_subprojects(workspace_root);
+
+    // Probe candidates for each directory scope.
+    let scan_dirs: Vec<PathBuf> = if subprojects.is_empty() {
+        vec![workspace_root.to_owned()]
+    } else {
+        subprojects
+            .iter()
+            .map(|s| workspace_root.join(s))
+            .collect()
+    };
+
+    // Always include the root itself (root build.gradle may have sources too).
+    let mut all_dirs = vec![workspace_root.to_owned()];
+    for d in &scan_dirs {
+        if d != workspace_root && !all_dirs.contains(d) {
+            all_dirs.push(d.clone());
+        }
+    }
+
+    let source_candidates = [
+        "src/main/kotlin",
+        "src/main/java",
+        "src/test/kotlin",
+        "src/test/java",
+    ];
+
+    for dir in &all_dirs {
+        for candidate in &source_candidates {
+            let path = dir.join(candidate);
+            if path.exists() && !roots.contains(&path) {
+                roots.push(path);
+            }
+        }
+    }
+
+    if !roots.is_empty() {
+        log::info!(
+            "build-layout: auto-discovered {} source roots",
+            roots.len()
+        );
+    }
+    roots
+}
+
+/// Extracts subproject directory names from `settings.gradle` / `settings.gradle.kts`.
+///
+/// Handles both forms:
+/// - `include(":app", ":core")` — Gradle convention (colon prefix)
+/// - `include("app", "core")` — variant without colon
+/// - Nested: `include(":feature:login")` → maps to `feature/login`
+fn settings_subprojects(workspace_root: &Path) -> Vec<String> {
+    for filename in &["settings.gradle.kts", "settings.gradle"] {
+        let path = workspace_root.join(filename);
+        let Ok(content) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        return parse_include_calls(&content);
+    }
+    Vec::new()
+}
+
+/// Parses `include("...", "...")` calls and returns directory paths.
+fn parse_include_calls(content: &str) -> Vec<String> {
+    let mut result = Vec::new();
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with("include") {
+            continue;
+        }
+        // Extract all quoted strings on this line.
+        let mut pos = 0;
+        while let Some(start) = trimmed[pos..].find('"') {
+            let start = pos + start + 1;
+            let Some(end) = trimmed[start..].find('"') else {
+                break;
+            };
+            let token = &trimmed[start..start + end];
+            // ":app" → "app", ":feature:login" → "feature/login"
+            let dir = token
+                .trim_start_matches(':')
+                .replace(':', std::path::MAIN_SEPARATOR_STR);
+            if !dir.is_empty() && !result.contains(&dir) {
+                result.push(dir);
+            }
+            pos = start + end + 1;
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 #[path = "workspace_json_tests.rs"]
 mod tests;

--- a/src/workspace_json_tests.rs
+++ b/src/workspace_json_tests.rs
@@ -6,6 +6,8 @@ fn make_workspace_json(dir: &TempDir, json: &str) {
     fs::write(dir.path().join("workspace.json"), json).unwrap();
 }
 
+// ─── workspace.json tests ─────────────────────────────────────────────────────
+
 #[test]
 fn missing_file_returns_empty() {
     let dir = TempDir::new().unwrap();
@@ -86,4 +88,90 @@ fn empty_modules_returns_empty() {
     make_workspace_json(&dir, r#"{"modules": []}"#);
     let paths = load_source_paths(dir.path());
     assert!(paths.is_empty());
+}
+
+// ─── build-layout detection tests ────────────────────────────────────────────
+
+#[test]
+fn no_build_file_returns_empty() {
+    let dir = TempDir::new().unwrap();
+    let paths = detect_build_layout_source_paths(dir.path());
+    assert!(paths.is_empty());
+}
+
+#[test]
+fn gradle_kts_probes_standard_dirs() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("build.gradle.kts"), "").unwrap();
+    let src = dir.path().join("src/main/kotlin");
+    fs::create_dir_all(&src).unwrap();
+    let test = dir.path().join("src/test/kotlin");
+    fs::create_dir_all(&test).unwrap();
+
+    let paths = detect_build_layout_source_paths(dir.path());
+    assert!(paths.contains(&src));
+    assert!(paths.contains(&test));
+}
+
+#[test]
+fn nonexistent_candidates_excluded() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("build.gradle.kts"), "").unwrap();
+    // No source dirs created.
+    let paths = detect_build_layout_source_paths(dir.path());
+    assert!(paths.is_empty());
+}
+
+#[test]
+fn maven_pom_triggers_detection() {
+    let dir = TempDir::new().unwrap();
+    fs::write(dir.path().join("pom.xml"), "<project/>").unwrap();
+    let src = dir.path().join("src/main/java");
+    fs::create_dir_all(&src).unwrap();
+
+    let paths = detect_build_layout_source_paths(dir.path());
+    assert!(paths.contains(&src));
+}
+
+#[test]
+fn settings_gradle_multimodule() {
+    let dir = TempDir::new().unwrap();
+    fs::write(
+        dir.path().join("settings.gradle.kts"),
+        r#"include(":app", ":core")"#,
+    )
+    .unwrap();
+    let app_src = dir.path().join("app/src/main/kotlin");
+    let core_src = dir.path().join("core/src/main/kotlin");
+    fs::create_dir_all(&app_src).unwrap();
+    fs::create_dir_all(&core_src).unwrap();
+
+    let paths = detect_build_layout_source_paths(dir.path());
+    assert!(paths.contains(&app_src));
+    assert!(paths.contains(&core_src));
+}
+
+// ─── parse_include_calls unit tests ──────────────────────────────────────────
+
+#[test]
+fn parses_colon_prefixed_includes() {
+    let content = r#"include(":app", ":core", ":data")"#;
+    let result = parse_include_calls(content);
+    assert_eq!(result, vec!["app", "core", "data"]);
+}
+
+#[test]
+fn parses_nested_module_paths() {
+    let content = r#"include(":feature:login", ":feature:home")"#;
+    let result = parse_include_calls(content);
+    let sep = std::path::MAIN_SEPARATOR_STR;
+    assert_eq!(result[0], format!("feature{sep}login"));
+    assert_eq!(result[1], format!("feature{sep}home"));
+}
+
+#[test]
+fn deduplicates_include_entries() {
+    let content = "include(\":app\")\ninclude(\":app\")";
+    let result = parse_include_calls(content);
+    assert_eq!(result.len(), 1);
 }

--- a/src/workspace_json_tests.rs
+++ b/src/workspace_json_tests.rs
@@ -1,0 +1,89 @@
+use super::*;
+use std::fs;
+use tempfile::TempDir;
+
+fn make_workspace_json(dir: &TempDir, json: &str) {
+    fs::write(dir.path().join("workspace.json"), json).unwrap();
+}
+
+#[test]
+fn missing_file_returns_empty() {
+    let dir = TempDir::new().unwrap();
+    let paths = load_source_paths(dir.path());
+    assert!(paths.is_empty());
+}
+
+#[test]
+fn malformed_json_returns_empty() {
+    let dir = TempDir::new().unwrap();
+    make_workspace_json(&dir, "{ not valid json }}}");
+    let paths = load_source_paths(dir.path());
+    assert!(paths.is_empty());
+}
+
+#[test]
+fn extracts_java_source_and_java_test() {
+    let dir = TempDir::new().unwrap();
+    let ws = dir.path().to_string_lossy();
+    let json = format!(
+        r#"{{
+            "modules": [{{
+                "contentRoots": [{{
+                    "sourceRoots": [
+                        {{"path": "<WORKSPACE>/src/main/kotlin", "type": "java-source"}},
+                        {{"path": "<WORKSPACE>/src/test/kotlin", "type": "java-test"}},
+                        {{"path": "<WORKSPACE>/src/main/resources", "type": "java-resource"}},
+                        {{"path": "<WORKSPACE>/src/test/resources", "type": "java-test-resource"}}
+                    ]
+                }}]
+            }}]
+        }}"#
+    );
+    make_workspace_json(&dir, &json);
+
+    let paths = load_source_paths(dir.path());
+    assert_eq!(paths.len(), 2);
+    assert_eq!(paths[0], dir.path().join("src/main/kotlin"));
+    assert_eq!(paths[1], dir.path().join("src/test/kotlin"));
+    // resources excluded
+    assert!(!paths.iter().any(|p| p.ends_with("resources")));
+}
+
+#[test]
+fn deduplicates_paths_across_modules() {
+    let dir = TempDir::new().unwrap();
+    let json = r#"{
+        "modules": [
+            {"contentRoots": [{"sourceRoots": [{"path": "<WORKSPACE>/src/main/kotlin", "type": "java-source"}]}]},
+            {"contentRoots": [{"sourceRoots": [{"path": "<WORKSPACE>/src/main/kotlin", "type": "java-source"}]}]}
+        ]
+    }"#;
+    make_workspace_json(&dir, json);
+
+    let paths = load_source_paths(dir.path());
+    assert_eq!(paths.len(), 1);
+}
+
+#[test]
+fn resolves_workspace_placeholder() {
+    let dir = TempDir::new().unwrap();
+    let json = r#"{
+        "modules": [{"contentRoots": [{"sourceRoots": [
+            {"path": "<WORKSPACE>/app/src/main/kotlin", "type": "java-source"}
+        ]}]}]
+    }"#;
+    make_workspace_json(&dir, json);
+
+    let paths = load_source_paths(dir.path());
+    assert_eq!(paths.len(), 1);
+    assert!(paths[0].is_absolute());
+    assert!(paths[0].ends_with("app/src/main/kotlin"));
+}
+
+#[test]
+fn empty_modules_returns_empty() {
+    let dir = TempDir::new().unwrap();
+    make_workspace_json(&dir, r#"{"modules": []}"#);
+    let paths = load_source_paths(dir.path());
+    assert!(paths.is_empty());
+}

--- a/src/workspace_json_tests.rs
+++ b/src/workspace_json_tests.rs
@@ -175,3 +175,17 @@ fn deduplicates_include_entries() {
     let result = parse_include_calls(content);
     assert_eq!(result.len(), 1);
 }
+
+#[test]
+fn parses_single_quoted_includes() {
+    let content = "include(':app', ':core')";
+    let result = parse_include_calls(content);
+    assert_eq!(result, vec!["app", "core"]);
+}
+
+#[test]
+fn ignores_include_build_lines() {
+    let content = "includeBuild(\"../other-project\")\ninclude(\":app\")";
+    let result = parse_include_calls(content);
+    assert_eq!(result, vec!["app"]);
+}


### PR DESCRIPTION
## Summary

Auto-discovers Kotlin/Java source roots without manual `sourcePaths` configuration.

## Discovery chain

On LSP init (and via new CLI subcommand), source roots are resolved in order:

1. **`workspace.json`** — JetBrains Gradle/Maven plugin format. Reads `modules[].contentRoots[].sourceRoots[]` for types `java-source` and `java-test`, resolves `<WORKSPACE>` placeholder.
2. **Build layout fallback** — activates when no `workspace.json` is present. Detects `build.gradle.kts` / `build.gradle` / `pom.xml`, parses `settings.gradle(.kts)` for multi-module `include()` calls, probes standard `src/main/kotlin|java` + `src/test/kotlin|java` dirs.
3. **Manual `sourcePaths`** — user config is always merged additively; it is never overridden.

## New CLI subcommand

```
kotlin-lsp sources [--root <dir>] [--json]
```

Shows what would be indexed, grouped by origin, with ✓/✗ existence markers:

```
[workspace.json]
  ✓ app/src/main/kotlin
  ✓ app/src/test/kotlin
  ✗ buildSrc/build/generated-sources/kotlin-dsl-accessors/kotlin
  ✓ utils/src/main/kotlin
```

## Files

- `src/workspace_json.rs` — `load_source_paths` + `detect_build_layout_source_paths` + `parse_include_calls`
- `src/workspace_json_tests.rs` — 14 tests
- `src/cli/sources.rs` — `sources` subcommand impl
- `src/cli/args.rs` / `run.rs` / `mod.rs` — wired in
- `src/backend/mod.rs` — `apply_initialization_options` merges discovered paths