### PR TITLE
feat: extract-sources CLI subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,23 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +85,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,10 +156,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cc"
@@ -142,6 +199,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -152,10 +211,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "cpufeatures"
@@ -164,6 +239,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -215,6 +314,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "deflate64"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac6b926516df9c60bfa16e107b21086399f8285a44ca9711344b9e553c5146e2"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +347,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -285,6 +411,16 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "foldhash"
@@ -401,13 +537,27 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -451,6 +601,15 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "httparse"
@@ -596,6 +755,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +800,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "kotlin-lsp"
 version = "0.11.0"
 dependencies = [
@@ -654,6 +843,7 @@ dependencies = [
  "tree-sitter-kotlin",
  "tree-sitter-swift-bundled",
  "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -715,10 +905,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
+]
+
+[[package]]
+name = "lzma-sys"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fda04ab3764e6cde78b9974eec4f779acaba7c4e84b36eca3cf77c581b85d27"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
 
 [[package]]
 name = "mio"
@@ -730,6 +951,12 @@ dependencies = [
  "wasi",
  "windows-sys",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "once_cell"
@@ -767,6 +994,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -799,6 +1036,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -821,6 +1064,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -849,6 +1098,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -906,6 +1161,12 @@ dependencies = [
  "linux-raw-sys",
  "windows-sys",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "same-file"
@@ -983,6 +1244,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1008,6 +1280,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "slab"
@@ -1038,6 +1316,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1066,11 +1350,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
 ]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -1338,6 +1661,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
 name = "wasm-encoder"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,6 +1858,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "xz2"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "388c44dc09d76f1536602ead6d325eb532f5c122f17782bd57fb47baeeb767e2"
+dependencies = [
+ "lzma-sys",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1534,6 +1911,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,7 +1964,77 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "2.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fabe6324e908f85a1c52063ce7aa26b68dcb7eb6dbc83a2d148403c9bc3eba50"
+dependencies = [
+ "aes",
+ "arbitrary",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "deflate64",
+ "displaydoc",
+ "flate2",
+ "getrandom 0.3.4",
+ "hmac",
+ "indexmap",
+ "lzma-rs",
+ "memchr",
+ "pbkdf2",
+ "sha1",
+ "thiserror",
+ "time",
+ "xz2",
+ "zeroize",
+ "zopfli",
+ "zstd",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ serde      = { version = "1", features = ["derive", "rc"] }
 serde_json = "1"
 bincode  = "1"
 sha2 = "0.10"
+zip = "2"
 futures = "0.3.32"
 lexopt = "0.3"
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -53,6 +53,46 @@ Small improvements identified by comparing against the JetBrains reference imple
 | **FoldingRange — block comments** | Detect `/* … */` multi-line comments and fold with `FoldingRangeKind::Comment`. Currently only `//` line-comment blocks are folded. | Low |
 | **FoldingRange — collapsedText** | Set `collapsed_text` on every fold range (e.g. `"..."` for blocks, `"imports"` for import folds). Improves editor display when a region is collapsed. | Trivial |
 
+## CLI subcommands
+
+`kotlin-lsp` ships with a standalone CLI in addition to the LSP server.
+
+```
+kotlin-lsp sources [--root <dir>] [--json]
+```
+Lists every source root that would be auto-discovered for a project (from `workspace.json` or standard Gradle/Maven build layout). Marks which paths exist on disk. Run this to verify the indexer will find your sources without starting the server.
+
+If source roots are missing, the command suggests `extract-sources` as a next step.
+
+```
+kotlin-lsp extract-sources [PATTERN…] [OPTIONS]
+```
+Unpacks `*-sources.jar` files from the Gradle module cache so the LSP server can serve hover docs and go-to-definition for library code.
+
+| Option | Default | Description |
+|---|---|---|
+| `PATTERN…` | (all) | Substring filter on artifact path, e.g. `androidx.compose` `org.jetbrains.kotlin` |
+| `--gradle-home <dir>` | `$GRADLE_USER_HOME` or `~/.gradle` | Gradle home directory |
+| `--output <dir>` | `~/.kotlin-lsp/sources` | Extraction root |
+| `--dry-run` | off | Print what would be extracted; write nothing |
+
+**Typical workflow:**
+
+```sh
+# 1. Check what source roots are auto-detected
+kotlin-lsp sources --root ./android
+
+# 2. Extract library sources (first time, or after a Gradle sync)
+kotlin-lsp extract-sources androidx.compose org.jetbrains.kotlin
+
+# 3. Add the output dir to your LSP config (one-time)
+#    sourcePaths = ["~/.kotlin-lsp/sources"]
+
+# 4. Re-index (or restart the server) to pick up new sources
+kotlin-lsp index --root ./android
+```
+
+The extractor deduplicates by artifact — when multiple versions are cached, only the latest is extracted.
 
 ## What gets indexed
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -34,6 +34,13 @@ pub(crate) enum Subcommand {
     },
     /// List auto-discovered source roots for the workspace.
     Sources,
+    /// Extract Gradle *-sources.jar files to a sourcePaths-ready directory.
+    ExtractSources {
+        gradle_home: Option<PathBuf>,
+        output: Option<PathBuf>,
+        dry_run: bool,
+        patterns: Vec<String>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,20 +78,17 @@ impl CliArgs {
             return Ok(None);
         };
         let parsed = parse_cli_flags(&mut args)?;
-        let subcommand = build_subcommand(
-            &subcommand,
-            parsed.positionals,
-            parsed.cst_only,
-            parsed.resolve,
-            parsed.phases,
-            parsed.show_tree,
-        )?;
+        let mode = parsed.mode;
+        let fmt = parsed.fmt;
+        let root = parsed.root.clone();
+        let verbose = parsed.verbose;
+        let subcommand = build_subcommand(&subcommand, parsed)?;
         Ok(Some(Self {
             subcommand,
-            mode: parsed.mode,
-            fmt: parsed.fmt,
-            root: parsed.root,
-            verbose: parsed.verbose,
+            mode,
+            fmt,
+            root,
+            verbose,
         }))
     }
 }
@@ -99,6 +103,9 @@ struct ParsedCliFlags {
     phases: bool,
     show_tree: bool,
     verbose: bool,
+    gradle_home: Option<PathBuf>,
+    output_dir: Option<PathBuf>,
+    dry_run: bool,
 }
 
 fn parse_first_argument(args: &mut lexopt::Parser) -> Result<Option<std::ffi::OsString>, String> {
@@ -140,6 +147,9 @@ fn parse_cli_flags(args: &mut lexopt::Parser) -> Result<ParsedCliFlags, String> 
         phases: false,
         show_tree: false,
         verbose: false,
+        gradle_home: None,
+        output_dir: None,
+        dry_run: false,
     };
 
     loop {
@@ -157,6 +167,15 @@ fn parse_cli_flags(args: &mut lexopt::Parser) -> Result<ParsedCliFlags, String> 
                 let value = args.value().map_err(|e| e.to_string())?;
                 parsed.root = Some(PathBuf::from(value.to_string_lossy().as_ref()));
             }
+            Some(lexopt::Arg::Long("gradle-home")) => {
+                let value = args.value().map_err(|e| e.to_string())?;
+                parsed.gradle_home = Some(PathBuf::from(value.to_string_lossy().as_ref()));
+            }
+            Some(lexopt::Arg::Long("output")) => {
+                let value = args.value().map_err(|e| e.to_string())?;
+                parsed.output_dir = Some(PathBuf::from(value.to_string_lossy().as_ref()));
+            }
+            Some(lexopt::Arg::Long("dry-run")) => parsed.dry_run = true,
             Some(lexopt::Arg::Short('h') | lexopt::Arg::Long("help")) => {
                 print_help();
                 std::process::exit(0);
@@ -174,14 +193,18 @@ fn parse_cli_flags(args: &mut lexopt::Parser) -> Result<ParsedCliFlags, String> 
     }
 }
 
-fn build_subcommand(
-    subcommand: &str,
-    positionals: Vec<String>,
-    cst_only: bool,
-    resolve: bool,
-    phases: bool,
-    show_tree: bool,
-) -> Result<Subcommand, String> {
+fn build_subcommand(subcommand: &str, parsed: ParsedCliFlags) -> Result<Subcommand, String> {
+    let ParsedCliFlags {
+        positionals,
+        cst_only,
+        resolve,
+        phases,
+        show_tree,
+        gradle_home,
+        output_dir,
+        dry_run,
+        ..
+    } = parsed;
     match subcommand {
         "find" => Ok(Subcommand::Find {
             name: first_positional(positionals, "find requires a NAME argument")?,
@@ -208,6 +231,12 @@ fn build_subcommand(
             )?),
         }),
         "sources" => Ok(Subcommand::Sources),
+        "extract-sources" => Ok(Subcommand::ExtractSources {
+            gradle_home,
+            output: output_dir,
+            dry_run,
+            patterns: positionals,
+        }),
         _ => unreachable!(),
     }
 }
@@ -256,7 +285,7 @@ fn first_positional(
 fn is_subcommand(value: &str) -> bool {
     matches!(
         value,
-        "find" | "refs" | "hover" | "index" | "tokens" | "tree" | "sources"
+        "find" | "refs" | "hover" | "index" | "tokens" | "tree" | "sources" | "extract-sources"
     )
 }
 
@@ -278,21 +307,25 @@ SUBCOMMANDS:
     hover   <file> <line> <col> Show type/doc info at a position
     index                       Build and cache the workspace index
     sources                     List auto-discovered source roots
+    extract-sources [PATTERN…]  Extract Gradle *-sources.jar to sourcePaths dir
     tokens  <file>              Dump semantic tokens (debug)
     tree    <file>              Dump tree-sitter parse tree (debug)
 
 OPTIONS:
-    --fast          Use rg/fd only; never load index (default when no cache)
-    --smart         Require index; build it if missing
-    --json          Output results as JSON array
-    --root <dir>    Workspace root (default: nearest .git dir or cwd)
-    --resolve       (tokens) Load index for Phase 2 cross-file resolution
-    --cst-only      (tokens) Force CST-only mode (default, kept for clarity)
-    --phases        (tokens) Show per-phase token breakdown with dedup markers
-    --tree          (tokens) Also print the parse tree after tokens
-    -v, --verbose   Show progress messages (indexing, cache status)
-    -h, --help      Print this help
-    -V, --version   Print version
+    --fast              Use rg/fd only; never load index (default when no cache)
+    --smart             Require index; build it if missing
+    --json              Output results as JSON array
+    --root <dir>        Workspace root (default: nearest .git dir or cwd)
+    --resolve           (tokens) Load index for Phase 2 cross-file resolution
+    --cst-only          (tokens) Force CST-only mode (default, kept for clarity)
+    --phases            (tokens) Show per-phase token breakdown with dedup markers
+    --tree              (tokens) Also print the parse tree after tokens
+    --gradle-home <dir> (extract-sources) Gradle home (default: $GRADLE_USER_HOME or ~/.gradle)
+    --output <dir>      (extract-sources) Output root (default: ~/.kotlin-lsp/sources)
+    --dry-run           (extract-sources) Print what would be extracted; write nothing
+    -v, --verbose       Show progress messages (indexing, cache status)
+    -h, --help          Print this help
+    -V, --version       Print version
 
 EXAMPLES:
     kotlin-lsp find MyViewModel
@@ -301,6 +334,10 @@ EXAMPLES:
     kotlin-lsp index --root ./android
     kotlin-lsp sources --root ./android
     kotlin-lsp sources --json
+    kotlin-lsp extract-sources
+    kotlin-lsp extract-sources androidx.compose org.jetbrains.kotlin
+    kotlin-lsp extract-sources --dry-run
+    kotlin-lsp extract-sources --output ~/my-sources androidx.compose
     kotlin-lsp tokens src/Foo.kt
     kotlin-lsp tokens --resolve src/Foo.kt
     kotlin-lsp tokens src/Foo.kt --tree

--- a/src/cli/extract_sources.rs
+++ b/src/cli/extract_sources.rs
@@ -1,0 +1,285 @@
+//! CLI `extract-sources` subcommand.
+//!
+//! Finds `*-sources.jar` files in the Gradle cache, deduplicates by keeping
+//! only the latest version of each artifact, and extracts `.kt`/`.java` sources
+//! to an output directory for use with `sourcePaths` configuration.
+//!
+//! This is a Rust port of `contrib/extract-sources.py`.
+
+use std::collections::HashMap;
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+pub(crate) struct ExtractOptions {
+    /// Override `$GRADLE_USER_HOME`. Defaults to `~/.gradle`.
+    pub gradle_home: Option<PathBuf>,
+    /// Extraction output root. Defaults to `~/.kotlin-lsp/sources`.
+    pub output: Option<PathBuf>,
+    /// Print what would be done without writing any files.
+    pub dry_run: bool,
+    /// Optional substring filters on artifact paths (e.g. `androidx.compose`).
+    pub patterns: Vec<String>,
+}
+
+// ── version comparison ────────────────────────────────────────────────────────
+
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
+enum VersionPart {
+    Numeric(u64),
+    Text(String),
+}
+
+fn version_key(version: &str) -> Vec<VersionPart> {
+    version
+        .split(['.', '-'])
+        .map(|p| match p.parse::<u64>() {
+            Ok(n) => VersionPart::Numeric(n),
+            Err(_) => VersionPart::Text(p.to_owned()),
+        })
+        .collect()
+}
+
+// ── Gradle cache path parsing ─────────────────────────────────────────────────
+
+struct GradleMeta {
+    group: String,
+    artifact: String,
+    version: String,
+}
+
+/// Parse `(group, artifact, version)` from a Gradle module cache path.
+///
+/// Gradle cache layout:
+/// `<home>/caches/modules-2/files-2.1/<group>/<artifact>/<version>/<hash>/<file>`
+fn parse_jar_meta(jar: &Path) -> Option<GradleMeta> {
+    let s = jar.to_string_lossy();
+    let idx = s.find("files-2.1")? + "files-2.1".len();
+    let rest = s[idx..].trim_start_matches(['/', '\\']);
+    let parts: Vec<&str> = rest.splitn(5, ['/', '\\']).collect();
+    if parts.len() < 3 {
+        return None;
+    }
+    Some(GradleMeta {
+        group: parts[0].to_owned(),
+        artifact: parts[1].to_owned(),
+        version: parts[2].to_owned(),
+    })
+}
+
+fn artifact_dir_name(jar: &Path) -> String {
+    if let Some(meta) = parse_jar_meta(jar) {
+        return format!("{}.{}", meta.group, meta.artifact);
+    }
+    let name = jar.file_name().and_then(|n| n.to_str()).unwrap_or("unknown");
+    for suffix in &["-sources.jar", ".jar"] {
+        if let Some(stripped) = name.strip_suffix(suffix) {
+            return stripped.to_owned();
+        }
+    }
+    name.to_owned()
+}
+
+// ── jar discovery & deduplication ────────────────────────────────────────────
+
+fn find_source_jars(root: &Path) -> Vec<PathBuf> {
+    walkdir::WalkDir::new(root)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name().to_string_lossy();
+            e.file_type().is_file()
+                && name.ends_with("-sources.jar")
+                && !name.ends_with("-samples-sources.jar")
+        })
+        .map(|e| e.into_path())
+        .collect()
+}
+
+fn select_latest(jars: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut best: HashMap<(String, String), (Vec<VersionPart>, PathBuf)> = HashMap::new();
+    let mut ungrouped: Vec<PathBuf> = Vec::new();
+
+    for jar in jars {
+        match parse_jar_meta(&jar) {
+            None => ungrouped.push(jar),
+            Some(meta) => {
+                let key = (meta.group, meta.artifact);
+                let vk = version_key(&meta.version);
+                let entry = best.entry(key).or_insert_with(|| (vk.clone(), jar.clone()));
+                if vk > entry.0 {
+                    *entry = (vk, jar);
+                }
+            }
+        }
+    }
+
+    let mut result: Vec<PathBuf> = best.into_values().map(|(_, p)| p).collect();
+    result.extend(ungrouped);
+    result
+}
+
+// ── extraction ────────────────────────────────────────────────────────────────
+
+/// Extract `.kt`/`.java` files from a JAR into `dest`.
+///
+/// Returns the count of files extracted (or that would be, when `dry_run`).
+fn extract_jar(jar: &Path, dest: &Path, dry_run: bool) -> Result<usize, String> {
+    let file = std::fs::File::open(jar).map_err(|e| format!("{}: {e}", jar.display()))?;
+    let mut archive =
+        zip::ZipArchive::new(file).map_err(|e| format!("{}: {e}", jar.display()))?;
+
+    let mut count = 0;
+    for i in 0..archive.len() {
+        let mut entry = archive.by_index(i).map_err(|e| e.to_string())?;
+        let entry_name = entry.name().to_owned();
+
+        if entry_name.ends_with('/') {
+            continue;
+        }
+        if !entry_name.ends_with(".kt") && !entry_name.ends_with(".java") {
+            continue;
+        }
+        // Zip-slip protection: reject paths with traversal or absolute roots.
+        if entry_name.contains("..") || entry_name.starts_with('/') || entry_name.starts_with('\\')
+        {
+            eprintln!("  WARNING: skipping unsafe path: {entry_name}");
+            continue;
+        }
+
+        if dry_run {
+            count += 1;
+            continue;
+        }
+
+        let target = dest.join(&entry_name);
+        if let Some(parent) = target.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
+        }
+        let mut buf = Vec::new();
+        entry.read_to_end(&mut buf).map_err(|e| e.to_string())?;
+        std::fs::write(&target, &buf).map_err(|e| e.to_string())?;
+        count += 1;
+    }
+    Ok(count)
+}
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+#[allow(deprecated)] // home_dir is deprecated for Windows edge cases; fine on Unix/macOS
+fn home_dir() -> PathBuf {
+    std::env::home_dir().unwrap_or_else(|| PathBuf::from("."))
+}
+
+fn default_gradle_home() -> PathBuf {
+    std::env::var("GRADLE_USER_HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| home_dir().join(".gradle"))
+}
+
+// ── entry point ───────────────────────────────────────────────────────────────
+
+pub(crate) fn run_extract_sources(opts: ExtractOptions) {
+    let search_root = opts
+        .gradle_home
+        .unwrap_or_else(default_gradle_home)
+        .join("caches")
+        .join("modules-2")
+        .join("files-2.1");
+
+    if !search_root.exists() {
+        eprintln!("ERROR: Gradle cache not found at {}", search_root.display());
+        eprintln!("Use --gradle-home to specify your Gradle home.");
+        std::process::exit(1);
+    }
+
+    let output_root = opts
+        .output
+        .unwrap_or_else(|| home_dir().join(".kotlin-lsp").join("sources"));
+
+    println!("Searching: {}", search_root.display());
+    println!("Output:    {}", output_root.display());
+    if !opts.patterns.is_empty() {
+        println!("Patterns:  {}", opts.patterns.join(", "));
+    }
+    if opts.dry_run {
+        println!("Dry run — no files will be written.");
+    }
+    println!();
+
+    let mut all_jars = find_source_jars(&search_root);
+    println!("Found {} *-sources.jar file(s) total.", all_jars.len());
+
+    if !opts.patterns.is_empty() {
+        all_jars.retain(|jar| {
+            let s = jar.to_string_lossy();
+            opts.patterns.iter().any(|p| s.contains(p.as_str()))
+        });
+        println!(
+            "After filtering: {} jar(s) match pattern(s).",
+            all_jars.len()
+        );
+    }
+
+    let selected = select_latest(all_jars);
+    println!(
+        "After dedup (latest version per artifact): {} jar(s).\n",
+        selected.len()
+    );
+
+    if selected.is_empty() {
+        println!("Nothing to extract.");
+        return;
+    }
+
+    let mut sorted = selected;
+    sorted.sort();
+
+    let mut total_files = 0usize;
+    let mut extracted_dirs: Vec<PathBuf> = Vec::new();
+
+    for jar in &sorted {
+        let dir_name = artifact_dir_name(jar);
+        let dest = output_root.join(&dir_name);
+        let version_str = parse_jar_meta(jar)
+            .map(|m| format!("  v{}", m.version))
+            .unwrap_or_default();
+
+        println!("  {dir_name}{version_str}");
+        println!("    src: {}", jar.display());
+        println!("    dst: {}", dest.display());
+
+        match extract_jar(jar, &dest, opts.dry_run) {
+            Ok(count) => {
+                let verb = if opts.dry_run { "would extract" } else { "extracted" };
+                println!("    {verb} {count} file(s)");
+                total_files += count;
+                if !extracted_dirs.contains(&dest) {
+                    extracted_dirs.push(dest);
+                }
+            }
+            Err(e) => eprintln!("  WARNING: {e}"),
+        }
+        println!();
+    }
+
+    let verb = if opts.dry_run { "Would extract" } else { "Extracted" };
+    println!(
+        "{verb} {total_files} file(s) across {} artifact(s).",
+        extracted_dirs.len()
+    );
+
+    if !opts.dry_run && !extracted_dirs.is_empty() {
+        println!();
+        println!("Add to your LSP config (sourcePaths accepts a parent dir):");
+        println!();
+        println!("  sourcePaths = [\"{}\"]", output_root.display());
+        println!();
+        println!("Or list individual artifact dirs:");
+        println!();
+        extracted_dirs.sort();
+        for d in &extracted_dirs {
+            println!("    \"{}\",", d.display());
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,6 +21,7 @@
 //! All diagnostics and mode notices go to stderr only.
 
 mod args;
+mod extract_sources;
 mod hover;
 mod output;
 mod run;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -138,6 +138,19 @@ pub(crate) async fn run(args: CliArgs) {
         }
         Subcommand::Tree { file } => run_tree(&file),
         Subcommand::Sources => super::sources::run_sources(&root, json),
+        Subcommand::ExtractSources {
+            gradle_home,
+            output,
+            dry_run,
+            patterns,
+        } => super::extract_sources::run_extract_sources(
+            super::extract_sources::ExtractOptions {
+                gradle_home,
+                output,
+                dry_run,
+                patterns,
+            },
+        ),
     }
 }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -43,12 +43,58 @@ fn cache_exists(root: &Path) -> bool {
 // ── Indexer bootstrap ─────────────────────────────────────────────────────────
 
 /// Build (or load from cache) a full workspace index.  Reports progress to stderr.
+///
+/// Source paths are collected from:
+/// 1. `workspace.json` (JetBrains IDE format) at the workspace root
+/// 2. Build-layout auto-detection (Gradle/Maven src dirs), if no workspace.json
+/// 3. `~/.kotlin-lsp/sources` — the default `extract-sources` output dir
 async fn build_index(root: &Path) -> Arc<Indexer> {
     let idx = Arc::new(Indexer::new());
+
+    let source_paths = collect_cli_source_paths(root);
+    if !source_paths.is_empty() {
+        *idx.source_paths_raw.write().unwrap() = source_paths;
+    }
+
     Arc::clone(&idx)
         .index_workspace_full(root, Arc::new(NoopReporter))
         .await;
     idx
+}
+
+/// Collect source paths for CLI indexing: workspace.json + build-layout + default extract dir.
+fn collect_cli_source_paths(root: &Path) -> Vec<String> {
+    let mut paths: Vec<String> = Vec::new();
+
+    let json_paths = crate::workspace_json::load_source_paths(root);
+    for p in &json_paths {
+        let s = p.to_string_lossy().into_owned();
+        if !paths.contains(&s) {
+            paths.push(s);
+        }
+    }
+
+    if json_paths.is_empty() {
+        for p in crate::workspace_json::detect_build_layout_source_paths(root) {
+            let s = p.to_string_lossy().into_owned();
+            if !paths.contains(&s) {
+                paths.push(s);
+            }
+        }
+    }
+
+    // Auto-include the well-known `extract-sources` output dir if present.
+    #[allow(deprecated)]
+    let home = std::env::home_dir().unwrap_or_else(|| PathBuf::from("."));
+    let default_sources = home.join(".kotlin-lsp").join("sources");
+    if default_sources.is_dir() {
+        let s = default_sources.to_string_lossy().into_owned();
+        if !paths.contains(&s) {
+            paths.push(s);
+        }
+    }
+
+    paths
 }
 
 // ── Location helpers ─────────────────────────────────────────────────────────

--- a/src/cli/sources.rs
+++ b/src/cli/sources.rs
@@ -82,4 +82,11 @@ pub(crate) fn run_sources(workspace_root: &Path, json: bool) {
     if missing > 0 {
         eprintln!("\n{missing} path(s) marked ✗ do not exist on disk.");
     }
+
+    if roots.is_empty() || roots.iter().any(|r| r.origin == "build-layout") {
+        eprintln!(
+            "\nTip: run `kotlin-lsp extract-sources` to unpack Gradle *-sources.jar files"
+        );
+        eprintln!("     so library source code is available for hover and go-to-definition.");
+    }
 }


### PR DESCRIPTION
Ports `contrib/extract-sources.py` to a built-in Rust subcommand — no Python dependency needed.

## Usage

```sh
# See what sources would be extracted (safe, no writes)
kotlin-lsp extract-sources --dry-run

# Extract all cached Gradle sources
kotlin-lsp extract-sources

# Filter to specific artifacts
kotlin-lsp extract-sources androidx.compose org.jetbrains.kotlin

# Custom output dir
kotlin-lsp extract-sources --output ~/my-sources

# Full workflow
kotlin-lsp sources --root ./android   # check what's auto-detected
kotlin-lsp extract-sources            # unpack library sources
kotlin-lsp index --root ./android     # re-index with new sources
```

## What this adds

- `src/cli/extract_sources.rs` — Gradle cache walker, version deduplication, JAR extractor with zip-slip protection
- `src/cli/args.rs` — `ExtractSources` subcommand variant + `--gradle-home`, `--output`, `--dry-run` flags
- `sources` subcommand now prints a tip to run `extract-sources` when no `workspace.json` is found
- `docs/features.md` — new CLI subcommands section with workflow example

The Python script in `contrib/` is kept as a reference but users can now use the binary directly.