### PR TITLE
feat(workspace): WorkspaceConfig + WorkspaceEvent + WorkspaceActor (Wave 1 MVI)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ mod stdlib_tail;
 mod str_ext;
 mod task_runner;
 mod types;
+mod workspace;
 mod workspace_json;
 
 pub(crate) use lines_ext::LinesExt;

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -1,0 +1,180 @@
+//! [`WorkspaceActor`] — the single serialised writer of workspace state.
+//!
+//! All workspace-level mutations (root, source paths, ignore patterns, scans)
+//! are processed here, one at a time, in arrival order.  Request handlers that
+//! only read index data continue to run concurrently via `Arc<Indexer>`.
+//!
+//! # Invariants
+//!
+//! * Source discovery runs only in [`WorkspaceActor::handle_initialize`].
+//! * Only this actor writes `Indexer::source_paths_raw` and `Indexer::ignore_matcher`.
+//! * The `Indexer` is long-lived; it is never replaced, so live-document state
+//!   accumulated in `live_lines`, `live_trees`, etc. survives reindex/root-switch.
+
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use crate::indexer::{Indexer, ProgressReporter};
+use crate::rg::IgnoreMatcher;
+
+use super::{WorkspaceConfig, WorkspaceEvent};
+
+// ─── WorkspaceActor ──────────────────────────────────────────────────────────
+
+/// MVI-style actor that owns all workspace write operations.
+///
+/// Generic over `R` (the progress reporter) so that LSP mode uses
+/// [`LspProgressReporter`](crate::indexer::ProgressReporter) and CLI / tests
+/// use [`NoopReporter`](crate::indexer::NoopReporter) — no heap allocation or
+/// vtable dispatch needed at the actor level.
+///
+/// Construct with [`WorkspaceActor::new`] and drive with [`WorkspaceActor::run`].
+pub(crate) struct WorkspaceActor<R: ProgressReporter + 'static> {
+    indexer: Arc<Indexer>,
+    reporter: Arc<R>,
+    rx: mpsc::Receiver<WorkspaceEvent>,
+}
+
+impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
+    /// Create a new actor.
+    ///
+    /// `reporter` is used for every workspace scan triggered by this actor.
+    /// For LSP mode, pass `Arc::new(LspProgressReporter(client.clone()))`.
+    /// For CLI mode or tests, pass `Arc::new(NoopReporter)`.
+    pub(crate) fn new(
+        indexer: Arc<Indexer>,
+        reporter: Arc<R>,
+        rx: mpsc::Receiver<WorkspaceEvent>,
+    ) -> Self {
+        Self {
+            indexer,
+            reporter,
+            rx,
+        }
+    }
+
+    /// Run the event loop until the sender side is dropped.
+    ///
+    /// The exhaustive `match` is the architectural guarantee: every new
+    /// [`WorkspaceEvent`] variant must be handled here or the code will not
+    /// compile.
+    pub(crate) async fn run(mut self) {
+        while let Some(event) = self.rx.recv().await {
+            match event {
+                WorkspaceEvent::Initialize { config } => self.handle_initialize(config).await,
+                WorkspaceEvent::Reindex => self.handle_reindex().await,
+                WorkspaceEvent::ChangeRoot { root } => self.handle_change_root(root).await,
+            }
+        }
+    }
+
+    // ── Event handlers ────────────────────────────────────────────────────────
+
+    async fn handle_initialize(&self, config: WorkspaceConfig) {
+        let root = config.root.clone();
+
+        // Set the root immediately so read-path handlers can see it without
+        // waiting for index_workspace_impl to run.  The scan will overwrite
+        // this with the same value once it acquires the indexing guard.
+        self.set_root(root.clone());
+        self.apply_ignore_patterns(&config.ignore_patterns, &root);
+
+        let sources = config.resolve_sources();
+        if !sources.is_empty() {
+            self.write_source_paths(sources);
+        }
+
+        self.spawn_scan(root, Vec::new()).await;
+    }
+
+    async fn handle_reindex(&self) {
+        let Some(root) = self.current_root() else {
+            log::warn!("WorkspaceActor: Reindex received but no workspace root is set");
+            return;
+        };
+        self.indexer.reset_index_state();
+        self.spawn_full_scan(root).await;
+    }
+
+    async fn handle_change_root(&self, root: PathBuf) {
+        self.set_root(root.clone());
+
+        // Re-resolve source paths for the new root (workspace.json, build layout, etc.).
+        // Explicit source paths from initialization are intentionally dropped because
+        // they were relative to the old root and are typically editor-session-scoped.
+        let config = WorkspaceConfig {
+            root: root.clone(),
+            explicit_source_paths: Vec::new(),
+            ignore_patterns: Vec::new(),
+        };
+        let sources = config.resolve_sources();
+        self.write_source_paths(sources);
+
+        self.indexer.reset_index_state();
+        self.spawn_full_scan(root).await;
+    }
+
+    // ── Internal helpers ──────────────────────────────────────────────────────
+
+    fn current_root(&self) -> Option<PathBuf> {
+        self.indexer
+            .workspace_root
+            .read()
+            .ok()
+            .and_then(|guard| guard.clone())
+    }
+
+    fn set_root(&self, root: PathBuf) {
+        if let Ok(mut guard) = self.indexer.workspace_root.write() {
+            *guard = Some(root);
+        } else {
+            log::warn!("WorkspaceActor: failed to write workspace root");
+        }
+    }
+
+    fn write_source_paths(&self, paths: Vec<String>) {
+        match self.indexer.source_paths_raw.write() {
+            Ok(mut guard) => *guard = paths,
+            Err(err) => log::warn!("WorkspaceActor: failed to write source_paths_raw: {err}"),
+        }
+    }
+
+    fn apply_ignore_patterns(&self, patterns: &[String], root: &Path) {
+        if patterns.is_empty() {
+            return;
+        }
+        match self.indexer.ignore_matcher.write() {
+            Ok(mut guard) => {
+                *guard = Some(Arc::new(IgnoreMatcher::new(patterns.to_vec(), root)));
+            }
+            Err(err) => log::warn!("WorkspaceActor: failed to write ignore_matcher: {err}"),
+        }
+    }
+
+    /// Spawn a prioritized bounded scan in the background.
+    /// `initial_paths` are indexed first (empty = no prioritization).
+    async fn spawn_scan(&self, root: PathBuf, initial_paths: Vec<PathBuf>) {
+        let indexer = Arc::clone(&self.indexer);
+        let reporter = Arc::clone(&self.reporter);
+        tokio::spawn(async move {
+            indexer
+                .index_workspace_prioritized(&root, initial_paths, reporter)
+                .await;
+        });
+    }
+
+    /// Spawn an unbounded full scan (used by Reindex and ChangeRoot).
+    async fn spawn_full_scan(&self, root: PathBuf) {
+        let indexer = Arc::clone(&self.indexer);
+        let reporter = Arc::clone(&self.reporter);
+        tokio::spawn(async move {
+            indexer.index_workspace_full(&root, reporter).await;
+        });
+    }
+}
+
+#[cfg(test)]
+#[path = "actor_tests.rs"]
+mod tests;

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -6,10 +6,12 @@
 //!
 //! # Invariants
 //!
-//! * Source discovery runs only in [`WorkspaceActor::handle_initialize`].
-//! * Only this actor writes `Indexer::source_paths_raw` and `Indexer::ignore_matcher`.
+//! * Only `WorkspaceActor` event handlers may call `resolve_sources()` and write
+//!   `Indexer::source_paths_raw` or `Indexer::ignore_matcher`.
 //! * The `Indexer` is long-lived; it is never replaced, so live-document state
 //!   accumulated in `live_lines`, `live_trees`, etc. survives reindex/root-switch.
+// Items unused until Wave 2 wires this into backend/CLI (ws-backend, ws-cli, ws-main).
+#![allow(dead_code)]
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -81,10 +83,8 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
         self.set_root(root.clone());
         self.apply_ignore_patterns(&config.ignore_patterns, &root);
 
-        let sources = config.resolve_sources();
-        if !sources.is_empty() {
-            self.write_source_paths(sources);
-        }
+        // Always write source paths — even when empty — to clear any prior state.
+        self.write_source_paths(config.resolve_sources());
 
         self.spawn_scan(root, Vec::new()).await;
     }
@@ -101,16 +101,17 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
     async fn handle_change_root(&self, root: PathBuf) {
         self.set_root(root.clone());
 
-        // Re-resolve source paths for the new root (workspace.json, build layout, etc.).
-        // Explicit source paths from initialization are intentionally dropped because
-        // they were relative to the old root and are typically editor-session-scoped.
+        // Clear stale ignore patterns from the previous root, then re-resolve
+        // source paths for the new root (workspace.json, build layout, etc.).
+        // Explicit source paths from initialization are intentionally dropped
+        // because they were relative to the old root and are editor-session-scoped.
         let config = WorkspaceConfig {
             root: root.clone(),
             explicit_source_paths: Vec::new(),
             ignore_patterns: Vec::new(),
         };
-        let sources = config.resolve_sources();
-        self.write_source_paths(sources);
+        self.apply_ignore_patterns(&config.ignore_patterns, &root);
+        self.write_source_paths(config.resolve_sources());
 
         self.indexer.reset_index_state();
         self.spawn_full_scan(root).await;
@@ -142,12 +143,12 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
     }
 
     fn apply_ignore_patterns(&self, patterns: &[String], root: &Path) {
-        if patterns.is_empty() {
-            return;
-        }
         match self.indexer.ignore_matcher.write() {
             Ok(mut guard) => {
-                *guard = Some(Arc::new(IgnoreMatcher::new(patterns.to_vec(), root)));
+                // Always write — even when empty — to clear any stale matcher from
+                // a previous Initialize or root switch.
+                *guard = (!patterns.is_empty())
+                    .then(|| Arc::new(IgnoreMatcher::new(patterns.to_vec(), root)));
             }
             Err(err) => log::warn!("WorkspaceActor: failed to write ignore_matcher: {err}"),
         }

--- a/src/workspace/actor_tests.rs
+++ b/src/workspace/actor_tests.rs
@@ -21,6 +21,18 @@ fn temp_dir() -> tempfile::TempDir {
     tempfile::tempdir().unwrap()
 }
 
+/// Poll `pred` every 10 ms until it returns `true` or 500 ms elapse.
+/// Returns whether the predicate became true within the timeout.
+async fn poll_until(pred: impl Fn() -> bool) -> bool {
+    for _ in 0..50 {
+        if pred() {
+            return true;
+        }
+        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
+    }
+    pred()
+}
+
 // ─── actor tests ─────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -42,13 +54,16 @@ async fn initialize_sets_workspace_root() {
     .await
     .unwrap();
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    let ready = poll_until(|| {
+        indexer.workspace_root.read().unwrap().is_some()
+    }).await;
+    assert!(ready, "workspace_root not set within timeout");
 
     let actual_root = indexer.workspace_root.read().unwrap().clone();
     assert_eq!(
         actual_root.as_deref(),
         Some(root.as_path()),
-        "workspace_root should be set synchronously by handle_initialize before scan starts"
+        "workspace_root should be set by handle_initialize"
     );
 }
 
@@ -71,7 +86,10 @@ async fn initialize_writes_explicit_source_paths() {
     .await
     .unwrap();
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    let ready = poll_until(|| {
+        !indexer.source_paths_raw.read().unwrap().is_empty()
+    }).await;
+    assert!(ready, "source_paths_raw not populated within timeout");
 
     let paths = indexer.source_paths_raw.read().unwrap().clone();
     assert!(
@@ -94,7 +112,10 @@ async fn change_root_updates_workspace_root() {
         .await
         .unwrap();
 
-    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+    let ready = poll_until(|| {
+        indexer.workspace_root.read().unwrap().is_some()
+    }).await;
+    assert!(ready, "workspace_root not set within timeout");
 
     let actual = indexer.workspace_root.read().unwrap().clone();
     assert_eq!(

--- a/src/workspace/actor_tests.rs
+++ b/src/workspace/actor_tests.rs
@@ -42,14 +42,14 @@ async fn initialize_sets_workspace_root() {
     .await
     .unwrap();
 
-    // Give the actor a moment to process
     tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
 
     let actual_root = indexer.workspace_root.read().unwrap().clone();
-    // The indexer's workspace_root is set by index_workspace_impl once the scan
-    // starts, not by the actor directly (scan takes ownership).  So we verify
-    // the actor at least didn't corrupt the indexer.
-    drop(actual_root);
+    assert_eq!(
+        actual_root.as_deref(),
+        Some(root.as_path()),
+        "workspace_root should be set synchronously by handle_initialize before scan starts"
+    );
 }
 
 #[tokio::test]

--- a/src/workspace/actor_tests.rs
+++ b/src/workspace/actor_tests.rs
@@ -1,0 +1,120 @@
+//! Integration tests for [`WorkspaceActor`].
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use crate::indexer::{Indexer, NoopReporter};
+use crate::workspace::{WorkspaceActor, WorkspaceConfig, WorkspaceEvent};
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn make_actor(
+    indexer: Arc<Indexer>,
+) -> (WorkspaceActor<NoopReporter>, mpsc::Sender<WorkspaceEvent>) {
+    let (tx, rx) = mpsc::channel(16);
+    let actor = WorkspaceActor::new(indexer, Arc::new(NoopReporter), rx);
+    (actor, tx)
+}
+
+fn temp_dir() -> tempfile::TempDir {
+    tempfile::tempdir().unwrap()
+}
+
+// ─── actor tests ─────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn initialize_sets_workspace_root() {
+    let indexer = Arc::new(Indexer::new());
+    let tmp = temp_dir();
+    let root = tmp.path().to_path_buf();
+
+    let (actor, tx) = make_actor(Arc::clone(&indexer));
+    tokio::spawn(actor.run());
+
+    tx.send(WorkspaceEvent::Initialize {
+        config: WorkspaceConfig {
+            root: root.clone(),
+            explicit_source_paths: Vec::new(),
+            ignore_patterns: Vec::new(),
+        },
+    })
+    .await
+    .unwrap();
+
+    // Give the actor a moment to process
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let actual_root = indexer.workspace_root.read().unwrap().clone();
+    // The indexer's workspace_root is set by index_workspace_impl once the scan
+    // starts, not by the actor directly (scan takes ownership).  So we verify
+    // the actor at least didn't corrupt the indexer.
+    drop(actual_root);
+}
+
+#[tokio::test]
+async fn initialize_writes_explicit_source_paths() {
+    let indexer = Arc::new(Indexer::new());
+    let tmp = temp_dir();
+    let root = tmp.path().to_path_buf();
+
+    let (actor, tx) = make_actor(Arc::clone(&indexer));
+    tokio::spawn(actor.run());
+
+    tx.send(WorkspaceEvent::Initialize {
+        config: WorkspaceConfig {
+            root: root.clone(),
+            explicit_source_paths: vec!["/some/lib".to_string()],
+            ignore_patterns: Vec::new(),
+        },
+    })
+    .await
+    .unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let paths = indexer.source_paths_raw.read().unwrap().clone();
+    assert!(
+        paths.contains(&"/some/lib".to_string()),
+        "source_paths_raw should contain the explicit path, got: {paths:?}"
+    );
+}
+
+#[tokio::test]
+async fn change_root_updates_workspace_root() {
+    let indexer = Arc::new(Indexer::new());
+    let tmp = temp_dir();
+    let root = tmp.path().to_path_buf();
+
+    let (actor, tx) = make_actor(Arc::clone(&indexer));
+    tokio::spawn(actor.run());
+
+    // Send ChangeRoot without a prior Initialize — the actor must set root directly.
+    tx.send(WorkspaceEvent::ChangeRoot { root: root.clone() })
+        .await
+        .unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+    let actual = indexer.workspace_root.read().unwrap().clone();
+    assert_eq!(
+        actual.as_deref(),
+        Some(root.as_path()),
+        "workspace_root should be updated after ChangeRoot"
+    );
+}
+
+#[tokio::test]
+async fn actor_stops_when_sender_dropped() {
+    let indexer = Arc::new(Indexer::new());
+    let (actor, tx) = make_actor(indexer);
+
+    let handle = tokio::spawn(actor.run());
+    drop(tx);
+
+    // Actor should exit cleanly once the sender is dropped
+    tokio::time::timeout(tokio::time::Duration::from_secs(2), handle)
+        .await
+        .expect("actor did not stop within 2s after sender drop")
+        .unwrap();
+}

--- a/src/workspace/config_tests.rs
+++ b/src/workspace/config_tests.rs
@@ -1,0 +1,130 @@
+//! Unit tests for [`WorkspaceConfig::resolve_sources`].
+
+use std::fs;
+use std::path::Path;
+
+use super::WorkspaceConfig;
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn config(root: &Path) -> WorkspaceConfig {
+    WorkspaceConfig {
+        root: root.to_path_buf(),
+        explicit_source_paths: Vec::new(),
+        ignore_patterns: Vec::new(),
+    }
+}
+
+fn config_with_explicit(root: &Path, explicit: &[&str]) -> WorkspaceConfig {
+    WorkspaceConfig {
+        root: root.to_path_buf(),
+        explicit_source_paths: explicit.iter().map(|s| s.to_string()).collect(),
+        ignore_patterns: Vec::new(),
+    }
+}
+
+/// Write a `build.gradle.kts` so that `detect_build_layout_source_paths` triggers.
+fn write_gradle(root: &Path) {
+    fs::write(root.join("build.gradle.kts"), "").unwrap();
+}
+
+// ─── resolve_sources tests ───────────────────────────────────────────────────
+
+#[test]
+fn no_workspace_json_no_build_file_no_layout_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    let sources = config(dir.path()).resolve_sources();
+    // No workspace.json, no build file → no layout paths from this dir
+    // (we accept that ~/.kotlin-lsp/sources may appear if it exists on the host)
+    let has_temp_dir_paths = sources
+        .iter()
+        .any(|s| s.starts_with(dir.path().to_str().unwrap_or("")));
+    assert!(
+        !has_temp_dir_paths,
+        "No paths from temp dir expected, got: {sources:?}"
+    );
+}
+
+#[test]
+fn explicit_paths_are_included() {
+    let dir = tempfile::tempdir().unwrap();
+    let sources = config_with_explicit(dir.path(), &["/some/external/lib", "/another/lib"])
+        .resolve_sources();
+    assert!(sources.contains(&"/some/external/lib".to_string()));
+    assert!(sources.contains(&"/another/lib".to_string()));
+}
+
+#[test]
+fn explicit_paths_come_first() {
+    let dir = tempfile::tempdir().unwrap();
+    // Create a Gradle build file + standard layout so auto-detection fires.
+    write_gradle(dir.path());
+    let src_main = dir.path().join("src").join("main").join("kotlin");
+    fs::create_dir_all(&src_main).unwrap();
+
+    let cfg = config_with_explicit(dir.path(), &["/explicit"]);
+    let sources = cfg.resolve_sources();
+
+    let explicit_pos = sources
+        .iter()
+        .position(|s| s == "/explicit")
+        .expect("explicit path missing");
+    let layout_pos = sources
+        .iter()
+        .position(|s| s.contains("src/main/kotlin"))
+        .expect("layout path missing");
+
+    assert!(
+        explicit_pos < layout_pos,
+        "Explicit path should appear before auto-discovered paths"
+    );
+}
+
+#[test]
+fn no_duplicate_paths() {
+    let dir = tempfile::tempdir().unwrap();
+    write_gradle(dir.path());
+    let src_main = dir.path().join("src").join("main").join("kotlin");
+    fs::create_dir_all(&src_main).unwrap();
+
+    let src_str = src_main.to_string_lossy().into_owned();
+    // Pass the auto-discovered path as explicit too — should appear exactly once.
+    let cfg = config_with_explicit(dir.path(), &[&src_str]);
+    let sources = cfg.resolve_sources();
+
+    let count = sources.iter().filter(|s| s.as_str() == src_str).count();
+    assert_eq!(count, 1, "Expected exactly one occurrence of {src_str}");
+}
+
+#[test]
+fn workspace_json_paths_are_included() {
+    let dir = tempfile::tempdir().unwrap();
+    let ws = dir.path().to_string_lossy();
+
+    let src_dir = dir.path().join("src").join("main").join("kotlin");
+    fs::create_dir_all(&src_dir).unwrap();
+
+    // Format expected by workspace_json::load_source_paths.
+    let json = format!(
+        r#"{{
+            "modules": [{{
+                "contentRoots": [{{
+                    "sourceRoots": [
+                        {{"path": "<WORKSPACE>/src/main/kotlin", "type": "java-source"}}
+                    ]
+                }}]
+            }}]
+        }}"#
+    );
+    // load_source_paths replaces <WORKSPACE> with the root, so write at workspace root.
+    let _ = ws; // used in format only via the path
+    fs::write(dir.path().join("workspace.json"), json).unwrap();
+
+    let sources = config(dir.path()).resolve_sources();
+    let src_str = src_dir.to_string_lossy().into_owned();
+    assert!(
+        sources.contains(&src_str),
+        "Expected workspace.json path in sources, got: {sources:?}"
+    );
+}
+

--- a/src/workspace/config_tests.rs
+++ b/src/workspace/config_tests.rs
@@ -71,7 +71,9 @@ fn explicit_paths_come_first() {
         .expect("explicit path missing");
     let layout_pos = sources
         .iter()
-        .position(|s| s.contains("src/main/kotlin"))
+        .position(|s| {
+            std::path::Path::new(s).ends_with(std::path::Path::new("src/main/kotlin"))
+        })
         .expect("layout path missing");
 
     assert!(

--- a/src/workspace/event.rs
+++ b/src/workspace/event.rs
@@ -1,0 +1,34 @@
+//! [`WorkspaceEvent`] — the sealed set of workspace-level state mutations.
+//!
+//! Every write to workspace state goes through one of these variants.
+//! Adding a new variant produces a compile error in [`WorkspaceActor::run`]
+//! until the handler is implemented — this is the key correctness invariant.
+
+use std::path::PathBuf;
+
+use super::WorkspaceConfig;
+
+/// All workspace-level mutations, serialised through [`WorkspaceActor`].
+///
+/// File-level events (textDocument/didOpen, didChange, etc.) are handled
+/// directly by the LSP backend for now; they will migrate here in a later phase.
+pub(crate) enum WorkspaceEvent {
+    /// Configure the workspace and start an initial scan.
+    ///
+    /// Must be the first event sent to a fresh actor.  Subsequent `Initialize`
+    /// events switch the root and restart the scan, discarding old source paths.
+    Initialize { config: WorkspaceConfig },
+
+    /// Re-scan the current workspace from scratch.
+    ///
+    /// Equivalent to the `kotlin-lsp/reindex` execute-command.  Keeps the
+    /// long-lived `Indexer` so live-document state is preserved.
+    Reindex,
+
+    /// Switch to a new workspace root and restart the scan.
+    ///
+    /// Source paths are re-resolved via `WorkspaceConfig::resolve_sources` for
+    /// the new root. Existing explicit `source_paths_raw` are discarded because
+    /// they were relative to the old root.
+    ChangeRoot { root: PathBuf },
+}

--- a/src/workspace/event.rs
+++ b/src/workspace/event.rs
@@ -3,6 +3,8 @@
 //! Every write to workspace state goes through one of these variants.
 //! Adding a new variant produces a compile error in [`WorkspaceActor::run`]
 //! until the handler is implemented — this is the key correctness invariant.
+// Items unused until Wave 2 wires this into backend/CLI (ws-backend, ws-cli, ws-main).
+#![allow(dead_code)]
 
 use std::path::PathBuf;
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -12,31 +12,31 @@
 //! # Source discovery
 //!
 //! [`WorkspaceConfig::resolve_sources`] is the canonical source-path resolver.
-//! It must be called in exactly one place: `WorkspaceActor::handle_initialize`.
-//! No other code should write `Indexer::source_paths_raw`.
+//! Only `WorkspaceActor` event handlers may call it — no other code should write
+//! `Indexer::source_paths_raw`.
 //!
 //! # Wiring status
 //!
 //! Wave 1 (this PR) establishes the infrastructure.
 //! Wave 2 (todos: `ws-backend`, `ws-cli`, `ws-main`) wires the actor into the
-//! LSP backend and CLI runner.  Until then the items below are intentionally
+//! LSP backend and CLI runner.  Until then the re-exports below are intentionally
 //! unreachable from `main()`.
-// Suppress dead_code and unused_imports: this module is infrastructure for
-// Wave 2 wiring (todos: ws-backend, ws-cli, ws-main).  Once those are merged
-// the allows can be removed.  #[cfg(test)] cannot be used because the items
-// are needed in production code — they are simply not yet connected to a caller.
-#![allow(dead_code, unused_imports)]
 
 pub(crate) mod actor;
 pub(crate) mod event;
 
+// Re-exports are unused until Wave 2 wires this module in (ws-backend, ws-cli, ws-main).
+#[allow(unused_imports)]
 pub(crate) use actor::WorkspaceActor;
+#[allow(unused_imports)]
 pub(crate) use event::WorkspaceEvent;
 
 use std::path::PathBuf;
 
 // ─── WorkspaceConfig ─────────────────────────────────────────────────────────
 
+// WorkspaceConfig is unused until Wave 2 wires this module in (ws-backend, ws-cli, ws-main).
+#[allow(dead_code)]
 /// Immutable snapshot of workspace configuration collected at startup.
 ///
 /// Passed inside [`WorkspaceEvent::Initialize`]; not mutated after construction.
@@ -84,13 +84,16 @@ impl WorkspaceConfig {
         }
 
         // Auto-include the well-known `extract-sources` output directory if present.
+        // Skip entirely when HOME is unknown to avoid accidentally indexing the
+        // current working directory (matches existing backend behaviour).
         #[allow(deprecated)]
-        let home = std::env::home_dir().unwrap_or_else(|| PathBuf::from("."));
-        let default_sources = home.join(".kotlin-lsp").join("sources");
-        if default_sources.is_dir() {
-            let s = default_sources.to_string_lossy().into_owned();
-            if !paths.contains(&s) {
-                paths.push(s);
+        if let Some(home) = std::env::home_dir() {
+            let default_sources = home.join(".kotlin-lsp").join("sources");
+            if default_sources.is_dir() {
+                let s = default_sources.to_string_lossy().into_owned();
+                if !paths.contains(&s) {
+                    paths.push(s);
+                }
             }
         }
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -63,23 +63,33 @@ impl WorkspaceConfig {
     /// 3. Build-layout auto-detection (standard Maven/Gradle `src/` dirs) —
     ///    only attempted when `workspace.json` is absent
     /// 4. `~/.kotlin-lsp/sources` (default `extract-sources` output dir)
+    ///
+    /// Called only from `WorkspaceActor` event handlers (`handle_initialize`,
+    /// `handle_change_root`).  No other code should call this method.
     pub(crate) fn resolve_sources(&self) -> Vec<String> {
-        let mut paths = self.explicit_source_paths.clone();
+        use std::collections::HashSet;
+
+        let mut seen: HashSet<String> = HashSet::new();
+        let mut paths: Vec<String> = Vec::new();
+
+        let mut push = |s: String| {
+            if seen.insert(s.clone()) {
+                paths.push(s);
+            }
+        };
+
+        for s in &self.explicit_source_paths {
+            push(s.clone());
+        }
 
         let json_paths = crate::workspace_json::load_source_paths(&self.root);
         for p in &json_paths {
-            let s = p.to_string_lossy().into_owned();
-            if !paths.contains(&s) {
-                paths.push(s);
-            }
+            push(p.to_string_lossy().into_owned());
         }
 
         if json_paths.is_empty() {
             for p in crate::workspace_json::detect_build_layout_source_paths(&self.root) {
-                let s = p.to_string_lossy().into_owned();
-                if !paths.contains(&s) {
-                    paths.push(s);
-                }
+                push(p.to_string_lossy().into_owned());
             }
         }
 
@@ -90,10 +100,7 @@ impl WorkspaceConfig {
         if let Some(home) = std::env::home_dir() {
             let default_sources = home.join(".kotlin-lsp").join("sources");
             if default_sources.is_dir() {
-                let s = default_sources.to_string_lossy().into_owned();
-                if !paths.contains(&s) {
-                    paths.push(s);
-                }
+                push(default_sources.to_string_lossy().into_owned());
             }
         }
 

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -1,0 +1,103 @@
+//! Workspace lifecycle management — configuration, events, and the MVI actor.
+//!
+//! # Architecture
+//!
+//! All workspace-level state mutations (root, source paths, ignore patterns, scans)
+//! flow through [`WorkspaceActor`] via [`WorkspaceEvent`]s sent on an `mpsc` channel.
+//! This serialises writes and gives a single, exhaustive `match` as the authority on
+//! what can happen to the workspace.
+//!
+//! Read-path handlers receive `Arc<Indexer>` directly and operate concurrently.
+//!
+//! # Source discovery
+//!
+//! [`WorkspaceConfig::resolve_sources`] is the canonical source-path resolver.
+//! It must be called in exactly one place: `WorkspaceActor::handle_initialize`.
+//! No other code should write `Indexer::source_paths_raw`.
+//!
+//! # Wiring status
+//!
+//! Wave 1 (this PR) establishes the infrastructure.
+//! Wave 2 (todos: `ws-backend`, `ws-cli`, `ws-main`) wires the actor into the
+//! LSP backend and CLI runner.  Until then the items below are intentionally
+//! unreachable from `main()`.
+// Suppress dead_code and unused_imports: this module is infrastructure for
+// Wave 2 wiring (todos: ws-backend, ws-cli, ws-main).  Once those are merged
+// the allows can be removed.  #[cfg(test)] cannot be used because the items
+// are needed in production code — they are simply not yet connected to a caller.
+#![allow(dead_code, unused_imports)]
+
+pub(crate) mod actor;
+pub(crate) mod event;
+
+pub(crate) use actor::WorkspaceActor;
+pub(crate) use event::WorkspaceEvent;
+
+use std::path::PathBuf;
+
+// ─── WorkspaceConfig ─────────────────────────────────────────────────────────
+
+/// Immutable snapshot of workspace configuration collected at startup.
+///
+/// Passed inside [`WorkspaceEvent::Initialize`]; not mutated after construction.
+pub(crate) struct WorkspaceConfig {
+    /// Absolute path to the workspace root (nearest `.git` ancestor of the opened file,
+    /// or an explicit `--root` flag in CLI mode, or the LSP `rootUri`).
+    pub root: PathBuf,
+
+    /// Source paths explicitly configured by the caller (e.g. LSP
+    /// `initializationOptions.indexingOptions.sourcePaths`).
+    /// These are merged with auto-discovered paths by [`resolve_sources`].
+    pub explicit_source_paths: Vec<String>,
+
+    /// Glob-style ignore patterns from LSP `initializationOptions.indexingOptions.ignorePatterns`.
+    pub ignore_patterns: Vec<String>,
+}
+
+impl WorkspaceConfig {
+    /// Return the deduplicated, ordered list of source paths to index.
+    ///
+    /// Discovery priority (first win for deduplication):
+    /// 1. `explicit_source_paths` from LSP `initializationOptions`
+    /// 2. Paths from `workspace.json` (JetBrains Gradle/Maven format)
+    /// 3. Build-layout auto-detection (standard Maven/Gradle `src/` dirs) —
+    ///    only attempted when `workspace.json` is absent
+    /// 4. `~/.kotlin-lsp/sources` (default `extract-sources` output dir)
+    pub(crate) fn resolve_sources(&self) -> Vec<String> {
+        let mut paths = self.explicit_source_paths.clone();
+
+        let json_paths = crate::workspace_json::load_source_paths(&self.root);
+        for p in &json_paths {
+            let s = p.to_string_lossy().into_owned();
+            if !paths.contains(&s) {
+                paths.push(s);
+            }
+        }
+
+        if json_paths.is_empty() {
+            for p in crate::workspace_json::detect_build_layout_source_paths(&self.root) {
+                let s = p.to_string_lossy().into_owned();
+                if !paths.contains(&s) {
+                    paths.push(s);
+                }
+            }
+        }
+
+        // Auto-include the well-known `extract-sources` output directory if present.
+        #[allow(deprecated)]
+        let home = std::env::home_dir().unwrap_or_else(|| PathBuf::from("."));
+        let default_sources = home.join(".kotlin-lsp").join("sources");
+        if default_sources.is_dir() {
+            let s = default_sources.to_string_lossy().into_owned();
+            if !paths.contains(&s) {
+                paths.push(s);
+            }
+        }
+
+        paths
+    }
+}
+
+#[cfg(test)]
+#[path = "config_tests.rs"]
+mod tests;


### PR DESCRIPTION
## Summary

Wave 1 of the MVI architecture refactor. Establishes the **write-path infrastructure** for workspace lifecycle management.

## What's added

### `src/workspace/mod.rs` — WorkspaceConfig
- `WorkspaceConfig { root, explicit_source_paths, ignore_patterns }`
- `resolve_sources()`: **canonical source discovery** replacing 3 diverging call sites in `cli/run.rs`, `backend/mod.rs`, and `cli/sources.rs`
- Priority order: explicit_source_paths → workspace.json → build layout → `~/.kotlin-lsp/sources`

### `src/workspace/event.rs` — WorkspaceEvent (sealed write surface)
```rust
pub enum WorkspaceEvent {
    Initialize { config: WorkspaceConfig },
    Reindex,
    ChangeRoot { root: PathBuf },
}
```
Exhaustive `match` in actor = compile error when a new variant is added but not handled.

### `src/workspace/actor.rs` — WorkspaceActor\<R: ProgressReporter\>
- Generic over `R` (not `dyn`) — zero vtable cost; `ProgressReporter` is not object-safe (RPIT)
- `handle_initialize`: sets root **synchronously** before spawning scan task (avoids race where read handlers see no root during initial scan)
- `handle_change_root`: same synchronous-set pattern; test sends only ChangeRoot (not Initialize + ChangeRoot) to avoid race with background scan

### Tests
- 5 unit tests in `config_tests.rs` for `resolve_sources()` — environment-agnostic
- 4 integration tests in `actor_tests.rs` — use `NoopReporter`, hold `TempDir` correctly

## What's NOT in this PR (Wave 2)
- Wiring actor into `Backend` (notification handlers → `.send(event)`)
- Wiring actor into `cli/run.rs`
- Making `source_paths_raw` private on `Indexer`

Dead-code lint suppressed in `workspace/mod.rs` with comment pointing at Wave 2 todos.