### PR TITLE
feat(workspace): wire WorkspaceActor into backend and CLI (Wave 2A)

### DIFF
--- a/src/backend/helpers.rs
+++ b/src/backend/helpers.rs
@@ -45,7 +45,7 @@ pub(super) fn resolve_references_scope(
     (parent, pkg)
 }
 
-pub(super) fn syntax_diagnostics(errors: &[SyntaxError]) -> Vec<Diagnostic> {
+pub(crate) fn syntax_diagnostics(errors: &[SyntaxError]) -> Vec<Diagnostic> {
     errors
         .iter()
         .map(|e| Diagnostic {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -33,7 +33,7 @@ mod progress {
 }
 
 /// Sends LSP `$/progress` notifications via `tower_lsp::Client`.
-struct LspProgressReporter(Client);
+pub(crate) struct LspProgressReporter(pub(crate) Client);
 
 impl ProgressReporter for LspProgressReporter {
     async fn begin(&self, token: &NumberOrString, message: &str) {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,15 +2,14 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use dashmap::DashMap;
-use tokio::task::AbortHandle;
+use tokio::sync::mpsc;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{async_trait, Client, LanguageServer};
 
-use self::helpers::syntax_diagnostics;
 use crate::indexer::{workspace_cache_path, IgnoreMatcher, Indexer, ProgressReporter};
 use crate::semantic_tokens;
+use crate::workspace::{WorkspaceConfig, WorkspaceEvent};
 
 pub(crate) mod actions;
 pub(crate) mod cursor;
@@ -94,40 +93,22 @@ impl ProgressReporter for LspProgressReporter {
 pub(crate) struct Backend {
     pub(super) client: Client,
     pub(super) indexer: Arc<Indexer>,
-    /// Per-URI abort handle for the pending debounced reindex task.
-    /// When a new change arrives we abort the previous pending task so only
-    /// the latest content is ever parsed.
-    pub(super) pending_reindex: DashMap<String, AbortHandle>,
+    event_tx: mpsc::Sender<WorkspaceEvent>,
     /// True if the client advertised `snippetSupport: true` during initialize.
     /// Used to decide whether to send `InsertTextFormat::SNIPPET` in completions.
     pub(super) snippet_support: Arc<AtomicBool>,
 }
 
-#[derive(Clone)]
-struct OpenedDocumentContext {
-    uri: Url,
-    text: String,
-    opened_file_path: Option<PathBuf>,
-}
-
-impl OpenedDocumentContext {
-    fn from_open_params(params: DidOpenTextDocumentParams) -> Self {
-        let uri = params.text_document.uri;
-        let opened_file_path = uri.to_file_path().ok();
-        Self {
-            uri,
-            text: params.text_document.text,
-            opened_file_path,
-        }
-    }
-}
-
 impl Backend {
-    pub(crate) fn new(client: Client) -> Self {
+    pub(crate) fn new(
+        client: Client,
+        indexer: Arc<Indexer>,
+        event_tx: mpsc::Sender<WorkspaceEvent>,
+    ) -> Self {
         Self {
             client,
-            indexer: Arc::new(Indexer::new()),
-            pending_reindex: DashMap::new(),
+            indexer,
+            event_tx,
             snippet_support: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -231,89 +212,49 @@ impl Backend {
             .filter(|workspace_root| workspace_root.is_dir())
     }
 
-    fn configure_initialized_workspace(
+    async fn configure_initialized_workspace(
         &self,
         params: &InitializeParams,
         workspace_root: &Path,
         workspace_pinned: bool,
     ) {
-        self.set_workspace_root(workspace_root.to_path_buf());
         if workspace_pinned {
             self.indexer.workspace_pinned.store(true, Ordering::Relaxed);
         }
-        self.apply_initialization_options(params.initialization_options.as_ref(), workspace_root);
-        self.spawn_workspace_indexing(workspace_root.to_path_buf(), Vec::new());
+        let (explicit_source_paths, ignore_patterns) =
+            self.apply_initialization_options(params.initialization_options.as_ref());
+        let _ = self
+            .event_tx
+            .send(WorkspaceEvent::Initialize {
+                config: WorkspaceConfig {
+                    root: workspace_root.to_path_buf(),
+                    explicit_source_paths,
+                    ignore_patterns,
+                },
+                completion_tx: None,
+            })
+            .await;
     }
 
     fn apply_initialization_options(
         &self,
         initialization_options: Option<&serde_json::Value>,
-        workspace_root: &Path,
-    ) {
-        if let Some(ignore_patterns) =
+    ) -> (Vec<String>, Vec<String>) {
+        let ignore_patterns =
             Self::collect_indexing_option_strings(initialization_options, "ignorePatterns")
-        {
+                .unwrap_or_default();
+        if !ignore_patterns.is_empty() {
             log::info!("ignorePatterns: {:?}", ignore_patterns);
-            match self.indexer.ignore_matcher.write() {
-                Ok(mut ignore_matcher) => {
-                    *ignore_matcher = Some(Arc::new(IgnoreMatcher::new(
-                        ignore_patterns,
-                        workspace_root,
-                    )));
-                }
-                Err(error) => {
-                    log::warn!("Failed to update ignore matcher: {error}");
-                }
-            }
         }
 
-        let mut all_source_paths: Vec<String> =
+        let explicit_source_paths =
             Self::collect_indexing_option_strings(initialization_options, "sourcePaths")
                 .unwrap_or_default();
-
-        // Auto-discover source roots from workspace.json (JetBrains Gradle/Maven format).
-        // Discovered paths are merged with any user-configured sourcePaths.
-        let workspace_json_paths = crate::workspace_json::load_source_paths(workspace_root);
-        for path in &workspace_json_paths {
-            let path_str = path.to_string_lossy().into_owned();
-            if !all_source_paths.contains(&path_str) {
-                all_source_paths.push(path_str);
-            }
+        if !explicit_source_paths.is_empty() {
+            log::info!("sourcePaths: {:?}", explicit_source_paths);
         }
 
-        // Fallback: if workspace.json wasn't present, probe standard Maven/Gradle layouts.
-        if workspace_json_paths.is_empty() {
-            for path in crate::workspace_json::detect_build_layout_source_paths(workspace_root) {
-                let path_str = path.to_string_lossy().into_owned();
-                if !all_source_paths.contains(&path_str) {
-                    all_source_paths.push(path_str);
-                }
-            }
-        }
-
-        // Auto-include ~/.kotlin-lsp/sources if present (default extract-sources output dir).
-        #[allow(deprecated)]
-        if let Some(home) = std::env::home_dir() {
-            let default_sources = home.join(".kotlin-lsp").join("sources");
-            if default_sources.is_dir() {
-                let path_str = default_sources.to_string_lossy().into_owned();
-                if !all_source_paths.contains(&path_str) {
-                    all_source_paths.push(path_str);
-                }
-            }
-        }
-
-        if !all_source_paths.is_empty() {
-            log::info!("sourcePaths (combined): {:?}", all_source_paths);
-            match self.indexer.source_paths_raw.write() {
-                Ok(mut source_paths_raw) => {
-                    *source_paths_raw = all_source_paths;
-                }
-                Err(error) => {
-                    log::warn!("Failed to update source paths: {error}");
-                }
-            }
-        }
+        (explicit_source_paths, ignore_patterns)
     }
 
     fn collect_indexing_option_strings(
@@ -329,220 +270,6 @@ impl Backend {
             .filter_map(|value| value.as_str().map(str::to_owned))
             .collect();
         (!collected_values.is_empty()).then_some(collected_values)
-    }
-
-    fn set_workspace_root(&self, workspace_root: PathBuf) {
-        match self.indexer.workspace_root.write() {
-            Ok(mut current_workspace_root) => {
-                *current_workspace_root = Some(workspace_root);
-            }
-            Err(error) => {
-                log::warn!("Failed to update workspace root: {error}");
-            }
-        }
-    }
-
-    fn current_workspace_root(&self) -> Option<PathBuf> {
-        match self.indexer.workspace_root.read() {
-            Ok(current_workspace_root) => current_workspace_root.clone(),
-            Err(error) => {
-                log::warn!("Failed to read workspace root: {error}");
-                None
-            }
-        }
-    }
-
-    fn spawn_workspace_indexing(&self, workspace_root: PathBuf, prioritized_paths: Vec<PathBuf>) {
-        let indexer = Arc::clone(&self.indexer);
-        let client = self.client.clone();
-        tokio::spawn(async move {
-            indexer
-                .index_workspace_prioritized(
-                    &workspace_root,
-                    prioritized_paths,
-                    Arc::new(LspProgressReporter(client)),
-                )
-                .await;
-        });
-    }
-
-    fn detect_workspace_root_switch(
-        &self,
-        workspace_pinned: bool,
-        opened_file_path: Option<&Path>,
-    ) -> Option<PathBuf> {
-        if workspace_pinned {
-            return None;
-        }
-
-        let opened_file_path = opened_file_path?;
-        let candidate_workspace_root = Self::auto_detect_workspace_root(opened_file_path)?;
-        self.should_switch_workspace_root(opened_file_path, &candidate_workspace_root)
-            .then_some(candidate_workspace_root)
-    }
-
-    fn auto_detect_workspace_root(opened_file_path: &Path) -> Option<PathBuf> {
-        let strong_markers = [
-            "build.gradle",
-            "settings.gradle",
-            "build.gradle.kts",
-            "Cargo.toml",
-            "pom.xml",
-            "settings.gradle.kts",
-        ];
-        let weak_markers = ["Package.swift"];
-        let mut current_directory = opened_file_path.parent().map(Path::to_path_buf);
-        let mut nearest_strong_marker_root: Option<PathBuf> = None;
-        let mut git_root: Option<PathBuf> = None;
-        let mut nearest_weak_marker_root: Option<PathBuf> = None;
-
-        while let Some(directory) = current_directory {
-            if nearest_strong_marker_root.is_none()
-                && strong_markers
-                    .iter()
-                    .any(|marker| directory.join(marker).exists())
-            {
-                nearest_strong_marker_root = Some(directory.clone());
-            }
-            if directory.join(".git").exists() {
-                git_root = Some(directory.clone());
-                break;
-            }
-            if nearest_weak_marker_root.is_none()
-                && weak_markers
-                    .iter()
-                    .any(|marker| directory.join(marker).exists())
-            {
-                nearest_weak_marker_root = Some(directory.clone());
-            }
-            current_directory = directory.parent().map(Path::to_path_buf);
-        }
-
-        nearest_strong_marker_root
-            .or(git_root)
-            .or(nearest_weak_marker_root)
-            .or_else(|| opened_file_path.parent().map(Path::to_path_buf))
-    }
-
-    fn should_switch_workspace_root(
-        &self,
-        opened_file_path: &Path,
-        candidate_workspace_root: &Path,
-    ) -> bool {
-        let candidate_workspace_root = Self::canonicalize_or_clone(candidate_workspace_root);
-        match self.current_workspace_root() {
-            None => true,
-            Some(current_workspace_root) => {
-                let current_workspace_root = Self::canonicalize_or_clone(&current_workspace_root);
-                let opened_file_path = Self::canonicalize_or_clone(opened_file_path);
-                !opened_file_path.starts_with(&current_workspace_root)
-                    && candidate_workspace_root != current_workspace_root
-            }
-        }
-    }
-
-    fn canonicalize_or_clone(path: &Path) -> PathBuf {
-        std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
-    }
-
-    fn switch_workspace_root_for_opened_document(
-        &self,
-        workspace_root: PathBuf,
-        opened_file_path: Option<PathBuf>,
-    ) {
-        self.set_workspace_root(workspace_root.clone());
-        self.indexer.workspace_pinned.store(true, Ordering::Relaxed);
-        self.indexer.root_generation.fetch_add(1, Ordering::SeqCst);
-        self.indexer.reset_index_state();
-        log::info!(
-            "Auto-detected workspace root (now pinned): {}",
-            workspace_root.display()
-        );
-        self.spawn_workspace_indexing(workspace_root, opened_file_path.into_iter().collect());
-    }
-
-    fn is_outside_pinned_workspace_root(
-        &self,
-        workspace_pinned: bool,
-        opened_file_path: Option<&Path>,
-    ) -> bool {
-        if !workspace_pinned {
-            return false;
-        }
-
-        match (opened_file_path, self.current_workspace_root()) {
-            (Some(opened_file_path), Some(current_workspace_root)) => {
-                let opened_file_path = Self::canonicalize_or_clone(opened_file_path);
-                let current_workspace_root =
-                    Self::canonicalize_or_clone(current_workspace_root.as_path());
-                !opened_file_path.starts_with(&current_workspace_root)
-            }
-            _ => false,
-        }
-    }
-
-    async fn store_live_document_state(&self, opened_document: &OpenedDocumentContext) {
-        self.indexer
-            .set_live_lines(&opened_document.uri, &opened_document.text);
-
-        let indexer = Arc::clone(&self.indexer);
-        let uri = opened_document.uri.clone();
-        let text = opened_document.text.clone();
-        let _ = tokio::task::spawn_blocking(move || indexer.store_live_tree(&uri, &text)).await;
-    }
-
-    fn spawn_outside_root_document_indexing(&self, opened_document: OpenedDocumentContext) {
-        let indexer = Arc::clone(&self.indexer);
-        let semaphore = indexer.parse_sem();
-        tokio::task::spawn(async move {
-            if let Ok(permit) = semaphore.acquire_owned().await {
-                let uri = opened_document.uri;
-                let text = opened_document.text;
-                let _ = tokio::task::spawn_blocking(move || {
-                    let _permit = permit;
-                    indexer.index_content(&uri, &text);
-                })
-                .await;
-            }
-        });
-    }
-
-    fn spawn_open_document_indexing(&self, opened_document: OpenedDocumentContext) {
-        let indexer = Arc::clone(&self.indexer);
-        let semaphore = indexer.parse_sem();
-        let client = self.client.clone();
-        let cached_indexer = Arc::clone(&self.indexer);
-        tokio::task::spawn(async move {
-            let uri = opened_document.uri;
-            let text = opened_document.text;
-            let uri_for_diagnostics = uri.clone();
-            let Ok(permit) = semaphore.acquire_owned().await else {
-                return;
-            };
-            let result = tokio::task::spawn_blocking(move || {
-                let _permit = permit;
-                let data = indexer.index_content(&uri, &text);
-                Arc::clone(&indexer).prewarm_completion_cache(&uri);
-                data
-            })
-            .await;
-
-            let diagnostics = match result {
-                Ok(Some(indexed_file_data)) => syntax_diagnostics(&indexed_file_data.syntax_errors),
-                Ok(None) => {
-                    let uri_string = uri_for_diagnostics.to_string();
-                    cached_indexer
-                        .files
-                        .get(&uri_string)
-                        .map(|file_data| syntax_diagnostics(&file_data.syntax_errors))
-                        .unwrap_or_default()
-                }
-                Err(_) => Vec::new(),
-            };
-            client
-                .publish_diagnostics(uri_for_diagnostics, diagnostics, None)
-                .await;
-        });
     }
 }
 
@@ -616,7 +343,8 @@ impl LanguageServer for Backend {
         let resolved_workspace_root = Self::resolve_workspace_root(&params);
         let workspace_pinned = resolved_workspace_root.is_some();
         if let Some(workspace_root) = resolved_workspace_root {
-            self.configure_initialized_workspace(&params, &workspace_root, workspace_pinned);
+            self.configure_initialized_workspace(&params, &workspace_root, workspace_pinned)
+                .await;
         }
 
         Ok(InitializeResult {
@@ -759,132 +487,44 @@ impl LanguageServer for Backend {
     // ── document sync ────────────────────────────────────────────────────────
 
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
-        let opened_document = OpenedDocumentContext::from_open_params(params);
-        let workspace_pinned = self.indexer.workspace_pinned.load(Ordering::Relaxed);
-
-        if let Some(workspace_root) = self.detect_workspace_root_switch(
-            workspace_pinned,
-            opened_document.opened_file_path.as_deref(),
-        ) {
-            self.switch_workspace_root_for_opened_document(
-                workspace_root,
-                opened_document.opened_file_path.clone(),
-            );
-        }
-
-        if self.is_outside_pinned_workspace_root(
-            workspace_pinned,
-            opened_document.opened_file_path.as_deref(),
-        ) {
-            log::info!(
-                "Outside-root file — indexing content only: {}",
-                opened_document
-                    .opened_file_path
-                    .as_deref()
-                    .map(|path| path.display().to_string())
-                    .unwrap_or_default()
-            );
-            self.store_live_document_state(&opened_document).await;
-            self.spawn_outside_root_document_indexing(opened_document);
-            return;
-        }
-
-        self.store_live_document_state(&opened_document).await;
-        self.spawn_open_document_indexing(opened_document);
+        let _ = self
+            .event_tx
+            .send(WorkspaceEvent::FileOpened {
+                uri: params.text_document.uri,
+                language_id: params.text_document.language_id,
+                content: params.text_document.text,
+            })
+            .await;
     }
 
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
-        if let Some(change) = params.content_changes.into_iter().last() {
-            let uri = params.text_document.uri;
-            let text = change.text;
-            let idx = Arc::clone(&self.indexer);
-
-            // Update live_lines immediately (no debounce) so completions()
-            // always sees the current line text even before re-indexing.
-            self.indexer.set_live_lines(&uri, &text);
-            // Parsing is CPU-bound; run on the blocking pool to avoid
-            // stalling the Tokio worker thread on large files.
-            {
-                let idx2 = Arc::clone(&self.indexer);
-                let uri2 = uri.clone();
-                let text2 = text.clone();
-                let _ =
-                    tokio::task::spawn_blocking(move || idx2.store_live_tree(&uri2, &text2)).await;
-            }
-
-            // True debounce: cancel any pending reindex for this file.
-            let key = uri.to_string();
-            if let Some((_, handle)) = self.pending_reindex.remove(&key) {
-                handle.abort();
-            }
-
-            let client = self.client.clone();
-            let sem = idx.parse_sem();
-            let handle = tokio::spawn(async move {
-                tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-                let permit = sem.acquire_owned().await;
-                let uri2 = uri.clone();
-                // Move the permit INTO spawn_blocking so it's held for the
-                // entire index_content call.  If this async task is aborted
-                // (debounce cancelled), spawn_blocking still runs to
-                // completion holding the permit — preventing a concurrent
-                // reindex for the same file from corrupting the shared maps.
-                let result = tokio::task::spawn_blocking(move || {
-                    let data = idx.index_content(&uri, &text);
-                    drop(permit);
-                    data
-                })
-                .await;
-
-                if let Ok(Some(data)) = result {
-                    let diags = syntax_diagnostics(&data.syntax_errors);
-                    client.publish_diagnostics(uri2, diags, None).await;
-                }
-            });
-            self.pending_reindex.insert(key, handle.abort_handle());
-        }
+        let _ = self
+            .event_tx
+            .send(WorkspaceEvent::FileChanged {
+                uri: params.text_document.uri,
+                changes: params.content_changes,
+            })
+            .await;
     }
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
-        let uri = &params.text_document.uri;
-
-        // Cancel any pending debounced reindex so it cannot re-publish
-        // diagnostics after the file has been closed.
-        let key = uri.to_string();
-        if let Some((_, handle)) = self.pending_reindex.remove(&key) {
-            handle.abort();
-        }
-
-        self.indexer.remove_live_tree(uri);
-        self.indexer.remove_live_lines(uri);
-        // Clear diagnostics so stale errors don't linger after the file is closed.
-        self.client
-            .publish_diagnostics(params.text_document.uri, Vec::new(), None)
+        let _ = self
+            .event_tx
+            .send(WorkspaceEvent::FileClosed {
+                uri: params.text_document.uri,
+            })
             .await;
     }
 
     // ── textDocument/didSave ─────────────────────────────────────────────────
 
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
-        // Re-index the saved file so the symbol index stays consistent with
-        // what is on disk (e.g. after an external format or code-gen step).
-        let uri = params.text_document.uri;
-        let idx = Arc::clone(&self.indexer);
-        let sem = idx.parse_sem();
-        tokio::task::spawn(async move {
-            if let Ok(path) = uri.to_file_path() {
-                if let Ok(content) = tokio::fs::read_to_string(&path).await {
-                    if let Ok(permit) = sem.acquire_owned().await {
-                        tokio::task::spawn_blocking(move || {
-                            let _permit = permit;
-                            idx.index_content(&uri, &content);
-                        })
-                        .await
-                        .ok();
-                    }
-                }
-            }
-        });
+        let _ = self
+            .event_tx
+            .send(WorkspaceEvent::FileSaved {
+                uri: params.text_document.uri,
+            })
+            .await;
     }
 
     async fn did_change_watched_files(&self, params: DidChangeWatchedFilesParams) {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -223,7 +223,7 @@ impl Backend {
         }
         let (explicit_source_paths, ignore_patterns) =
             self.apply_initialization_options(params.initialization_options.as_ref());
-        let _ = self
+        if self
             .event_tx
             .send(WorkspaceEvent::Initialize {
                 config: WorkspaceConfig {
@@ -233,7 +233,14 @@ impl Backend {
                 },
                 completion_tx: None,
             })
-            .await;
+            .await
+            .is_err()
+        {
+            log::error!(
+                "configure_initialized_workspace: workspace actor channel closed; \
+                 indexing will not start"
+            );
+        }
     }
 
     fn apply_initialization_options(

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -46,7 +46,7 @@ fn cache_exists(root: &Path) -> bool {
 
 /// Build (or load from cache) a full workspace index. Reports progress to stderr.
 ///
-/// Source paths are collected from:
+/// Source paths are resolved by [`WorkspaceConfig::resolve_sources`] inside the actor:
 /// 1. `workspace.json` (JetBrains IDE format) at the workspace root
 /// 2. Build-layout auto-detection (Gradle/Maven src dirs), if no workspace.json
 /// 3. `~/.kotlin-lsp/sources` — the default `extract-sources` output dir
@@ -57,54 +57,40 @@ async fn build_index(root: &Path) -> Arc<Indexer> {
     let actor = WorkspaceActor::new(Arc::clone(&indexer), Arc::new(NoopReporter), event_rx, None);
     tokio::spawn(actor.run());
 
-    let _ = event_tx
+    if event_tx
         .send(WorkspaceEvent::Initialize {
             config: WorkspaceConfig {
                 root: root.to_path_buf(),
-                explicit_source_paths: collect_cli_source_paths(root),
+                // Source discovery is performed by resolve_sources() inside the actor;
+                // passing an empty list here avoids duplicating the filesystem work.
+                explicit_source_paths: Vec::new(),
                 ignore_patterns: Vec::new(),
             },
             completion_tx: Some(completion_tx),
         })
-        .await;
-    let _ = completion_rx.await;
+        .await
+        .is_err()
+    {
+        log::error!("CLI: workspace actor channel closed; indexing will not start");
+        return indexer;
+    }
+
+    match tokio::time::timeout(
+        tokio::time::Duration::from_secs(120),
+        completion_rx,
+    )
+    .await
+    {
+        Ok(Ok(())) => {}
+        Ok(Err(_)) => {
+            log::warn!("CLI: workspace scan ended without sending completion signal");
+        }
+        Err(_) => {
+            log::warn!("CLI: workspace scan did not complete within 120 s; proceeding with partial index");
+        }
+    }
 
     indexer
-}
-
-/// Collect source paths for CLI indexing: workspace.json + build-layout + default extract dir.
-fn collect_cli_source_paths(root: &Path) -> Vec<String> {
-    let mut paths: Vec<String> = Vec::new();
-
-    let json_paths = crate::workspace_json::load_source_paths(root);
-    for p in &json_paths {
-        let s = p.to_string_lossy().into_owned();
-        if !paths.contains(&s) {
-            paths.push(s);
-        }
-    }
-
-    if json_paths.is_empty() {
-        for p in crate::workspace_json::detect_build_layout_source_paths(root) {
-            let s = p.to_string_lossy().into_owned();
-            if !paths.contains(&s) {
-                paths.push(s);
-            }
-        }
-    }
-
-    // Auto-include the well-known `extract-sources` output dir if present.
-    #[allow(deprecated)]
-    let home = std::env::home_dir().unwrap_or_else(|| PathBuf::from("."));
-    let default_sources = home.join(".kotlin-lsp").join("sources");
-    if default_sources.is_dir() {
-        let s = default_sources.to_string_lossy().into_owned();
-        if !paths.contains(&s) {
-            paths.push(s);
-        }
-    }
-
-    paths
 }
 
 // ── Location helpers ─────────────────────────────────────────────────────────

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -3,10 +3,12 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use tokio::sync::{mpsc, oneshot};
 use tower_lsp::lsp_types::Location;
 
 use crate::indexer::{Indexer, NoopReporter};
 use crate::rg::{rg_find_definition, rg_word_search, RgSearchRequest};
+use crate::workspace::{WorkspaceActor, WorkspaceConfig, WorkspaceEvent};
 
 use super::args::{CliArgs, Mode, OutputFmt, Subcommand};
 use super::hover::hover_at;
@@ -42,24 +44,32 @@ fn cache_exists(root: &Path) -> bool {
 
 // ── Indexer bootstrap ─────────────────────────────────────────────────────────
 
-/// Build (or load from cache) a full workspace index.  Reports progress to stderr.
+/// Build (or load from cache) a full workspace index. Reports progress to stderr.
 ///
 /// Source paths are collected from:
 /// 1. `workspace.json` (JetBrains IDE format) at the workspace root
 /// 2. Build-layout auto-detection (Gradle/Maven src dirs), if no workspace.json
 /// 3. `~/.kotlin-lsp/sources` — the default `extract-sources` output dir
 async fn build_index(root: &Path) -> Arc<Indexer> {
-    let idx = Arc::new(Indexer::new());
+    let indexer = Arc::new(Indexer::new());
+    let (event_tx, event_rx) = mpsc::channel(16);
+    let (completion_tx, completion_rx) = oneshot::channel();
+    let actor = WorkspaceActor::new(Arc::clone(&indexer), Arc::new(NoopReporter), event_rx, None);
+    tokio::spawn(actor.run());
 
-    let source_paths = collect_cli_source_paths(root);
-    if !source_paths.is_empty() {
-        *idx.source_paths_raw.write().unwrap() = source_paths;
-    }
-
-    Arc::clone(&idx)
-        .index_workspace_full(root, Arc::new(NoopReporter))
+    let _ = event_tx
+        .send(WorkspaceEvent::Initialize {
+            config: WorkspaceConfig {
+                root: root.to_path_buf(),
+                explicit_source_paths: collect_cli_source_paths(root),
+                ignore_patterns: Vec::new(),
+            },
+            completion_tx: Some(completion_tx),
+        })
         .await;
-    idx
+    let _ = completion_rx.await;
+
+    indexer
 }
 
 /// Collect source paths for CLI indexing: workspace.json + build-layout + default extract dir.

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn make_backend(client: tower_lsp::Client) -> backend::Backend {
     let (event_tx, event_rx) = mpsc::channel(64);
     let actor = workspace::WorkspaceActor::new(
         Arc::clone(&indexer),
-        Arc::new(indexer::NoopReporter),
+        Arc::new(backend::LspProgressReporter(client.clone())),
         event_rx,
         Some(client.clone()),
     );

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,9 @@ pub(crate) use lines_ext::LinesExt;
 pub(crate) use str_ext::StrExt;
 pub(crate) use types::Language;
 
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
 use tower_lsp::{LspService, Server};
 
 fn main() {
@@ -33,6 +36,19 @@ fn main() {
         .build()
         .unwrap()
         .block_on(async_main());
+}
+
+fn make_backend(client: tower_lsp::Client) -> backend::Backend {
+    let indexer = Arc::new(indexer::Indexer::new());
+    let (event_tx, event_rx) = mpsc::channel(64);
+    let actor = workspace::WorkspaceActor::new(
+        Arc::clone(&indexer),
+        Arc::new(indexer::NoopReporter),
+        event_rx,
+        Some(client.clone()),
+    );
+    tokio::spawn(actor.run());
+    backend::Backend::new(client, indexer, event_tx)
 }
 
 async fn async_main() {
@@ -114,7 +130,7 @@ async fn async_main() {
             });
             eprintln!("Client connected: {peer}");
             let (reader, writer) = tokio::io::split(stream);
-            let (service, socket) = LspService::new(backend::Backend::new);
+            let (service, socket) = LspService::new(make_backend);
             Server::new(reader, writer, socket).serve(service).await;
             eprintln!("Client disconnected, waiting for next connection…");
         }
@@ -123,6 +139,6 @@ async fn async_main() {
     // Default: stdio transport
     let stdin = tokio::io::stdin();
     let stdout = tokio::io::stdout();
-    let (service, socket) = LspService::new(backend::Backend::new);
+    let (service, socket) = LspService::new(make_backend);
     Server::new(stdin, stdout, socket).serve(service).await;
 }

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -192,7 +192,15 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
             let indexer = Arc::clone(&self.indexer);
             let uri = uri.clone();
             let text = text.clone();
-            let _ = tokio::task::spawn_blocking(move || indexer.store_live_tree(&uri, &text)).await;
+            // Fire-and-forget: live-tree parse runs on a blocking thread but we
+            // do not await it in the actor loop to avoid blocking subsequent events.
+            // The 300 ms debounce below provides ample time for the parse to finish
+            // before index_content consumes the updated live tree.
+            // Dropping the JoinHandle detaches from the task; the blocking thread
+            // continues and cannot be cancelled.
+            drop(tokio::task::spawn_blocking(move || {
+                indexer.store_live_tree(&uri, &text);
+            }));
         }
 
         let key = uri.to_string();

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -1,7 +1,7 @@
 //! [`WorkspaceActor`] — the single serialised writer of workspace state.
 //!
 //! All workspace-level mutations (root, source paths, ignore patterns, scans)
-//! are processed here, one at a time, in arrival order.  Request handlers that
+//! are processed here, one at a time, in arrival order. Request handlers that
 //! only read index data continue to run concurrently via `Arc<Indexer>`.
 //!
 //! # Invariants
@@ -13,11 +13,17 @@
 // Items unused until Wave 2 wires this into backend/CLI (ws-backend, ws-cli, ws-main).
 #![allow(dead_code)]
 
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
+use tokio::task::AbortHandle;
+use tower_lsp::lsp_types::Url;
+use tower_lsp::Client;
 
+use crate::backend::helpers::syntax_diagnostics;
 use crate::indexer::{Indexer, ProgressReporter};
 use crate::rg::IgnoreMatcher;
 
@@ -37,6 +43,8 @@ pub(crate) struct WorkspaceActor<R: ProgressReporter + 'static> {
     indexer: Arc<Indexer>,
     reporter: Arc<R>,
     rx: mpsc::Receiver<WorkspaceEvent>,
+    client: Option<Client>,
+    pending_reindex: HashMap<String, AbortHandle>,
 }
 
 impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
@@ -49,11 +57,14 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
         indexer: Arc<Indexer>,
         reporter: Arc<R>,
         rx: mpsc::Receiver<WorkspaceEvent>,
+        client: Option<Client>,
     ) -> Self {
         Self {
             indexer,
             reporter,
             rx,
+            client,
+            pending_reindex: HashMap::new(),
         }
     }
 
@@ -65,20 +76,37 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
     pub(crate) async fn run(mut self) {
         while let Some(event) = self.rx.recv().await {
             match event {
-                WorkspaceEvent::Initialize { config } => self.handle_initialize(config).await,
+                WorkspaceEvent::Initialize {
+                    config,
+                    completion_tx,
+                } => self.handle_initialize(config, completion_tx).await,
                 WorkspaceEvent::Reindex => self.handle_reindex().await,
                 WorkspaceEvent::ChangeRoot { root } => self.handle_change_root(root).await,
+                WorkspaceEvent::FileOpened {
+                    uri,
+                    language_id,
+                    content,
+                } => self.handle_file_opened(uri, language_id, content).await,
+                WorkspaceEvent::FileChanged { uri, changes } => {
+                    self.handle_file_changed(uri, changes).await;
+                }
+                WorkspaceEvent::FileSaved { uri } => self.handle_file_saved(uri).await,
+                WorkspaceEvent::FileClosed { uri } => self.handle_file_closed(uri).await,
             }
         }
     }
 
     // ── Event handlers ────────────────────────────────────────────────────────
 
-    async fn handle_initialize(&self, config: WorkspaceConfig) {
+    async fn handle_initialize(
+        &mut self,
+        config: WorkspaceConfig,
+        completion_tx: Option<oneshot::Sender<()>>,
+    ) {
         let root = config.root.clone();
 
         // Set the root immediately so read-path handlers can see it without
-        // waiting for index_workspace_impl to run.  The scan will overwrite
+        // waiting for index_workspace_impl to run. The scan will overwrite
         // this with the same value once it acquires the indexing guard.
         self.set_root(root.clone());
         self.apply_ignore_patterns(&config.ignore_patterns, &root);
@@ -86,10 +114,10 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
         // Always write source paths — even when empty — to clear any prior state.
         self.write_source_paths(config.resolve_sources());
 
-        self.spawn_scan(root, Vec::new()).await;
+        self.spawn_scan(root, Vec::new(), completion_tx).await;
     }
 
-    async fn handle_reindex(&self) {
+    async fn handle_reindex(&mut self) {
         let Some(root) = self.current_root() else {
             log::warn!("WorkspaceActor: Reindex received but no workspace root is set");
             return;
@@ -98,7 +126,7 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
         self.spawn_full_scan(root).await;
     }
 
-    async fn handle_change_root(&self, root: PathBuf) {
+    async fn handle_change_root(&mut self, root: PathBuf) {
         self.set_root(root.clone());
 
         // Clear stale ignore patterns from the previous root, then re-resolve
@@ -115,6 +143,119 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
 
         self.indexer.reset_index_state();
         self.spawn_full_scan(root).await;
+    }
+
+    async fn handle_file_opened(&mut self, uri: Url, _language_id: String, content: String) {
+        let opened_file_path = uri.to_file_path().ok();
+        let workspace_pinned = self.indexer.workspace_pinned.load(Ordering::Relaxed);
+
+        if let Some(workspace_root) =
+            self.detect_workspace_root_switch(workspace_pinned, opened_file_path.as_deref())
+        {
+            self.switch_workspace_root_for_opened_document(
+                workspace_root,
+                opened_file_path.clone(),
+            )
+            .await;
+        }
+
+        if self.is_outside_pinned_workspace_root(workspace_pinned, opened_file_path.as_deref()) {
+            log::info!(
+                "Outside-root file — indexing content only: {}",
+                opened_file_path
+                    .as_deref()
+                    .map(|path| path.display().to_string())
+                    .unwrap_or_default()
+            );
+            self.store_live_document_state(&uri, &content).await;
+            self.spawn_outside_root_document_indexing(uri, content);
+            return;
+        }
+
+        self.store_live_document_state(&uri, &content).await;
+        self.spawn_open_document_indexing(uri, content);
+    }
+
+    async fn handle_file_changed(
+        &mut self,
+        uri: Url,
+        changes: Vec<tower_lsp::lsp_types::TextDocumentContentChangeEvent>,
+    ) {
+        let Some(change) = changes.into_iter().last() else {
+            return;
+        };
+        let text = change.text;
+        let indexer = Arc::clone(&self.indexer);
+
+        self.indexer.set_live_lines(&uri, &text);
+        {
+            let indexer = Arc::clone(&self.indexer);
+            let uri = uri.clone();
+            let text = text.clone();
+            let _ = tokio::task::spawn_blocking(move || indexer.store_live_tree(&uri, &text)).await;
+        }
+
+        let key = uri.to_string();
+        if let Some(handle) = self.pending_reindex.remove(&key) {
+            handle.abort();
+        }
+
+        let client = self.client.clone();
+        let sem = indexer.parse_sem();
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+            let permit = sem.acquire_owned().await;
+            let diagnostics_uri = uri.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                let data = indexer.index_content(&uri, &text);
+                drop(permit);
+                data
+            })
+            .await;
+
+            if let (Some(client), Ok(Some(data))) = (client, result) {
+                let diagnostics = syntax_diagnostics(&data.syntax_errors);
+                client
+                    .publish_diagnostics(diagnostics_uri, diagnostics, None)
+                    .await;
+            }
+        });
+        self.pending_reindex.insert(key, handle.abort_handle());
+    }
+
+    async fn handle_file_saved(&mut self, uri: Url) {
+        let indexer = Arc::clone(&self.indexer);
+        let sem = indexer.parse_sem();
+        tokio::task::spawn(async move {
+            let Ok(path) = uri.to_file_path() else {
+                return;
+            };
+            let Ok(content) = tokio::fs::read_to_string(&path).await else {
+                return;
+            };
+            let Ok(permit) = sem.acquire_owned().await else {
+                return;
+            };
+            tokio::task::spawn_blocking(move || {
+                let _permit = permit;
+                indexer.index_content(&uri, &content);
+            })
+            .await
+            .ok();
+        });
+    }
+
+    async fn handle_file_closed(&mut self, uri: Url) {
+        let key = uri.to_string();
+        if let Some(handle) = self.pending_reindex.remove(&key) {
+            handle.abort();
+        }
+
+        self.indexer.remove_live_tree(&uri);
+        self.indexer.remove_live_lines(&uri);
+        if let Some(client) = &self.client {
+            client.publish_diagnostics(uri, Vec::new(), None).await;
+        }
     }
 
     // ── Internal helpers ──────────────────────────────────────────────────────
@@ -154,15 +295,197 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
         }
     }
 
+    fn detect_workspace_root_switch(
+        &self,
+        workspace_pinned: bool,
+        opened_file_path: Option<&Path>,
+    ) -> Option<PathBuf> {
+        if workspace_pinned {
+            return None;
+        }
+
+        let opened_file_path = opened_file_path?;
+        let candidate_workspace_root = Self::auto_detect_workspace_root(opened_file_path)?;
+        self.should_switch_workspace_root(opened_file_path, &candidate_workspace_root)
+            .then_some(candidate_workspace_root)
+    }
+
+    fn auto_detect_workspace_root(opened_file_path: &Path) -> Option<PathBuf> {
+        let strong_markers = [
+            "build.gradle",
+            "settings.gradle",
+            "build.gradle.kts",
+            "Cargo.toml",
+            "pom.xml",
+            "settings.gradle.kts",
+        ];
+        let weak_markers = ["Package.swift"];
+        let mut current_directory = opened_file_path.parent().map(Path::to_path_buf);
+        let mut nearest_strong_marker_root: Option<PathBuf> = None;
+        let mut git_root: Option<PathBuf> = None;
+        let mut nearest_weak_marker_root: Option<PathBuf> = None;
+
+        while let Some(directory) = current_directory {
+            if nearest_strong_marker_root.is_none()
+                && strong_markers
+                    .iter()
+                    .any(|marker| directory.join(marker).exists())
+            {
+                nearest_strong_marker_root = Some(directory.clone());
+            }
+            if directory.join(".git").exists() {
+                git_root = Some(directory.clone());
+                break;
+            }
+            if nearest_weak_marker_root.is_none()
+                && weak_markers
+                    .iter()
+                    .any(|marker| directory.join(marker).exists())
+            {
+                nearest_weak_marker_root = Some(directory.clone());
+            }
+            current_directory = directory.parent().map(Path::to_path_buf);
+        }
+
+        nearest_strong_marker_root
+            .or(git_root)
+            .or(nearest_weak_marker_root)
+            .or_else(|| opened_file_path.parent().map(Path::to_path_buf))
+    }
+
+    fn should_switch_workspace_root(
+        &self,
+        opened_file_path: &Path,
+        candidate_workspace_root: &Path,
+    ) -> bool {
+        let candidate_workspace_root = Self::canonicalize_or_clone(candidate_workspace_root);
+        match self.current_root() {
+            None => true,
+            Some(current_workspace_root) => {
+                let current_workspace_root = Self::canonicalize_or_clone(&current_workspace_root);
+                let opened_file_path = Self::canonicalize_or_clone(opened_file_path);
+                !opened_file_path.starts_with(&current_workspace_root)
+                    && candidate_workspace_root != current_workspace_root
+            }
+        }
+    }
+
+    fn canonicalize_or_clone(path: &Path) -> PathBuf {
+        std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    }
+
+    async fn switch_workspace_root_for_opened_document(
+        &mut self,
+        workspace_root: PathBuf,
+        opened_file_path: Option<PathBuf>,
+    ) {
+        self.set_root(workspace_root.clone());
+        self.indexer.workspace_pinned.store(true, Ordering::Relaxed);
+        self.indexer.root_generation.fetch_add(1, Ordering::SeqCst);
+        self.indexer.reset_index_state();
+        log::info!(
+            "Auto-detected workspace root (now pinned): {}",
+            workspace_root.display()
+        );
+        self.spawn_scan(workspace_root, opened_file_path.into_iter().collect(), None)
+            .await;
+    }
+
+    fn is_outside_pinned_workspace_root(
+        &self,
+        workspace_pinned: bool,
+        opened_file_path: Option<&Path>,
+    ) -> bool {
+        if !workspace_pinned {
+            return false;
+        }
+
+        match (opened_file_path, self.current_root()) {
+            (Some(opened_file_path), Some(current_workspace_root)) => {
+                let opened_file_path = Self::canonicalize_or_clone(opened_file_path);
+                let current_workspace_root =
+                    Self::canonicalize_or_clone(current_workspace_root.as_path());
+                !opened_file_path.starts_with(&current_workspace_root)
+            }
+            _ => false,
+        }
+    }
+
+    async fn store_live_document_state(&self, uri: &Url, content: &str) {
+        self.indexer.set_live_lines(uri, content);
+
+        let indexer = Arc::clone(&self.indexer);
+        let uri = uri.clone();
+        let content = content.to_owned();
+        let _ = tokio::task::spawn_blocking(move || indexer.store_live_tree(&uri, &content)).await;
+    }
+
+    fn spawn_outside_root_document_indexing(&self, uri: Url, content: String) {
+        let indexer = Arc::clone(&self.indexer);
+        let semaphore = indexer.parse_sem();
+        tokio::task::spawn(async move {
+            if let Ok(permit) = semaphore.acquire_owned().await {
+                let _ = tokio::task::spawn_blocking(move || {
+                    let _permit = permit;
+                    indexer.index_content(&uri, &content);
+                })
+                .await;
+            }
+        });
+    }
+
+    fn spawn_open_document_indexing(&self, uri: Url, content: String) {
+        let indexer = Arc::clone(&self.indexer);
+        let semaphore = indexer.parse_sem();
+        let cached_indexer = Arc::clone(&self.indexer);
+        let client = self.client.clone();
+        tokio::task::spawn(async move {
+            let diagnostics_uri = uri.clone();
+            let Ok(permit) = semaphore.acquire_owned().await else {
+                return;
+            };
+            let result = tokio::task::spawn_blocking(move || {
+                let _permit = permit;
+                let data = indexer.index_content(&uri, &content);
+                Arc::clone(&indexer).prewarm_completion_cache(&uri);
+                data
+            })
+            .await;
+
+            let diagnostics = match result {
+                Ok(Some(indexed_file_data)) => syntax_diagnostics(&indexed_file_data.syntax_errors),
+                Ok(None) => cached_indexer
+                    .files
+                    .get(diagnostics_uri.as_str())
+                    .map(|file_data| syntax_diagnostics(&file_data.syntax_errors))
+                    .unwrap_or_default(),
+                Err(_) => Vec::new(),
+            };
+            if let Some(client) = client {
+                client
+                    .publish_diagnostics(diagnostics_uri, diagnostics, None)
+                    .await;
+            }
+        });
+    }
+
     /// Spawn a prioritized bounded scan in the background.
     /// `initial_paths` are indexed first (empty = no prioritization).
-    async fn spawn_scan(&self, root: PathBuf, initial_paths: Vec<PathBuf>) {
+    async fn spawn_scan(
+        &self,
+        root: PathBuf,
+        initial_paths: Vec<PathBuf>,
+        completion_tx: Option<oneshot::Sender<()>>,
+    ) {
         let indexer = Arc::clone(&self.indexer);
         let reporter = Arc::clone(&self.reporter);
         tokio::spawn(async move {
             indexer
                 .index_workspace_prioritized(&root, initial_paths, reporter)
                 .await;
+            if let Some(completion_tx) = completion_tx {
+                let _ = completion_tx.send(());
+            }
         });
     }
 

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -204,11 +204,13 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
         let sem = indexer.parse_sem();
         let handle = tokio::spawn(async move {
             tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-            let permit = sem.acquire_owned().await;
+            let Ok(permit) = sem.acquire_owned().await else {
+                return;
+            };
             let diagnostics_uri = uri.clone();
             let result = tokio::task::spawn_blocking(move || {
                 let data = indexer.index_content(&uri, &text);
-                drop(permit);
+                drop(permit); // release semaphore after index_content completes
                 data
             })
             .await;

--- a/src/workspace/actor_tests.rs
+++ b/src/workspace/actor_tests.rs
@@ -1,8 +1,9 @@
 //! Integration tests for [`WorkspaceActor`].
 
 use std::sync::Arc;
+use std::time::Duration;
 
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, oneshot};
 
 use crate::indexer::{Indexer, NoopReporter};
 use crate::workspace::{WorkspaceActor, WorkspaceConfig, WorkspaceEvent};
@@ -21,16 +22,18 @@ fn temp_dir() -> tempfile::TempDir {
     tempfile::tempdir().unwrap()
 }
 
-/// Poll `pred` every 10 ms until it returns `true` or 500 ms elapse.
-/// Returns whether the predicate became true within the timeout.
-async fn poll_until(pred: impl Fn() -> bool) -> bool {
-    for _ in 0..50 {
-        if pred() {
-            return true;
+/// Poll `condition` every yield until it returns `true` or `timeout` elapses.
+async fn poll_until<F: Fn() -> bool>(condition: F, timeout: Duration) {
+    tokio::time::timeout(timeout, async {
+        loop {
+            if condition() {
+                break;
+            }
+            tokio::task::yield_now().await;
         }
-        tokio::time::sleep(tokio::time::Duration::from_millis(10)).await;
-    }
-    pred()
+    })
+    .await
+    .expect("condition not met within timeout");
 }
 
 // ─── actor tests ─────────────────────────────────────────────────────────────
@@ -55,16 +58,28 @@ async fn initialize_sets_workspace_root() {
     .await
     .unwrap();
 
-    let ready = poll_until(|| {
-        indexer.workspace_root.read().unwrap().is_some()
-    }).await;
-    assert!(ready, "workspace_root not set within timeout");
+    // workspace_root is set synchronously in handle_initialize before the scan
+    // spawns, so polling for it is deterministic and avoids the full scan latency.
+    let expected = root.clone();
+    let idx = Arc::clone(&indexer);
+    poll_until(
+        move || {
+            idx.workspace_root
+                .read()
+                .ok()
+                .and_then(|g| g.clone())
+                .map(|r| r == expected)
+                .unwrap_or(false)
+        },
+        Duration::from_secs(2),
+    )
+    .await;
 
     let actual_root = indexer.workspace_root.read().unwrap().clone();
     assert_eq!(
         actual_root.as_deref(),
         Some(root.as_path()),
-        "workspace_root should be set by handle_initialize"
+        "workspace_root should be set synchronously by handle_initialize before scan starts"
     );
 }
 
@@ -77,21 +92,34 @@ async fn initialize_writes_explicit_source_paths() {
     let (actor, tx) = make_actor(Arc::clone(&indexer));
     tokio::spawn(actor.run());
 
+    let (completion_tx, completion_rx) = oneshot::channel();
     tx.send(WorkspaceEvent::Initialize {
         config: WorkspaceConfig {
             root: root.clone(),
             explicit_source_paths: vec!["/some/lib".to_string()],
             ignore_patterns: Vec::new(),
         },
-        completion_tx: None,
+        completion_tx: Some(completion_tx),
     })
     .await
     .unwrap();
 
-    let ready = poll_until(|| {
-        !indexer.source_paths_raw.read().unwrap().is_empty()
-    }).await;
-    assert!(ready, "source_paths_raw not populated within timeout");
+    // source_paths_raw is written synchronously in handle_initialize; the
+    // completion_tx fires when the background scan also finishes.  Poll the
+    // paths directly so the test doesn't wait for the full scan.
+    let idx = Arc::clone(&indexer);
+    poll_until(
+        move || {
+            idx.source_paths_raw
+                .read()
+                .ok()
+                .map(|g| g.contains(&"/some/lib".to_string()))
+                .unwrap_or(false)
+        },
+        Duration::from_secs(2),
+    )
+    .await;
+    drop(completion_rx); // not needed; poll was deterministic
 
     let paths = indexer.source_paths_raw.read().unwrap().clone();
     assert!(
@@ -114,10 +142,20 @@ async fn change_root_updates_workspace_root() {
         .await
         .unwrap();
 
-    let ready = poll_until(|| {
-        indexer.workspace_root.read().unwrap().is_some()
-    }).await;
-    assert!(ready, "workspace_root not set within timeout");
+    let expected = root.clone();
+    let idx = Arc::clone(&indexer);
+    poll_until(
+        move || {
+            idx.workspace_root
+                .read()
+                .ok()
+                .and_then(|g| g.clone())
+                .map(|r| r == expected)
+                .unwrap_or(false)
+        },
+        Duration::from_secs(2),
+    )
+    .await;
 
     let actual = indexer.workspace_root.read().unwrap().clone();
     assert_eq!(
@@ -136,7 +174,7 @@ async fn actor_stops_when_sender_dropped() {
     drop(tx);
 
     // Actor should exit cleanly once the sender is dropped
-    tokio::time::timeout(tokio::time::Duration::from_secs(2), handle)
+    tokio::time::timeout(Duration::from_secs(2), handle)
         .await
         .expect("actor did not stop within 2s after sender drop")
         .unwrap();

--- a/src/workspace/actor_tests.rs
+++ b/src/workspace/actor_tests.rs
@@ -13,7 +13,7 @@ fn make_actor(
     indexer: Arc<Indexer>,
 ) -> (WorkspaceActor<NoopReporter>, mpsc::Sender<WorkspaceEvent>) {
     let (tx, rx) = mpsc::channel(16);
-    let actor = WorkspaceActor::new(indexer, Arc::new(NoopReporter), rx);
+    let actor = WorkspaceActor::new(indexer, Arc::new(NoopReporter), rx, None);
     (actor, tx)
 }
 
@@ -50,6 +50,7 @@ async fn initialize_sets_workspace_root() {
             explicit_source_paths: Vec::new(),
             ignore_patterns: Vec::new(),
         },
+        completion_tx: None,
     })
     .await
     .unwrap();
@@ -82,6 +83,7 @@ async fn initialize_writes_explicit_source_paths() {
             explicit_source_paths: vec!["/some/lib".to_string()],
             ignore_patterns: Vec::new(),
         },
+        completion_tx: None,
     })
     .await
     .unwrap();

--- a/src/workspace/event.rs
+++ b/src/workspace/event.rs
@@ -8,22 +8,25 @@
 
 use std::path::PathBuf;
 
+use tokio::sync::oneshot;
+use tower_lsp::lsp_types::{TextDocumentContentChangeEvent, Url};
+
 use super::WorkspaceConfig;
 
 /// All workspace-level mutations, serialised through [`WorkspaceActor`].
-///
-/// File-level events (textDocument/didOpen, didChange, etc.) are handled
-/// directly by the LSP backend for now; they will migrate here in a later phase.
 pub(crate) enum WorkspaceEvent {
     /// Configure the workspace and start an initial scan.
     ///
-    /// Must be the first event sent to a fresh actor.  Subsequent `Initialize`
+    /// Must be the first event sent to a fresh actor. Subsequent `Initialize`
     /// events switch the root and restart the scan, discarding old source paths.
-    Initialize { config: WorkspaceConfig },
+    Initialize {
+        config: WorkspaceConfig,
+        completion_tx: Option<oneshot::Sender<()>>,
+    },
 
     /// Re-scan the current workspace from scratch.
     ///
-    /// Equivalent to the `kotlin-lsp/reindex` execute-command.  Keeps the
+    /// Equivalent to the `kotlin-lsp/reindex` execute-command. Keeps the
     /// long-lived `Indexer` so live-document state is preserved.
     Reindex,
 
@@ -33,4 +36,23 @@ pub(crate) enum WorkspaceEvent {
     /// the new root. Existing explicit `source_paths_raw` are discarded because
     /// they were relative to the old root.
     ChangeRoot { root: PathBuf },
+
+    /// Store live document state and schedule indexing for a newly opened file.
+    FileOpened {
+        uri: Url,
+        language_id: String,
+        content: String,
+    },
+
+    /// Update live document state and debounce re-indexing after edits.
+    FileChanged {
+        uri: Url,
+        changes: Vec<TextDocumentContentChangeEvent>,
+    },
+
+    /// Re-index the current on-disk content for a saved file.
+    FileSaved { uri: Url },
+
+    /// Drop live document state for a closed file.
+    FileClosed { uri: Url },
 }

--- a/src/workspace_json_tests.rs
+++ b/src/workspace_json_tests.rs
@@ -26,7 +26,7 @@ fn malformed_json_returns_empty() {
 #[test]
 fn extracts_java_source_and_java_test() {
     let dir = TempDir::new().unwrap();
-    let ws = dir.path().to_string_lossy();
+    let _ws = dir.path().to_string_lossy();
     let json = format!(
         r#"{{
             "modules": [{{


### PR DESCRIPTION
## Summary
- add WorkspaceEvent file variants plus an Initialize completion hook for CLI startup
- route backend didOpen/didChange/didSave/didClose through WorkspaceActor via event_tx
- wire CLI and main to create the shared Indexer, actor task, and initialization event flow
- preserve live document indexing/diagnostics inside WorkspaceActor and fix the pre-existing workspace_json_tests warning so validation is clean

## Validation
- cargo test -q
- cargo clippy -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines