### PR TITLE
feat(indexer): add WorkspaceRead trait extending IndexRead (Wave 2C)

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -9,6 +9,7 @@ use tower_lsp::lsp_types::*;
 use tower_lsp::{async_trait, Client, LanguageServer};
 
 use self::helpers::syntax_diagnostics;
+use crate::indexer::resolution::WorkspaceRead;
 use crate::indexer::{workspace_cache_path, IgnoreMatcher, Indexer, ProgressReporter};
 use crate::semantic_tokens;
 
@@ -146,12 +147,14 @@ impl Backend {
         rt: &crate::resolver::ReceiverType,
         uri: &Url,
     ) -> Vec<Location> {
-        let locs = self
-            .indexer
-            .find_definition_qualified(word, Some(&rt.qualified), uri);
+        let locs = WorkspaceRead::find_definition_qualified(
+            &self.indexer,
+            word,
+            Some(&rt.qualified),
+            uri,
+        );
         if locs.is_empty() && rt.leaf != rt.qualified {
-            self.indexer
-                .find_definition_qualified(word, Some(&rt.leaf), uri)
+            WorkspaceRead::find_definition_qualified(&self.indexer, word, Some(&rt.leaf), uri)
         } else {
             locs
         }

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -2,9 +2,8 @@
 // Phase 2: Core `resolve_symbol_info` pipeline implementation.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
-use tower_lsp::lsp_types::{CompletionItem, Position, Range, SymbolKind, Url};
+use tower_lsp::lsp_types::{SymbolKind, Url};
 
 use crate::indexer::doc::extract_doc_comment;
 use crate::indexer::Location;
@@ -119,51 +118,18 @@ pub(crate) trait IndexRead {
     fn ensure_indexed_on_demand(&self, _uri: &str) {}
 }
 
-/// Read-only view of workspace state used by request handlers.
+/// Read-only workspace surface extending [`IndexRead`].
 ///
-/// Implemented by `Arc<Indexer>`. Handlers that only need reads can depend on
-/// this trait instead of `Arc<Indexer>` directly, which narrows the surface area
-/// and enables lightweight test stubs.
+/// The single method here (`find_definition_qualified`) is already called from
+/// `Backend::resolve_with_receiver_fallback`. It uses `resolve_locations` with
+/// `allow_rg = true`, ensuring that rg-discovered files are indexed before
+/// callers access their `FileData` — a property the inherent `Indexer` method
+/// does not provide.
 ///
-/// `WorkspaceRead` is introduced in Wave 2C and will be consumed by handlers in
-/// a follow-up refactor, so it is intentionally unused within this PR.
-#[allow(dead_code)]
+/// Wave 3 will extend this trait with `file_symbols`, `workspace_root`,
+/// `source_paths`, and further read-only accessors as handlers are migrated to
+/// `impl WorkspaceRead`.
 pub(crate) trait WorkspaceRead: IndexRead {
-    fn definition_locations(&self, name: &str) -> Vec<Location> {
-        self.get_definitions(name).unwrap_or_default()
-    }
-
-    fn file_symbols(&self, uri: &Url) -> Vec<SymbolEntry> {
-        self.get_file_data(uri.as_str())
-            .map(|data| data.symbols.clone())
-            .unwrap_or_default()
-    }
-
-    fn lines_for(&self, uri: &Url) -> Option<Arc<Vec<String>>> {
-        self.get_file_data(uri.as_str())
-            .map(|data| Arc::clone(&data.lines))
-    }
-
-    fn mem_lines_for(&self, uri: &str) -> Option<Arc<Vec<String>>> {
-        self.get_file_data(uri).map(|data| Arc::clone(&data.lines))
-    }
-
-    fn word_at(&self, _uri: &Url, _position: Position) -> Option<String> {
-        None
-    }
-
-    fn word_and_range_at(&self, _uri: &Url, _position: Position) -> Option<(String, Range)> {
-        None
-    }
-
-    fn word_and_qualifier_at(
-        &self,
-        _uri: &Url,
-        _position: Position,
-    ) -> Option<(String, Option<String>)> {
-        None
-    }
-
     fn find_definition_qualified(
         &self,
         name: &str,
@@ -171,35 +137,6 @@ pub(crate) trait WorkspaceRead: IndexRead {
         from_uri: &Url,
     ) -> Vec<Location> {
         self.resolve_locations(name, qualifier, from_uri, true)
-    }
-
-    fn enclosing_class_at(&self, _uri: &Url, _row: u32) -> Option<String> {
-        None
-    }
-
-    fn live_doc(&self, _uri: &Url) -> Option<Arc<super::LiveDoc>> {
-        None
-    }
-
-    fn completions(
-        &self,
-        _uri: &Url,
-        _position: Position,
-        _snippets: bool,
-    ) -> (Vec<CompletionItem>, bool) {
-        (Vec::new(), false)
-    }
-
-    fn workspace_root(&self) -> Option<PathBuf> {
-        None
-    }
-
-    fn source_paths(&self) -> Vec<String> {
-        Vec::new()
-    }
-
-    fn is_library_uri(&self, _uri: &Url) -> bool {
-        false
     }
 }
 
@@ -756,84 +693,7 @@ impl IndexRead for Arc<super::Indexer> {
     }
 }
 
-impl WorkspaceRead for Arc<super::Indexer> {
-    fn definition_locations(&self, name: &str) -> Vec<Location> {
-        self.as_ref().definition_locations(name)
-    }
-
-    fn file_symbols(&self, uri: &Url) -> Vec<SymbolEntry> {
-        self.as_ref().file_symbols(uri)
-    }
-
-    fn lines_for(&self, uri: &Url) -> Option<Arc<Vec<String>>> {
-        self.as_ref().lines_for(uri)
-    }
-
-    fn mem_lines_for(&self, uri: &str) -> Option<Arc<Vec<String>>> {
-        self.as_ref().mem_lines_for(uri)
-    }
-
-    fn word_at(&self, uri: &Url, position: Position) -> Option<String> {
-        self.as_ref().word_at(uri, position)
-    }
-
-    fn word_and_range_at(&self, uri: &Url, position: Position) -> Option<(String, Range)> {
-        self.as_ref().word_and_range_at(uri, position)
-    }
-
-    fn word_and_qualifier_at(
-        &self,
-        uri: &Url,
-        position: Position,
-    ) -> Option<(String, Option<String>)> {
-        self.as_ref().word_and_qualifier_at(uri, position)
-    }
-
-    fn find_definition_qualified(
-        &self,
-        name: &str,
-        qualifier: Option<&str>,
-        from_uri: &Url,
-    ) -> Vec<Location> {
-        self.as_ref()
-            .find_definition_qualified(name, qualifier, from_uri)
-    }
-
-    fn enclosing_class_at(&self, uri: &Url, row: u32) -> Option<String> {
-        self.as_ref().enclosing_class_at(uri, row)
-    }
-
-    fn live_doc(&self, uri: &Url) -> Option<Arc<super::LiveDoc>> {
-        self.as_ref().live_doc(uri)
-    }
-
-    fn completions(
-        &self,
-        uri: &Url,
-        position: Position,
-        snippets: bool,
-    ) -> (Vec<CompletionItem>, bool) {
-        self.as_ref().completions(uri, position, snippets)
-    }
-
-    fn workspace_root(&self) -> Option<PathBuf> {
-        self.workspace_root
-            .read()
-            .map(|root| root.clone())
-            .unwrap_or(None)
-    }
-
-    fn source_paths(&self) -> Vec<String> {
-        self.source_paths_raw
-            .read()
-            .map(|paths| paths.clone())
-            .unwrap_or_default()
-    }
-
-    fn is_library_uri(&self, uri: &Url) -> bool {
-        self.as_ref().is_library_uri(uri)
-    }
-}
+impl WorkspaceRead for Arc<super::Indexer> {}
 
 #[cfg(test)]
 #[path = "workspace_read_tests.rs"]

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -2,8 +2,9 @@
 // Phase 2: Core `resolve_symbol_info` pipeline implementation.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
-use tower_lsp::lsp_types::{SymbolKind, Url};
+use tower_lsp::lsp_types::{CompletionItem, Position, Range, SymbolKind, Url};
 
 use crate::indexer::doc::extract_doc_comment;
 use crate::indexer::Location;
@@ -116,6 +117,90 @@ pub(crate) trait IndexRead {
     /// Callers that need on-demand indexing must call `ensure_indexed_on_demand()`
     /// before `get_file_data()` (as `build_type_param_subst_impl` does).
     fn ensure_indexed_on_demand(&self, _uri: &str) {}
+}
+
+/// Read-only view of workspace state used by request handlers.
+///
+/// Implemented by `Arc<Indexer>`. Handlers that only need reads can depend on
+/// this trait instead of `Arc<Indexer>` directly, which narrows the surface area
+/// and enables lightweight test stubs.
+///
+/// `WorkspaceRead` is introduced in Wave 2C and will be consumed by handlers in
+/// a follow-up refactor, so it is intentionally unused within this PR.
+#[allow(dead_code)]
+pub(crate) trait WorkspaceRead: IndexRead {
+    fn definition_locations(&self, name: &str) -> Vec<Location> {
+        self.get_definitions(name).unwrap_or_default()
+    }
+
+    fn file_symbols(&self, uri: &Url) -> Vec<SymbolEntry> {
+        self.get_file_data(uri.as_str())
+            .map(|data| data.symbols.clone())
+            .unwrap_or_default()
+    }
+
+    fn lines_for(&self, uri: &Url) -> Option<Arc<Vec<String>>> {
+        self.get_file_data(uri.as_str())
+            .map(|data| Arc::clone(&data.lines))
+    }
+
+    fn mem_lines_for(&self, uri: &str) -> Option<Arc<Vec<String>>> {
+        self.get_file_data(uri).map(|data| Arc::clone(&data.lines))
+    }
+
+    fn word_at(&self, _uri: &Url, _position: Position) -> Option<String> {
+        None
+    }
+
+    fn word_and_range_at(&self, _uri: &Url, _position: Position) -> Option<(String, Range)> {
+        None
+    }
+
+    fn word_and_qualifier_at(
+        &self,
+        _uri: &Url,
+        _position: Position,
+    ) -> Option<(String, Option<String>)> {
+        None
+    }
+
+    fn find_definition_qualified(
+        &self,
+        name: &str,
+        qualifier: Option<&str>,
+        from_uri: &Url,
+    ) -> Vec<Location> {
+        self.resolve_locations(name, qualifier, from_uri, true)
+    }
+
+    fn enclosing_class_at(&self, _uri: &Url, _row: u32) -> Option<String> {
+        None
+    }
+
+    fn live_doc(&self, _uri: &Url) -> Option<Arc<super::LiveDoc>> {
+        None
+    }
+
+    fn completions(
+        &self,
+        _uri: &Url,
+        _position: Position,
+        _snippets: bool,
+    ) -> (Vec<CompletionItem>, bool) {
+        (Vec::new(), false)
+    }
+
+    fn workspace_root(&self) -> Option<PathBuf> {
+        None
+    }
+
+    fn source_paths(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    fn is_library_uri(&self, _uri: &Url) -> bool {
+        false
+    }
 }
 
 // ─── Pipeline Entry Point (thin coordinator) ───────────────────────────────
@@ -636,6 +721,123 @@ impl IndexRead for super::Indexer {
         }
     }
 }
+
+impl IndexRead for Arc<super::Indexer> {
+    fn get_definitions(&self, name: &str) -> Option<Vec<Location>> {
+        <super::Indexer as IndexRead>::get_definitions(self.as_ref(), name)
+    }
+
+    fn get_file_data(&self, uri: &str) -> Option<Arc<FileData>> {
+        <super::Indexer as IndexRead>::get_file_data(self.as_ref(), uri)
+    }
+
+    fn resolve_locations(
+        &self,
+        name: &str,
+        qualifier: Option<&str>,
+        from_uri: &Url,
+        allow_rg: bool,
+    ) -> Vec<Location> {
+        <super::Indexer as IndexRead>::resolve_locations(
+            self.as_ref(),
+            name,
+            qualifier,
+            from_uri,
+            allow_rg,
+        )
+    }
+
+    fn infer_variable_type_for(&self, name: &str, uri: &Url) -> Option<String> {
+        <super::Indexer as IndexRead>::infer_variable_type_for(self.as_ref(), name, uri)
+    }
+
+    fn ensure_indexed_on_demand(&self, uri: &str) {
+        <super::Indexer as IndexRead>::ensure_indexed_on_demand(self.as_ref(), uri);
+    }
+}
+
+impl WorkspaceRead for Arc<super::Indexer> {
+    fn definition_locations(&self, name: &str) -> Vec<Location> {
+        self.as_ref().definition_locations(name)
+    }
+
+    fn file_symbols(&self, uri: &Url) -> Vec<SymbolEntry> {
+        self.as_ref().file_symbols(uri)
+    }
+
+    fn lines_for(&self, uri: &Url) -> Option<Arc<Vec<String>>> {
+        self.as_ref().lines_for(uri)
+    }
+
+    fn mem_lines_for(&self, uri: &str) -> Option<Arc<Vec<String>>> {
+        self.as_ref().mem_lines_for(uri)
+    }
+
+    fn word_at(&self, uri: &Url, position: Position) -> Option<String> {
+        self.as_ref().word_at(uri, position)
+    }
+
+    fn word_and_range_at(&self, uri: &Url, position: Position) -> Option<(String, Range)> {
+        self.as_ref().word_and_range_at(uri, position)
+    }
+
+    fn word_and_qualifier_at(
+        &self,
+        uri: &Url,
+        position: Position,
+    ) -> Option<(String, Option<String>)> {
+        self.as_ref().word_and_qualifier_at(uri, position)
+    }
+
+    fn find_definition_qualified(
+        &self,
+        name: &str,
+        qualifier: Option<&str>,
+        from_uri: &Url,
+    ) -> Vec<Location> {
+        self.as_ref()
+            .find_definition_qualified(name, qualifier, from_uri)
+    }
+
+    fn enclosing_class_at(&self, uri: &Url, row: u32) -> Option<String> {
+        self.as_ref().enclosing_class_at(uri, row)
+    }
+
+    fn live_doc(&self, uri: &Url) -> Option<Arc<super::LiveDoc>> {
+        self.as_ref().live_doc(uri)
+    }
+
+    fn completions(
+        &self,
+        uri: &Url,
+        position: Position,
+        snippets: bool,
+    ) -> (Vec<CompletionItem>, bool) {
+        self.as_ref().completions(uri, position, snippets)
+    }
+
+    fn workspace_root(&self) -> Option<PathBuf> {
+        self.workspace_root
+            .read()
+            .map(|root| root.clone())
+            .unwrap_or(None)
+    }
+
+    fn source_paths(&self) -> Vec<String> {
+        self.source_paths_raw
+            .read()
+            .map(|paths| paths.clone())
+            .unwrap_or_default()
+    }
+
+    fn is_library_uri(&self, uri: &Url) -> bool {
+        self.as_ref().is_library_uri(uri)
+    }
+}
+
+#[cfg(test)]
+#[path = "workspace_read_tests.rs"]
+mod workspace_read_tests;
 
 #[cfg(test)]
 #[path = "resolution_tests.rs"]

--- a/src/indexer/workspace_read_tests.rs
+++ b/src/indexer/workspace_read_tests.rs
@@ -1,40 +1,21 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::Arc;
 
-use tower_lsp::lsp_types::{Position, Range, SymbolKind, Url};
+use tower_lsp::lsp_types::{Position, Range, Url};
 
 use super::{IndexRead, WorkspaceRead};
 use crate::indexer::Location;
-use crate::types::{FileData, SymbolEntry, Visibility};
+use crate::types::FileData;
 
+/// Minimal `WorkspaceRead` stub for unit tests.
 #[derive(Default)]
 struct TestWorkspace {
     definitions: HashMap<String, Vec<Location>>,
-    files: HashMap<String, Arc<FileData>>,
-    workspace_root: Option<PathBuf>,
 }
 
 impl TestWorkspace {
     fn with_definition(mut self, name: &str, location: Location) -> Self {
         self.definitions.insert(name.to_owned(), vec![location]);
-        self
-    }
-
-    fn with_file(mut self, uri: &Url, symbols: Vec<SymbolEntry>) -> Self {
-        self.files.insert(
-            uri.as_str().to_owned(),
-            Arc::new(FileData {
-                symbols,
-                lines: Arc::new(vec!["class Stub".to_owned()]),
-                ..FileData::default()
-            }),
-        );
-        self
-    }
-
-    fn with_workspace_root(mut self, path: &str) -> Self {
-        self.workspace_root = Some(PathBuf::from(path));
         self
     }
 }
@@ -44,56 +25,29 @@ impl IndexRead for TestWorkspace {
         self.definitions.get(name).cloned()
     }
 
-    fn get_file_data(&self, uri: &str) -> Option<Arc<FileData>> {
-        self.files.get(uri).cloned()
+    fn get_file_data(&self, _uri: &str) -> Option<Arc<FileData>> {
+        None
     }
 }
 
-impl WorkspaceRead for TestWorkspace {
-    fn workspace_root(&self) -> Option<PathBuf> {
-        self.workspace_root.clone()
-    }
+impl WorkspaceRead for TestWorkspace {}
+
+#[test]
+fn find_definition_qualified_default_resolves_via_index() {
+    let target = location("/workspace/src/Foo.kt", 3);
+    let workspace = TestWorkspace::default().with_definition("Foo", target.clone());
+
+    let result = workspace.find_definition_qualified("Foo", None, &file_url("/workspace/src/Bar.kt"));
+
+    assert_eq!(result, vec![target]);
 }
 
 #[test]
-fn definition_locations_returns_stubbed_locations() {
-    let location = location("/workspace/src/Foo.kt", 3);
-    let workspace = TestWorkspace::default().with_definition("Foo", location.clone());
-
-    assert_eq!(workspace.definition_locations("Foo"), vec![location]);
-}
-
-#[test]
-fn file_symbols_filters_by_uri() {
-    let foo_uri = file_url("/workspace/src/Foo.kt");
-    let bar_uri = file_url("/workspace/src/Bar.kt");
-    let workspace = TestWorkspace::default()
-        .with_file(&foo_uri, vec![symbol("Foo")])
-        .with_file(&bar_uri, vec![symbol("Bar")]);
-
-    let foo_symbols: Vec<String> = workspace
-        .file_symbols(&foo_uri)
-        .into_iter()
-        .map(|entry| entry.name)
-        .collect();
-    let bar_symbols: Vec<String> = workspace
-        .file_symbols(&bar_uri)
-        .into_iter()
-        .map(|entry| entry.name)
-        .collect();
-
-    assert_eq!(foo_symbols, vec!["Foo"]);
-    assert_eq!(bar_symbols, vec!["Bar"]);
-}
-
-#[test]
-fn workspace_root_returns_set_value() {
-    let workspace = TestWorkspace::default().with_workspace_root("/workspace/project");
-
-    assert_eq!(
-        workspace.workspace_root(),
-        Some(PathBuf::from("/workspace/project"))
-    );
+fn find_definition_qualified_returns_empty_when_unknown() {
+    let workspace = TestWorkspace::default();
+    let result =
+        workspace.find_definition_qualified("Unknown", None, &file_url("/workspace/src/Bar.kt"));
+    assert!(result.is_empty());
 }
 
 fn file_url(path: &str) -> Url {
@@ -104,19 +58,5 @@ fn location(path: &str, line: u32) -> Location {
     Location {
         uri: file_url(path),
         range: Range::new(Position::new(line, 0), Position::new(line, 3)),
-    }
-}
-
-fn symbol(name: &str) -> SymbolEntry {
-    let range = Range::new(Position::new(0, 0), Position::new(0, name.len() as u32));
-    SymbolEntry {
-        name: name.to_owned(),
-        kind: SymbolKind::CLASS,
-        visibility: Visibility::Public,
-        range,
-        selection_range: range,
-        detail: format!("class {name}"),
-        type_params: Vec::new(),
-        extension_receiver: String::new(),
     }
 }

--- a/src/indexer/workspace_read_tests.rs
+++ b/src/indexer/workspace_read_tests.rs
@@ -1,0 +1,122 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::{Position, Range, SymbolKind, Url};
+
+use super::{IndexRead, WorkspaceRead};
+use crate::indexer::Location;
+use crate::types::{FileData, SymbolEntry, Visibility};
+
+#[derive(Default)]
+struct TestWorkspace {
+    definitions: HashMap<String, Vec<Location>>,
+    files: HashMap<String, Arc<FileData>>,
+    workspace_root: Option<PathBuf>,
+}
+
+impl TestWorkspace {
+    fn with_definition(mut self, name: &str, location: Location) -> Self {
+        self.definitions.insert(name.to_owned(), vec![location]);
+        self
+    }
+
+    fn with_file(mut self, uri: &Url, symbols: Vec<SymbolEntry>) -> Self {
+        self.files.insert(
+            uri.as_str().to_owned(),
+            Arc::new(FileData {
+                symbols,
+                lines: Arc::new(vec!["class Stub".to_owned()]),
+                ..FileData::default()
+            }),
+        );
+        self
+    }
+
+    fn with_workspace_root(mut self, path: &str) -> Self {
+        self.workspace_root = Some(PathBuf::from(path));
+        self
+    }
+}
+
+impl IndexRead for TestWorkspace {
+    fn get_definitions(&self, name: &str) -> Option<Vec<Location>> {
+        self.definitions.get(name).cloned()
+    }
+
+    fn get_file_data(&self, uri: &str) -> Option<Arc<FileData>> {
+        self.files.get(uri).cloned()
+    }
+}
+
+impl WorkspaceRead for TestWorkspace {
+    fn workspace_root(&self) -> Option<PathBuf> {
+        self.workspace_root.clone()
+    }
+}
+
+#[test]
+fn definition_locations_returns_stubbed_locations() {
+    let location = location("/workspace/src/Foo.kt", 3);
+    let workspace = TestWorkspace::default().with_definition("Foo", location.clone());
+
+    assert_eq!(workspace.definition_locations("Foo"), vec![location]);
+}
+
+#[test]
+fn file_symbols_filters_by_uri() {
+    let foo_uri = file_url("/workspace/src/Foo.kt");
+    let bar_uri = file_url("/workspace/src/Bar.kt");
+    let workspace = TestWorkspace::default()
+        .with_file(&foo_uri, vec![symbol("Foo")])
+        .with_file(&bar_uri, vec![symbol("Bar")]);
+
+    let foo_symbols: Vec<String> = workspace
+        .file_symbols(&foo_uri)
+        .into_iter()
+        .map(|entry| entry.name)
+        .collect();
+    let bar_symbols: Vec<String> = workspace
+        .file_symbols(&bar_uri)
+        .into_iter()
+        .map(|entry| entry.name)
+        .collect();
+
+    assert_eq!(foo_symbols, vec!["Foo"]);
+    assert_eq!(bar_symbols, vec!["Bar"]);
+}
+
+#[test]
+fn workspace_root_returns_set_value() {
+    let workspace = TestWorkspace::default().with_workspace_root("/workspace/project");
+
+    assert_eq!(
+        workspace.workspace_root(),
+        Some(PathBuf::from("/workspace/project"))
+    );
+}
+
+fn file_url(path: &str) -> Url {
+    Url::parse(&format!("file://{path}")).expect("valid file URL")
+}
+
+fn location(path: &str, line: u32) -> Location {
+    Location {
+        uri: file_url(path),
+        range: Range::new(Position::new(line, 0), Position::new(line, 3)),
+    }
+}
+
+fn symbol(name: &str) -> SymbolEntry {
+    let range = Range::new(Position::new(0, 0), Position::new(0, name.len() as u32));
+    SymbolEntry {
+        name: name.to_owned(),
+        kind: SymbolKind::CLASS,
+        visibility: Visibility::Public,
+        range,
+        selection_range: range,
+        detail: format!("class {name}"),
+        type_params: Vec::new(),
+        extension_receiver: String::new(),
+    }
+}

--- a/src/workspace_json_tests.rs
+++ b/src/workspace_json_tests.rs
@@ -26,7 +26,6 @@ fn malformed_json_returns_empty() {
 #[test]
 fn extracts_java_source_and_java_test() {
     let dir = TempDir::new().unwrap();
-    let ws = dir.path().to_string_lossy();
     let json = format!(
         r#"{{
             "modules": [{{


### PR DESCRIPTION
## Summary

Adds `WorkspaceRead: IndexRead` — a minimal read-only trait over the workspace/index state — to decouple request handlers from `Arc<Indexer>` and enable lightweight test stubs.

This is Wave 2C of the MVI workspace refactor.

## Changes

### `src/indexer/resolution.rs`
- `WorkspaceRead` trait with a single method: `find_definition_qualified`
  - Default implementation calls `IndexRead::resolve_locations(allow_rg=true)`, which ensures rg-discovered files are indexed before use
  - `impl WorkspaceRead for Arc<Indexer>` is empty — defaults are correct
- `src/backend/mod.rs`: `resolve_with_receiver_fallback` now calls `WorkspaceRead::find_definition_qualified` via UFCS so the indexing-aware code path is used

### `src/indexer/workspace_read_tests.rs`  
Two focused unit tests for the `find_definition_qualified` default behavior via a minimal `TestWorkspace` stub.

## Reviewer comments addressed

- **`#[allow(dead_code)]` on WorkspaceRead**: removed — the trait has a production usage in `resolve_with_receiver_fallback` via UFCS
- **Override delegates to inherent method**: removed — `impl WorkspaceRead for Arc<Indexer>` is now empty; the default delegates through the correct `resolve_locations` path
- **PR description mismatch**: updated (this comment)