### PR TITLE
refactor: rename workspace types to Moneta-style readable names

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -11,7 +11,7 @@ use self::helpers::syntax_diagnostics;
 use crate::indexer::resolution::WorkspaceRead;
 use crate::indexer::{workspace_cache_path, IgnoreMatcher, Indexer, ProgressReporter};
 use crate::semantic_tokens;
-use crate::workspace::{WorkspaceConfig, WorkspaceEvent};
+use crate::workspace::{Config, Event};
 
 pub(crate) mod actions;
 pub(crate) mod cursor;
@@ -95,7 +95,7 @@ impl ProgressReporter for LspProgressReporter {
 pub(crate) struct Backend {
     pub(super) client: Client,
     pub(super) indexer: Arc<Indexer>,
-    event_tx: mpsc::Sender<WorkspaceEvent>,
+    event_tx: mpsc::Sender<Event>,
     /// True if the client advertised `snippetSupport: true` during initialize.
     /// Used to decide whether to send `InsertTextFormat::SNIPPET` in completions.
     pub(super) snippet_support: Arc<AtomicBool>,
@@ -105,7 +105,7 @@ impl Backend {
     pub(crate) fn new(
         client: Client,
         indexer: Arc<Indexer>,
-        event_tx: mpsc::Sender<WorkspaceEvent>,
+        event_tx: mpsc::Sender<Event>,
     ) -> Self {
         Self {
             client,
@@ -229,8 +229,8 @@ impl Backend {
             self.apply_initialization_options(params.initialization_options.as_ref());
         if self
             .event_tx
-            .send(WorkspaceEvent::Initialize {
-                config: WorkspaceConfig {
+            .send(Event::Initialize {
+                config: Config {
                     root: workspace_root.to_path_buf(),
                     explicit_source_paths,
                     ignore_patterns,
@@ -500,7 +500,7 @@ impl LanguageServer for Backend {
     async fn did_open(&self, params: DidOpenTextDocumentParams) {
         let _ = self
             .event_tx
-            .send(WorkspaceEvent::FileOpened {
+            .send(Event::FileOpened {
                 uri: params.text_document.uri,
                 language_id: params.text_document.language_id,
                 content: params.text_document.text,
@@ -511,7 +511,7 @@ impl LanguageServer for Backend {
     async fn did_change(&self, params: DidChangeTextDocumentParams) {
         let _ = self
             .event_tx
-            .send(WorkspaceEvent::FileChanged {
+            .send(Event::FileChanged {
                 uri: params.text_document.uri,
                 changes: params.content_changes,
             })
@@ -521,7 +521,7 @@ impl LanguageServer for Backend {
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         let _ = self
             .event_tx
-            .send(WorkspaceEvent::FileClosed {
+            .send(Event::FileClosed {
                 uri: params.text_document.uri,
             })
             .await;
@@ -532,7 +532,7 @@ impl LanguageServer for Backend {
     async fn did_save(&self, params: DidSaveTextDocumentParams) {
         let _ = self
             .event_tx
-            .send(WorkspaceEvent::FileSaved {
+            .send(Event::FileSaved {
                 uri: params.text_document.uri,
             })
             .await;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -8,7 +8,7 @@ use tower_lsp::lsp_types::Location;
 
 use crate::indexer::{Indexer, NoopReporter};
 use crate::rg::{rg_find_definition, rg_word_search, RgSearchRequest};
-use crate::workspace::{WorkspaceActor, WorkspaceConfig, WorkspaceEvent};
+use crate::workspace::{Actor, Config, Event};
 
 use super::args::{CliArgs, Mode, OutputFmt, Subcommand};
 use super::hover::hover_at;
@@ -46,7 +46,7 @@ fn cache_exists(root: &Path) -> bool {
 
 /// Build (or load from cache) a full workspace index. Reports progress to stderr.
 ///
-/// Source paths are resolved by [`WorkspaceConfig::resolve_sources`] inside the actor:
+/// Source paths are resolved by [`Config::resolve_sources`] inside the actor:
 /// 1. `workspace.json` (JetBrains IDE format) at the workspace root
 /// 2. Build-layout auto-detection (Gradle/Maven src dirs), if no workspace.json
 /// 3. `~/.kotlin-lsp/sources` — the default `extract-sources` output dir
@@ -54,12 +54,12 @@ async fn build_index(root: &Path) -> Arc<Indexer> {
     let indexer = Arc::new(Indexer::new());
     let (event_tx, event_rx) = mpsc::channel(16);
     let (completion_tx, completion_rx) = oneshot::channel();
-    let actor = WorkspaceActor::new(Arc::clone(&indexer), Arc::new(NoopReporter), event_rx, None);
+    let actor = Actor::new(Arc::clone(&indexer), Arc::new(NoopReporter), event_rx, None);
     tokio::spawn(actor.run());
 
     if event_tx
-        .send(WorkspaceEvent::Initialize {
-            config: WorkspaceConfig {
+        .send(Event::Initialize {
+            config: Config {
                 root: root.to_path_buf(),
                 // Source discovery is performed by resolve_sources() inside the actor;
                 // passing an empty list here avoids duplicating the filesystem work.

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
 fn make_backend(client: tower_lsp::Client) -> backend::Backend {
     let indexer = Arc::new(indexer::Indexer::new());
     let (event_tx, event_rx) = mpsc::channel(64);
-    let actor = workspace::WorkspaceActor::new(
+    let actor = workspace::Actor::new(
         Arc::clone(&indexer),
         Arc::new(backend::LspProgressReporter(client.clone())),
         event_rx,

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -1,4 +1,4 @@
-//! [`WorkspaceActor`] — the single serialised writer of workspace state.
+//! [`Actor`] — the single serialised writer of workspace state.
 //!
 //! All workspace-level mutations (root, source paths, ignore patterns, scans)
 //! are processed here, one at a time, in arrival order. Request handlers that
@@ -6,13 +6,13 @@
 //!
 //! # Invariants
 //!
-//! * Only `WorkspaceActor` event handlers may call `resolve_sources()` and write
+//! * Only `Actor` event handlers may call `resolve_sources()` and write
 //!   `Indexer::source_paths_raw` or `Indexer::ignore_matcher`.
 //! * The `Indexer` is long-lived; it is never replaced, so live-document state
 //!   accumulated in `live_lines`, `live_trees`, etc. survives reindex/root-switch.
 //! * The actor's `phase` field is the authoritative lifecycle state. Before
-//!   `Initialize` fires it is `WorkspacePhase::Uninitialized`; after it is
-//!   `WorkspacePhase::Ready(WorkspaceData)`.
+//!   `Initialize` fires it is `State::Uninitialized`; after it is
+//!   `State::Ready(ReadyState)`.
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
@@ -28,10 +28,10 @@ use crate::backend::helpers::syntax_diagnostics;
 use crate::indexer::{Indexer, ProgressReporter};
 use crate::rg::IgnoreMatcher;
 
-use super::contract::{WorkspaceData, WorkspacePhase};
-use super::{WorkspaceConfig, WorkspaceEvent};
+use super::contract::{ReadyState, State};
+use super::{Config, Event};
 
-// ─── WorkspaceActor ──────────────────────────────────────────────────────────
+// ─── Actor ──────────────────────────────────────────────────────────
 
 /// MVI-style actor that owns all workspace write operations.
 ///
@@ -40,20 +40,20 @@ use super::{WorkspaceConfig, WorkspaceEvent};
 /// use [`NoopReporter`](crate::indexer::NoopReporter) — no heap allocation or
 /// vtable dispatch needed at the actor level.
 ///
-/// Construct with [`WorkspaceActor::new`] and drive with [`WorkspaceActor::run`].
-pub(crate) struct WorkspaceActor<R: ProgressReporter + 'static> {
+/// Construct with [`Actor::new`] and drive with [`Actor::run`].
+pub(crate) struct Actor<R: ProgressReporter + 'static> {
     indexer: Arc<Indexer>,
     reporter: Arc<R>,
-    rx: mpsc::Receiver<WorkspaceEvent>,
+    rx: mpsc::Receiver<Event>,
     client: Option<Client>,
     pending_reindex: HashMap<String, AbortHandle>,
     /// Lifecycle phase — `Uninitialized` until the first `Initialize` event.
     /// Shared so that read-path consumers can observe workspace state without
     /// touching Indexer's internal lock fields directly.
-    phase: Arc<RwLock<WorkspacePhase>>,
+    phase: Arc<RwLock<State>>,
 }
 
-impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
+impl<R: ProgressReporter + 'static> Actor<R> {
     /// Create a new actor.
     ///
     /// `reporter` is used for every workspace scan triggered by this actor.
@@ -62,7 +62,7 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
     pub(crate) fn new(
         indexer: Arc<Indexer>,
         reporter: Arc<R>,
-        rx: mpsc::Receiver<WorkspaceEvent>,
+        rx: mpsc::Receiver<Event>,
         client: Option<Client>,
     ) -> Self {
         Self {
@@ -71,40 +71,40 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
             rx,
             client,
             pending_reindex: HashMap::new(),
-            phase: Arc::new(RwLock::new(WorkspacePhase::Uninitialized)),
+            phase: Arc::new(RwLock::new(State::Uninitialized)),
         }
     }
 
     /// Expose the shared phase handle for read-path consumers introduced in Wave 3.
     #[allow(dead_code)]
-    pub(crate) fn phase_handle(&self) -> Arc<RwLock<WorkspacePhase>> {
+    pub(crate) fn state_stream(&self) -> Arc<RwLock<State>> {
         Arc::clone(&self.phase)
     }
 
     /// Run the event loop until the sender side is dropped.
     ///
     /// The exhaustive `match` is the architectural guarantee: every new
-    /// [`WorkspaceEvent`] variant must be handled here or the code will not
+    /// [`Event`] variant must be handled here or the code will not
     /// compile.
     pub(crate) async fn run(mut self) {
         while let Some(event) = self.rx.recv().await {
             match event {
-                WorkspaceEvent::Initialize {
+                Event::Initialize {
                     config,
                     completion_tx,
                 } => self.handle_initialize(config, completion_tx).await,
-                WorkspaceEvent::Reindex => self.handle_reindex().await,
-                WorkspaceEvent::ChangeRoot { root } => self.handle_change_root(root).await,
-                WorkspaceEvent::FileOpened {
+                Event::Reindex => self.handle_reindex().await,
+                Event::ChangeRoot { root } => self.handle_change_root(root).await,
+                Event::FileOpened {
                     uri,
                     language_id,
                     content,
                 } => self.handle_file_opened(uri, language_id, content).await,
-                WorkspaceEvent::FileChanged { uri, changes } => {
+                Event::FileChanged { uri, changes } => {
                     self.handle_file_changed(uri, changes).await;
                 }
-                WorkspaceEvent::FileSaved { uri } => self.handle_file_saved(uri).await,
-                WorkspaceEvent::FileClosed { uri } => self.handle_file_closed(uri).await,
+                Event::FileSaved { uri } => self.handle_file_saved(uri).await,
+                Event::FileClosed { uri } => self.handle_file_closed(uri).await,
             }
         }
     }
@@ -113,10 +113,10 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
 
     async fn handle_initialize(
         &mut self,
-        config: WorkspaceConfig,
+        config: Config,
         completion_tx: Option<oneshot::Sender<()>>,
     ) {
-        let data = WorkspaceData::from_config(&config);
+        let data = ReadyState::from_config(&config);
         let root = data.root.clone();
 
         // Set the root immediately so read-path handlers can see it without
@@ -134,7 +134,7 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
 
     async fn handle_reindex(&mut self) {
         let Some(root) = self.current_root() else {
-            log::warn!("WorkspaceActor: Reindex received but no workspace root is set");
+            log::warn!("Actor: Reindex received but no workspace root is set");
             return;
         };
         self.indexer.reset_index_state();
@@ -146,12 +146,12 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
         // source paths for the new root (workspace.json, build layout, etc.).
         // Explicit source paths from initialization are intentionally dropped
         // because they were relative to the old root and are editor-session-scoped.
-        let config = WorkspaceConfig {
+        let config = Config {
             root: root.clone(),
             explicit_source_paths: Vec::new(),
             ignore_patterns: Vec::new(),
         };
-        let data = WorkspaceData::from_config(&config);
+        let data = ReadyState::from_config(&config);
 
         self.apply_ignore_patterns(&config.ignore_patterns, &root);
         self.write_source_paths(data.source_paths.clone());
@@ -287,9 +287,9 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
 
     // ── Phase management ──────────────────────────────────────────────────────
 
-    /// Atomically transition to `WorkspacePhase::Ready`.
-    async fn set_phase(&self, data: WorkspaceData) {
-        self.phase.write().await.set_ready(data);
+    /// Atomically transition to `State::Ready`.
+    async fn set_phase(&self, data: ReadyState) {
+        self.phase.write().await.set_state(data);
     }
 
     // ── Internal helpers ──────────────────────────────────────────────────────
@@ -306,14 +306,14 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
         if let Ok(mut guard) = self.indexer.workspace_root.write() {
             *guard = Some(root);
         } else {
-            log::warn!("WorkspaceActor: failed to write workspace root");
+            log::warn!("Actor: failed to write workspace root");
         }
     }
 
     fn write_source_paths(&self, paths: Vec<String>) {
         match self.indexer.source_paths_raw.write() {
             Ok(mut guard) => *guard = paths,
-            Err(err) => log::warn!("WorkspaceActor: failed to write source_paths_raw: {err}"),
+            Err(err) => log::warn!("Actor: failed to write source_paths_raw: {err}"),
         }
     }
 
@@ -325,7 +325,7 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
                 *guard = (!patterns.is_empty())
                     .then(|| Arc::new(IgnoreMatcher::new(patterns.to_vec(), root)));
             }
-            Err(err) => log::warn!("WorkspaceActor: failed to write ignore_matcher: {err}"),
+            Err(err) => log::warn!("Actor: failed to write ignore_matcher: {err}"),
         }
     }
 
@@ -413,12 +413,12 @@ impl<R: ProgressReporter + 'static> WorkspaceActor<R> {
         workspace_root: PathBuf,
         opened_file_path: Option<PathBuf>,
     ) {
-        let config = WorkspaceConfig {
+        let config = Config {
             root: workspace_root.clone(),
             explicit_source_paths: Vec::new(),
             ignore_patterns: Vec::new(),
         };
-        let data = WorkspaceData::from_config(&config);
+        let data = ReadyState::from_config(&config);
 
         self.apply_ignore_patterns(&config.ignore_patterns, &workspace_root);
         self.write_source_paths(data.source_paths.clone());

--- a/src/workspace/actor_tests.rs
+++ b/src/workspace/actor_tests.rs
@@ -1,4 +1,4 @@
-//! Integration tests for [`WorkspaceActor`].
+//! Integration tests for [`Actor`].
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -6,15 +6,15 @@ use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::indexer::{Indexer, NoopReporter};
-use crate::workspace::{WorkspaceActor, WorkspaceConfig, WorkspaceEvent};
+use crate::workspace::{Actor, Config, Event};
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
 fn make_actor(
     indexer: Arc<Indexer>,
-) -> (WorkspaceActor<NoopReporter>, mpsc::Sender<WorkspaceEvent>) {
+) -> (Actor<NoopReporter>, mpsc::Sender<Event>) {
     let (tx, rx) = mpsc::channel(16);
-    let actor = WorkspaceActor::new(indexer, Arc::new(NoopReporter), rx, None);
+    let actor = Actor::new(indexer, Arc::new(NoopReporter), rx, None);
     (actor, tx)
 }
 
@@ -47,8 +47,8 @@ async fn initialize_sets_workspace_root() {
     let (actor, tx) = make_actor(Arc::clone(&indexer));
     tokio::spawn(actor.run());
 
-    tx.send(WorkspaceEvent::Initialize {
-        config: WorkspaceConfig {
+    tx.send(Event::Initialize {
+        config: Config {
             root: root.clone(),
             explicit_source_paths: Vec::new(),
             ignore_patterns: Vec::new(),
@@ -93,8 +93,8 @@ async fn initialize_writes_explicit_source_paths() {
     tokio::spawn(actor.run());
 
     let (completion_tx, completion_rx) = oneshot::channel();
-    tx.send(WorkspaceEvent::Initialize {
-        config: WorkspaceConfig {
+    tx.send(Event::Initialize {
+        config: Config {
             root: root.clone(),
             explicit_source_paths: vec!["/some/lib".to_string()],
             ignore_patterns: Vec::new(),
@@ -138,7 +138,7 @@ async fn change_root_updates_workspace_root() {
     tokio::spawn(actor.run());
 
     // Send ChangeRoot without a prior Initialize — the actor must set root directly.
-    tx.send(WorkspaceEvent::ChangeRoot { root: root.clone() })
+    tx.send(Event::ChangeRoot { root: root.clone() })
         .await
         .unwrap();
 

--- a/src/workspace/config_tests.rs
+++ b/src/workspace/config_tests.rs
@@ -1,22 +1,22 @@
-//! Unit tests for [`WorkspaceConfig::resolve_sources`].
+//! Unit tests for [`Config::resolve_sources`].
 
 use std::fs;
 use std::path::Path;
 
-use super::WorkspaceConfig;
+use super::Config;
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
-fn config(root: &Path) -> WorkspaceConfig {
-    WorkspaceConfig {
+fn config(root: &Path) -> Config {
+    Config {
         root: root.to_path_buf(),
         explicit_source_paths: Vec::new(),
         ignore_patterns: Vec::new(),
     }
 }
 
-fn config_with_explicit(root: &Path, explicit: &[&str]) -> WorkspaceConfig {
-    WorkspaceConfig {
+fn config_with_explicit(root: &Path, explicit: &[&str]) -> Config {
+    Config {
         root: root.to_path_buf(),
         explicit_source_paths: explicit.iter().map(|s| s.to_string()).collect(),
         ignore_patterns: Vec::new(),

--- a/src/workspace/contract.rs
+++ b/src/workspace/contract.rs
@@ -8,29 +8,29 @@
 //!
 //! | Type | Role |
 //! |---|---|
-//! | [`WorkspaceEvent`] | Inputs — every write to workspace state |
-//! | [`WorkspacePhase`] | State — `Uninitialized` or `Ready(WorkspaceData)` |
-//! | [`WorkspaceEffect`] | Outputs — one-shot side-effects from the actor |
+//! | [`Event`] | Inputs — every write to workspace state |
+//! | [`State`] | State — `Uninitialized` or `Ready(ReadyState)` |
+//! | [`Effect`] | Outputs — one-shot side-effects from the actor |
 //!
 //! # Compiler enforcement
 //!
-//! * Adding a [`WorkspaceEvent`] variant → compile error in `WorkspaceActor::run`
+//! * Adding a [`Event`] variant → compile error in `Actor::run`
 //!   until the handler is implemented.
-//! * Adding a [`WorkspaceEffect`] variant → compile error in every site that
+//! * Adding a [`Effect`] variant → compile error in every site that
 //!   matches on the effect channel.
-//! * Accessing [`WorkspacePhase::Ready`] data requires an explicit `match` or
-//!   a call to [`WorkspacePhase::ready`] — there is no way to get a
-//!   `&WorkspaceData` without acknowledging the `Uninitialized` case.
+//! * Accessing [`State::Ready`] data requires an explicit `match` or
+//!   a call to [`State::ready`] — there is no way to get a
+//!   `&ReadyState` without acknowledging the `Uninitialized` case.
 
 // Items re-exported here are the single source of truth for the workspace
 // public surface.  Individual types are unused at the re-export site until
 // Wave 2/3 wires backend and CLI through this contract.
 #[allow(unused_imports)]
-pub(crate) use super::event::WorkspaceEvent;
+pub(crate) use super::event::Event;
 #[allow(unused_imports)]
-pub(crate) use super::phase::{WorkspaceData, WorkspacePhase};
+pub(crate) use super::phase::{ReadyState, State};
 
-// ─── WorkspaceEffect ─────────────────────────────────────────────────────────
+// ─── Effect ─────────────────────────────────────────────────────────
 
 /// One-shot effects emitted by the workspace actor.
 ///
@@ -40,7 +40,7 @@ pub(crate) use super::phase::{WorkspaceData, WorkspacePhase};
 /// This mirrors `BusinessEffect` / `UiEffect` from Moneta: the actor sends
 /// effects for transient events that don't belong in the persistent state.
 #[allow(dead_code)] // consumed by Wave 3 CLI and test subscribers
-pub(crate) enum WorkspaceEffect {
+pub(crate) enum Effect {
     /// Emitted when a workspace scan finishes (initial or reindex).
     ///
     /// CLI mode waits for this before returning to the interactive prompt.

--- a/src/workspace/event.rs
+++ b/src/workspace/event.rs
@@ -1,7 +1,7 @@
-//! [`WorkspaceEvent`] — the sealed set of workspace-level state mutations.
+//! [`Event`] — the sealed set of workspace-level state mutations.
 //!
 //! Every write to workspace state goes through one of these variants.
-//! Adding a new variant produces a compile error in [`WorkspaceActor::run`]
+//! Adding a new variant produces a compile error in [`Actor::run`]
 //! until the handler is implemented — this is the key correctness invariant.
 // Items unused until Wave 2 wires this into backend/CLI (ws-backend, ws-cli, ws-main).
 #![allow(dead_code)]
@@ -11,16 +11,16 @@ use std::path::PathBuf;
 use tokio::sync::oneshot;
 use tower_lsp::lsp_types::{TextDocumentContentChangeEvent, Url};
 
-use super::WorkspaceConfig;
+use super::Config;
 
-/// All workspace-level mutations, serialised through [`WorkspaceActor`].
-pub(crate) enum WorkspaceEvent {
+/// All workspace-level mutations, serialised through [`Actor`].
+pub(crate) enum Event {
     /// Configure the workspace and start an initial scan.
     ///
     /// Must be the first event sent to a fresh actor. Subsequent `Initialize`
     /// events switch the root and restart the scan, discarding old source paths.
     Initialize {
-        config: WorkspaceConfig,
+        config: Config,
         completion_tx: Option<oneshot::Sender<()>>,
     },
 
@@ -32,7 +32,7 @@ pub(crate) enum WorkspaceEvent {
 
     /// Switch to a new workspace root and restart the scan.
     ///
-    /// Source paths are re-resolved via `WorkspaceConfig::resolve_sources` for
+    /// Source paths are re-resolved via `Config::resolve_sources` for
     /// the new root. Existing explicit `source_paths_raw` are discarded because
     /// they were relative to the old root.
     ChangeRoot { root: PathBuf },

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -3,7 +3,7 @@
 //! # Architecture
 //!
 //! All workspace-level state mutations (root, source paths, ignore patterns, scans)
-//! flow through [`WorkspaceActor`] via [`WorkspaceEvent`]s sent on an `mpsc` channel.
+//! flow through [`Actor`] via [`Event`]s sent on an `mpsc` channel.
 //! This serialises writes and gives a single, exhaustive `match` as the authority on
 //! what can happen to the workspace.
 //!
@@ -11,8 +11,8 @@
 //!
 //! # Source discovery
 //!
-//! [`WorkspaceConfig::resolve_sources`] is the canonical source-path resolver.
-//! Only `WorkspaceActor` event handlers may call it — no other code should write
+//! [`Config::resolve_sources`] is the canonical source-path resolver.
+//! Only `Actor` event handlers may call it — no other code should write
 //! `Indexer::source_paths_raw`.
 //!
 //! # Wiring status
@@ -29,22 +29,22 @@ pub(crate) mod phase;
 
 // Re-exports are unused until Wave 2 wires this module in (ws-backend, ws-cli, ws-main).
 #[allow(unused_imports)]
-pub(crate) use actor::WorkspaceActor;
+pub(crate) use actor::Actor;
 #[allow(unused_imports)]
-pub(crate) use contract::{WorkspaceData, WorkspaceEffect, WorkspacePhase};
+pub(crate) use contract::{ReadyState, Effect, State};
 #[allow(unused_imports)]
-pub(crate) use event::WorkspaceEvent;
+pub(crate) use event::Event;
 
 use std::path::PathBuf;
 
-// ─── WorkspaceConfig ─────────────────────────────────────────────────────────
+// ─── Config ─────────────────────────────────────────────────────────
 
-// WorkspaceConfig is unused until Wave 2 wires this module in (ws-backend, ws-cli, ws-main).
+// Config is unused until Wave 2 wires this module in (ws-backend, ws-cli, ws-main).
 #[allow(dead_code)]
 /// Immutable snapshot of workspace configuration collected at startup.
 ///
-/// Passed inside [`WorkspaceEvent::Initialize`]; not mutated after construction.
-pub(crate) struct WorkspaceConfig {
+/// Passed inside [`Event::Initialize`]; not mutated after construction.
+pub(crate) struct Config {
     /// Absolute path to the workspace root (nearest `.git` ancestor of the opened file,
     /// or an explicit `--root` flag in CLI mode, or the LSP `rootUri`).
     pub root: PathBuf,
@@ -58,7 +58,7 @@ pub(crate) struct WorkspaceConfig {
     pub ignore_patterns: Vec<String>,
 }
 
-impl WorkspaceConfig {
+impl Config {
     /// Return the deduplicated, ordered list of source paths to index.
     ///
     /// Discovery priority (first win for deduplication):
@@ -68,7 +68,7 @@ impl WorkspaceConfig {
     ///    only attempted when `workspace.json` is absent
     /// 4. `~/.kotlin-lsp/sources` (default `extract-sources` output dir)
     ///
-    /// Called only from `WorkspaceActor` event handlers (`handle_initialize`,
+    /// Called only from `Actor` event handlers (`handle_initialize`,
     /// `handle_change_root`).  No other code should call this method.
     pub(crate) fn resolve_sources(&self) -> Vec<String> {
         use std::collections::HashSet;

--- a/src/workspace/phase.rs
+++ b/src/workspace/phase.rs
@@ -1,35 +1,35 @@
-//! [`WorkspacePhase`] — lifecycle state of the workspace actor.
+//! [`State`] — lifecycle state of the workspace actor.
 //!
 //! Mirrors the `StoreState { Uninitialized | Ready<T> }` pattern from Moneta's
-//! MVI layer.  Before the first [`super::WorkspaceEvent::Initialize`] arrives
-//! the actor is `Uninitialized`; after it, `Ready(WorkspaceData)`.
+//! MVI layer.  Before the first [`super::Event::Initialize`] arrives
+//! the actor is `Uninitialized`; after it, `Ready(ReadyState)`.
 //!
-//! All code that needs workspace state should call [`WorkspacePhase::ready`]
+//! All code that needs workspace state should call [`State::ready`]
 //! and handle `None` (pre-init) explicitly — the named `Uninitialized` variant
 //! makes the pre-init case visible at every call site rather than a generic
 //! `Option<PathBuf>` whose meaning is unclear.
 
 use std::path::PathBuf;
 
-use super::WorkspaceConfig;
+use super::Config;
 
-// ─── WorkspaceData ────────────────────────────────────────────────────────────
+// ─── ReadyState ────────────────────────────────────────────────────────────
 
 /// Immutable snapshot of workspace state captured at initialisation time.
 ///
-/// Produced from a [`WorkspaceConfig`] the first time the actor processes a
-/// [`WorkspaceEvent::Initialize`] event, and updated on every
-/// [`WorkspaceEvent::ChangeRoot`].
+/// Produced from a [`Config`] the first time the actor processes a
+/// [`Event::Initialize`] event, and updated on every
+/// [`Event::ChangeRoot`].
 ///
 /// Carries the resolved (not raw) source-path list so that no caller ever has
 /// to re-run source discovery.
 #[derive(Debug, Clone)]
-pub(crate) struct WorkspaceData {
+pub(crate) struct ReadyState {
     /// Absolute path to the workspace root.
     pub root: PathBuf,
 
     /// Resolved, deduplicated list of source paths (output of
-    /// [`WorkspaceConfig::resolve_sources`]).
+    /// [`Config::resolve_sources`]).
     pub source_paths: Vec<String>,
 
     /// Ignore patterns in effect for this workspace.
@@ -38,8 +38,8 @@ pub(crate) struct WorkspaceData {
     pub ignore_patterns: Vec<String>,
 }
 
-impl WorkspaceData {
-    pub(crate) fn from_config(config: &WorkspaceConfig) -> Self {
+impl ReadyState {
+    pub(crate) fn from_config(config: &Config) -> Self {
         Self {
             root: config.root.clone(),
             source_paths: config.resolve_sources(),
@@ -48,37 +48,37 @@ impl WorkspaceData {
     }
 }
 
-// ─── WorkspacePhase ──────────────────────────────────────────────────────────
+// ─── State ──────────────────────────────────────────────────────────
 
 /// Lifecycle phase of the workspace actor.
 ///
 /// ```text
 /// ┌──────────────┐  Initialize  ┌────────────────────────┐
-/// │ Uninitialized│─────────────▶│  Ready(WorkspaceData)  │
+/// │ Uninitialized│─────────────▶│  Ready(ReadyState)  │
 /// └──────────────┘              └────────────────────────┘
 ///                                         │  ChangeRoot
 ///                                         ▼
 ///                               ┌────────────────────────┐
-///                               │  Ready(WorkspaceData') │
+///                               │  Ready(ReadyState') │
 ///                               └────────────────────────┘
 /// ```
 ///
 /// There is no transition back to `Uninitialized`.  A `ChangeRoot` replaces
 /// `Ready` with a fresh `Ready` for the new root.
 #[derive(Debug, Clone, Default)]
-pub(crate) enum WorkspacePhase {
+pub(crate) enum State {
     #[default]
     Uninitialized,
-    Ready(WorkspaceData),
+    Ready(ReadyState),
 }
 
-impl WorkspacePhase {
-    /// Return a reference to the inner [`WorkspaceData`], or `None` if the
+impl State {
+    /// Return a reference to the inner [`ReadyState`], or `None` if the
     /// workspace has not been initialised yet.
-    pub(crate) fn ready(&self) -> Option<&WorkspaceData> {
+    pub(crate) fn ready(&self) -> Option<&ReadyState> {
         match self {
-            WorkspacePhase::Ready(data) => Some(data),
-            WorkspacePhase::Uninitialized => None,
+            State::Ready(data) => Some(data),
+            State::Uninitialized => None,
         }
     }
 
@@ -86,16 +86,16 @@ impl WorkspacePhase {
     /// Returns `None` and does nothing when `Uninitialized`.
     // Used by Wave 3 read handlers; present here for the pattern to be complete.
     #[allow(dead_code)]
-    pub(crate) fn with_ready<F, T>(&self, f: F) -> Option<T>
+    pub(crate) fn ready_or_none<F, T>(&self, f: F) -> Option<T>
     where
-        F: FnOnce(&WorkspaceData) -> T,
+        F: FnOnce(&ReadyState) -> T,
     {
         self.ready().map(f)
     }
 
     /// Transition to `Ready` (or replace the current `Ready`).
-    pub(crate) fn set_ready(&mut self, data: WorkspaceData) {
-        *self = WorkspacePhase::Ready(data);
+    pub(crate) fn set_state(&mut self, data: ReadyState) {
+        *self = State::Ready(data);
     }
 }
 

--- a/src/workspace/phase_tests.rs
+++ b/src/workspace/phase_tests.rs
@@ -1,11 +1,11 @@
-//! Tests for [`WorkspacePhase`] lifecycle transitions.
+//! Tests for [`State`] lifecycle transitions.
 
 use std::path::PathBuf;
 
-use super::{WorkspaceData, WorkspacePhase};
+use super::{ReadyState, State};
 
-fn stub_data(root: &str) -> WorkspaceData {
-    WorkspaceData {
+fn stub_data(root: &str) -> ReadyState {
+    ReadyState {
         root: PathBuf::from(root),
         source_paths: vec![format!("{root}/src")],
         ignore_patterns: vec![],
@@ -14,43 +14,43 @@ fn stub_data(root: &str) -> WorkspaceData {
 
 #[test]
 fn default_phase_is_uninitialized() {
-    let phase = WorkspacePhase::default();
+    let phase = State::default();
     assert!(phase.ready().is_none());
 }
 
 #[test]
-fn set_ready_transitions_to_ready() {
-    let mut phase = WorkspacePhase::default();
-    phase.set_ready(stub_data("/workspace"));
+fn set_state_transitions_to_ready() {
+    let mut phase = State::default();
+    phase.set_state(stub_data("/workspace"));
     assert!(phase.ready().is_some());
     assert_eq!(phase.ready().unwrap().root, PathBuf::from("/workspace"));
 }
 
 #[test]
-fn with_ready_runs_block_only_when_ready() {
-    let uninitialized = WorkspacePhase::default();
-    assert!(uninitialized.with_ready(|d| d.root.clone()).is_none());
+fn ready_or_none_runs_block_only_when_ready() {
+    let uninitialized = State::default();
+    assert!(uninitialized.ready_or_none(|d| d.root.clone()).is_none());
 
-    let mut ready = WorkspacePhase::default();
-    ready.set_ready(stub_data("/project"));
-    let root = ready.with_ready(|d| d.root.clone());
+    let mut ready = State::default();
+    ready.set_state(stub_data("/project"));
+    let root = ready.ready_or_none(|d| d.root.clone());
     assert_eq!(root, Some(PathBuf::from("/project")));
 }
 
 #[test]
-fn set_ready_replaces_existing_ready() {
-    let mut phase = WorkspacePhase::default();
-    phase.set_ready(stub_data("/old-root"));
-    phase.set_ready(stub_data("/new-root"));
+fn set_state_replaces_existing_ready() {
+    let mut phase = State::default();
+    phase.set_state(stub_data("/old-root"));
+    phase.set_state(stub_data("/new-root"));
     assert_eq!(phase.ready().unwrap().root, PathBuf::from("/new-root"));
 }
 
 #[test]
 fn source_paths_preserved_in_ready_data() {
-    let mut phase = WorkspacePhase::default();
+    let mut phase = State::default();
     let mut data = stub_data("/ws");
     data.source_paths.push("/ws/lib".to_owned());
-    phase.set_ready(data);
+    phase.set_state(data);
     assert_eq!(
         phase.ready().unwrap().source_paths,
         vec!["/ws/src".to_owned(), "/ws/lib".to_owned()]


### PR DESCRIPTION
Drop redundant `Workspace` prefix from MVI types — module path provides context.

## Renames
| Before | After |
|---|---|
| `WorkspaceEvent` | `Event` |
| `WorkspacePhase` | `State` |
| `WorkspaceData` | `ReadyState` |
| `WorkspaceEffect` | `Effect` |
| `WorkspaceActor` | `Actor` |
| `WorkspaceConfig` | `Config` |
| `phase_handle()` | `state_stream()` |
| `set_ready()` | `set_state()` |
| `with_ready()` | `ready_or_none()` |

Inspired by Moneta's MVI naming: types are short, module path provides context (`workspace::Event` not `workspace::WorkspaceEvent`).

**Pure rename — no behavioral changes. All 816 tests pass.**