### PR TITLE
Wave 4: ScanQueue OpQueue + FileChanged coalescing

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -239,17 +239,58 @@ If not, and if ≥2 distinct implementations could exist (production + test stub
 - Reserve `Box<dyn Trait>` only for heterogeneous runtime collections or plugin registries.
 - Apply the Rule of Three: wait for the second concrete implementation before abstracting.
 
-### 4. No deep nesting
+### 4. Max 2 levels of `{}` nesting
 
-Functions should have at most 3 levels of indentation in their body.
+A function body is level 1. Every `{` block inside it adds a level. Two is the limit.
 
-Flatten with:
+**Flatten guards with `let-else`** instead of `if let { … } else { … }` or `match { Ok(x) => { … } Err => warn }`:
+
+```rust
+// ✗ — three levels: fn body → if → body
+fn set_root(&self, root: PathBuf) {
+    if let Ok(mut guard) = self.indexer.workspace_root.write() {
+        *guard = Some(root);
+    } else {
+        log::warn!("failed to write workspace root");
+    }
+}
+
+// ✓ — one level: fn body only (see src/workspace/actor.rs Actor::set_root)
+fn set_root(&self, root: PathBuf) {
+    let Ok(mut guard) = self.indexer.workspace_root.write() else {
+        log::warn!("Actor: failed to write workspace root");
+        return;
+    };
+    *guard = Some(root);
+}
+```
+
+When a function needs multiple `Option`/`Result` values, use **separate `let-else`** lines instead of a nested `match (a, b)`:
+
+```rust
+// ✓ — flat (see Actor::is_outside_pinned_workspace_root in src/workspace/actor.rs)
+let Some(opened) = opened_file_path else { return false; };
+let Some(root) = self.current_root()  else { return false; };
+```
+
+**Replace `while`/`loop` + `match`** with `let-else` guards inside the loop:
+
+```rust
+// ✓ — flat loop, no match (see Actor::drain_file_changed_batch in src/workspace/actor.rs)
+loop {
+    let Ok(event) = self.rx.try_recv() else { break };
+    let Event::FileChanged { uri, changes } = event else {
+        self.pushback = Some(event);
+        break;
+    };
+    batch.insert(uri.to_string(), (uri, changes));
+}
+```
+
+Other tools:
 - Early `return` / `return None` guards at the top
 - The `?` operator for error propagation
-- `let … else` for mandatory destructuring
 - Extracted helper functions for inner loops or match arms
-
-A `match` nested inside another `match` inside an `if` is a signal to extract.
 
 ### 5. Section comments inside a function body signal a split
 
@@ -374,6 +415,36 @@ pub(crate) fn with_ready(&self) -> Option<&WorkspaceData> { … }
 
 Remove the allow when the consuming code lands. If the consuming code never lands, the item
 should be deleted.
+
+### 15. Flat event dispatch — one line per variant
+
+The `match` in an event loop is a **dispatch table**, not an implementation. Each arm must be a single method call. All logic lives in named handler functions.
+
+```rust
+// ✓ — flat dispatch, handlers carry the meaning (see Actor::handle_event in src/workspace/actor.rs)
+async fn handle_event(&mut self, event: Event) {
+    match event {
+        Event::Initialize { config, completion_tx } => self.handle_initialize(config, completion_tx).await,
+        Event::Reindex                              => self.handle_reindex().await,
+        Event::FileChanged { uri, changes }         => self.drain_and_apply_file_changes(uri, changes).await,
+        Event::FileSaved { uri }                    => self.handle_file_saved(uri).await,
+        // …
+    }
+}
+```
+
+The calling loop stays readable regardless of how complex individual handlers grow:
+
+```rust
+// ✓ — the loop itself has zero logic (see Actor::run in src/workspace/actor.rs)
+pub(crate) async fn run(mut self) {
+    while let Some(event) = self.receive_event().await {
+        self.handle_event(event).await;
+    }
+}
+```
+
+If an arm needs more than one expression, extract a named method. The arm name must then read as a verb phrase that summarises what happens: `on_scan_completed`, `drain_and_apply_file_changes`.
 
 ## Architecture patterns (from rust-analyzer)
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -7,7 +7,6 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{async_trait, Client, LanguageServer};
 
-use self::helpers::syntax_diagnostics;
 use crate::indexer::resolution::WorkspaceRead;
 use crate::indexer::{workspace_cache_path, IgnoreMatcher, Indexer, ProgressReporter};
 use crate::semantic_tokens;

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -821,8 +821,6 @@ impl Indexer {
         }
         Arc::clone(&self).run_pending_reindex(reporter).await;
     }
-
-    /// If a reindex was queued while a scan was in progress, run it now.
     ///
     /// Called at the end of every public scan function, after the full workflow
     /// (impl + apply + source_paths + save_cache) completes. Mirrors RA's

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -651,7 +651,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         // Runs even if the scan task panics (JoinError path).
         tokio::spawn(async move {
             let completion_tx = scan_handle.await.ok().flatten();
-            completion_tx.map(|tx| tx.send(()));
+            let _ = completion_tx.map(|tx| tx.send(()));
             let _ = scan_done_tx.send(()).await;
         });
     }

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -37,7 +37,7 @@ use super::{Config, Event};
 /// MVI-style actor that owns all workspace write operations.
 ///
 /// Generic over `R` (the progress reporter) so that LSP mode uses
-/// [`LspProgressReporter`](crate::indexer::ProgressReporter) and CLI / tests
+/// [`LspProgressReporter`](crate::backend::LspProgressReporter) and CLI / tests
 /// use [`NoopReporter`](crate::indexer::NoopReporter) — no heap allocation or
 /// vtable dispatch needed at the actor level.
 ///
@@ -92,9 +92,9 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         }
     }
 
-    /// Expose the shared phase handle for read-path consumers introduced in Wave 3.
+    /// Expose the shared state handle for read-path consumers introduced in Wave 3.
     #[allow(dead_code)]
-    pub(crate) fn state_stream(&self) -> Arc<RwLock<State>> {
+    pub(crate) fn state_handle(&self) -> Arc<RwLock<State>> {
         Arc::clone(&self.phase)
     }
 
@@ -186,7 +186,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         // Always write source paths — even when empty — to clear any prior state.
         let source_paths = data.source_paths.clone();
         self.write_source_paths(source_paths.clone());
-        self.set_phase(data).await;
+        self.set_state(data).await;
 
         let args = ScanArgs {
             root,
@@ -236,7 +236,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         self.apply_ignore_patterns(&config.ignore_patterns, &root);
         self.write_source_paths(data.source_paths.clone());
         self.set_root(root.clone());
-        self.set_phase(data.clone()).await;
+        self.set_state(data.clone()).await;
 
         self.indexer.reset_index_state();
         let args = ScanArgs {
@@ -371,10 +371,10 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         }
     }
 
-    // ── Phase management ──────────────────────────────────────────────────────
+    // ── State management ──────────────────────────────────────────────────────
 
     /// Atomically transition to `State::Ready`.
-    async fn set_phase(&self, data: ReadyState) {
+    async fn set_state(&self, data: ReadyState) {
         self.phase.write().await.set_state(data);
     }
 
@@ -510,7 +510,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         let source_paths = data.source_paths.clone();
         self.write_source_paths(source_paths.clone());
         self.set_root(workspace_root.clone());
-        self.set_phase(data).await;
+        self.set_state(data).await;
         self.indexer.workspace_pinned.store(true, Ordering::Relaxed);
         self.indexer.root_generation.fetch_add(1, Ordering::SeqCst);
         self.indexer.reset_index_state();

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -32,6 +32,20 @@ use super::contract::{ReadyState, State};
 use super::scan_queue::{ScanArgs, ScanKind, ScanQueue};
 use super::{Config, Event};
 
+const STRONG_BUILD_MARKERS: &[&str] = &[
+    "build.gradle",
+    "settings.gradle",
+    "build.gradle.kts",
+    "Cargo.toml",
+    "pom.xml",
+    "settings.gradle.kts",
+];
+const WEAK_BUILD_MARKERS: &[&str] = &["Package.swift"];
+
+fn has_any_marker(dir: &Path, markers: &[&str]) -> bool {
+    markers.iter().any(|marker| dir.join(marker).exists())
+}
+
 // ─── Actor ──────────────────────────────────────────────────────────
 
 /// MVI-style actor that owns all workspace write operations.
@@ -104,41 +118,36 @@ impl<R: ProgressReporter + 'static> Actor<R> {
     /// [`Event`] variant must be handled here or the code will not
     /// compile.
     pub(crate) async fn run(mut self) {
-        loop {
-            // Drain the pushback buffer before waiting on channels.
-            let event = if let Some(ev) = self.pushback.take() {
-                ev
-            } else {
-                tokio::select! {
-                    maybe_ev = self.rx.recv() => match maybe_ev {
-                        None => break,
-                        Some(ev) => ev,
-                    },
-                    Some(()) = self.scan_done_rx.recv() => {
-                        self.on_scan_completed();
-                        continue;
-                    },
-                }
-            };
+        while let Some(event) = self.receive_event().await {
+            self.handle_event(event).await;
+        }
+    }
 
-            match event {
-                Event::Initialize {
-                    config,
-                    completion_tx,
-                } => self.handle_initialize(config, completion_tx).await,
-                Event::Reindex => self.handle_reindex().await,
-                Event::ChangeRoot { root } => self.handle_change_root(root).await,
-                Event::FileOpened {
-                    uri,
-                    language_id,
-                    content,
-                } => self.handle_file_opened(uri, language_id, content).await,
-                Event::FileChanged { uri, changes } => {
-                    self.drain_and_apply_file_changes(uri, changes).await;
-                }
-                Event::FileSaved { uri } => self.handle_file_saved(uri).await,
-                Event::FileClosed { uri } => self.handle_file_closed(uri).await,
+    /// Pull the next `Event` from the channel, draining the pushback slot first.
+    ///
+    /// When a scan completes between events, `on_scan_completed` is called
+    /// transparently and the loop retries — callers never see a `None` for that.
+    async fn receive_event(&mut self) -> Option<Event> {
+        if let Some(ev) = self.pushback.take() {
+            return Some(ev);
+        }
+        loop {
+            tokio::select! {
+                maybe_ev = self.rx.recv() => return maybe_ev,
+                Some(()) = self.scan_done_rx.recv() => self.on_scan_completed(),
             }
+        }
+    }
+
+    async fn handle_event(&mut self, event: Event) {
+        match event {
+            Event::Initialize { config, completion_tx } => self.handle_initialize(config, completion_tx).await,
+            Event::Reindex => self.handle_reindex().await,
+            Event::ChangeRoot { root } => self.handle_change_root(root).await,
+            Event::FileOpened { uri, language_id, content } => self.handle_file_opened(uri, language_id, content).await,
+            Event::FileChanged { uri, changes } => self.drain_and_apply_file_changes(uri, changes).await,
+            Event::FileSaved { uri } => self.handle_file_saved(uri).await,
+            Event::FileClosed { uri } => self.handle_file_closed(uri).await,
         }
     }
 
@@ -305,26 +314,32 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         uri: Url,
         changes: Vec<tower_lsp::lsp_types::TextDocumentContentChangeEvent>,
     ) {
-        let mut batch: HashMap<
-            String,
-            (Url, Vec<tower_lsp::lsp_types::TextDocumentContentChangeEvent>),
-        > = HashMap::new();
-        batch.insert(uri.to_string(), (uri, changes));
-        loop {
-            match self.rx.try_recv() {
-                Ok(Event::FileChanged { uri, changes }) => {
-                    batch.insert(uri.to_string(), (uri, changes));
-                }
-                Ok(other) => {
-                    self.pushback = Some(other);
-                    break;
-                }
-                Err(_) => break,
-            }
-        }
-        for (_, (uri, changes)) in batch {
+        let mut batch = self.drain_file_changed_batch(uri, changes);
+        for (_, (uri, changes)) in batch.drain() {
             self.handle_file_changed(uri, changes).await;
         }
+    }
+
+    /// Drain all immediately available `FileChanged` events into a deduplicated map.
+    ///
+    /// Starts with the triggering event then drains the channel with `try_recv`.
+    /// Any non-`FileChanged` event is pushed back for the next iteration.
+    fn drain_file_changed_batch(
+        &mut self,
+        uri: Url,
+        changes: Vec<tower_lsp::lsp_types::TextDocumentContentChangeEvent>,
+    ) -> HashMap<String, (Url, Vec<tower_lsp::lsp_types::TextDocumentContentChangeEvent>)> {
+        let mut batch = HashMap::new();
+        batch.insert(uri.to_string(), (uri, changes));
+        loop {
+            let Ok(event) = self.rx.try_recv() else { break };
+            let Event::FileChanged { uri, changes } = event else {
+                self.pushback = Some(event);
+                break;
+            };
+            batch.insert(uri.to_string(), (uri, changes));
+        }
+        batch
     }
 
     /// Apply a root-switch config (no explicit source paths or ignore patterns).
@@ -391,11 +406,11 @@ impl<R: ProgressReporter + 'static> Actor<R> {
     }
 
     fn set_root(&self, root: PathBuf) {
-        if let Ok(mut guard) = self.indexer.workspace_root.write() {
-            *guard = Some(root);
-        } else {
+        let Ok(mut guard) = self.indexer.workspace_root.write() else {
             log::warn!("Actor: failed to write workspace root");
-        }
+            return;
+        };
+        *guard = Some(root);
     }
 
     fn write_source_paths(&self, paths: Vec<String>) {
@@ -415,15 +430,14 @@ impl<R: ProgressReporter + 'static> Actor<R> {
     }
 
     fn apply_ignore_patterns(&self, patterns: &[String], root: &Path) {
-        match self.indexer.ignore_matcher.write() {
-            Ok(mut guard) => {
-                // Always write — even when empty — to clear any stale matcher from
-                // a previous Initialize or root switch.
-                *guard = (!patterns.is_empty())
-                    .then(|| Arc::new(IgnoreMatcher::new(patterns.to_vec(), root)));
-            }
-            Err(err) => log::warn!("Actor: failed to write ignore_matcher: {err}"),
-        }
+        let Ok(mut guard) = self.indexer.ignore_matcher.write() else {
+            log::warn!("Actor: failed to write ignore_matcher");
+            return;
+        };
+        // Always write — even when empty — to clear any stale matcher from
+        // a previous Initialize or root switch.
+        *guard = (!patterns.is_empty())
+            .then(|| Arc::new(IgnoreMatcher::new(patterns.to_vec(), root)));
     }
 
     fn detect_workspace_root_switch(
@@ -442,45 +456,26 @@ impl<R: ProgressReporter + 'static> Actor<R> {
     }
 
     fn auto_detect_workspace_root(opened_file_path: &Path) -> Option<PathBuf> {
-        let strong_markers = [
-            "build.gradle",
-            "settings.gradle",
-            "build.gradle.kts",
-            "Cargo.toml",
-            "pom.xml",
-            "settings.gradle.kts",
-        ];
-        let weak_markers = ["Package.swift"];
-        let mut current_directory = opened_file_path.parent().map(Path::to_path_buf);
-        let mut nearest_strong_marker_root: Option<PathBuf> = None;
-        let mut git_root: Option<PathBuf> = None;
-        let mut nearest_weak_marker_root: Option<PathBuf> = None;
+        let mut strong: Option<PathBuf> = None;
+        let mut git: Option<PathBuf> = None;
+        let mut weak: Option<PathBuf> = None;
 
-        while let Some(directory) = current_directory {
-            if nearest_strong_marker_root.is_none()
-                && strong_markers
-                    .iter()
-                    .any(|marker| directory.join(marker).exists())
-            {
-                nearest_strong_marker_root = Some(directory.clone());
+        for dir in opened_file_path.ancestors().skip(1) {
+            if strong.is_none() && has_any_marker(dir, STRONG_BUILD_MARKERS) {
+                strong = Some(dir.to_path_buf());
             }
-            if directory.join(".git").exists() {
-                git_root = Some(directory.clone());
+            if dir.join(".git").exists() {
+                git = Some(dir.to_path_buf());
                 break;
             }
-            if nearest_weak_marker_root.is_none()
-                && weak_markers
-                    .iter()
-                    .any(|marker| directory.join(marker).exists())
-            {
-                nearest_weak_marker_root = Some(directory.clone());
+            if weak.is_none() && has_any_marker(dir, WEAK_BUILD_MARKERS) {
+                weak = Some(dir.to_path_buf());
             }
-            current_directory = directory.parent().map(Path::to_path_buf);
         }
 
-        nearest_strong_marker_root
-            .or(git_root)
-            .or(nearest_weak_marker_root)
+        strong
+            .or(git)
+            .or(weak)
             .or_else(|| opened_file_path.parent().map(Path::to_path_buf))
     }
 
@@ -489,16 +484,13 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         opened_file_path: &Path,
         candidate_workspace_root: &Path,
     ) -> bool {
-        let candidate_workspace_root = Self::canonicalize_or_clone(candidate_workspace_root);
-        match self.current_root() {
-            None => true,
-            Some(current_workspace_root) => {
-                let current_workspace_root = Self::canonicalize_or_clone(&current_workspace_root);
-                let opened_file_path = Self::canonicalize_or_clone(opened_file_path);
-                !opened_file_path.starts_with(&current_workspace_root)
-                    && candidate_workspace_root != current_workspace_root
-            }
-        }
+        let Some(current_root) = self.current_root() else {
+            return true;
+        };
+        let candidate = Self::canonicalize_or_clone(candidate_workspace_root);
+        let current = Self::canonicalize_or_clone(&current_root);
+        let file = Self::canonicalize_or_clone(opened_file_path);
+        !file.starts_with(&current) && candidate != current
     }
 
     fn canonicalize_or_clone(path: &Path) -> PathBuf {
@@ -539,16 +531,11 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         if !workspace_pinned {
             return false;
         }
-
-        match (opened_file_path, self.current_root()) {
-            (Some(opened_file_path), Some(current_workspace_root)) => {
-                let opened_file_path = Self::canonicalize_or_clone(opened_file_path);
-                let current_workspace_root =
-                    Self::canonicalize_or_clone(current_workspace_root.as_path());
-                !opened_file_path.starts_with(&current_workspace_root)
-            }
-            _ => false,
-        }
+        let Some(opened_file_path) = opened_file_path else { return false; };
+        let Some(current_root) = self.current_root() else { return false; };
+        let opened = Self::canonicalize_or_clone(opened_file_path);
+        let root = Self::canonicalize_or_clone(current_root.as_path());
+        !opened.starts_with(&root)
     }
 
     async fn store_live_document_state(&self, uri: &Url, content: &str) {
@@ -564,13 +551,12 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         let indexer = Arc::clone(&self.indexer);
         let semaphore = indexer.parse_sem();
         tokio::task::spawn(async move {
-            if let Ok(permit) = semaphore.acquire_owned().await {
-                let _ = tokio::task::spawn_blocking(move || {
-                    let _permit = permit;
-                    indexer.index_content(&uri, &content);
-                })
-                .await;
-            }
+            let Ok(permit) = semaphore.acquire_owned().await else { return };
+            let _ = tokio::task::spawn_blocking(move || {
+                let _permit = permit;
+                indexer.index_content(&uri, &content);
+            })
+            .await;
         });
     }
 
@@ -651,9 +637,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
                 *guard = args.source_paths.clone();
             }
             match args.kind {
-                ScanKind::Full => {
-                    indexer.index_workspace_full(&args.root, reporter).await;
-                }
+                ScanKind::Full => indexer.index_workspace_full(&args.root, reporter).await,
                 ScanKind::Prioritized { initial_paths } => {
                     indexer
                         .index_workspace_prioritized(&args.root, initial_paths, reporter)
@@ -667,9 +651,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         // Runs even if the scan task panics (JoinError path).
         tokio::spawn(async move {
             let completion_tx = scan_handle.await.ok().flatten();
-            if let Some(tx) = completion_tx {
-                let _ = tx.send(());
-            }
+            completion_tx.map(|tx| tx.send(()));
             let _ = scan_done_tx.send(()).await;
         });
     }

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -115,10 +115,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
                         Some(ev) => ev,
                     },
                     Some(()) = self.scan_done_rx.recv() => {
-                        self.scan_queue.completed();
-                        if let Some(args) = self.scan_queue.try_start() {
-                            self.execute_scan(args);
-                        }
+                        self.on_scan_completed();
                         continue;
                     },
                 }
@@ -137,29 +134,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
                     content,
                 } => self.handle_file_opened(uri, language_id, content).await,
                 Event::FileChanged { uri, changes } => {
-                    // Coalesce: drain all immediately available FileChanged events.
-                    // Last change per URI wins (HashMap deduplication).
-                    let mut batch: HashMap<
-                        String,
-                        (Url, Vec<tower_lsp::lsp_types::TextDocumentContentChangeEvent>),
-                    > = HashMap::new();
-                    batch.insert(uri.to_string(), (uri, changes));
-                    loop {
-                        match self.rx.try_recv() {
-                            Ok(Event::FileChanged { uri, changes }) => {
-                                batch.insert(uri.to_string(), (uri, changes));
-                            }
-                            Ok(other) => {
-                                // Non-FileChanged event — push back and stop draining.
-                                self.pushback = Some(other);
-                                break;
-                            }
-                            Err(_) => break, // channel empty or closed
-                        }
-                    }
-                    for (_, (uri, changes)) in batch {
-                        self.handle_file_changed(uri, changes).await;
-                    }
+                    self.drain_and_apply_file_changes(uri, changes).await;
                 }
                 Event::FileSaved { uri } => self.handle_file_saved(uri).await,
                 Event::FileClosed { uri } => self.handle_file_closed(uri).await,
@@ -205,38 +180,18 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             return;
         };
         self.indexer.reset_index_state();
-        let source_paths = self
-            .indexer
-            .source_paths_raw
-            .read()
-            .ok()
-            .map(|g| g.clone())
-            .unwrap_or_default();
         let args = ScanArgs {
             root,
             kind: ScanKind::Full,
-            source_paths,
+            source_paths: self.current_source_paths(),
             completion_tx: None,
         };
         self.enqueue_and_start_scan(args);
     }
 
     async fn handle_change_root(&mut self, root: PathBuf) {
-        // Clear stale ignore patterns from the previous root, then re-resolve
-        // source paths for the new root (workspace.json, build layout, etc.).
-        // Explicit source paths from initialization are intentionally dropped
-        // because they were relative to the old root and are editor-session-scoped.
-        let config = Config {
-            root: root.clone(),
-            explicit_source_paths: Vec::new(),
-            ignore_patterns: Vec::new(),
-        };
-        let data = ReadyState::from_config(&config);
-
-        self.apply_ignore_patterns(&config.ignore_patterns, &root);
-        self.write_source_paths(data.source_paths.clone());
-        self.set_root(root.clone());
-        self.set_state(data.clone()).await;
+        let config = Config::for_root(root.clone());
+        let data = self.apply_root_switch_config(&config).await;
 
         self.indexer.reset_index_state();
         let args = ScanArgs {
@@ -288,52 +243,12 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             return;
         };
         let text = change.text;
-        let indexer = Arc::clone(&self.indexer);
 
         self.indexer.set_live_lines(&uri, &text);
-        {
-            let indexer = Arc::clone(&self.indexer);
-            let uri = uri.clone();
-            let text = text.clone();
-            // Fire-and-forget: live-tree parse runs on a blocking thread but we
-            // do not await it in the actor loop to avoid blocking subsequent events.
-            // The 300 ms debounce below provides ample time for the parse to finish
-            // before index_content consumes the updated live tree.
-            // Dropping the JoinHandle detaches from the task; the blocking thread
-            // continues and cannot be cancelled.
-            drop(tokio::task::spawn_blocking(move || {
-                indexer.store_live_tree(&uri, &text);
-            }));
-        }
-
-        let key = uri.to_string();
-        if let Some(handle) = self.pending_reindex.remove(&key) {
-            handle.abort();
-        }
-
-        let client = self.client.clone();
-        let sem = indexer.parse_sem();
-        let handle = tokio::spawn(async move {
-            tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
-            let Ok(permit) = sem.acquire_owned().await else {
-                return;
-            };
-            let diagnostics_uri = uri.clone();
-            let result = tokio::task::spawn_blocking(move || {
-                let data = indexer.index_content(&uri, &text);
-                drop(permit); // release semaphore after index_content completes
-                data
-            })
-            .await;
-
-            if let (Some(client), Ok(Some(data))) = (client, result) {
-                let diagnostics = syntax_diagnostics(&data.syntax_errors);
-                client
-                    .publish_diagnostics(diagnostics_uri, diagnostics, None)
-                    .await;
-            }
-        });
-        self.pending_reindex.insert(key, handle.abort_handle());
+        // Fire-and-forget: live-tree parse must finish before the 300ms debounce
+        // below fires index_content — that window is the correctness coupling.
+        self.spawn_live_tree_update(uri.clone(), text.clone());
+        self.reschedule_debounced_reindex(uri, text);
     }
 
     async fn handle_file_saved(&mut self, uri: Url) {
@@ -380,6 +295,93 @@ impl<R: ProgressReporter + 'static> Actor<R> {
 
     // ── Internal helpers ──────────────────────────────────────────────────────
 
+    /// Coalesce all immediately available `FileChanged` events before applying.
+    ///
+    /// Drains the channel via `try_recv`, deduplicating by URI (last write wins).
+    /// A non-`FileChanged` event encountered during the drain is pushed back for
+    /// the next loop iteration.
+    async fn drain_and_apply_file_changes(
+        &mut self,
+        uri: Url,
+        changes: Vec<tower_lsp::lsp_types::TextDocumentContentChangeEvent>,
+    ) {
+        let mut batch: HashMap<
+            String,
+            (Url, Vec<tower_lsp::lsp_types::TextDocumentContentChangeEvent>),
+        > = HashMap::new();
+        batch.insert(uri.to_string(), (uri, changes));
+        loop {
+            match self.rx.try_recv() {
+                Ok(Event::FileChanged { uri, changes }) => {
+                    batch.insert(uri.to_string(), (uri, changes));
+                }
+                Ok(other) => {
+                    self.pushback = Some(other);
+                    break;
+                }
+                Err(_) => break,
+            }
+        }
+        for (_, (uri, changes)) in batch {
+            self.handle_file_changed(uri, changes).await;
+        }
+    }
+
+    /// Apply a root-switch config (no explicit source paths or ignore patterns).
+    ///
+    /// Shared by `handle_change_root` and `switch_workspace_root_for_opened_document`.
+    /// *Not* used by `handle_initialize`, which preserves editor-provided
+    /// `explicit_source_paths`/`ignore_patterns` and has a stricter root-first ordering.
+    async fn apply_root_switch_config(&mut self, config: &Config) -> ReadyState {
+        let data = ReadyState::from_config(config);
+        self.apply_ignore_patterns(&config.ignore_patterns, &data.root);
+        self.write_source_paths(data.source_paths.clone());
+        self.set_root(data.root.clone());
+        self.set_state(data.clone()).await;
+        data
+    }
+
+    /// Fire-and-forget: update the live parse tree on a blocking thread.
+    ///
+    /// The 300 ms debounce in `reschedule_debounced_reindex` provides ample time
+    /// for this to finish before `index_content` consumes the updated tree.
+    fn spawn_live_tree_update(&self, uri: Url, text: String) {
+        let indexer = Arc::clone(&self.indexer);
+        drop(tokio::task::spawn_blocking(move || {
+            indexer.store_live_tree(&uri, &text);
+        }));
+    }
+
+    /// Cancel any in-flight reindex for `uri` and schedule a fresh one after 300 ms.
+    fn reschedule_debounced_reindex(&mut self, uri: Url, text: String) {
+        let key = uri.to_string();
+        if let Some(handle) = self.pending_reindex.remove(&key) {
+            handle.abort();
+        }
+        let indexer = Arc::clone(&self.indexer);
+        let client = self.client.clone();
+        let handle = tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+            let Ok(permit) = indexer.parse_sem().acquire_owned().await else {
+                return;
+            };
+            let diagnostics_uri = uri.clone();
+            let result = tokio::task::spawn_blocking(move || {
+                let data = indexer.index_content(&uri, &text);
+                drop(permit); // release semaphore after index_content completes
+                data
+            })
+            .await;
+            if let (Some(client), Ok(Some(data))) = (client, result) {
+                let diagnostics = syntax_diagnostics(&data.syntax_errors);
+                client
+                    .publish_diagnostics(diagnostics_uri, diagnostics, None)
+                    .await;
+            }
+        });
+        self.pending_reindex.insert(key, handle.abort_handle());
+    }
+
     fn current_root(&self) -> Option<PathBuf> {
         self.indexer
             .workspace_root
@@ -401,6 +403,15 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             Ok(mut guard) => *guard = paths,
             Err(err) => log::warn!("Actor: failed to write source_paths_raw: {err}"),
         }
+    }
+
+    fn current_source_paths(&self) -> Vec<String> {
+        self.indexer
+            .source_paths_raw
+            .read()
+            .ok()
+            .map(|guard| guard.clone())
+            .unwrap_or_default()
     }
 
     fn apply_ignore_patterns(&self, patterns: &[String], root: &Path) {
@@ -499,18 +510,9 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         workspace_root: PathBuf,
         opened_file_path: Option<PathBuf>,
     ) {
-        let config = Config {
-            root: workspace_root.clone(),
-            explicit_source_paths: Vec::new(),
-            ignore_patterns: Vec::new(),
-        };
-        let data = ReadyState::from_config(&config);
+        let config = Config::for_root(workspace_root.clone());
+        let data = self.apply_root_switch_config(&config).await;
 
-        self.apply_ignore_patterns(&config.ignore_patterns, &workspace_root);
-        let source_paths = data.source_paths.clone();
-        self.write_source_paths(source_paths.clone());
-        self.set_root(workspace_root.clone());
-        self.set_state(data).await;
         self.indexer.workspace_pinned.store(true, Ordering::Relaxed);
         self.indexer.root_generation.fetch_add(1, Ordering::SeqCst);
         self.indexer.reset_index_state();
@@ -523,7 +525,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             kind: ScanKind::Prioritized {
                 initial_paths: opened_file_path.into_iter().collect(),
             },
-            source_paths,
+            source_paths: data.source_paths,
             completion_tx: None,
         };
         self.enqueue_and_start_scan(args);
@@ -608,6 +610,13 @@ impl<R: ProgressReporter + 'static> Actor<R> {
     }
 
     // ── Scan queue management ─────────────────────────────────────────────────
+
+    fn on_scan_completed(&mut self) {
+        self.scan_queue.completed();
+        if let Some(args) = self.scan_queue.try_start() {
+            self.execute_scan(args);
+        }
+    }
 
     /// Queue a scan request and start it immediately if no scan is in progress.
     ///

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -29,6 +29,7 @@ use crate::indexer::{Indexer, ProgressReporter};
 use crate::rg::IgnoreMatcher;
 
 use super::contract::{ReadyState, State};
+use super::scan_queue::{ScanArgs, ScanKind, ScanQueue};
 use super::{Config, Event};
 
 // ─── Actor ──────────────────────────────────────────────────────────
@@ -51,6 +52,17 @@ pub(crate) struct Actor<R: ProgressReporter + 'static> {
     /// Shared so that read-path consumers can observe workspace state without
     /// touching Indexer's internal lock fields directly.
     phase: Arc<RwLock<State>>,
+    /// Coalescing queue for full-workspace scans (Initialize / Reindex / ChangeRoot).
+    /// At most one scan runs at a time; newer requests replace pending ones.
+    scan_queue: ScanQueue,
+    /// Signals the actor's `run()` loop when a scan task finishes (or panics).
+    scan_done_tx: mpsc::Sender<()>,
+    scan_done_rx: mpsc::Receiver<()>,
+    /// Single-slot pushback for the FileChanged drain loop.
+    /// When a non-FileChanged event is encountered while draining, it is stored
+    /// here so it is processed at the start of the next loop iteration.
+    /// Invariant: at most one event is stored at any time.
+    pushback: Option<Event>,
 }
 
 impl<R: ProgressReporter + 'static> Actor<R> {
@@ -65,6 +77,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         rx: mpsc::Receiver<Event>,
         client: Option<Client>,
     ) -> Self {
+        let (scan_done_tx, scan_done_rx) = mpsc::channel(8);
         Self {
             indexer,
             reporter,
@@ -72,6 +85,10 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             client,
             pending_reindex: HashMap::new(),
             phase: Arc::new(RwLock::new(State::Uninitialized)),
+            scan_queue: ScanQueue::new(),
+            scan_done_tx,
+            scan_done_rx,
+            pushback: None,
         }
     }
 
@@ -87,7 +104,26 @@ impl<R: ProgressReporter + 'static> Actor<R> {
     /// [`Event`] variant must be handled here or the code will not
     /// compile.
     pub(crate) async fn run(mut self) {
-        while let Some(event) = self.rx.recv().await {
+        loop {
+            // Drain the pushback buffer before waiting on channels.
+            let event = if let Some(ev) = self.pushback.take() {
+                ev
+            } else {
+                tokio::select! {
+                    maybe_ev = self.rx.recv() => match maybe_ev {
+                        None => break,
+                        Some(ev) => ev,
+                    },
+                    Some(()) = self.scan_done_rx.recv() => {
+                        self.scan_queue.completed();
+                        if let Some(args) = self.scan_queue.try_start() {
+                            self.execute_scan(args);
+                        }
+                        continue;
+                    },
+                }
+            };
+
             match event {
                 Event::Initialize {
                     config,
@@ -101,7 +137,29 @@ impl<R: ProgressReporter + 'static> Actor<R> {
                     content,
                 } => self.handle_file_opened(uri, language_id, content).await,
                 Event::FileChanged { uri, changes } => {
-                    self.handle_file_changed(uri, changes).await;
+                    // Coalesce: drain all immediately available FileChanged events.
+                    // Last change per URI wins (HashMap deduplication).
+                    let mut batch: HashMap<
+                        String,
+                        (Url, Vec<tower_lsp::lsp_types::TextDocumentContentChangeEvent>),
+                    > = HashMap::new();
+                    batch.insert(uri.to_string(), (uri, changes));
+                    loop {
+                        match self.rx.try_recv() {
+                            Ok(Event::FileChanged { uri, changes }) => {
+                                batch.insert(uri.to_string(), (uri, changes));
+                            }
+                            Ok(other) => {
+                                // Non-FileChanged event — push back and stop draining.
+                                self.pushback = Some(other);
+                                break;
+                            }
+                            Err(_) => break, // channel empty or closed
+                        }
+                    }
+                    for (_, (uri, changes)) in batch {
+                        self.handle_file_changed(uri, changes).await;
+                    }
                 }
                 Event::FileSaved { uri } => self.handle_file_saved(uri).await,
                 Event::FileClosed { uri } => self.handle_file_closed(uri).await,
@@ -126,10 +184,19 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         self.apply_ignore_patterns(&config.ignore_patterns, &root);
 
         // Always write source paths — even when empty — to clear any prior state.
-        self.write_source_paths(data.source_paths.clone());
+        let source_paths = data.source_paths.clone();
+        self.write_source_paths(source_paths.clone());
         self.set_phase(data).await;
 
-        self.spawn_scan(root, Vec::new(), completion_tx).await;
+        let args = ScanArgs {
+            root,
+            kind: ScanKind::Prioritized {
+                initial_paths: Vec::new(),
+            },
+            source_paths,
+            completion_tx,
+        };
+        self.enqueue_and_start_scan(args);
     }
 
     async fn handle_reindex(&mut self) {
@@ -138,7 +205,20 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             return;
         };
         self.indexer.reset_index_state();
-        self.spawn_full_scan(root).await;
+        let source_paths = self
+            .indexer
+            .source_paths_raw
+            .read()
+            .ok()
+            .map(|g| g.clone())
+            .unwrap_or_default();
+        let args = ScanArgs {
+            root,
+            kind: ScanKind::Full,
+            source_paths,
+            completion_tx: None,
+        };
+        self.enqueue_and_start_scan(args);
     }
 
     async fn handle_change_root(&mut self, root: PathBuf) {
@@ -156,10 +236,16 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         self.apply_ignore_patterns(&config.ignore_patterns, &root);
         self.write_source_paths(data.source_paths.clone());
         self.set_root(root.clone());
-        self.set_phase(data).await;
+        self.set_phase(data.clone()).await;
 
         self.indexer.reset_index_state();
-        self.spawn_full_scan(root).await;
+        let args = ScanArgs {
+            root,
+            kind: ScanKind::Full,
+            source_paths: data.source_paths,
+            completion_tx: None,
+        };
+        self.enqueue_and_start_scan(args);
     }
 
     async fn handle_file_opened(&mut self, uri: Url, _language_id: String, content: String) {
@@ -421,7 +507,8 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         let data = ReadyState::from_config(&config);
 
         self.apply_ignore_patterns(&config.ignore_patterns, &workspace_root);
-        self.write_source_paths(data.source_paths.clone());
+        let source_paths = data.source_paths.clone();
+        self.write_source_paths(source_paths.clone());
         self.set_root(workspace_root.clone());
         self.set_phase(data).await;
         self.indexer.workspace_pinned.store(true, Ordering::Relaxed);
@@ -431,8 +518,15 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             "Auto-detected workspace root (now pinned): {}",
             workspace_root.display()
         );
-        self.spawn_scan(workspace_root, opened_file_path.into_iter().collect(), None)
-            .await;
+        let args = ScanArgs {
+            root: workspace_root,
+            kind: ScanKind::Prioritized {
+                initial_paths: opened_file_path.into_iter().collect(),
+            },
+            source_paths,
+            completion_tx: None,
+        };
+        self.enqueue_and_start_scan(args);
     }
 
     fn is_outside_pinned_workspace_root(
@@ -513,32 +607,61 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         });
     }
 
-    /// Spawn a prioritized bounded scan in the background.
-    /// `initial_paths` are indexed first (empty = no prioritization).
-    async fn spawn_scan(
-        &self,
-        root: PathBuf,
-        initial_paths: Vec<PathBuf>,
-        completion_tx: Option<oneshot::Sender<()>>,
-    ) {
-        let indexer = Arc::clone(&self.indexer);
-        let reporter = Arc::clone(&self.reporter);
-        tokio::spawn(async move {
-            indexer
-                .index_workspace_prioritized(&root, initial_paths, reporter)
-                .await;
-            if let Some(completion_tx) = completion_tx {
-                let _ = completion_tx.send(());
-            }
-        });
+    // ── Scan queue management ─────────────────────────────────────────────────
+
+    /// Queue a scan request and start it immediately if no scan is in progress.
+    ///
+    /// If a scan is already running, bump `root_generation` to invalidate it
+    /// (so stale results are discarded) and store the new request as pending.
+    fn enqueue_and_start_scan(&mut self, args: ScanArgs) {
+        if self.scan_queue.is_in_progress() {
+            // Invalidate the in-flight scan so it discards its (now-stale) results.
+            self.indexer.root_generation.fetch_add(1, Ordering::SeqCst);
+        }
+        self.scan_queue.request(args);
+        if let Some(args) = self.scan_queue.try_start() {
+            self.execute_scan(args);
+        }
     }
 
-    /// Spawn an unbounded full scan (used by Reindex and ChangeRoot).
-    async fn spawn_full_scan(&self, root: PathBuf) {
+    /// Spawn a workspace scan task.
+    ///
+    /// Sends to `scan_done_tx` when the task finishes — even on panic — so the
+    /// actor's `run()` loop always clears `in_progress` and can start queued work.
+    fn execute_scan(&self, args: ScanArgs) {
         let indexer = Arc::clone(&self.indexer);
         let reporter = Arc::clone(&self.reporter);
+        let scan_done_tx = self.scan_done_tx.clone();
+
+        let scan_handle = tokio::spawn(async move {
+            // Claim this scan's source paths right before running.  By the time
+            // this task executes, the actor may have processed later events that
+            // overwrote source_paths_raw.  Writing here ensures finalize_workspace_scan
+            // uses the paths that were configured when this scan was enqueued.
+            if let Ok(mut guard) = indexer.source_paths_raw.write() {
+                *guard = args.source_paths.clone();
+            }
+            match args.kind {
+                ScanKind::Full => {
+                    indexer.index_workspace_full(&args.root, reporter).await;
+                }
+                ScanKind::Prioritized { initial_paths } => {
+                    indexer
+                        .index_workspace_prioritized(&args.root, initial_paths, reporter)
+                        .await;
+                }
+            }
+            args.completion_tx
+        });
+
+        // Watcher task: forwards completion_tx signal and notifies actor.
+        // Runs even if the scan task panics (JoinError path).
         tokio::spawn(async move {
-            indexer.index_workspace_full(&root, reporter).await;
+            let completion_tx = scan_handle.await.ok().flatten();
+            if let Some(tx) = completion_tx {
+                let _ = tx.send(());
+            }
+            let _ = scan_done_tx.send(()).await;
         });
     }
 }

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -179,6 +179,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             },
             source_paths,
             completion_tx,
+            expected_generation: 0, // stamped by enqueue_and_start_scan
         };
         self.enqueue_and_start_scan(args);
     }
@@ -194,6 +195,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             kind: ScanKind::Full,
             source_paths: self.current_source_paths(),
             completion_tx: None,
+            expected_generation: 0, // stamped by enqueue_and_start_scan
         };
         self.enqueue_and_start_scan(args);
     }
@@ -208,6 +210,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             kind: ScanKind::Full,
             source_paths: data.source_paths,
             completion_tx: None,
+            expected_generation: 0, // stamped by enqueue_and_start_scan
         };
         self.enqueue_and_start_scan(args);
     }
@@ -519,6 +522,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             },
             source_paths: data.source_paths,
             completion_tx: None,
+            expected_generation: 0, // stamped by enqueue_and_start_scan
         };
         self.enqueue_and_start_scan(args);
     }
@@ -613,6 +617,12 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             // Invalidate the in-flight scan so it discards its (now-stale) results.
             self.indexer.root_generation.fetch_add(1, Ordering::SeqCst);
         }
+        // Stamp the generation *after* any bump so the task knows which
+        // generation it was enqueued for.
+        let args = ScanArgs {
+            expected_generation: self.indexer.root_generation.load(Ordering::SeqCst),
+            ..args
+        };
         self.scan_queue.request(args);
         if let Some(args) = self.scan_queue.try_start() {
             self.execute_scan(args);
@@ -627,8 +637,14 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         let indexer = Arc::clone(&self.indexer);
         let reporter = Arc::clone(&self.reporter);
         let scan_done_tx = self.scan_done_tx.clone();
+        let expected_gen = args.expected_generation;
 
         let scan_handle = tokio::spawn(async move {
+            // Bail out immediately if a newer scan superseded this one before
+            // the task even started running.
+            if indexer.root_generation.load(Ordering::SeqCst) != expected_gen {
+                return None;
+            }
             // Claim this scan's source paths right before running.  By the time
             // this task executes, the actor may have processed later events that
             // overwrote source_paths_raw.  Writing here ensures finalize_workspace_scan
@@ -636,6 +652,9 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             if let Ok(mut guard) = indexer.source_paths_raw.write() {
                 *guard = args.source_paths.clone();
             }
+            // Clone before the match so we can check generation after the scan
+            // even if index_workspace_full moves the Arc.
+            let generation_ref = Arc::clone(&indexer);
             match args.kind {
                 ScanKind::Full => indexer.index_workspace_full(&args.root, reporter).await,
                 ScanKind::Prioritized { initial_paths } => {
@@ -644,7 +663,13 @@ impl<R: ProgressReporter + 'static> Actor<R> {
                         .await;
                 }
             }
-            args.completion_tx
+            // Only signal completion if this scan is still the current one.
+            // A newer request may have arrived while the scan was running.
+            if generation_ref.root_generation.load(Ordering::SeqCst) == expected_gen {
+                args.completion_tx
+            } else {
+                None
+            }
         });
 
         // Watcher task: forwards completion_tx signal and notifies actor.

--- a/src/workspace/actor_tests.rs
+++ b/src/workspace/actor_tests.rs
@@ -179,3 +179,107 @@ async fn actor_stops_when_sender_dropped() {
         .expect("actor did not stop within 2s after sender drop")
         .unwrap();
 }
+
+// ─── OpQueue coalescing tests ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn multiple_initialize_last_one_runs() {
+    // Three Initialize events are queued before the actor can process any.
+    // The actor starts scan1 immediately (from event 1), then coalesces events
+    // 2 and 3 into a single pending scan.  After scan1 finishes, only scan3
+    // (last-write-wins) runs.  The final workspace root must be from event 3.
+    let indexer = Arc::new(Indexer::new());
+    let tmp1 = temp_dir();
+    let tmp2 = temp_dir();
+    let tmp3 = temp_dir();
+
+    let (actor, tx) = make_actor(Arc::clone(&indexer));
+    tokio::spawn(actor.run());
+
+    let (done_tx, done_rx) = oneshot::channel();
+    // try_send: all three land in the channel before the actor runs.
+    tx.try_send(Event::Initialize {
+        config: Config {
+            root: tmp1.path().to_path_buf(),
+            explicit_source_paths: Vec::new(),
+            ignore_patterns: Vec::new(),
+        },
+        completion_tx: None,
+    })
+    .unwrap();
+    tx.try_send(Event::Initialize {
+        config: Config {
+            root: tmp2.path().to_path_buf(),
+            explicit_source_paths: Vec::new(),
+            ignore_patterns: Vec::new(),
+        },
+        completion_tx: None,
+    })
+    .unwrap();
+    tx.try_send(Event::Initialize {
+        config: Config {
+            root: tmp3.path().to_path_buf(),
+            explicit_source_paths: Vec::new(),
+            ignore_patterns: Vec::new(),
+        },
+        completion_tx: Some(done_tx),
+    })
+    .unwrap();
+
+    // The last initialize's completion_tx fires when all pending scans finish.
+    tokio::time::timeout(Duration::from_secs(5), done_rx)
+        .await
+        .expect("last initialize should complete within 5s")
+        .unwrap();
+
+    let root = indexer.workspace_root.read().unwrap().clone();
+    assert_eq!(
+        root.as_deref(),
+        Some(tmp3.path()),
+        "final workspace root should be from the last Initialize"
+    );
+}
+
+#[tokio::test]
+async fn file_changed_coalesced_per_uri() {
+    // Three FileChanged events for the same URI arrive in rapid succession.
+    // The coalescing logic keeps only the last change per URI.
+    // live_lines should reflect the final content ("v3").
+    let indexer = Arc::new(Indexer::new());
+    let (actor, tx) = make_actor(Arc::clone(&indexer));
+    tokio::spawn(actor.run());
+
+    let uri = tower_lsp::lsp_types::Url::parse("file:///tmp/test.kt").unwrap();
+
+    // Queue all three before the actor drains them.
+    for text in ["v1", "v2", "v3"] {
+        tx.try_send(Event::FileChanged {
+            uri: uri.clone(),
+            changes: vec![tower_lsp::lsp_types::TextDocumentContentChangeEvent {
+                range: None,
+                range_length: None,
+                text: text.to_string(),
+            }],
+        })
+        .unwrap();
+    }
+
+    // Wait until live_lines is populated (actor processed the batch).
+    let uri_clone = uri.clone();
+    let idx = Arc::clone(&indexer);
+    poll_until(
+        move || idx.live_lines.contains_key(uri_clone.as_str()),
+        Duration::from_secs(2),
+    )
+    .await;
+
+    let lines = indexer
+        .live_lines
+        .get(uri.as_str())
+        .map(|r| r.value().as_ref().join("\n"));
+    assert_eq!(
+        lines.as_deref(),
+        Some("v3"),
+        "last FileChanged per URI should win after coalescing"
+    );
+}

--- a/src/workspace/event.rs
+++ b/src/workspace/event.rs
@@ -1,7 +1,7 @@
 //! [`Event`] — the sealed set of workspace-level state mutations.
 //!
 //! Every write to workspace state goes through one of these variants.
-//! Adding a new variant produces a compile error in [`Actor::run`]
+//! Adding a new variant produces a compile error in [`super::Actor::run`]
 //! until the handler is implemented — this is the key correctness invariant.
 // Items unused until Wave 2 wires this into backend/CLI (ws-backend, ws-cli, ws-main).
 #![allow(dead_code)]

--- a/src/workspace/event.rs
+++ b/src/workspace/event.rs
@@ -1,7 +1,7 @@
 //! [`Event`] — the sealed set of workspace-level state mutations.
 //!
 //! Every write to workspace state goes through one of these variants.
-//! Adding a new variant produces a compile error in [`super::Actor::run`]
+//! Adding a new variant produces a compile error in [`super::Actor::handle_event`]
 //! until the handler is implemented — this is the key correctness invariant.
 // Items unused until Wave 2 wires this into backend/CLI (ws-backend, ws-cli, ws-main).
 #![allow(dead_code)]

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod actor;
 pub(crate) mod contract;
 pub(crate) mod event;
 pub(crate) mod phase;
+pub(crate) mod scan_queue;
 
 // Re-exports are unused until Wave 2 wires this module in (ws-backend, ws-cli, ws-main).
 #[allow(unused_imports)]
@@ -100,6 +101,9 @@ impl Config {
         // Auto-include the well-known `extract-sources` output directory if present.
         // Skip entirely when HOME is unknown to avoid accidentally indexing the
         // current working directory (matches existing backend behaviour).
+        // Skipped in test builds so actor tests don't accidentally index the
+        // developer's local library sources and time out.
+        #[cfg(not(test))]
         #[allow(deprecated)]
         if let Some(home) = std::env::home_dir() {
             let default_sources = home.join(".kotlin-lsp").join("sources");

--- a/src/workspace/mod.rs
+++ b/src/workspace/mod.rs
@@ -60,6 +60,19 @@ pub(crate) struct Config {
 }
 
 impl Config {
+    /// Convenience constructor for a clean root-switch config with no
+    /// editor-provided overrides.  Used by `handle_change_root` and the
+    /// auto-detect workspace root path — explicitly *not* used by
+    /// `handle_initialize`, which may carry session-level `explicit_source_paths`
+    /// and `ignore_patterns`.
+    pub(crate) fn for_root(root: PathBuf) -> Self {
+        Self {
+            root,
+            explicit_source_paths: Vec::new(),
+            ignore_patterns: Vec::new(),
+        }
+    }
+
     /// Return the deduplicated, ordered list of source paths to index.
     ///
     /// Discovery priority (first win for deduplication):

--- a/src/workspace/phase.rs
+++ b/src/workspace/phase.rs
@@ -18,8 +18,8 @@ use super::Config;
 /// Immutable snapshot of workspace state captured at initialisation time.
 ///
 /// Produced from a [`Config`] the first time the actor processes a
-/// [`Event::Initialize`] event, and updated on every
-/// [`Event::ChangeRoot`].
+/// [`super::Event::Initialize`] event, and updated on every
+/// [`super::Event::ChangeRoot`].
 ///
 /// Carries the resolved (not raw) source-path list so that no caller ever has
 /// to re-run source discovery.

--- a/src/workspace/scan_queue.rs
+++ b/src/workspace/scan_queue.rs
@@ -1,0 +1,93 @@
+//! [`ScanQueue`] — coalescing queue for full-workspace scans.
+//!
+//! Prevents concurrent duplicate scans from the thundering-herd problem:
+//! if `Initialize`, `Reindex`, or `ChangeRoot` events arrive while a scan
+//! is in progress, the latest request replaces any earlier pending request
+//! (last-write-wins). When the running scan finishes, the pending scan starts.
+//!
+//! Based on `rust-analyzer`'s `OpQueue` pattern.
+
+use std::path::PathBuf;
+
+use tokio::sync::oneshot;
+
+// ─── ScanKind ────────────────────────────────────────────────────────────────
+
+/// Discriminates between the two scan strategies the actor can trigger.
+pub(crate) enum ScanKind {
+    /// Index the workspace, prioritising `initial_paths` first.
+    Prioritized { initial_paths: Vec<PathBuf> },
+    /// Full unconditional re-scan (used by Reindex and ChangeRoot).
+    Full,
+}
+
+// ─── ScanArgs ────────────────────────────────────────────────────────────────
+
+/// Arguments passed to a single workspace scan.
+pub(crate) struct ScanArgs {
+    pub(crate) root: PathBuf,
+    pub(crate) kind: ScanKind,
+    /// Source paths snapshot captured at request time.  Passed to
+    /// `index_source_paths` so that each scan uses the paths that were
+    /// configured when it was enqueued — not whichever set a later event may
+    /// have written by the time the scan actually finishes.
+    pub(crate) source_paths: Vec<String>,
+    /// Fired when the scan completes. `None` if the caller does not need notification.
+    /// Dropped (without signalling) if this request is superseded before it starts.
+    pub(crate) completion_tx: Option<oneshot::Sender<()>>,
+}
+
+// ─── ScanQueue ───────────────────────────────────────────────────────────────
+
+/// Coalescing queue that holds at most one pending scan and one in-progress scan.
+pub(crate) struct ScanQueue {
+    /// The next scan to run once the current one finishes. Replaced on every
+    /// new request — only the most recent one ever runs.
+    pending: Option<ScanArgs>,
+    /// `true` while a scan task is running.
+    in_progress: bool,
+}
+
+impl ScanQueue {
+    pub(crate) fn new() -> Self {
+        Self {
+            pending: None,
+            in_progress: false,
+        }
+    }
+
+    /// Returns `true` if a scan is currently running.
+    pub(crate) fn is_in_progress(&self) -> bool {
+        self.in_progress
+    }
+
+    /// Store a new scan request, replacing any previous pending one.
+    ///
+    /// The superseded request's `completion_tx` is dropped silently.
+    /// Callers that need to distinguish cancellation should use a
+    /// `oneshot::Sender<Result<(), Cancelled>>` pattern instead.
+    pub(crate) fn request(&mut self, args: ScanArgs) {
+        self.pending = Some(args);
+    }
+
+    /// Returns the next args to execute if no scan is currently in progress,
+    /// and marks `in_progress = true`.  Returns `None` if busy.
+    pub(crate) fn try_start(&mut self) -> Option<ScanArgs> {
+        if self.in_progress {
+            return None;
+        }
+        let args = self.pending.take()?;
+        self.in_progress = true;
+        Some(args)
+    }
+
+    /// Mark the current scan as finished.  Call this before `try_start` to
+    /// check for a pending follow-up scan.
+    pub(crate) fn completed(&mut self) {
+        self.in_progress = false;
+    }
+}
+
+#[cfg(test)]
+#[path = "scan_queue_tests.rs"]
+mod tests;

--- a/src/workspace/scan_queue.rs
+++ b/src/workspace/scan_queue.rs
@@ -35,6 +35,11 @@ pub(crate) struct ScanArgs {
     /// Fired when the scan completes. `None` if the caller does not need notification.
     /// Dropped (without signalling) if this request is superseded before it starts.
     pub(crate) completion_tx: Option<oneshot::Sender<()>>,
+    /// The value of `Indexer::root_generation` at the moment this scan was
+    /// enqueued.  The scan task checks this before writing shared state and
+    /// before signalling `completion_tx`; if the current generation no longer
+    /// matches, the scan has been superseded and should discard its results.
+    pub(crate) expected_generation: u64,
 }
 
 // ─── ScanQueue ───────────────────────────────────────────────────────────────

--- a/src/workspace/scan_queue_tests.rs
+++ b/src/workspace/scan_queue_tests.rs
@@ -1,0 +1,75 @@
+//! Unit tests for [`ScanQueue`].
+
+use tokio::sync::oneshot;
+
+use super::{ScanArgs, ScanKind, ScanQueue};
+use std::path::PathBuf;
+
+fn dummy_args(root: &str) -> ScanArgs {
+    ScanArgs {
+        root: PathBuf::from(root),
+        kind: ScanKind::Full,
+        source_paths: Vec::new(),
+        completion_tx: None,
+    }
+}
+
+#[test]
+fn starts_when_idle() {
+    let mut q = ScanQueue::new();
+    q.request(dummy_args("/a"));
+    let args = q.try_start().expect("should start when idle");
+    assert_eq!(args.root, PathBuf::from("/a"));
+    assert!(q.is_in_progress());
+}
+
+#[test]
+fn returns_none_when_busy() {
+    let mut q = ScanQueue::new();
+    q.request(dummy_args("/a"));
+    q.try_start();
+    q.request(dummy_args("/b"));
+    assert!(q.try_start().is_none(), "should not start a second scan");
+}
+
+#[test]
+fn last_write_wins() {
+    let mut q = ScanQueue::new();
+    q.request(dummy_args("/a"));
+    q.try_start(); // scan A starts
+    q.request(dummy_args("/b"));
+    q.request(dummy_args("/c")); // /b is replaced
+    q.completed();
+    let args = q.try_start().expect("pending should have /c");
+    assert_eq!(args.root, PathBuf::from("/c"));
+}
+
+#[test]
+fn completion_tx_dropped_when_superseded() {
+    let mut q = ScanQueue::new();
+    q.request(dummy_args("/a"));
+    q.try_start(); // scan A starts — in_progress
+
+    let (tx1, mut rx1) = oneshot::channel::<()>();
+    q.request(ScanArgs {
+        root: PathBuf::from("/b"),
+        kind: ScanKind::Full,
+        source_paths: Vec::new(),
+        completion_tx: Some(tx1),
+    });
+    // /b pending is now replaced by /c, dropping tx1
+    q.request(dummy_args("/c"));
+
+    // tx1 was dropped — receiver sees closed
+    assert!(rx1.try_recv().is_err());
+}
+
+#[test]
+fn idle_when_no_pending_after_complete() {
+    let mut q = ScanQueue::new();
+    q.request(dummy_args("/a"));
+    q.try_start();
+    q.completed();
+    assert!(!q.is_in_progress());
+    assert!(q.try_start().is_none(), "nothing pending");
+}

--- a/src/workspace/scan_queue_tests.rs
+++ b/src/workspace/scan_queue_tests.rs
@@ -60,8 +60,11 @@ fn completion_tx_dropped_when_superseded() {
     // /b pending is now replaced by /c, dropping tx1
     q.request(dummy_args("/c"));
 
-    // tx1 was dropped — receiver sees closed
-    assert!(rx1.try_recv().is_err());
+    // tx1 was dropped when /b was superseded — receiver must see Closed, not just Empty
+    assert!(matches!(
+        rx1.try_recv(),
+        Err(tokio::sync::oneshot::error::TryRecvError::Closed)
+    ));
 }
 
 #[test]

--- a/src/workspace/scan_queue_tests.rs
+++ b/src/workspace/scan_queue_tests.rs
@@ -11,6 +11,7 @@ fn dummy_args(root: &str) -> ScanArgs {
         kind: ScanKind::Full,
         source_paths: Vec::new(),
         completion_tx: None,
+        expected_generation: 0,
     }
 }
 
@@ -56,6 +57,7 @@ fn completion_tx_dropped_when_superseded() {
         kind: ScanKind::Full,
         source_paths: Vec::new(),
         completion_tx: Some(tx1),
+        expected_generation: 0,
     });
     // /b pending is now replaced by /c, dropping tx1
     q.request(dummy_args("/c"));


### PR DESCRIPTION
## Changes

### ScanQueue (OpQueue pattern)
- New `scan_queue.rs`: `ScanQueue` with last-write-wins semantics; pending scan supersedes any previously queued one
- `ScanArgs` captures `source_paths` at request time — fixes a real race where rapid Initialize events would cause scan1 to finalize using scan3's source paths (actor overwrites `source_paths_raw` synchronously before scans run)
- `enqueue_and_start_scan()` bumps `root_generation` when superseding an in-flight scan

### FileChanged coalescing (r-a pattern D)
- Actor `run()` drains all `FileChanged` events via `try_recv()` after processing each one
- HashMap dedup per URI — only last change per file is applied
- Single-slot pushback for non-FileChanged events that arrive during drain

### execute_scan() watcher pattern
- Spawns a scan task + a watcher task; watcher fires `scan_done_tx` even on panic
- Prevents `scan_done_rx` from never resolving if the scan task panics

### Bug fix: home sources in test builds
- `#[cfg(not(test))]` gate on `~/.kotlin-lsp/sources` auto-detection in `resolve_sources()`
- Actor integration tests on dev machines with large source directories were timing out at 5s

## Tests
- `multiple_initialize_last_one_runs`: 3 rapid Initialize events → only 2 scans run, final root = event3's
- `file_changed_coalesced_per_uri`: 3 FileChanged for same URI → coalesced to last content
- 821 tests pass, zero clippy warnings