### PR TITLE
w7: quiescent state + 177× faster tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -832,6 +832,7 @@ dependencies = [
  "ignore",
  "lexopt",
  "log",
+ "parking_lot",
  "serde",
  "serde_json",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ sha2 = "0.10"
 zip = "2"
 futures = "0.3.32"
 lexopt = "0.3"
+parking_lot = "0.12.5"
 
 [profile.release]
 opt-level = 3

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -164,9 +164,11 @@ async fn build_index_inner(root: &Path, source_paths: Vec<String>) -> Arc<Indexe
 
 /// Collect source paths for CLI indexing: workspace.json + default extract dir.
 ///
-/// Build-layout paths auto-detected under `root` are intentionally excluded —
-/// those files are already covered by `index_workspace_full`'s workspace scan.
-/// Only paths that live *outside* the workspace root need a separate indexing pass.
+/// When `workspace.json` provides no explicit `sourcePaths`, Gradle/Maven
+/// build-layout paths under `root` are included so CLI completions behave like
+/// the full LSP path. External library paths (outside the workspace root) are
+/// always included via the configured `sourcePaths` key or the default
+/// `~/.kotlin-lsp/sources` directory.
 ///
 /// When `no_stdlib` is true, `~/.kotlin-lsp/sources` is excluded regardless of
 /// whether it appears in `workspace.json` or is auto-detected. Use this for fast

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -202,8 +202,22 @@ fn collect_cli_source_paths(root: &Path, no_stdlib: bool) -> Vec<String> {
         }
     }
 
-    // If workspace.json declares explicit sourcePaths, use those and skip the
-    // global default.  An absent key (None) falls through to the global default.
+    // When workspace files declare no source roots, try Gradle/Maven build
+    // layout detection so `complete` behaves like the LSP path.
+    if json_paths.is_empty() {
+        for p in crate::workspace_json::detect_build_layout_source_paths(root) {
+            if is_external(&p) {
+                let s = p.to_string_lossy().into_owned();
+                if !paths.contains(&s) {
+                    paths.push(s);
+                }
+            }
+        }
+    }
+
+    // `workspace.json` `sourcePaths` key — explicit library overrides.
+    // When present (even as `[]`), it takes precedence over the default
+    // `~/.kotlin-lsp/sources` directory so a project can opt out entirely.
     if let Some(configured) = crate::workspace_json::load_configured_source_paths(root) {
         for p in configured {
             if is_external(&p) && !(no_stdlib && is_stdlib(&p)) {
@@ -213,16 +227,20 @@ fn collect_cli_source_paths(root: &Path, no_stdlib: bool) -> Vec<String> {
                 }
             }
         }
-        return paths;
+    } else if !no_stdlib {
+        // Auto-include the well-known `extract-sources` output dir if present.
+        if default_sources.is_dir() {
+            let s = default_sources.to_string_lossy().into_owned();
+            if !paths.contains(&s) {
+                paths.push(s);
+            }
+        }
     }
 
-    if no_stdlib {
-        return paths;
-    }
-
-    // Auto-include the well-known `extract-sources` output dir if present.
-    if default_sources.is_dir() {
-        let s = default_sources.to_string_lossy().into_owned();
+    // Android SDK sources — always added when detectable, independent of
+    // --no-stdlib (SDK sources are platform APIs, not stdlib).
+    for p in crate::workspace_json::detect_android_sdk_source_paths(root) {
+        let s = p.to_string_lossy().into_owned();
         if !paths.contains(&s) {
             paths.push(s);
         }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -164,7 +164,7 @@ async fn build_index_inner(root: &Path, source_paths: Vec<String>) -> Arc<Indexe
 
 /// Collect source paths for CLI indexing: workspace.json + default extract dir.
 ///
-/// When `workspace.json` provides no explicit `sourcePaths`, Gradle/Maven
+/// When `workspace.json` declares no JetBrains module source roots, Gradle/Maven
 /// build-layout paths under `root` are included so CLI completions behave like
 /// the full LSP path. External library paths (outside the workspace root) are
 /// always included via the configured `sourcePaths` key or the default

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -204,13 +204,12 @@ fn collect_cli_source_paths(root: &Path, no_stdlib: bool) -> Vec<String> {
 
     // When workspace files declare no source roots, try Gradle/Maven build
     // layout detection so `complete` behaves like the LSP path.
+    // These paths are under the workspace root so `is_external` does not apply.
     if json_paths.is_empty() {
         for p in crate::workspace_json::detect_build_layout_source_paths(root) {
-            if is_external(&p) {
-                let s = p.to_string_lossy().into_owned();
-                if !paths.contains(&s) {
-                    paths.push(s);
-                }
+            let s = p.to_string_lossy().into_owned();
+            if !paths.contains(&s) {
+                paths.push(s);
             }
         }
     }

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -91,12 +91,12 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         loop {
             tokio::select! {
                 biased;
+                Some(()) = self.scan_done_rx.recv() => {
+                    self.scan_handler.on_scan_completed();
+                }
                 maybe_event = self.rx.recv() => {
                     let Some(event) = maybe_event else { break };
                     self.handle_event(event).await;
-                }
-                Some(()) = self.scan_done_rx.recv() => {
-                    self.scan_handler.on_scan_completed();
                 }
             }
             let is_ready = self.is_ready().await;

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -96,8 +96,7 @@ impl<R: ProgressReporter + 'static> Actor<R> {
                     self.handle_event(event).await;
                 }
                 Some(()) = self.scan_done_rx.recv() => {
-                    // scan_done_rx fires when a background scan finishes;
-                    // is_scanning was already cleared by the scan task before sending.
+                    self.scan_handler.on_scan_completed();
                 }
             }
             let is_ready = self.is_ready().await;

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -38,6 +38,7 @@ use super::{Config, Event};
 /// Construct with [`Actor::new`] and drive with [`Actor::run`].
 pub(crate) struct Actor<R: ProgressReporter + 'static> {
     rx: mpsc::Receiver<Event>,
+    scan_done_rx: mpsc::UnboundedReceiver<()>,
     scan_handler: ScanHandler<R>,
     file_change_handler: FileChangeHandler,
     document_handler: DocumentHandler,
@@ -56,9 +57,16 @@ impl<R: ProgressReporter + 'static> Actor<R> {
         client: Option<Client>,
     ) -> Self {
         let state = Arc::new(RwLock::new(State::Uninitialized));
+        let (scan_done_tx, scan_done_rx) = mpsc::unbounded_channel();
         Self {
             rx,
-            scan_handler: ScanHandler::new(Arc::clone(&indexer), reporter, Arc::clone(&state)),
+            scan_done_rx,
+            scan_handler: ScanHandler::new(
+                Arc::clone(&indexer),
+                reporter,
+                Arc::clone(&state),
+                scan_done_tx,
+            ),
             file_change_handler: FileChangeHandler::new(Arc::clone(&indexer), client.clone()),
             document_handler: DocumentHandler::new(indexer, client),
         }
@@ -73,29 +81,76 @@ impl<R: ProgressReporter + 'static> Actor<R> {
     /// Run the event loop until the sender side is dropped.
     ///
     /// The exhaustive `match` is the architectural guarantee: every new
-    /// [`Event`] variant must be handled here or the code will not
-    /// compile.
+    /// [`Event`] variant must be handled here or the code will not compile.
+    ///
+    /// After each event or scan completion, checks whether the workspace has
+    /// transitioned into the quiescent "ready" state and fires [`on_became_ready`]
+    /// exactly once per such transition.
     pub(crate) async fn run(mut self) {
-        while let Some(event) = self.rx.recv().await {
-            match event {
-                Event::Initialize {
-                    config,
-                    completion_tx,
-                } => self.handle_initialize(config, completion_tx).await,
-                Event::Reindex => self.handle_reindex().await,
-                Event::ChangeRoot { root } => self.handle_change_root(root).await,
-                Event::FileOpened {
-                    uri,
-                    language_id,
-                    content,
-                } => self.handle_file_opened(uri, language_id, content).await,
-                Event::FileChanged { uri, changes } => {
-                    self.handle_file_changed(uri, changes).await;
+        let mut was_ready = false;
+        loop {
+            tokio::select! {
+                biased;
+                maybe_event = self.rx.recv() => {
+                    let Some(event) = maybe_event else { break };
+                    self.handle_event(event).await;
                 }
-                Event::FileSaved { uri } => self.handle_file_saved(uri).await,
-                Event::FileClosed { uri } => self.handle_file_closed(uri).await,
-                Event::FileDeleted { uri } => self.handle_file_deleted(uri).await,
+                Some(()) = self.scan_done_rx.recv() => {
+                    // scan_done_rx fires when a background scan finishes;
+                    // is_scanning was already cleared by the scan task before sending.
+                }
             }
+            let is_ready = self.is_ready().await;
+            if !was_ready && is_ready {
+                self.on_became_ready().await;
+            }
+            was_ready = is_ready;
+        }
+    }
+
+    /// Returns `true` when the workspace has been initialised **and** no
+    /// background scan is currently in flight.
+    async fn is_ready(&self) -> bool {
+        self.scan_handler
+            .state_stream()
+            .read()
+            .await
+            .ready()
+            .is_some()
+            && !self.scan_handler.is_scanning()
+    }
+
+    /// Called exactly once each time the workspace transitions from a
+    /// non-quiescent state into the quiescent ready state.
+    async fn on_became_ready(&self) {
+        if let Some(state) = self.scan_handler.state_stream().read().await.ready() {
+            log::info!(
+                "Workspace ready: {} ({} source path(s))",
+                state.root.display(),
+                state.source_paths.len(),
+            );
+        }
+    }
+
+    async fn handle_event(&mut self, event: Event) {
+        match event {
+            Event::Initialize {
+                config,
+                completion_tx,
+            } => self.handle_initialize(config, completion_tx).await,
+            Event::Reindex => self.handle_reindex().await,
+            Event::ChangeRoot { root } => self.handle_change_root(root).await,
+            Event::FileOpened {
+                uri,
+                language_id,
+                content,
+            } => self.handle_file_opened(uri, language_id, content).await,
+            Event::FileChanged { uri, changes } => {
+                self.handle_file_changed(uri, changes).await;
+            }
+            Event::FileSaved { uri } => self.handle_file_saved(uri).await,
+            Event::FileClosed { uri } => self.handle_file_closed(uri).await,
+            Event::FileDeleted { uri } => self.handle_file_deleted(uri).await,
         }
     }
 

--- a/src/workspace/actor_tests.rs
+++ b/src/workspace/actor_tests.rs
@@ -16,8 +16,13 @@ fn make_actor(indexer: Arc<Indexer>) -> (Actor<NoopReporter>, mpsc::Sender<Event
     (actor, tx)
 }
 
+/// Create a temp dir with a `workspace.json` that opts out of all external
+/// sources (`sourcePaths:[]`), preventing actor tests from accidentally
+/// indexing `~/.kotlin-lsp/sources` or any real Android SDK on the host.
 fn temp_dir() -> tempfile::TempDir {
-    tempfile::tempdir().unwrap()
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();
+    dir
 }
 
 /// Poll `condition` every yield until it returns `true` or `timeout` elapses.
@@ -280,5 +285,66 @@ async fn file_changed_coalesced_per_uri() {
         lines.as_deref(),
         Some("v3"),
         "last FileChanged per URI should win after coalescing"
+    );
+}
+
+// ─── Quiescent state tests ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn actor_remains_responsive_after_scan_completes() {
+    // After a scan completes (completion_tx fires), the actor must still accept
+    // and process subsequent events — i.e. the scan_done_rx handling in the
+    // select loop must not block or consume the event rx.
+    let indexer = Arc::new(Indexer::new());
+    let tmp = temp_dir();
+    let root = tmp.path().to_path_buf();
+
+    let (actor, tx) = make_actor(Arc::clone(&indexer));
+    tokio::spawn(actor.run());
+
+    let (done_tx, done_rx) = oneshot::channel();
+    tx.send(Event::Initialize {
+        config: Config {
+            root: root.clone(),
+            explicit_source_paths: Vec::new(),
+            ignore_patterns: Vec::new(),
+            pin_workspace: false,
+        },
+        completion_tx: Some(done_tx),
+    })
+    .await
+    .unwrap();
+
+    // Wait for the first scan to complete (quiescent → BecameReady fires).
+    tokio::time::timeout(Duration::from_secs(5), done_rx)
+        .await
+        .expect("Initialize should complete within 5s")
+        .unwrap();
+
+    // Actor must still accept a subsequent event without deadlocking.
+    let tmp2 = temp_dir();
+    let root2 = tmp2.path().to_path_buf();
+    let (done_tx2, done_rx2) = oneshot::channel();
+    tx.send(Event::Initialize {
+        config: Config {
+            root: root2.clone(),
+            explicit_source_paths: Vec::new(),
+            ignore_patterns: Vec::new(),
+            pin_workspace: false,
+        },
+        completion_tx: Some(done_tx2),
+    })
+    .await
+    .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(5), done_rx2)
+        .await
+        .expect("second Initialize should complete within 5s")
+        .unwrap();
+
+    assert_eq!(
+        indexer.workspace_root.get().as_deref(),
+        Some(root2.as_path()),
+        "workspace_root should reflect the second Initialize root"
     );
 }

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -1,6 +1,5 @@
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use tokio::sync::{mpsc, oneshot, RwLock};
 
@@ -8,13 +7,14 @@ use crate::indexer::{Indexer, ProgressReporter};
 use crate::rg::IgnoreMatcher;
 
 use super::phase::{ReadyState, State};
+use super::scan_queue::{ScanArgs, ScanKind, ScanQueue};
 use super::Config;
 
 pub(crate) struct ScanHandler<R: ProgressReporter + 'static> {
     indexer: Arc<Indexer>,
     reporter: Arc<R>,
     state: Arc<RwLock<State>>,
-    is_scanning: Arc<AtomicBool>,
+    scan_queue: Mutex<ScanQueue>,
     scan_done_tx: mpsc::UnboundedSender<()>,
 }
 
@@ -29,14 +29,28 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             indexer,
             reporter,
             state,
-            is_scanning: Arc::new(AtomicBool::new(false)),
+            scan_queue: Mutex::new(ScanQueue::new()),
             scan_done_tx,
         }
     }
 
     /// Returns `true` while a background index scan is in flight.
     pub(crate) fn is_scanning(&self) -> bool {
-        self.is_scanning.load(Ordering::Acquire)
+        self.scan_queue.lock().unwrap().is_in_progress()
+    }
+
+    /// Called by the actor when `scan_done_rx` fires.
+    ///
+    /// Marks the current scan complete and starts any pending follow-up.
+    pub(crate) fn on_scan_completed(&self) {
+        let maybe_next = {
+            let mut queue = self.scan_queue.lock().unwrap();
+            queue.completed();
+            queue.try_start()
+        };
+        if let Some(args) = maybe_next {
+            self.execute_scan(args);
+        }
     }
 
     pub(crate) fn state_stream(&self) -> Arc<RwLock<State>> {
@@ -49,7 +63,14 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
         completion_tx: Option<oneshot::Sender<()>>,
     ) {
         let data = self.apply_config(config).await;
-        self.spawn_scan(data.root, Vec::new(), completion_tx).await;
+        self.enqueue_scan(ScanArgs {
+            root: data.root,
+            kind: ScanKind::Prioritized {
+                initial_paths: Vec::new(),
+            },
+            completion_tx,
+            expected_generation: 0,
+        });
     }
 
     pub(crate) async fn handle_reindex(&self) {
@@ -58,7 +79,12 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             return;
         };
         self.indexer.reset_index_state();
-        self.spawn_full_scan(root).await;
+        self.enqueue_scan(ScanArgs {
+            root,
+            kind: ScanKind::Full,
+            completion_tx: None,
+            expected_generation: 0,
+        });
     }
 
     pub(crate) async fn handle_change_root(&self, root: PathBuf) {
@@ -70,7 +96,12 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
         };
         let data = self.apply_config(config).await;
         self.indexer.reset_index_state();
-        self.spawn_full_scan(data.root).await;
+        self.enqueue_scan(ScanArgs {
+            root: data.root,
+            kind: ScanKind::Full,
+            completion_tx: None,
+            expected_generation: 0,
+        });
     }
 
     pub(crate) async fn switch_workspace_root_for_opened_document(
@@ -90,8 +121,14 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             "Auto-detected workspace root (now pinned): {}",
             data.root.display()
         );
-        self.spawn_scan(data.root, opened_file_path.into_iter().collect(), None)
-            .await;
+        self.enqueue_scan(ScanArgs {
+            root: data.root,
+            kind: ScanKind::Prioritized {
+                initial_paths: opened_file_path.into_iter().collect(),
+            },
+            completion_tx: None,
+            expected_generation: 0,
+        });
     }
 
     /// Apply a [`Config`] to the indexer and transition the phase state.
@@ -136,39 +173,67 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
         }
     }
 
-    async fn spawn_scan(
-        &self,
-        root: PathBuf,
-        initial_paths: Vec<PathBuf>,
-        completion_tx: Option<oneshot::Sender<()>>,
-    ) {
-        let indexer = Arc::clone(&self.indexer);
-        let reporter = Arc::clone(&self.reporter);
-        let is_scanning = Arc::clone(&self.is_scanning);
-        let scan_done_tx = self.scan_done_tx.clone();
-        is_scanning.store(true, Ordering::Release);
-        tokio::spawn(async move {
-            indexer
-                .index_workspace_prioritized(&root, initial_paths, reporter)
-                .await;
-            is_scanning.store(false, Ordering::Release);
-            let _ = scan_done_tx.send(());
-            if let Some(completion_tx) = completion_tx {
-                let _ = completion_tx.send(());
+    /// Enqueue a scan request. If a scan is in progress the generation is
+    /// bumped to invalidate it; the new request replaces any earlier pending
+    /// one (last-write-wins). Starts the scan immediately when the queue is idle.
+    fn enqueue_scan(&self, args: ScanArgs) {
+        let maybe_args = {
+            let mut queue = self.scan_queue.lock().unwrap();
+            if queue.is_in_progress() {
+                self.indexer.workspace_root.bump_generation();
             }
-        });
+            let gen = self.indexer.workspace_root.generation();
+            let args = ScanArgs {
+                expected_generation: gen,
+                ..args
+            };
+            queue.request(args);
+            queue.try_start()
+        };
+        if let Some(args) = maybe_args {
+            self.execute_scan(args);
+        }
     }
 
-    async fn spawn_full_scan(&self, root: PathBuf) {
+    /// Spawn the tokio task for a single scan. Bails out early if the scan
+    /// has been superseded (generation mismatch) before or after indexing.
+    fn execute_scan(&self, args: ScanArgs) {
         let indexer = Arc::clone(&self.indexer);
         let reporter = Arc::clone(&self.reporter);
-        let is_scanning = Arc::clone(&self.is_scanning);
         let scan_done_tx = self.scan_done_tx.clone();
-        is_scanning.store(true, Ordering::Release);
         tokio::spawn(async move {
-            indexer.index_workspace_full(&root, reporter).await;
-            is_scanning.store(false, Ordering::Release);
+            let ScanArgs {
+                root,
+                kind,
+                completion_tx,
+                expected_generation,
+                ..
+            } = args;
+
+            if indexer.workspace_root.generation() != expected_generation {
+                let _ = scan_done_tx.send(());
+                return;
+            }
+
+            match kind {
+                ScanKind::Prioritized { initial_paths } => {
+                    Arc::clone(&indexer)
+                        .index_workspace_prioritized(&root, initial_paths, reporter)
+                        .await;
+                }
+                ScanKind::Full => {
+                    Arc::clone(&indexer)
+                        .index_workspace_full(&root, reporter)
+                        .await;
+                }
+            }
+
             let _ = scan_done_tx.send(());
+            if indexer.workspace_root.generation() == expected_generation {
+                if let Some(tx) = completion_tx {
+                    let _ = tx.send(());
+                }
+            }
         });
     }
 }

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -261,7 +261,9 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 }
             }
 
-            // _done drops here → scan_done_tx fires.
+            // Signal scan complete first so the queue accepts new requests
+            // before the caller's completion channel fires.
+            drop(_done);
             if indexer.workspace_root.generation() == expected_generation {
                 if let Some(tx) = completion_tx {
                     let _ = tx.send(());

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -1,6 +1,7 @@
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
+use parking_lot::Mutex;
 use tokio::sync::{mpsc, oneshot, RwLock};
 
 use crate::indexer::{Indexer, ProgressReporter};
@@ -16,6 +17,18 @@ pub(crate) struct ScanHandler<R: ProgressReporter + 'static> {
     state: Arc<RwLock<State>>,
     scan_queue: Mutex<ScanQueue>,
     scan_done_tx: mpsc::UnboundedSender<()>,
+}
+
+/// RAII guard that sends on `scan_done_tx` when dropped, guaranteeing the
+/// actor's `scan_done_rx` is always unblocked even if the task panics.
+struct ScanDoneGuard(Option<mpsc::UnboundedSender<()>>);
+
+impl Drop for ScanDoneGuard {
+    fn drop(&mut self) {
+        if let Some(tx) = self.0.take() {
+            let _ = tx.send(());
+        }
+    }
 }
 
 impl<R: ProgressReporter + 'static> ScanHandler<R> {
@@ -36,7 +49,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
 
     /// Returns `true` while a background index scan is in flight.
     pub(crate) fn is_scanning(&self) -> bool {
-        self.scan_queue.lock().unwrap().is_in_progress()
+        self.scan_queue.lock().is_in_progress()
     }
 
     /// Called by the actor when `scan_done_rx` fires.
@@ -44,7 +57,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
     /// Marks the current scan complete and starts any pending follow-up.
     pub(crate) fn on_scan_completed(&self) {
         let maybe_next = {
-            let mut queue = self.scan_queue.lock().unwrap();
+            let mut queue = self.scan_queue.lock();
             queue.completed();
             queue.try_start()
         };
@@ -70,6 +83,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             },
             completion_tx,
             expected_generation: 0,
+            reset_before_scan: false,
         });
     }
 
@@ -78,12 +92,14 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             log::warn!("Actor: Reindex received but no workspace root is set");
             return;
         };
-        self.indexer.reset_index_state();
+        // `reset_index_state()` is deferred into the scan task so it never
+        // races with a concurrently running scan.
         self.enqueue_scan(ScanArgs {
             root,
             kind: ScanKind::Full,
             completion_tx: None,
             expected_generation: 0,
+            reset_before_scan: true,
         });
     }
 
@@ -95,12 +111,14 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             pin_workspace: true,
         };
         let data = self.apply_config(config).await;
-        self.indexer.reset_index_state();
+        // `reset_index_state()` is deferred into the scan task (see `execute_scan`)
+        // so it cannot race with a concurrently running scan for the old root.
         self.enqueue_scan(ScanArgs {
             root: data.root,
             kind: ScanKind::Full,
             completion_tx: None,
             expected_generation: 0,
+            reset_before_scan: true,
         });
     }
 
@@ -116,11 +134,12 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             pin_workspace: true,
         };
         let data = self.apply_config(config).await;
-        self.indexer.reset_index_state();
         log::info!(
             "Auto-detected workspace root (now pinned): {}",
             data.root.display()
         );
+        // `reset_index_state()` is deferred into the scan task so it cannot
+        // race with any scan still completing for the previous root.
         self.enqueue_scan(ScanArgs {
             root: data.root,
             kind: ScanKind::Prioritized {
@@ -128,6 +147,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             },
             completion_tx: None,
             expected_generation: 0,
+            reset_before_scan: true,
         });
     }
 
@@ -178,7 +198,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
     /// one (last-write-wins). Starts the scan immediately when the queue is idle.
     fn enqueue_scan(&self, args: ScanArgs) {
         let maybe_args = {
-            let mut queue = self.scan_queue.lock().unwrap();
+            let mut queue = self.scan_queue.lock();
             if queue.is_in_progress() {
                 self.indexer.workspace_root.bump_generation();
             }
@@ -197,6 +217,9 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
 
     /// Spawn the tokio task for a single scan. Bails out early if the scan
     /// has been superseded (generation mismatch) before or after indexing.
+    ///
+    /// The `ScanDoneGuard` RAII type guarantees `scan_done_tx` is always
+    /// signalled on task completion or panic, keeping the queue unblocked.
     fn execute_scan(&self, args: ScanArgs) {
         let indexer = Arc::clone(&self.indexer);
         let reporter = Arc::clone(&self.reporter);
@@ -207,12 +230,22 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 kind,
                 completion_tx,
                 expected_generation,
+                reset_before_scan,
                 ..
             } = args;
 
+            // The RAII guard ensures scan_done_tx fires even if this task panics.
+            let _done = ScanDoneGuard(Some(scan_done_tx));
+
             if indexer.workspace_root.generation() != expected_generation {
-                let _ = scan_done_tx.send(());
                 return;
+            }
+
+            // Safe to reset here: the queue was idle when execute_scan was called
+            // (either the queue had no in-progress scan, or on_scan_completed just
+            // finished the previous one). No other scan task is running at this point.
+            if reset_before_scan {
+                indexer.reset_index_state();
             }
 
             match kind {
@@ -228,7 +261,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 }
             }
 
-            let _ = scan_done_tx.send(());
+            // _done drops here → scan_done_tx fires.
             if indexer.workspace_root.generation() == expected_generation {
                 if let Some(tx) = completion_tx {
                     let _ = tx.send(());

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -1,7 +1,8 @@
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use tokio::sync::{oneshot, RwLock};
+use tokio::sync::{mpsc, oneshot, RwLock};
 
 use crate::indexer::{Indexer, ProgressReporter};
 use crate::rg::IgnoreMatcher;
@@ -13,15 +14,29 @@ pub(crate) struct ScanHandler<R: ProgressReporter + 'static> {
     indexer: Arc<Indexer>,
     reporter: Arc<R>,
     state: Arc<RwLock<State>>,
+    is_scanning: Arc<AtomicBool>,
+    scan_done_tx: mpsc::UnboundedSender<()>,
 }
 
 impl<R: ProgressReporter + 'static> ScanHandler<R> {
-    pub(crate) fn new(indexer: Arc<Indexer>, reporter: Arc<R>, state: Arc<RwLock<State>>) -> Self {
+    pub(crate) fn new(
+        indexer: Arc<Indexer>,
+        reporter: Arc<R>,
+        state: Arc<RwLock<State>>,
+        scan_done_tx: mpsc::UnboundedSender<()>,
+    ) -> Self {
         Self {
             indexer,
             reporter,
             state,
+            is_scanning: Arc::new(AtomicBool::new(false)),
+            scan_done_tx,
         }
+    }
+
+    /// Returns `true` while a background index scan is in flight.
+    pub(crate) fn is_scanning(&self) -> bool {
+        self.is_scanning.load(Ordering::Acquire)
     }
 
     pub(crate) fn state_stream(&self) -> Arc<RwLock<State>> {
@@ -143,10 +158,15 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
     ) {
         let indexer = Arc::clone(&self.indexer);
         let reporter = Arc::clone(&self.reporter);
+        let is_scanning = Arc::clone(&self.is_scanning);
+        let scan_done_tx = self.scan_done_tx.clone();
+        is_scanning.store(true, Ordering::Release);
         tokio::spawn(async move {
             indexer
                 .index_workspace_prioritized(&root, initial_paths, reporter)
                 .await;
+            is_scanning.store(false, Ordering::Release);
+            let _ = scan_done_tx.send(());
             if let Some(completion_tx) = completion_tx {
                 let _ = completion_tx.send(());
             }
@@ -156,8 +176,13 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
     async fn spawn_full_scan(&self, root: PathBuf) {
         let indexer = Arc::clone(&self.indexer);
         let reporter = Arc::clone(&self.reporter);
+        let is_scanning = Arc::clone(&self.is_scanning);
+        let scan_done_tx = self.scan_done_tx.clone();
+        is_scanning.store(true, Ordering::Release);
         tokio::spawn(async move {
             indexer.index_workspace_full(&root, reporter).await;
+            is_scanning.store(false, Ordering::Release);
+            let _ = scan_done_tx.send(());
         });
     }
 }

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -48,18 +48,8 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
         config: Config,
         completion_tx: Option<oneshot::Sender<()>>,
     ) {
-        let data = ReadyState::from_config(&config);
-        let root = data.root.clone();
-
-        self.set_root(root.clone());
-        self.apply_ignore_patterns(&config.ignore_patterns, &root);
-        self.indexer
-            .workspace_pinned
-            .store(config.pin_workspace, std::sync::atomic::Ordering::Relaxed);
-        self.write_source_paths(data.source_paths.clone());
-        self.set_phase(data).await;
-
-        self.spawn_scan(root, Vec::new(), completion_tx).await;
+        let data = self.apply_config(config).await;
+        self.spawn_scan(data.root, Vec::new(), completion_tx).await;
     }
 
     pub(crate) async fn handle_reindex(&self) {
@@ -73,23 +63,14 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
 
     pub(crate) async fn handle_change_root(&self, root: PathBuf) {
         let config = Config {
-            root: root.clone(),
+            root,
             explicit_source_paths: Vec::new(),
             ignore_patterns: Vec::new(),
             pin_workspace: true,
         };
-        let data = ReadyState::from_config(&config);
-
-        self.apply_ignore_patterns(&config.ignore_patterns, &root);
-        self.write_source_paths(data.source_paths.clone());
-        self.set_root(root.clone());
-        self.indexer
-            .workspace_pinned
-            .store(true, std::sync::atomic::Ordering::Relaxed);
-        self.set_phase(data).await;
-
+        let data = self.apply_config(config).await;
         self.indexer.reset_index_state();
-        self.spawn_full_scan(root).await;
+        self.spawn_full_scan(data.root).await;
     }
 
     pub(crate) async fn switch_workspace_root_for_opened_document(
@@ -98,31 +79,36 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
         opened_file_path: Option<PathBuf>,
     ) {
         let config = Config {
-            root: workspace_root.clone(),
+            root: workspace_root,
             explicit_source_paths: Vec::new(),
             ignore_patterns: Vec::new(),
             pin_workspace: true,
         };
-        let data = ReadyState::from_config(&config);
-
-        self.apply_ignore_patterns(&config.ignore_patterns, &workspace_root);
-        self.write_source_paths(data.source_paths.clone());
-        self.set_root(workspace_root.clone());
-        self.set_phase(data).await;
-        self.indexer
-            .workspace_pinned
-            .store(true, std::sync::atomic::Ordering::Relaxed);
+        let data = self.apply_config(config).await;
         self.indexer.reset_index_state();
         log::info!(
             "Auto-detected workspace root (now pinned): {}",
-            workspace_root.display()
+            data.root.display()
         );
-        self.spawn_scan(workspace_root, opened_file_path.into_iter().collect(), None)
+        self.spawn_scan(data.root, opened_file_path.into_iter().collect(), None)
             .await;
     }
 
-    pub(crate) async fn set_phase(&self, data: ReadyState) {
-        self.state.write().await.set_state(data);
+    /// Apply a [`Config`] to the indexer and transition the phase state.
+    ///
+    /// The single write path shared by Initialize, ChangeRoot, and
+    /// switch_workspace_root_for_opened_document. Returns the resolved
+    /// [`ReadyState`] so callers can extract the root for subsequent scans.
+    async fn apply_config(&self, config: Config) -> ReadyState {
+        let data = ReadyState::from_config(&config);
+        self.set_root(data.root.clone());
+        self.apply_ignore_patterns(&config.ignore_patterns, &data.root);
+        self.indexer
+            .workspace_pinned
+            .store(config.pin_workspace, std::sync::atomic::Ordering::Relaxed);
+        self.write_source_paths(data.source_paths.clone());
+        self.state.write().await.set_state(data.clone());
+        data
     }
 
     pub(crate) fn current_root(&self) -> Option<PathBuf> {

--- a/src/workspace/scan_handler_tests.rs
+++ b/src/workspace/scan_handler_tests.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use tokio::sync::RwLock;
+use tokio::sync::{mpsc, RwLock};
 
 use crate::indexer::{Indexer, NoopReporter};
 use crate::workspace::phase::State;
@@ -9,10 +9,12 @@ use crate::workspace::Config;
 use super::ScanHandler;
 
 fn make_handler(indexer: Arc<Indexer>) -> ScanHandler<NoopReporter> {
+    let (scan_done_tx, _scan_done_rx) = mpsc::unbounded_channel();
     ScanHandler::new(
         indexer,
         Arc::new(NoopReporter),
         Arc::new(RwLock::new(State::Uninitialized)),
+        scan_done_tx,
     )
 }
 
@@ -21,6 +23,8 @@ async fn handle_initialize_updates_root_and_source_paths() {
     let indexer = Arc::new(Indexer::new());
     let temp_dir = tempfile::tempdir().unwrap();
     let root = temp_dir.path().to_path_buf();
+    // Opt out of real external sources so the test doesn't scan ~/.kotlin-lsp/sources.
+    std::fs::write(root.join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();
     let handler = make_handler(Arc::clone(&indexer));
 
     handler

--- a/src/workspace/scan_queue.rs
+++ b/src/workspace/scan_queue.rs
@@ -1,6 +1,5 @@
 //! [`ScanQueue`] — coalescing queue for full-workspace scans.
 //! Wired into [`ScanHandler`] as part of the w7 quiescent-state work.
-#![allow(dead_code)]
 //!
 //! Prevents concurrent duplicate scans from the thundering-herd problem:
 //! if `Initialize`, `Reindex`, or `ChangeRoot` events arrive while a scan
@@ -29,18 +28,11 @@ pub(crate) enum ScanKind {
 pub(crate) struct ScanArgs {
     pub(crate) root: PathBuf,
     pub(crate) kind: ScanKind,
-    /// Source paths snapshot captured at request time.  Passed to
-    /// `index_source_paths` so that each scan uses the paths that were
-    /// configured when it was enqueued — not whichever set a later event may
-    /// have written by the time the scan actually finishes.
-    pub(crate) source_paths: Vec<String>,
     /// Fired when the scan completes. `None` if the caller does not need notification.
     /// Dropped (without signalling) if this request is superseded before it starts.
     pub(crate) completion_tx: Option<oneshot::Sender<()>>,
-    /// The value of `Indexer::root_generation` at the moment this scan was
-    /// enqueued.  The scan task checks this before writing shared state and
-    /// before signalling `completion_tx`; if the current generation no longer
-    /// matches, the scan has been superseded and should discard its results.
+    /// Generation stamped by [`ScanHandler::enqueue_scan`] after any in-progress bump.
+    /// The scan task compares this against the live generation to detect superseded scans.
     pub(crate) expected_generation: u64,
 }
 

--- a/src/workspace/scan_queue.rs
+++ b/src/workspace/scan_queue.rs
@@ -34,6 +34,10 @@ pub(crate) struct ScanArgs {
     /// Generation stamped by [`ScanHandler::enqueue_scan`] after any in-progress bump.
     /// The scan task compares this against the live generation to detect superseded scans.
     pub(crate) expected_generation: u64,
+    /// When `true`, the scan task calls `Indexer::reset_index_state` immediately before
+    /// running the indexer. Deferred until the task starts so the reset never races
+    /// with a concurrently running scan that was enqueued before this one.
+    pub(crate) reset_before_scan: bool,
 }
 
 // ─── ScanQueue ───────────────────────────────────────────────────────────────

--- a/src/workspace/scan_queue_tests.rs
+++ b/src/workspace/scan_queue_tests.rs
@@ -9,7 +9,6 @@ fn dummy_args(root: &str) -> ScanArgs {
     ScanArgs {
         root: PathBuf::from(root),
         kind: ScanKind::Full,
-        source_paths: Vec::new(),
         completion_tx: None,
         expected_generation: 0,
     }
@@ -55,7 +54,6 @@ fn completion_tx_dropped_when_superseded() {
     q.request(ScanArgs {
         root: PathBuf::from("/b"),
         kind: ScanKind::Full,
-        source_paths: Vec::new(),
         completion_tx: Some(tx1),
         expected_generation: 0,
     });

--- a/src/workspace/scan_queue_tests.rs
+++ b/src/workspace/scan_queue_tests.rs
@@ -11,6 +11,7 @@ fn dummy_args(root: &str) -> ScanArgs {
         kind: ScanKind::Full,
         completion_tx: None,
         expected_generation: 0,
+        reset_before_scan: false,
     }
 }
 
@@ -56,6 +57,7 @@ fn completion_tx_dropped_when_superseded() {
         kind: ScanKind::Full,
         completion_tx: Some(tx1),
         expected_generation: 0,
+        reset_before_scan: false,
     });
     // /b pending is now replaced by /c, dropping tx1
     q.request(dummy_args("/c"));


### PR DESCRIPTION
## What

- **Quiescent state** on the workspace actor: after each scan completes the actor evaluates `is_ready()` and fires `on_became_ready()` exactly once per non-ready → ready transition (log with root path + source count). Covers initial scan, reindex, and change-root cycles.
- **177× test speed-up**: 830 lib tests went from 408s → 2.3s. Root cause: actor/e2e tests used bare temp dirs with no `workspace.json`, so `Config::resolve_sources` fell back to `~/.kotlin-lsp/sources` and indexed the full Android library corpus on every test.

## Changes

### ScanHandler
- `is_scanning: Arc<AtomicBool>` + `scan_done_tx: mpsc::UnboundedSender<()>` field
- Both `spawn_scan` and `spawn_full_scan` set the flag before spawning and clear + signal on completion

### Actor
- `scan_done_rx: mpsc::UnboundedReceiver<()>` paired with ScanHandler's sender
- `is_ready()`: State is Ready AND `is_scanning` is false
- `on_became_ready()`: info-level log on first quiescence (hook for future: progress end, library cache priming)
- `was_ready` bool ensures BecameReady fires exactly once per transition
- `handle_event()` extracted to keep run() readable

### Test mocked sources
- `actor_tests::temp_dir()` now writes `workspace.json` with `sourcePaths:[]`
- `indexer_tests` e2e tests get the same opt-out
- `scan_handler_tests` updated for new `ScanHandler::new` signature (scan_done_tx arg)

## Also includes (from mvi-write-consolidation base)
- CLI source path parity: `collect_cli_source_paths` now calls `detect_build_layout_source_paths` and `detect_android_sdk_source_paths`, matching `Config::resolve_sources` on the LSP path