### PR TITLE
refactor: move rg_context() to Indexer, eliminate raw lock repetition

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -115,9 +115,7 @@ impl Backend {
     }
 
     pub(crate) async fn rg_context(&self) -> (Option<PathBuf>, Option<Arc<IgnoreMatcher>>) {
-        let root = self.indexer.workspace_root.get();
-        let ignore = self.indexer.ignore_matcher.read().unwrap().clone();
-        (root, ignore)
+        self.indexer.rg_context()
     }
 
     /// Try `find_definition_qualified` with `rt.qualified`, falling back to `rt.leaf`
@@ -388,7 +386,7 @@ impl LanguageServer for Backend {
         params: ExecuteCommandParams,
     ) -> Result<Option<serde_json::Value>> {
         if params.command == "kotlin-lsp/reindex" {
-            let root = self.indexer.workspace_root.get();
+            let (root, _) = self.indexer.rg_context();
             let Some(root) = root else {
                 self.client
                     .show_message(MessageType::WARNING, "kotlin-lsp: no workspace root set")
@@ -425,8 +423,7 @@ impl LanguageServer for Backend {
                 }
                 pb
             } else {
-                // Acquire current root upfront and drop the lock before any await.
-                let current_root_opt = { self.indexer.workspace_root.get() };
+                let (current_root_opt, _) = self.indexer.rg_context();
                 match current_root_opt {
                     Some(r) => r,
                     None => {

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -129,12 +129,7 @@ impl Backend {
         };
 
         // Direct subtypes from the index.
-        let mut locs: Vec<Location> = self
-            .indexer
-            .subtypes
-            .get(&word)
-            .map(|v| v.clone())
-            .unwrap_or_default();
+        let mut locs: Vec<Location> = self.indexer.subtypes_of(&word);
 
         // If index is empty for this symbol (cold start), try rg-based heuristic
         // to find implementors quickly to avoid client timeouts in large projects.
@@ -181,7 +176,6 @@ impl Backend {
                     .iter()
                     .any(|l| l.uri == loc.uri && l.range == loc.range)
                 {
-                    locs.push(loc.clone());
                     if let Some(data) = self.indexer.file_data_for(loc.uri.as_str()) {
                         if let Some(sym) =
                             data.symbols.iter().find(|s| s.selection_range == loc.range)
@@ -189,6 +183,7 @@ impl Backend {
                             queue.push(sym.name.clone());
                         }
                     }
+                    locs.push(loc);
                 }
             }
         }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -357,6 +357,14 @@ impl Indexer {
         self.library_uris.contains(uri.as_str())
     }
 
+    /// Returns the workspace root and ignore matcher, ready to pass to `rg`/`fd` helpers.
+    /// Acquires both read locks and clones — always call outside of any existing lock scope.
+    pub(crate) fn rg_context(&self) -> (Option<PathBuf>, Option<Arc<IgnoreMatcher>>) {
+        let root = self.workspace_root.read().unwrap().clone();
+        let matcher = self.ignore_matcher.read().unwrap().clone();
+        (root, matcher)
+    }
+
     pub(crate) fn remove_live_lines(&self, uri: &Url) {
         self.live_lines.remove(uri.as_str());
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -360,7 +360,7 @@ impl Indexer {
     /// Returns the workspace root and ignore matcher, ready to pass to `rg`/`fd` helpers.
     /// Acquires both read locks and clones — always call outside of any existing lock scope.
     pub(crate) fn rg_context(&self) -> (Option<PathBuf>, Option<Arc<IgnoreMatcher>>) {
-        let root = self.workspace_root.read().unwrap().clone();
+        let root = self.workspace_root.get();
         let matcher = self.ignore_matcher.read().unwrap().clone();
         (root, matcher)
     }

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -919,8 +919,7 @@ fn lambda_receiver_type_named_arg_ml(
             let locs = idx.resolve_symbol_no_rg(outer, uri);
             locs.first().map(|l| l.uri.to_string()).or_else(|| {
                 // On-demand: use rg to find and index the outer class.
-                let root = idx.workspace_root.get();
-                let matcher = idx.ignore_matcher.read().unwrap().clone();
+                let (root, matcher) = idx.rg_context();
                 let rg_locs =
                     crate::rg::rg_find_definition(outer, root.as_deref(), matcher.as_deref());
                 for loc in &rg_locs {

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -105,8 +105,7 @@ pub(crate) fn find_fun_signature_full(fn_name: &str, idx: &Indexer, uri: &Url) -
         return Some(sig);
     }
     // Slow path: rg to locate the definition, index on-demand.
-    let root = idx.workspace_root.get();
-    let matcher = idx.ignore_matcher.read().unwrap().clone();
+    let (root, matcher) = idx.rg_context();
     let locs = crate::rg::rg_find_definition(fn_name, root.as_deref(), matcher.as_deref());
     for loc in &locs {
         let file_uri_str = loc.uri.as_str();

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -406,8 +406,7 @@ pub(crate) fn resolve_symbol_inner(
     }
 
     // 5 ── project-wide rg ───────────────────────────────────────────────────
-    let root = idx.workspace_root.get();
-    let matcher = idx.ignore_matcher.read().unwrap().clone();
+    let (root, matcher) = idx.rg_context();
     rg_find_definition(name, root.as_deref(), matcher.as_deref())
 }
 
@@ -650,10 +649,8 @@ fn resolve_via_imports(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
         }
 
         // iii) on-demand fd + parse (indexing race or file never opened).
-        let root_opt = idx.workspace_root.get();
-        let root = root_opt.as_deref();
-        let matcher = idx.ignore_matcher.read().unwrap().clone();
-        let locs = fd_find_and_parse(name, &imp.full_path, root, matcher.as_deref());
+        let (root, matcher) = idx.rg_context();
+        let locs = fd_find_and_parse(name, &imp.full_path, root.as_deref(), matcher.as_deref());
         if !locs.is_empty() {
             return locs;
         }
@@ -932,10 +929,8 @@ fn resolve_star_imports(idx: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
         }
 
         // b) rg scoped to the package directory for unindexed files
-        let root_opt = idx.workspace_root.get();
-        let root = root_opt.as_deref();
-        let matcher = idx.ignore_matcher.read().unwrap().clone();
-        let locs = rg_in_package_dir(name, &pkg, root, matcher.as_deref());
+        let (root, matcher) = idx.rg_context();
+        let locs = rg_in_package_dir(name, &pkg, root.as_deref(), matcher.as_deref());
         if !locs.is_empty() {
             return locs;
         }

--- a/src/semantic_tokens/resolve.rs
+++ b/src/semantic_tokens/resolve.rs
@@ -439,7 +439,7 @@ fn owner_member_token_type(
 ) -> Option<u32> {
     let receiver_leaf = receiver_type.rsplit('.').next().unwrap_or(receiver_type);
     for loc in indexer.definition_locations(receiver_leaf) {
-        let Some(file_data) = indexer.files.get(loc.uri.as_str()) else {
+        let Some(file_data) = indexer.file_data_for(loc.uri.as_str()) else {
             continue;
         };
         let owner_range = file_data
@@ -467,7 +467,7 @@ fn extension_member_token_type(
     member_name: &str,
 ) -> Option<u32> {
     for loc in indexer.definition_locations(member_name) {
-        let Some(file_data) = indexer.files.get(loc.uri.as_str()) else {
+        let Some(file_data) = indexer.file_data_for(loc.uri.as_str()) else {
             continue;
         };
         if let Some(symbol) = file_data.symbols.iter().find(|symbol| {
@@ -510,7 +510,7 @@ fn enum_entry_reference_token(node: Node<'_>, src: &[u8], indexer: &Indexer) -> 
     let receiver_kind = resolve_symbol_kind(node_text(receiver, src), indexer, |kind| {
         kind == SymbolKind::ENUM
     })?;
-    let receiver_data = indexer.files.get(receiver_kind.uri.as_str())?;
+    let receiver_data = indexer.file_data_for(receiver_kind.uri.as_str())?;
     receiver_data
         .symbols
         .iter()
@@ -528,7 +528,7 @@ fn resolve_symbol_kind(
     matches_kind: impl Fn(SymbolKind) -> bool,
 ) -> Option<ResolvedReference> {
     for location in indexer.definition_locations(name) {
-        let Some(data) = indexer.files.get(location.uri.as_str()) else {
+        let Some(data) = indexer.file_data_for(location.uri.as_str()) else {
             continue;
         };
         let Some(symbol) = data


### PR DESCRIPTION
## Summary

Builds on #82 (DashMap encapsulation). Three follow-up cleanup passes:

### 1. `rg_context()` moved to Indexer (`src/indexer.rs`)
- Added `Indexer::rg_context() -> (Option<PathBuf>, Option<Arc<IgnoreMatcher>>)`
- Eliminated repeated raw `workspace_root.read().unwrap() / ignore_matcher.read().unwrap()` pairs from 6 call sites across `backend/mod.rs`, `resolver/mod.rs`, `infer/it_this.rs`, `infer/sig.rs`
- `Backend::rg_context()` now delegates to the new method

### 2. `file_data_for()` in semantic tokens (`src/semantic_tokens/resolve.rs`)
- Replaced 4 direct `indexer.files.get(...)` calls with the encapsulated `file_data_for()` accessor
- Keeps all DashMap access inside Indexer, consistent with the encapsulation established in #82

### 3. `subtypes_of()` in goto-implementation (`src/backend/nav.rs`)
- Replaced remaining direct `indexer.subtypes.get()` with `indexer.subtypes_of()`
- Removed redundant `loc.clone()` in BFS loop — `loc` is already owned from `subtypes_of()` iterator