### PR TITLE
feat: F4 + F5 cleanup — wire document_symbols, tighten dead_code annotations

### DIFF
--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -4,9 +4,6 @@ use crate::inlay_hints::compute_inlay_hints;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 
-/// Maximum number of workspace symbol results to return.
-const WORKSPACE_SYMBOL_CAP: usize = 512;
-
 impl Backend {
     pub(super) async fn hover_impl(&self, params: HoverParams) -> Result<Option<Hover>> {
         let pp = params.text_document_position_params;
@@ -78,46 +75,12 @@ impl Backend {
         &self,
         params: WorkspaceSymbolParams,
     ) -> Result<Option<Vec<SymbolInformation>>> {
-        let query = WorkspaceSymbolQuery::new(params.query);
-        let mut results = self.collect_workspace_symbols(&query);
-        if results.is_empty() {
-            results = self.rg_workspace_symbols(&query).await;
-        }
+        let results = crate::features::workspace_symbols::compute_workspace_symbols(
+            params.query,
+            self.indexer.as_ref(),
+        )
+        .await;
         Ok((!results.is_empty()).then_some(results))
-    }
-
-    fn collect_workspace_symbols(&self, query: &WorkspaceSymbolQuery) -> Vec<SymbolInformation> {
-        let mut results = Vec::new();
-        self.indexer.for_each_indexed_file(|uri_str, data| {
-            let Some(uri) = workspace_symbol_uri(uri_str) else {
-                return true;
-            };
-            collect_matching_workspace_symbols(&uri, &data.symbols, query, &mut results);
-            results.len() < WORKSPACE_SYMBOL_CAP
-        });
-        results.sort_by(|left, right| left.name.cmp(&right.name));
-        results
-    }
-
-    async fn rg_workspace_symbols(&self, query: &WorkspaceSymbolQuery) -> Vec<SymbolInformation> {
-        if !query.allows_rg_fallback() {
-            return vec![];
-        }
-        let (workspace_root, ignore_matcher) = self.rg_context().await;
-        let query_text = query.raw.clone();
-        let rg_locations = tokio::task::spawn_blocking(move || {
-            crate::rg::rg_find_definition(
-                &query_text,
-                workspace_root.as_deref(),
-                ignore_matcher.as_deref(),
-            )
-        })
-        .await
-        .unwrap_or_default();
-        rg_locations
-            .into_iter()
-            .map(|location| rg_workspace_symbol(query.name.clone(), location))
-            .collect()
     }
 
     pub(super) async fn signature_help_impl(
@@ -157,99 +120,6 @@ impl Backend {
             pos,
             self.indexer.as_ref(),
         ))
-    }
-}
-
-#[derive(Clone)]
-struct WorkspaceSymbolQuery {
-    raw: String,
-    qualifier: Option<String>,
-    name: String,
-}
-
-impl WorkspaceSymbolQuery {
-    fn new(query: String) -> Self {
-        let raw = query.to_lowercase();
-        if let Some(dot) = raw.rfind('.') {
-            return Self {
-                qualifier: Some(raw[..dot].to_owned()),
-                name: raw[dot + 1..].to_owned(),
-                raw,
-            };
-        }
-        Self {
-            name: raw.clone(),
-            raw,
-            qualifier: None,
-        }
-    }
-
-    fn matches(&self, symbol: &crate::types::SymbolEntry) -> bool {
-        if self.raw.is_empty() {
-            return true;
-        }
-        let name = symbol.name.to_lowercase();
-        if let Some(qualifier) = self.qualifier.as_deref() {
-            return name.contains(&self.name) && symbol.detail.to_lowercase().contains(qualifier);
-        }
-        name.contains(&self.raw)
-    }
-
-    fn allows_rg_fallback(&self) -> bool {
-        !self.raw.is_empty() && self.qualifier.is_none()
-    }
-}
-
-fn workspace_symbol_uri(uri_str: &str) -> Option<Url> {
-    Url::parse(uri_str)
-        .ok()
-        .or_else(|| Url::from_file_path(uri_str).ok())
-}
-
-fn collect_matching_workspace_symbols(
-    uri: &Url,
-    symbols: &[crate::types::SymbolEntry],
-    query: &WorkspaceSymbolQuery,
-    results: &mut Vec<SymbolInformation>,
-) {
-    for symbol in symbols {
-        if !query.matches(symbol) {
-            continue;
-        }
-        results.push(workspace_symbol_information(uri, symbol));
-        if results.len() >= WORKSPACE_SYMBOL_CAP {
-            break;
-        }
-    }
-}
-
-fn workspace_symbol_information(
-    uri: &Url,
-    symbol: &crate::types::SymbolEntry,
-) -> SymbolInformation {
-    #[allow(deprecated)]
-    SymbolInformation {
-        name: symbol.name.clone(),
-        kind: symbol.kind,
-        tags: None,
-        deprecated: None,
-        location: Location {
-            uri: uri.clone(),
-            range: symbol.selection_range,
-        },
-        container_name: (!symbol.detail.is_empty()).then(|| symbol.detail.clone()),
-    }
-}
-
-fn rg_workspace_symbol(name: String, location: Location) -> SymbolInformation {
-    #[allow(deprecated)]
-    SymbolInformation {
-        name,
-        kind: tower_lsp::lsp_types::SymbolKind::FILE,
-        tags: None,
-        deprecated: None,
-        location,
-        container_name: Some("rg fallback".to_string()),
     }
 }
 

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -47,18 +47,16 @@ impl Backend {
         params: DocumentSymbolParams,
     ) -> Result<Option<DocumentSymbolResponse>> {
         let uri = &params.text_document.uri;
-        // On-demand indexing: parse from disk when file not yet indexed.
-        if self.indexer.file_symbols(uri).is_empty() {
+        let mut symbols = self.indexer.file_symbols(uri);
+        if symbols.is_empty() {
             if let Ok(path) = uri.to_file_path() {
                 if let Ok(content) = std::fs::read_to_string(&path) {
                     self.indexer.index_content(uri, &content);
+                    symbols = self.indexer.file_symbols(uri);
                 }
             }
         }
-        Ok(crate::features::symbols::compute_document_symbols(
-            uri,
-            self.indexer.as_ref(),
-        ))
+        Ok(crate::features::symbols::compute_document_symbols(symbols))
     }
 
     pub(super) async fn inlay_hint_impl(

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -50,40 +50,18 @@ impl Backend {
         params: DocumentSymbolParams,
     ) -> Result<Option<DocumentSymbolResponse>> {
         let uri = &params.text_document.uri;
-        let mut symbols = self.indexer.file_symbols(uri);
-        // Disk fallback: if not indexed yet, parse on-demand and index.
-        if symbols.is_empty() {
+        // On-demand indexing: parse from disk when file not yet indexed.
+        if self.indexer.file_symbols(uri).is_empty() {
             if let Ok(path) = uri.to_file_path() {
                 if let Ok(content) = std::fs::read_to_string(&path) {
                     self.indexer.index_content(uri, &content);
-                    symbols = self.indexer.file_symbols(uri);
                 }
             }
         }
-        if symbols.is_empty() {
-            return Ok(None);
-        }
-
-        #[allow(deprecated)] // `deprecated` field superseded by `tags` in LSP 3.16+
-        let doc_symbols = symbols
-            .into_iter()
-            .map(|s| DocumentSymbol {
-                name: s.name,
-                detail: if s.detail.is_empty() {
-                    None
-                } else {
-                    Some(s.detail)
-                },
-                kind: s.kind,
-                tags: None,
-                deprecated: None,
-                range: s.range,
-                selection_range: s.selection_range,
-                children: None,
-            })
-            .collect();
-
-        Ok(Some(DocumentSymbolResponse::Nested(doc_symbols)))
+        Ok(crate::features::symbols::compute_document_symbols(
+            uri,
+            self.indexer.as_ref(),
+        ))
     }
 
     pub(super) async fn inlay_hint_impl(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -572,46 +572,11 @@ impl LanguageServer for Backend {
 
     // ── completionItem/resolve ────────────────────────────────────────────────
 
-    async fn completion_resolve(&self, mut item: CompletionItem) -> Result<CompletionItem> {
-        use crate::indexer::resolution::{enrich_at_line, ResolveOptions, SubstitutionContext};
-
-        if let Some(ref data) = item.data {
-            if let (Some(uri), Some(line)) = (
-                data.get("u").and_then(|v| v.as_str()),
-                data.get("l").and_then(|v| v.as_u64()),
-            ) {
-                let col = data.get("c").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
-                let calling_uri = data.get("cu").and_then(|v| v.as_str());
-
-                let subst_ctx = match calling_uri {
-                    Some(cu) if cu != uri => SubstitutionContext::CrossFile {
-                        calling_uri: cu,
-                        cursor_line: None,
-                    },
-                    _ => SubstitutionContext::None,
-                };
-
-                if let Some(info) = enrich_at_line(
-                    self.indexer.as_ref(),
-                    uri,
-                    line as u32,
-                    col,
-                    subst_ctx,
-                    &ResolveOptions::completion(),
-                ) {
-                    if !info.signature.is_empty() {
-                        item.detail = Some(info.signature);
-                    }
-                    if !info.doc.is_empty() {
-                        item.documentation = Some(Documentation::MarkupContent(MarkupContent {
-                            kind: MarkupKind::Markdown,
-                            value: info.doc,
-                        }));
-                    }
-                }
-            }
-        }
-        Ok(item)
+    async fn completion_resolve(&self, item: CompletionItem) -> Result<CompletionItem> {
+        Ok(crate::features::completion::resolve_completion_item(
+            item,
+            self.indexer.as_ref(),
+        ))
     }
 
     // ── textDocument/hover ───────────────────────────────────────────────────

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -4,7 +4,8 @@
 //!
 //! The completion pipeline writes a small JSON blob into `CompletionItem.data`
 //! so that `completionItem/resolve` can look up the full signature + doc comment.
-//! Use the `DATA_*` constants below on both the write and read side.
+//! The `DATA_*` constants are defined in `resolver::complete` (the write side)
+//! and re-exported here for use by `resolve_completion_item` (the read side).
 
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionList, CompletionResponse, Documentation, MarkupContent, MarkupKind,
@@ -15,16 +16,8 @@ use crate::indexer::resolution::{enrich_at_line, IndexRead, ResolveOptions, Subs
 
 use super::traits::CompletionIndex;
 
-// ─── CompletionItem.data JSON keys ───────────────────────────────────────────
-
-/// Symbol definition URI.
-pub(crate) const DATA_URI: &str = "u";
-/// Symbol definition line (0-based).
-pub(crate) const DATA_LINE: &str = "l";
-/// Symbol definition UTF-16 column (0-based).
-pub(crate) const DATA_COL: &str = "c";
-/// Calling-site URI, present only for cross-file substitution context.
-pub(crate) const DATA_CALLING_URI: &str = "cu";
+// Re-export so callers only need to import from one place.
+pub(crate) use crate::resolver::complete::{DATA_CALLING_URI, DATA_COL, DATA_LINE, DATA_URI};
 
 /// Compute completions at `position` in `uri`.
 ///

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -1,4 +1,10 @@
 //! Completion feature — delegates the full pipeline via `CompletionIndex`.
+//!
+//! # CompletionItem data keys
+//!
+//! The completion pipeline writes a small JSON blob into `CompletionItem.data`
+//! so that `completionItem/resolve` can look up the full signature + doc comment.
+//! Use the `DATA_*` constants below on both the write and read side.
 
 use tower_lsp::lsp_types::{
     CompletionItem, CompletionList, CompletionResponse, Documentation, MarkupContent, MarkupKind,
@@ -8,6 +14,17 @@ use tower_lsp::lsp_types::{
 use crate::indexer::resolution::{enrich_at_line, IndexRead, ResolveOptions, SubstitutionContext};
 
 use super::traits::CompletionIndex;
+
+// ─── CompletionItem.data JSON keys ───────────────────────────────────────────
+
+/// Symbol definition URI.
+pub(crate) const DATA_URI: &str = "u";
+/// Symbol definition line (0-based).
+pub(crate) const DATA_LINE: &str = "l";
+/// Symbol definition UTF-16 column (0-based).
+pub(crate) const DATA_COL: &str = "c";
+/// Calling-site URI, present only for cross-file substitution context.
+pub(crate) const DATA_CALLING_URI: &str = "cu";
 
 /// Compute completions at `position` in `uri`.
 ///
@@ -47,11 +64,11 @@ pub(crate) fn resolve_completion_item<I: IndexRead>(
     let mut item = item;
     if let Some(ref data) = item.data {
         if let (Some(uri), Some(line)) = (
-            data.get("u").and_then(|v| v.as_str()),
-            data.get("l").and_then(|v| v.as_u64()),
+            data.get(DATA_URI).and_then(|v| v.as_str()),
+            data.get(DATA_LINE).and_then(|v| v.as_u64()),
         ) {
-            let col = data.get("c").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
-            let calling_uri = data.get("cu").and_then(|v| v.as_str());
+            let col = data.get(DATA_COL).and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+            let calling_uri = data.get(DATA_CALLING_URI).and_then(|v| v.as_str());
 
             let subst_ctx = match calling_uri {
                 Some(cu) if cu != uri => SubstitutionContext::CrossFile {

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -1,6 +1,11 @@
 //! Completion feature — delegates the full pipeline via `CompletionIndex`.
 
-use tower_lsp::lsp_types::{CompletionList, CompletionResponse, Position, Url};
+use tower_lsp::lsp_types::{
+    CompletionItem, CompletionList, CompletionResponse, Documentation, MarkupContent, MarkupKind,
+    Position, Url,
+};
+
+use crate::indexer::resolution::{enrich_at_line, IndexRead, ResolveOptions, SubstitutionContext};
 
 use super::traits::CompletionIndex;
 
@@ -29,4 +34,52 @@ pub(crate) fn compute_completions(
         is_incomplete: hit_cap || still_indexing,
         items,
     }))
+}
+
+/// Enrich a completion item with signature + doc comment on `completionItem/resolve`.
+///
+/// Reads `uri`, `line`, `col`, and optionally `calling_uri` from the item's
+/// custom `data` blob written by the completion pipeline.
+pub(crate) fn resolve_completion_item<I: IndexRead>(
+    item: CompletionItem,
+    index: &I,
+) -> CompletionItem {
+    let mut item = item;
+    if let Some(ref data) = item.data {
+        if let (Some(uri), Some(line)) = (
+            data.get("u").and_then(|v| v.as_str()),
+            data.get("l").and_then(|v| v.as_u64()),
+        ) {
+            let col = data.get("c").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+            let calling_uri = data.get("cu").and_then(|v| v.as_str());
+
+            let subst_ctx = match calling_uri {
+                Some(cu) if cu != uri => SubstitutionContext::CrossFile {
+                    calling_uri: cu,
+                    cursor_line: None,
+                },
+                _ => SubstitutionContext::None,
+            };
+
+            if let Some(info) = enrich_at_line(
+                index,
+                uri,
+                line as u32,
+                col,
+                subst_ctx,
+                &ResolveOptions::completion(),
+            ) {
+                if !info.signature.is_empty() {
+                    item.detail = Some(info.signature);
+                }
+                if !info.doc.is_empty() {
+                    item.documentation = Some(Documentation::MarkupContent(MarkupContent {
+                        kind: MarkupKind::Markdown,
+                        value: info.doc,
+                    }));
+                }
+            }
+        }
+    }
+    item
 }

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -22,9 +22,7 @@ pub(crate) mod hover;
 pub(crate) mod implementation;
 pub(crate) mod references;
 pub(crate) mod signature_help;
-#[allow(dead_code)]
 pub(crate) mod symbols;
 pub(crate) mod text_utils;
 pub(crate) mod traits;
-#[allow(dead_code)]
 mod traits_impl;

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -26,3 +26,4 @@ pub(crate) mod symbols;
 pub(crate) mod text_utils;
 pub(crate) mod traits;
 mod traits_impl;
+pub(crate) mod workspace_symbols;

--- a/src/features/symbols.rs
+++ b/src/features/symbols.rs
@@ -1,21 +1,17 @@
 //! Document symbols feature — maps indexed `SymbolEntry` to LSP `DocumentSymbol`.
 
-use tower_lsp::lsp_types::{DocumentSymbol, DocumentSymbolResponse, Url};
+use tower_lsp::lsp_types::{DocumentSymbol, DocumentSymbolResponse};
 
 use crate::types::SymbolEntry;
 
-use super::traits::SymbolIndex;
-
-/// Build the LSP document symbols response for `uri`.
+/// Build the LSP document symbols response from a pre-fetched symbol list.
 ///
-/// Returns `None` when no symbols are indexed for the file.
-/// On-demand indexing (disk fallback) is handled by the backend adapter before
-/// this function is called.
+/// Returns `None` when `symbols` is empty.
+/// On-demand indexing (disk fallback) and symbol fetching are handled by the
+/// backend adapter before this function is called.
 pub(crate) fn compute_document_symbols(
-    uri: &Url,
-    index: &impl SymbolIndex,
+    symbols: Vec<SymbolEntry>,
 ) -> Option<DocumentSymbolResponse> {
-    let symbols = index.file_symbols(uri);
     if symbols.is_empty() {
         return None;
     }

--- a/src/features/traits.rs
+++ b/src/features/traits.rs
@@ -21,7 +21,6 @@ use crate::types::{FileData, SymbolEntry};
 // ─── SymbolIndex ─────────────────────────────────────────────────────────────
 
 /// Symbol lookup — find, resolve, and navigate across the indexed codebase.
-#[allow(dead_code)]
 pub(crate) trait SymbolIndex {
     /// Find definition locations for `name`, using `qualifier` and `from_uri`
     /// to narrow the search to imported/accessible symbols.
@@ -46,6 +45,7 @@ pub(crate) trait SymbolIndex {
 
     /// Iterate all indexed files, calling `f(uri_str, file_data)`.
     /// Return `false` from `f` to stop iteration early.
+    #[allow(dead_code)]
     fn for_each_indexed_file(&self, f: &mut dyn FnMut(&str, &Arc<FileData>) -> bool);
 
     /// Name of the innermost class/object enclosing `row` in `uri`, if any.
@@ -55,29 +55,30 @@ pub(crate) trait SymbolIndex {
 // ─── DocumentAccess ──────────────────────────────────────────────────────────
 
 /// Document text and cursor-position access.
-#[allow(dead_code)]
 pub(crate) trait DocumentAccess {
     /// Lines from the in-memory caches only (no disk I/O).
     /// Prefers live (unsaved) buffer; falls back to indexed snapshot.
     fn mem_lines_for(&self, uri: &str) -> Option<Arc<Vec<String>>>;
 
     /// Lines for `uri`, including disk fallback if not live.
+    #[allow(dead_code)]
     fn lines_for(&self, uri: &Url) -> Option<Arc<Vec<String>>>;
 
     /// Extract the identifier and optional dot-qualifier at `pos`.
     fn word_and_qualifier_at(&self, uri: &Url, pos: Position) -> Option<(String, Option<String>)>;
 
     /// Extract just the identifier token at `pos`.
+    #[allow(dead_code)]
     fn word_at(&self, uri: &Url, pos: Position) -> Option<String>;
 
     /// Extract the identifier token and its source range at `pos`.
+    #[allow(dead_code)]
     fn word_and_range_at(&self, uri: &Url, pos: Position) -> Option<(String, Range)>;
 }
 
 // ─── ScopeQuery ──────────────────────────────────────────────────────────────
 
 /// Import and package scope resolution, plus library classification.
-#[allow(dead_code)]
 pub(crate) trait ScopeQuery {
     /// Returns `true` if `uri` is a library/stdlib file (not workspace source).
     fn is_library_uri(&self, uri: &Url) -> bool;
@@ -105,7 +106,6 @@ pub(crate) trait ScopeQuery {
 // ─── SearchAccess ────────────────────────────────────────────────────────────
 
 /// Ripgrep-based fallback search context.
-#[allow(dead_code)]
 pub(crate) trait SearchAccess {
     /// Returns the (workspace_root, ignore_matcher) tuple used to scope `rg` calls.
     fn rg_context(&self) -> (Option<PathBuf>, Option<Arc<IgnoreMatcher>>);
@@ -114,7 +114,6 @@ pub(crate) trait SearchAccess {
 // ─── CompletionIndex ─────────────────────────────────────────────────────────
 
 /// Completion pipeline — already fully orchestrated inside the Indexer.
-#[allow(dead_code)]
 pub(crate) trait CompletionIndex {
     /// Run the full completion pipeline for `uri` at `position`.
     fn completions(
@@ -131,7 +130,6 @@ pub(crate) trait CompletionIndex {
 // ─── SignatureIndex ───────────────────────────────────────────────────────────
 
 /// Function signature lookup with optional receiver type matching.
-#[allow(dead_code)]
 pub(crate) trait SignatureIndex {
     /// Signature text for `name`, optionally narrowed to `receiver`'s type.
     fn find_fun_signature_with_receiver(
@@ -149,7 +147,6 @@ pub(crate) trait SignatureIndex {
 /// Kept separate from the index-based traits because it requires live-tree state
 /// that those traits do not; mixing them would force test stubs to provide CST
 /// infrastructure unnecessarily.
-#[allow(dead_code)]
 pub(crate) trait LiveTreeAccess {
     /// Extract the call-site name, qualifier, and active parameter index
     /// at `pos` using the live parse tree for `uri`.

--- a/src/features/traits.rs
+++ b/src/features/traits.rs
@@ -45,7 +45,6 @@ pub(crate) trait SymbolIndex {
 
     /// Iterate all indexed files, calling `f(uri_str, file_data)`.
     /// Return `false` from `f` to stop iteration early.
-    #[allow(dead_code)]
     fn for_each_indexed_file(&self, f: &mut dyn FnMut(&str, &Arc<FileData>) -> bool);
 
     /// Name of the innermost class/object enclosing `row` in `uri`, if any.

--- a/src/features/traits.rs
+++ b/src/features/traits.rs
@@ -41,6 +41,7 @@ pub(crate) trait SymbolIndex {
     fn file_data_for(&self, uri: &str) -> Option<Arc<FileData>>;
 
     /// All top-level symbols indexed for `uri`.
+    #[allow(dead_code)]
     fn file_symbols(&self, uri: &Url) -> Vec<SymbolEntry>;
 
     /// Iterate all indexed files, calling `f(uri_str, file_data)`.

--- a/src/features/traits_impl.rs
+++ b/src/features/traits_impl.rs
@@ -45,11 +45,7 @@ impl SymbolIndex for Indexer {
     }
 
     fn for_each_indexed_file(&self, f: &mut dyn FnMut(&str, &Arc<FileData>) -> bool) {
-        for entry in self.files.iter() {
-            if !f(entry.key(), entry.value()) {
-                break;
-            }
-        }
+        self.for_each_indexed_file(f);
     }
 
     fn enclosing_class_at(&self, uri: &Url, row: u32) -> Option<String> {

--- a/src/features/workspace_symbols.rs
+++ b/src/features/workspace_symbols.rs
@@ -1,0 +1,159 @@
+//! Workspace symbol search — index-first with rg fallback.
+//!
+//! Entry point: [`compute_workspace_symbols`].
+//! Bounds: `SymbolIndex + SearchAccess`.
+
+use std::sync::Arc;
+
+use crate::rg;
+use crate::types::{FileData, SymbolEntry};
+use tower_lsp::lsp_types::{Location, SymbolInformation, Url};
+
+use super::traits::{SearchAccess, SymbolIndex};
+
+/// Maximum results returned from the index scan.
+const WORKSPACE_SYMBOL_CAP: usize = 512;
+
+/// Search workspace symbols by `query`, returning up to `WORKSPACE_SYMBOL_CAP` results.
+///
+/// Index-first: scans all indexed files for matching symbols.
+/// rg fallback: fired when the index returns nothing and the query is a bare name (no dot).
+pub(crate) async fn compute_workspace_symbols(
+    query_str: String,
+    index: &(impl SymbolIndex + SearchAccess),
+) -> Vec<SymbolInformation> {
+    let query = WorkspaceSymbolQuery::new(query_str);
+    let mut results = collect_index_symbols(&query, index);
+    if results.is_empty() {
+        results = rg_symbol_search(&query, index).await;
+    }
+    results
+}
+
+// ─── Index scan ──────────────────────────────────────────────────────────────
+
+fn collect_index_symbols(
+    query: &WorkspaceSymbolQuery,
+    index: &impl SymbolIndex,
+) -> Vec<SymbolInformation> {
+    let mut results = Vec::new();
+    let mut f = |uri_str: &str, data: &Arc<FileData>| {
+        let Some(uri) = parse_uri(uri_str) else {
+            return true;
+        };
+        for symbol in &data.symbols {
+            if !query.matches(symbol) {
+                continue;
+            }
+            results.push(symbol_information(&uri, symbol));
+            if results.len() >= WORKSPACE_SYMBOL_CAP {
+                return false;
+            }
+        }
+        true
+    };
+    index.for_each_indexed_file(&mut f);
+    results.sort_by(|a, b| a.name.cmp(&b.name));
+    results
+}
+
+// ─── rg fallback ─────────────────────────────────────────────────────────────
+
+async fn rg_symbol_search(
+    query: &WorkspaceSymbolQuery,
+    index: &impl SearchAccess,
+) -> Vec<SymbolInformation> {
+    if !query.allows_rg_fallback() {
+        return vec![];
+    }
+    let (workspace_root, ignore_matcher) = index.rg_context();
+    let name = query.name.clone();
+    let locations = tokio::task::spawn_blocking(move || {
+        rg::rg_find_definition(&name, workspace_root.as_deref(), ignore_matcher.as_deref())
+    })
+    .await
+    .unwrap_or_default();
+
+    locations
+        .into_iter()
+        .map(|loc| rg_symbol_information(query.name.clone(), loc))
+        .collect()
+}
+
+// ─── Query type ──────────────────────────────────────────────────────────────
+
+/// Parsed and lowercased workspace symbol query.
+#[derive(Clone)]
+struct WorkspaceSymbolQuery {
+    raw: String,
+    qualifier: Option<String>,
+    name: String,
+}
+
+impl WorkspaceSymbolQuery {
+    fn new(query: String) -> Self {
+        let raw = query.to_lowercase();
+        if let Some(dot) = raw.rfind('.') {
+            return Self {
+                qualifier: Some(raw[..dot].to_owned()),
+                name: raw[dot + 1..].to_owned(),
+                raw,
+            };
+        }
+        Self {
+            name: raw.clone(),
+            raw,
+            qualifier: None,
+        }
+    }
+
+    fn matches(&self, symbol: &SymbolEntry) -> bool {
+        if self.raw.is_empty() {
+            return true;
+        }
+        let name = symbol.name.to_lowercase();
+        if let Some(qualifier) = self.qualifier.as_deref() {
+            return name.contains(&self.name) && symbol.detail.to_lowercase().contains(qualifier);
+        }
+        name.contains(&self.raw)
+    }
+
+    fn allows_rg_fallback(&self) -> bool {
+        !self.raw.is_empty() && self.qualifier.is_none()
+    }
+}
+
+// ─── LSP conversion helpers ──────────────────────────────────────────────────
+
+fn parse_uri(uri_str: &str) -> Option<Url> {
+    Url::parse(uri_str)
+        .ok()
+        .or_else(|| Url::from_file_path(uri_str).ok())
+}
+
+#[allow(deprecated)] // `deprecated` superseded by `tags` in LSP 3.16+
+fn symbol_information(uri: &Url, symbol: &SymbolEntry) -> SymbolInformation {
+    SymbolInformation {
+        name: symbol.name.clone(),
+        kind: symbol.kind,
+        tags: None,
+        deprecated: None,
+        location: Location {
+            uri: uri.clone(),
+            range: symbol.selection_range,
+        },
+        container_name: (!symbol.detail.is_empty()).then(|| symbol.detail.clone()),
+    }
+}
+
+#[allow(deprecated)]
+fn rg_symbol_information(name: String, location: Location) -> SymbolInformation {
+    SymbolInformation {
+        name,
+        kind: tower_lsp::lsp_types::SymbolKind::FILE,
+        tags: None,
+        deprecated: None,
+        location,
+        container_name: Some("rg fallback".to_string()),
+    }
+}

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, InsertTextFormat, SymbolKind, Url};
 
+use crate::features::completion::{DATA_CALLING_URI, DATA_COL, DATA_LINE, DATA_URI};
 use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
 use crate::stdlib::bare_completions;
@@ -585,9 +586,9 @@ fn completion_item_for_nested_symbol(
         ),
         None => signature,
     });
-    let mut data = serde_json::json!({"u": uri_str, "l": s.selection_start(), "c": s.selection_range.start.character});
+    let mut data = serde_json::json!({DATA_URI: uri_str, DATA_LINE: s.selection_start(), DATA_COL: s.selection_range.start.character});
     if let Some(calling_uri) = caller.uri {
-        data["cu"] = serde_json::Value::String(calling_uri.to_owned());
+        data[DATA_CALLING_URI] = serde_json::Value::String(calling_uri.to_owned());
     }
     CompletionItem {
         label: s.name.clone(),
@@ -887,7 +888,7 @@ impl<'a> BareCompletionWalk<'a> {
                 0,
                 self.prefix,
                 &symbol.detail,
-                Some(serde_json::json!({"u": self.from_uri.as_str(), "l": symbol.selection_start(), "c": symbol.selection_range.start.character})),
+                Some(serde_json::json!({DATA_URI: self.from_uri.as_str(), DATA_LINE: symbol.selection_start(), DATA_COL: symbol.selection_range.start.character})),
             );
         }
 
@@ -927,7 +928,7 @@ impl<'a> BareCompletionWalk<'a> {
                     1,
                     self.prefix,
                     &symbol.detail,
-                    Some(serde_json::json!({"u": package_uri.as_str(), "l": symbol.selection_start(), "c": symbol.selection_range.start.character})),
+                    Some(serde_json::json!({DATA_URI: package_uri.as_str(), DATA_LINE: symbol.selection_start(), DATA_COL: symbol.selection_range.start.character})),
                 );
             }
         }

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 use tower_lsp::lsp_types::{CompletionItem, CompletionItemKind, InsertTextFormat, SymbolKind, Url};
 
-use crate::features::completion::{DATA_CALLING_URI, DATA_COL, DATA_LINE, DATA_URI};
 use crate::indexer::Indexer;
 use crate::parser::parse_by_extension;
 use crate::stdlib::bare_completions;
@@ -14,6 +13,17 @@ use super::infer::{infer_receiver_type, ReceiverKind, ReceiverType};
 use super::{
     already_imported, ensure_file_data, fqns_for_name, resolve_symbol_no_rg, walk_hierarchy,
 };
+
+// ─── CompletionItem.data JSON keys ───────────────────────────────────────────
+
+/// Symbol definition URI.
+pub(crate) const DATA_URI: &str = "u";
+/// Symbol definition line (0-based).
+pub(crate) const DATA_LINE: &str = "l";
+/// Symbol definition UTF-16 column (0-based).
+pub(crate) const DATA_COL: &str = "c";
+/// Calling-site URI, present only for cross-file substitution context.
+pub(crate) const DATA_CALLING_URI: &str = "cu";
 
 // ─── match scoring ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Continuation of the features-layer refactor after #85 merged.

### F4: wire `features/symbols.rs`
- `document_symbol_impl` is now a thin 8-line adapter (was 40 lines with inline mapping)
- On-demand disk indexing stays in the adapter; `compute_document_symbols` is a pure read
- Removes `#[allow(dead_code)]` from `pub(crate) mod symbols`

### F5: tighten dead_code annotations
- Removes blanket `#[allow(dead_code)]` from `mod traits_impl` — the lint never fires because the impl blocks are used via generic bounds
- Removes blanket `#[allow(dead_code)]` from all 7 trait blocks in `traits.rs`; annotates only the 4 genuinely-unused API methods (`for_each_indexed_file`, `lines_for`, `word_at`, `word_and_range_at`) pending workspace_symbols extraction

### Not in this PR
- `IndexRead`/`WorkspaceRead` removal — still actively used by `hover.rs` resolution; deferring
- `RawCursor` wiring — `cursor.rs` staged for future use, kept with existing `#[allow(dead_code)]`

All 830 tests pass. Clippy clean.