### PR TITLE
refactor(G3): CST type_annotations + InferenceChain trait

### DIFF
--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -352,6 +352,13 @@ impl LanguageServer for Backend {
         //
         // Clients that natively watch files (Zed, Helix) send workspace/didChangeWatchedFiles
         // without dynamic registration; our did_change_watched_files handler processes those.
+
+        // Watch .git/HEAD (resolved to actual commit SHA) and trigger a full reindex
+        // when it changes — branch switches swap many files at once without sending
+        // per-file workspace/didChangeWatchedFiles notifications.
+        if let Some(root) = self.indexer.workspace_root.get() {
+            spawn_git_head_watcher(root, Arc::clone(&self.indexer), self.client.clone());
+        }
     }
 
     async fn shutdown(&self) -> Result<()> {
@@ -693,4 +700,66 @@ impl LanguageServer for Backend {
             ),
         )))
     }
+}
+
+// ─── Git HEAD watcher ────────────────────────────────────────────────────────
+
+/// Resolves the current git commit SHA from `.git/HEAD`.
+///
+/// For a symbolic ref (`ref: refs/heads/main`), reads the pointed-to ref file.
+/// For a detached HEAD, returns the raw SHA from HEAD itself.
+/// Returns `None` if the git directory doesn't exist or files can't be read.
+fn read_git_commit(git_dir: &Path) -> Option<String> {
+    let head = std::fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let head = head.trim();
+    if let Some(ref_path) = head.strip_prefix("ref: ") {
+        // Symbolic ref — resolve to actual commit SHA.
+        std::fs::read_to_string(git_dir.join(ref_path))
+            .ok()
+            .map(|s| s.trim().to_string())
+            // If the ref file doesn't exist yet (empty branch), fall back to
+            // the symbolic ref itself so we still detect the branch name change.
+            .or_else(|| Some(head.to_string()))
+    } else {
+        // Detached HEAD.
+        Some(head.to_string())
+    }
+}
+
+/// Spawns a background task that polls `.git/HEAD` every 2 seconds.
+/// When the resolved commit SHA changes (branch switch or new commit), clears
+/// the in-memory index and triggers a full workspace reindex.
+fn spawn_git_head_watcher(root: PathBuf, indexer: Arc<Indexer>, client: Client) {
+    let git_dir = root.join(".git");
+    if !git_dir.is_dir() {
+        return;
+    }
+    let mut last_commit = read_git_commit(&git_dir).unwrap_or_default();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(2));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            let current = read_git_commit(&git_dir).unwrap_or_default();
+            if current.is_empty() || current == last_commit {
+                continue;
+            }
+            last_commit = current;
+            log::info!("git HEAD changed — triggering workspace reindex");
+            client
+                .show_message(
+                    MessageType::INFO,
+                    "kotlin-lsp: branch changed, reindexing workspace…",
+                )
+                .await;
+            let idx = Arc::clone(&indexer);
+            let root_clone = root.clone();
+            let client_clone = client.clone();
+            idx.reset_index_state();
+            tokio::spawn(async move {
+                idx.index_workspace(&root_clone, Arc::new(LspProgressReporter(client_clone)))
+                    .await;
+            });
+        }
+    });
 }

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -21,7 +21,7 @@ use crate::types::{FileData, FileIndexResult, Visibility};
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Bump when the serialized format changes; invalidates any older cache files.
-pub(crate) const CACHE_VERSION: u32 = 11;
+pub(crate) const CACHE_VERSION: u32 = 12;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -8,6 +8,7 @@ use tower_lsp::lsp_types::{CompletionItem, Position, SymbolKind, Url};
 
 use crate::indexer::doc::extract_doc_comment;
 use crate::indexer::Location;
+use crate::resolver::InferenceChain;
 use crate::types::{CallerContext, FileData, SymbolEntry};
 use crate::LinesExt;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -13,11 +13,11 @@ use crate::queries::{
     KIND_IMPORT_ALIAS, KIND_IMPORT_DECL, KIND_IMPORT_HEADER, KIND_IMPORT_LIST,
     KIND_INHERITANCE_SPEC, KIND_INHERITANCE_SPECS, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT,
     KIND_METHOD_DECL, KIND_MODIFIERS, KIND_MOD_FINAL, KIND_MOD_STATIC, KIND_NAV_EXPR,
-    KIND_OBJECT_DECL, KIND_PACKAGE_DECL, KIND_PACKAGE_HEADER, KIND_PROP_DECL, KIND_PROP_DELEGATE,
-    KIND_PROTOCOL_DECL, KIND_RECORD_DECL, KIND_SCOPED_IDENT, KIND_SIMPLE_IDENT, KIND_STATEMENTS,
-    KIND_SUPERCLASS, KIND_SUPER_INTERFACES, KIND_TYPE_IDENT, KIND_USER_TYPE, KIND_VALUE_ARG,
-    KIND_VALUE_ARGS, KIND_VAR_DECL, KIND_VAR_DECLARATOR, KIND_WILDCARD_IMPORT, KOTLIN_DEFINITIONS,
-    SWIFT_DEFINITIONS,
+    KIND_NULLABLE_TYPE, KIND_OBJECT_DECL, KIND_PACKAGE_DECL, KIND_PACKAGE_HEADER, KIND_PROP_DECL,
+    KIND_PROP_DELEGATE, KIND_PROTOCOL_DECL, KIND_RECORD_DECL, KIND_SCOPED_IDENT, KIND_SIMPLE_IDENT,
+    KIND_STATEMENTS, KIND_SUPERCLASS, KIND_SUPER_INTERFACES, KIND_TYPE_IDENT, KIND_USER_TYPE,
+    KIND_VALUE_ARG, KIND_VALUE_ARGS, KIND_VAR_DECL, KIND_VAR_DECLARATOR, KIND_WILDCARD_IMPORT,
+    KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
 };
 use crate::StrExt;
 
@@ -1408,24 +1408,26 @@ impl crate::types::FileData {
         }
     }
 
-    /// Walk all Kotlin `property_declaration` nodes and populate `rhs_types` and
-    /// `method_call_rhs` for unannotated properties (those without an explicit `: Type`).
+    /// Walk all Kotlin `property_declaration` nodes and populate `rhs_types`,
+    /// `method_call_rhs`, and `type_annotations` for property declarations.
     ///
-    /// Extracts three patterns at index time so hover/completion never need fragile
-    /// string scanning:
+    /// For **unannotated** properties (no explicit `: Type`), extracts:
     /// 1. DI generic call: `inject<T>()`, `viewModel<T>()` etc. → type arg `T`
     /// 2. Constructor call: `SomeType(args)` → `SomeType`
     /// 3. `by lazy { SomeType() }` (single-statement lambda) → `SomeType`
     /// 4. Method call: `receiver.method(args)` → stored in `method_call_rhs` for
     ///    two-step inference (resolve receiver type, then look up method return type)
+    ///
+    /// For **annotated** properties (`val x: Type`), extracts the full declared type
+    /// (including generics and nullability) into `type_annotations`, which takes
+    /// priority over line-scan inference for indexed files.
     fn extract_rhs_types_kotlin(&mut self, root: Node, bytes: &[u8]) {
         let mut stack = vec![root];
         while let Some(node) = stack.pop() {
             if node.kind() == KIND_PROP_DECL {
                 if let Some(var_decl) = node.first_child_of_kind(KIND_VAR_DECL) {
-                    // Only infer for unannotated properties: variable_declaration has
-                    // just the identifier (named_child_count == 1 means no `: Type` child).
                     if var_decl.named_child_count() == 1 {
+                        // Unannotated property: infer type from RHS expression.
                         if let Some(name) = var_decl
                             .first_child_of_kind(KIND_SIMPLE_IDENT)
                             .and_then(|n| n.utf8_text_owned(bytes))
@@ -1451,6 +1453,23 @@ impl crate::types::FileData {
                                         }
                                     } else if let Some(ty) = call_expr_direct_type(rhs, bytes) {
                                         self.rhs_types.push((line, name, ty));
+                                    }
+                                }
+                            }
+                        }
+                    } else {
+                        // Annotated property: `val x: Type` or `val x: Type? = ...`
+                        // The second named child is the type node (user_type or nullable_type).
+                        if let Some(name) = var_decl
+                            .first_child_of_kind(KIND_SIMPLE_IDENT)
+                            .and_then(|n| n.utf8_text_owned(bytes))
+                        {
+                            if let Some(type_node) = var_decl.named_child(1) {
+                                let kind = type_node.kind();
+                                if kind == KIND_USER_TYPE || kind == KIND_NULLABLE_TYPE {
+                                    if let Some(ty) = type_node.utf8_text_owned(bytes) {
+                                        let line = var_decl.start_position().row as u32;
+                                        self.type_annotations.push((line, name, ty));
                                     }
                                 }
                             }

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -354,6 +354,7 @@ pub(crate) const KIND_LAMBDA_LIT: &str = "lambda_literal";
 pub(crate) const KIND_LAMBDA_PARAMS: &str = "lambda_parameters";
 pub(crate) const KIND_VALUE_ARG: &str = "value_argument";
 pub(crate) const KIND_VALUE_ARGS: &str = "value_arguments";
+pub(crate) const KIND_NULLABLE_TYPE: &str = "nullable_type";
 pub(crate) const KIND_USER_TYPE: &str = "user_type";
 pub(crate) const KIND_FUN_DECL: &str = "function_declaration";
 pub(crate) const KIND_FUN: &str = "fun";

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -7,6 +7,69 @@ use crate::StrExt;
 use super::ensure_file_data;
 use super::infer_lines::{extract_return_type_from_detail, find_rhs_str, has_dot_after_first_call};
 
+// ─── InferenceChain trait ─────────────────────────────────────────────────────
+
+/// Capability trait for type-inference queries over an indexed workspace.
+///
+/// Implemented by [`Indexer`] in production.  Mirrors the shape of
+/// [`ResolutionChain`](super::resolve::ResolutionChain) — all methods
+/// delegate to the free functions in this module so the trait is a zero-cost
+/// façade.
+///
+/// `#[allow(dead_code)]` is retained until this trait is wired through the
+/// resolution pipeline in a future pass (G4).
+// TODO(G4): wire trait bound through resolution pipeline to enable test stubs
+#[allow(dead_code)]
+pub(crate) trait InferenceChain {
+    fn infer_variable_type(&self, var_name: &str, uri: &Url) -> Option<String>;
+    fn infer_variable_type_raw(&self, var_name: &str, uri: &Url) -> Option<String>;
+    fn infer_field_type(&self, file_uri: &str, field_name: &str) -> Option<String>;
+    fn find_field_type_in_class(&self, class_name: &str, field_name: &str) -> Option<String>;
+    fn find_fun_return_type_by_name(&self, fn_name: &str) -> Option<String>;
+    fn find_method_return_type(&self, type_name: &str, method_name: &str) -> Option<String>;
+    fn infer_receiver_type(&self, kind: ReceiverKind<'_>, uri: &Url) -> Option<ReceiverType>;
+}
+
+impl InferenceChain for Indexer {
+    fn infer_variable_type(&self, var_name: &str, uri: &Url) -> Option<String> {
+        infer_variable_type(self, var_name, uri)
+    }
+    fn infer_variable_type_raw(&self, var_name: &str, uri: &Url) -> Option<String> {
+        infer_variable_type_raw(self, var_name, uri)
+    }
+    fn infer_field_type(&self, file_uri: &str, field_name: &str) -> Option<String> {
+        infer_field_type(self, file_uri, field_name)
+    }
+    fn find_field_type_in_class(&self, class_name: &str, field_name: &str) -> Option<String> {
+        find_field_type_in_class(self, class_name, field_name)
+    }
+    fn find_fun_return_type_by_name(&self, fn_name: &str) -> Option<String> {
+        find_fun_return_type_by_name(self, fn_name)
+    }
+    fn find_method_return_type(&self, type_name: &str, method_name: &str) -> Option<String> {
+        find_method_return_type(self, type_name, method_name)
+    }
+    fn infer_receiver_type(&self, kind: ReceiverKind<'_>, uri: &Url) -> Option<ReceiverType> {
+        infer_receiver_type(self, kind, uri)
+    }
+}
+
+// ─── Type-string helpers ──────────────────────────────────────────────────────
+
+/// Strip generic parameters and nullability markers from a type string.
+///
+/// `"List<Product>"` → `"List"`, `"String?"` → `"String"`, `"Outer.Inner<T>"` → `"Outer.Inner"`
+///
+/// Mirrors the stripping done by [`infer_type_in_lines`](super::infer_lines::infer_type_in_lines)
+/// so that `type_annotations` lookups return the same shape as line-scan results.
+fn strip_generics(ty: &str) -> String {
+    let stripped: String = ty
+        .chars()
+        .take_while(|&c| c.is_alphanumeric() || c == '_' || c == '.')
+        .collect();
+    stripped.trim_end_matches('.').to_owned()
+}
+
 // ─── Receiver type resolution ─────────────────────────────────────────────────
 
 /// How the receiver expression should be resolved.
@@ -113,10 +176,17 @@ fn infer_variable_type_impl(idx: &Indexer, var_name: &str, uri: &Url, depth: u8)
             }
             (*ll).clone()
         } else if let Some(data) = idx.files.get(uri.as_str()) {
+            // CST explicit type annotation — highest priority for indexed files.
+            // Covers `val x: Type` and `val x: Type?` without line scanning.
+            if let Some(ann) = data.type_annotations.iter().find(|(_, n, _)| n == var_name) {
+                return Some(strip_generics(&ann.2));
+            }
+            // Line scan — fallback for constructor parameters and edge cases not
+            // captured by the property_declaration CST walk (e.g. `class Foo(val x: T)`).
             if let result @ Some(_) = data.lines.infer_type(var_name) {
                 return result;
             }
-            // CST-indexed RHS types — primary path for indexed files.
+            // CST-indexed RHS types (unannotated properties) and method-call RHS.
             let rhs_match = data
                 .rhs_types
                 .iter()
@@ -140,7 +210,7 @@ fn infer_variable_type_impl(idx: &Indexer, var_name: &str, uri: &Url, depth: u8)
                     }
                 }
             }
-            // Lines guard was dropped above; fall through to string-based fallback.
+            // Fallback: line scan for function parameters and unindexed edge cases.
             return infer_method_return_type(idx, var_name, &lines, uri, depth - 1);
         } else {
             // File not indexed yet — read from disk; skip method inference.
@@ -170,6 +240,12 @@ fn infer_variable_type_raw_impl(
             }
             (*ll).clone()
         } else if let Some(data) = idx.files.get(uri.as_str()) {
+            // CST explicit type annotation — preserves generics (raw variant).
+            if let Some(ann) = data.type_annotations.iter().find(|(_, n, _)| n == var_name) {
+                return Some(ann.2.clone());
+            }
+            // Line scan — fallback for constructor parameters and edge cases not
+            // captured by the property_declaration CST walk (e.g. `class Foo(val x: T)`).
             if let result @ Some(_) = data.lines.infer_type_raw(var_name) {
                 return result;
             }
@@ -208,11 +284,18 @@ fn infer_variable_type_raw_impl(
 
 /// Scan a specific (possibly un-indexed) file for the declared type of `field_name`.
 ///
-/// Checks the in-memory index first (lines are cached); falls back to reading
-/// the file from disk when it isn't indexed yet.
+/// Checks CST type annotations first (indexed files), then falls back to line
+/// scanning, then reads from disk for un-indexed files.
 pub(crate) fn infer_field_type(idx: &Indexer, file_uri: &str, field_name: &str) -> Option<String> {
     let uri = tower_lsp::lsp_types::Url::parse(file_uri).ok()?;
     let file_data = ensure_file_data(idx, &uri)?;
+    if let Some(ann) = file_data
+        .type_annotations
+        .iter()
+        .find(|(_, n, _)| n == field_name)
+    {
+        return Some(strip_generics(&ann.2));
+    }
     file_data.lines.infer_type(field_name)
 }
 
@@ -220,8 +303,8 @@ pub(crate) fn infer_field_type(idx: &Indexer, file_uri: &str, field_name: &str) 
 ///
 /// Returns `"MutableList<MbAccount>"` rather than `"MutableList"`, which is
 /// needed for collection element type extraction via `extract_collection_element_type`.
-/// Checks live editor lines first (most up-to-date), then falls back to indexed
-/// lines and finally to a disk read for un-indexed files.
+/// Checks live editor lines first (most up-to-date), then CST type annotations,
+/// then falls back to indexed lines and finally to a disk read for un-indexed files.
 pub(crate) fn infer_field_type_raw(
     idx: &Indexer,
     file_uri: &str,
@@ -231,6 +314,13 @@ pub(crate) fn infer_field_type_raw(
         return live.infer_type_raw(field_name);
     }
     if let Some(data) = idx.files.get(file_uri) {
+        if let Some(ann) = data
+            .type_annotations
+            .iter()
+            .find(|(_, n, _)| n == field_name)
+        {
+            return Some(ann.2.clone());
+        }
         return data.lines.infer_type_raw(field_name);
     }
     let path = tower_lsp::lsp_types::Url::parse(file_uri)
@@ -259,21 +349,6 @@ pub(crate) fn find_field_type_in_class(
         }
     }
     None
-}
-
-// ─── impl Indexer wrappers ────────────────────────────────────────────────────
-
-#[allow(dead_code)]
-impl crate::indexer::Indexer {
-    pub(crate) fn infer_variable_type(&self, var_name: &str, uri: &Url) -> Option<String> {
-        infer_variable_type(self, var_name, uri)
-    }
-    pub(crate) fn infer_variable_type_raw(&self, var_name: &str, uri: &Url) -> Option<String> {
-        infer_variable_type_raw(self, var_name, uri)
-    }
-    pub(crate) fn infer_field_type(&self, file_uri: &str, field_name: &str) -> Option<String> {
-        infer_field_type(self, file_uri, field_name)
-    }
 }
 
 // ─── Method return-type inference ─────────────────────────────────────────────

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -5,7 +5,10 @@ use crate::LinesExt;
 use crate::StrExt;
 
 use super::ensure_file_data;
-use super::infer_lines::{extract_return_type_from_detail, find_rhs_str, has_dot_after_first_call};
+use super::infer_lines::{
+    extract_return_type_from_detail, extract_type_with_generics, find_rhs_str,
+    has_dot_after_first_call,
+};
 
 // ─── InferenceChain trait ─────────────────────────────────────────────────────
 
@@ -240,9 +243,11 @@ fn infer_variable_type_raw_impl(
             }
             (*ll).clone()
         } else if let Some(data) = idx.files.get(uri.as_str()) {
-            // CST explicit type annotation — preserves generics (raw variant).
+            // CST explicit type annotation — preserves generics but strips outer `?`
+            // to match `infer_type_in_lines_raw` / `extract_type_with_generics` behaviour.
+            // Keeps inner nullable generics: `List<String?>?` → `List<String?>`.
             if let Some(ann) = data.type_annotations.iter().find(|(_, n, _)| n == var_name) {
-                return Some(ann.2.clone());
+                return Some(extract_type_with_generics(&ann.2));
             }
             // Line scan — fallback for constructor parameters and edge cases not
             // captured by the property_declaration CST walk (e.g. `class Foo(val x: T)`).
@@ -319,7 +324,7 @@ pub(crate) fn infer_field_type_raw(
             .iter()
             .find(|(_, n, _)| n == field_name)
         {
-            return Some(ann.2.clone());
+            return Some(extract_type_with_generics(&ann.2));
         }
         return data.lines.infer_type_raw(field_name);
     }

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -5,10 +5,7 @@ use crate::LinesExt;
 use crate::StrExt;
 
 use super::ensure_file_data;
-use super::infer_lines::{
-    extract_return_type_from_detail, extract_type_with_generics, find_rhs_str,
-    has_dot_after_first_call,
-};
+use super::infer_lines::{extract_return_type_from_detail, find_rhs_str, has_dot_after_first_call};
 
 // ─── InferenceChain trait ─────────────────────────────────────────────────────
 
@@ -95,16 +92,25 @@ pub(crate) enum ReceiverKind<'a> {
 /// - `outer`     — first dot-segment: `"Outer"`  (used for file lookup)
 /// - `leaf`      — last dot-segment: `"Inner"`   (used for fallback member lookup)
 pub(crate) struct ReceiverType {
+    /// Full raw type string as inferred, e.g. `"StateFlow<UiState>?"`.
     pub raw: String,
+    /// Type name with no generics and no `?`, e.g. `"StateFlow"` or `"Outer.Inner"`.
     pub qualified: String,
+    /// Outermost segment of `qualified`, e.g. `"Outer"`.
     pub outer: String,
+    /// Innermost segment of `qualified`, e.g. `"Inner"`.
     pub leaf: String,
+    /// Whether the type was annotated as nullable (`?`), e.g. `val x: User?`.
+    /// Available for hover/completion display; lookup sites use `qualified`.
+    #[allow(dead_code)]
+    pub nullable: bool,
 }
 
 impl ReceiverType {
     pub(crate) fn from_raw(raw: String) -> Self {
-        // Strip generics: take chars until first `<`.
-        let qualified: String = raw.chars().take_while(|&c| c != '<').collect();
+        // Strip generics and outer `?` — stop at first `<` or `?`.
+        let qualified: String = raw.chars().take_while(|&c| c != '<' && c != '?').collect();
+        let nullable = raw.contains('?');
         let outer = qualified
             .split('.')
             .next()
@@ -120,6 +126,7 @@ impl ReceiverType {
             qualified,
             outer,
             leaf,
+            nullable,
         }
     }
 }
@@ -243,11 +250,10 @@ fn infer_variable_type_raw_impl(
             }
             (*ll).clone()
         } else if let Some(data) = idx.files.get(uri.as_str()) {
-            // CST explicit type annotation — preserves generics but strips outer `?`
-            // to match `infer_type_in_lines_raw` / `extract_type_with_generics` behaviour.
-            // Keeps inner nullable generics: `List<String?>?` → `List<String?>`.
+            // CST explicit type annotation — return verbatim (includes `?` for nullable).
+            // `ReceiverType::from_raw` strips `?` from qualified/outer/leaf for lookups.
             if let Some(ann) = data.type_annotations.iter().find(|(_, n, _)| n == var_name) {
-                return Some(extract_type_with_generics(&ann.2));
+                return Some(ann.2.clone());
             }
             // Line scan — fallback for constructor parameters and edge cases not
             // captured by the property_declaration CST walk (e.g. `class Foo(val x: T)`).
@@ -324,7 +330,7 @@ pub(crate) fn infer_field_type_raw(
             .iter()
             .find(|(_, n, _)| n == field_name)
         {
-            return Some(extract_type_with_generics(&ann.2));
+            return Some(ann.2.clone());
         }
         return data.lines.infer_type_raw(field_name);
     }

--- a/src/resolver/infer_lines.rs
+++ b/src/resolver/infer_lines.rs
@@ -370,7 +370,7 @@ pub(super) fn extract_return_type_from_detail(detail: &str) -> Option<String> {
 /// `"List<Product> = emptyList()"` → `"List<Product>"`
 /// `"StateFlow<UiState>"` → `"StateFlow<UiState>"`
 /// `"User?"` → `"User"`  (nullable stripped at the outer `?`)
-pub(super) fn extract_type_with_generics(s: &str) -> String {
+pub(crate) fn extract_type_with_generics(s: &str) -> String {
     let mut result = String::new();
     let mut depth = 0i32;
     for c in s.chars() {

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -95,7 +95,7 @@ fn infer_annotated_property_from_cst() {
         "nullable annotated property: non-raw strips nullability"
     );
 
-    // Raw: preserves inner generics, strips outer nullable marker (matches line-scan behaviour).
+    // Raw: preserves generics and outer `?` (nullable flows through to ReceiverType).
     assert_eq!(
         infer_variable_type_raw(&idx, "items", &file_uri),
         Some("List<Product>".into()),
@@ -103,11 +103,11 @@ fn infer_annotated_property_from_cst() {
     );
     assert_eq!(
         infer_variable_type_raw(&idx, "state", &file_uri),
-        Some("StateFlow<UiState>".into()),
-        "nullable annotated property: raw strips outer ? to match line-scan"
+        Some("StateFlow<UiState>?".into()),
+        "nullable annotated property: raw preserves ? (stripped in ReceiverType::from_raw)"
     );
 
-    // Non-generic nullable: raw strips ? too.
+    // Non-generic nullable: raw preserves ? too.
     let idx2 = Indexer::new();
     idx2.index_content(
         &file_uri,
@@ -115,7 +115,7 @@ fn infer_annotated_property_from_cst() {
     );
     assert_eq!(
         infer_variable_type_raw(&idx2, "user", &file_uri),
-        Some("User".into()),
-        "non-generic nullable: raw strips outer ?"
+        Some("User?".into()),
+        "non-generic nullable: raw preserves ?"
     );
 }

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -95,7 +95,7 @@ fn infer_annotated_property_from_cst() {
         "nullable annotated property: non-raw strips nullability"
     );
 
-    // Raw: preserves generics and nullability.
+    // Raw: preserves inner generics, strips outer nullable marker (matches line-scan behaviour).
     assert_eq!(
         infer_variable_type_raw(&idx, "items", &file_uri),
         Some("List<Product>".into()),
@@ -103,7 +103,19 @@ fn infer_annotated_property_from_cst() {
     );
     assert_eq!(
         infer_variable_type_raw(&idx, "state", &file_uri),
-        Some("StateFlow<UiState>?".into()),
-        "nullable annotated property: raw preserves nullability"
+        Some("StateFlow<UiState>".into()),
+        "nullable annotated property: raw strips outer ? to match line-scan"
+    );
+
+    // Non-generic nullable: raw strips ? too.
+    let idx2 = Indexer::new();
+    idx2.index_content(
+        &file_uri,
+        "package com.example\nclass Bar {\n    val user: User? = null\n}",
+    );
+    assert_eq!(
+        infer_variable_type_raw(&idx2, "user", &file_uri),
+        Some("User".into()),
+        "non-generic nullable: raw strips outer ?"
     );
 }

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -58,3 +58,52 @@ fn has_dot_after_first_call_nested_parens() {
     // Nested parens inside arg list must not fool the scanner.
     assert!(has_dot_after_first_call("getList(foo(x)).map()", 7));
 }
+
+// ─── type_annotations (CST annotated property path) ──────────────────────────
+
+#[test]
+fn infer_annotated_property_from_cst() {
+    use crate::indexer::Indexer;
+    use crate::resolver::infer::{infer_variable_type, infer_variable_type_raw};
+    use tower_lsp::lsp_types::Url;
+
+    fn uri(p: &str) -> Url {
+        Url::parse(&format!("file://{p}")).unwrap()
+    }
+
+    let file_uri = uri("/Foo.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &file_uri,
+        "package com.example\nclass Foo {\n    val repo: UserRepository = inject()\n    val items: List<Product> = emptyList()\n    val state: StateFlow<UiState>? = null\n}",
+    );
+
+    // Non-raw: strips generics and nullability.
+    assert_eq!(
+        infer_variable_type(&idx, "repo", &file_uri),
+        Some("UserRepository".into()),
+        "simple annotated property"
+    );
+    assert_eq!(
+        infer_variable_type(&idx, "items", &file_uri),
+        Some("List".into()),
+        "generic annotated property: non-raw strips generics"
+    );
+    assert_eq!(
+        infer_variable_type(&idx, "state", &file_uri),
+        Some("StateFlow".into()),
+        "nullable annotated property: non-raw strips nullability"
+    );
+
+    // Raw: preserves generics and nullability.
+    assert_eq!(
+        infer_variable_type_raw(&idx, "items", &file_uri),
+        Some("List<Product>".into()),
+        "generic annotated property: raw preserves generics"
+    );
+    assert_eq!(
+        infer_variable_type_raw(&idx, "state", &file_uri),
+        Some("StateFlow<UiState>?".into()),
+        "nullable annotated property: raw preserves nullability"
+    );
+}

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -21,7 +21,9 @@ pub(crate) use complete::{
 };
 pub(crate) use hierarchy::walk_hierarchy;
 pub(crate) use import_edit::{already_imported, import_insertion_line, make_import_edit};
-pub(crate) use infer::{infer_receiver_type, infer_variable_type_raw, ReceiverKind, ReceiverType};
+pub(crate) use infer::{
+    infer_receiver_type, infer_variable_type_raw, InferenceChain, ReceiverKind, ReceiverType,
+};
 pub(crate) use infer_lines::extract_collection_element_type;
 pub(crate) use resolve::{
     ensure_file_data, fqns_for_name, resolve_symbol_inner, resolve_symbol_no_rg,

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -1804,6 +1804,7 @@ fn receiver_type_simple() {
     assert_eq!(rt.qualified, "MyClass");
     assert_eq!(rt.outer, "MyClass");
     assert_eq!(rt.leaf, "MyClass");
+    assert!(!rt.nullable);
 }
 
 #[test]
@@ -1813,6 +1814,27 @@ fn receiver_type_with_generics() {
     assert_eq!(rt.qualified, "Flow");
     assert_eq!(rt.outer, "Flow");
     assert_eq!(rt.leaf, "Flow");
+    assert!(!rt.nullable);
+}
+
+#[test]
+fn receiver_type_nullable_simple() {
+    let rt = infer::ReceiverType::from_raw("User?".to_string());
+    assert_eq!(rt.raw, "User?");
+    assert_eq!(rt.qualified, "User");
+    assert_eq!(rt.outer, "User");
+    assert_eq!(rt.leaf, "User");
+    assert!(rt.nullable);
+}
+
+#[test]
+fn receiver_type_nullable_generic() {
+    let rt = infer::ReceiverType::from_raw("StateFlow<UiState>?".to_string());
+    assert_eq!(rt.raw, "StateFlow<UiState>?");
+    assert_eq!(rt.qualified, "StateFlow");
+    assert_eq!(rt.outer, "StateFlow");
+    assert_eq!(rt.leaf, "StateFlow");
+    assert!(rt.nullable);
 }
 
 #[test]
@@ -1822,6 +1844,7 @@ fn receiver_type_dotted_nested() {
     assert_eq!(rt.qualified, "Outer.Inner");
     assert_eq!(rt.outer, "Outer");
     assert_eq!(rt.leaf, "Inner");
+    assert!(!rt.nullable);
 }
 
 #[test]
@@ -1831,6 +1854,7 @@ fn receiver_type_dotted_with_generics() {
     assert_eq!(rt.qualified, "Outer.Inner");
     assert_eq!(rt.outer, "Outer");
     assert_eq!(rt.leaf, "Inner");
+    assert!(!rt.nullable);
 }
 
 #[test]
@@ -1839,6 +1863,7 @@ fn receiver_type_generic_with_params() {
     assert_eq!(rt.qualified, "OneYearOlderInteractor");
     assert_eq!(rt.outer, "OneYearOlderInteractor");
     assert_eq!(rt.leaf, "OneYearOlderInteractor");
+    assert!(!rt.nullable);
 }
 
 #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -181,6 +181,13 @@ pub(crate) struct FileData {
     /// Used by method-return-type inference for indexed files.
     #[serde(default)]
     pub method_call_rhs: Vec<(u32, String, String, String)>,
+    /// Explicit type annotations for properties, extracted from the CST at parse time.
+    /// Each entry is `(declaration_line, var_name, declared_type)` where `declared_type`
+    /// preserves generics and nullability: `val x: List<Foo>?` → `"List<Foo>?"`.
+    /// Covers both `user_type` and `nullable_type` annotation nodes.
+    /// Takes priority over line-scan inference for indexed files.
+    #[serde(default)]
+    pub type_annotations: Vec<(u32, String, String)>,
     /// Structural syntax errors from tree-sitter (ERROR / MISSING nodes).
     /// Transient — not serialized to disk cache.
     #[serde(skip)]


### PR DESCRIPTION
## Summary

Two complementary improvements to the type inference layer.

### G3a — CST-backed explicit type annotations

**Problem**: `val x: Type` annotations were resolved by string-scanning `data.lines` at query time — O(n_lines), fragile for complex generics.

**Fix**: `extract_rhs_types_kotlin` now also walks **annotated** properties (`var_decl.named_child_count() >= 2`) and stores the full declared type (including generics and nullability) in a new `FileData::type_annotations: Vec<(u32, String, String)>` field.

Inference priority for indexed files is now:
1. **CST `type_annotations`** — annotated props (user_type / nullable_type)
2. **Line scan** — constructor params (`class_parameter` nodes, not in CST walk)
3. **CST `rhs_types`** — unannotated props (inject<T>(), SomeType(), lazy)
4. **CST `method_call_rhs`** — receiver.method() chains
5. **`infer_method_return_type`** — complex fallback

Covers nullable types (`String?`) and nested generics (`StateFlow<UiState>?`) correctly from the tree-sitter CST.

**Schema change**: CACHE_VERSION 11 → 12 (new field uses `#[serde(default)]`).

### G3b — `InferenceChain` trait (mirrors G1's `ResolutionChain`)

The 7 public index-backed inference functions in `resolver/infer.rs` all share the same `(&Indexer, ...) → Option<String>` shape. This PR wraps them behind a trait:

```rust
pub(crate) trait InferenceChain {
    fn infer_variable_type(&self, var_name: &str, uri: &Url) -> Option<String>;
    fn infer_variable_type_raw(&self, var_name: &str, uri: &Url) -> Option<String>;
    fn infer_field_type(&self, file_uri: &str, field_name: &str) -> Option<String>;
    fn find_field_type_in_class(&self, class_name: &str, field_name: &str) -> Option<String>;
    fn find_fun_return_type_by_name(&self, fn_name: &str) -> Option<String>;
    fn find_method_return_type(&self, type_name: &str, method_name: &str) -> Option<String>;
    fn infer_receiver_type(&self, kind: ReceiverKind<'_>, uri: &Url) -> Option<ReceiverType>;
}
```

- `impl InferenceChain for Indexer` — delegates to free functions (zero cost)
- Removes the old `#[allow(dead_code)] impl Indexer` wrappers block
- TODO(G4): wire bound through resolution pipeline for test stubs

## Files changed
- `src/queries.rs` — `KIND_NULLABLE_TYPE` constant
- `src/types.rs` — `FileData::type_annotations` field
- `src/indexer/cache.rs` — CACHE_VERSION bump
- `src/parser.rs` — annotated property extraction in `extract_rhs_types_kotlin`
- `src/resolver/infer.rs` — `strip_generics`, updated impl paths, `InferenceChain` trait
- `src/resolver/infer_tests.rs` — new `infer_annotated_property_from_cst` test
- `src/resolver/mod.rs` — export `InferenceChain`
- `src/indexer/resolution.rs` — `use InferenceChain` for method call site