### PR TITLE
fix(rg): scope rg searches to sourceRoots when configured (issue #78)

### DIFF
--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -177,14 +177,16 @@ impl Backend {
     }
 
     async fn rg_reference_locations(&self, search: &ReferenceSearch) -> Vec<Location> {
-        let (workspace_root, source_paths, ignore_matcher) = self.rg_context().await;
+        let file_path = search.uri.to_file_path().ok();
+        let (root, source_paths, ignore_matcher) =
+            self.rg_scope_for_file(file_path.as_deref()).await;
         let request = search.clone();
         tokio::task::spawn_blocking(move || {
             let rg_request = crate::rg::RgSearchRequest::new(
                 &request.name,
                 request.parent_class.as_deref(),
                 request.declared_pkg.as_deref(),
-                workspace_root.as_deref(),
+                root.as_deref(),
                 request.include_decl,
                 &request.uri,
                 &request.decl_files,

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -177,7 +177,7 @@ impl Backend {
     }
 
     async fn rg_reference_locations(&self, search: &ReferenceSearch) -> Vec<Location> {
-        let (workspace_root, ignore_matcher) = self.rg_context().await;
+        let (workspace_root, source_paths, ignore_matcher) = self.rg_context().await;
         let request = search.clone();
         tokio::task::spawn_blocking(move || {
             let rg_request = crate::rg::RgSearchRequest::new(
@@ -188,7 +188,8 @@ impl Backend {
                 request.include_decl,
                 &request.uri,
                 &request.decl_files,
-            );
+            )
+            .with_source_paths(&source_paths);
             crate::rg::rg_find_references(&rg_request, ignore_matcher.as_deref())
         })
         .await
@@ -299,12 +300,13 @@ impl Backend {
         if !query.allows_rg_fallback() {
             return vec![];
         }
-        let (workspace_root, ignore_matcher) = self.rg_context().await;
+        let (workspace_root, source_paths, ignore_matcher) = self.rg_context().await;
         let query_text = query.raw.clone();
         let rg_locations = tokio::task::spawn_blocking(move || {
             crate::rg::rg_find_definition(
                 &query_text,
                 workspace_root.as_deref(),
+                &source_paths,
                 ignore_matcher.as_deref(),
             )
         })

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -136,9 +136,27 @@ impl Backend {
         &self,
     ) -> (Option<PathBuf>, Vec<String>, Option<Arc<IgnoreMatcher>>) {
         let root = self.indexer.workspace_root.read().unwrap().clone();
-        let source_paths = self.indexer.source_paths_raw.read().unwrap().clone();
+        let all_source_paths = self.indexer.source_paths_raw.read().unwrap().clone();
         let ignore = self.indexer.ignore_matcher.read().unwrap().clone();
-        (root, source_paths, ignore)
+        // Only scope rg to paths under the workspace root (project source directories).
+        // External library paths (Android SDK, ~/.kotlin-lsp/sources) are for indexing
+        // only and must not be searched when resolving references.
+        let workspace_source_paths = match &root {
+            Some(root_path) => all_source_paths
+                .into_iter()
+                .filter(|p| {
+                    let path = std::path::Path::new(p);
+                    let abs = if path.is_absolute() {
+                        path.to_path_buf()
+                    } else {
+                        root_path.join(path)
+                    };
+                    abs.starts_with(root_path)
+                })
+                .collect(),
+            None => Vec::new(),
+        };
+        (root, workspace_source_paths, ignore)
     }
 
     /// Try `find_definition_qualified` with `rt.qualified`, falling back to `rt.leaf`

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -132,10 +132,13 @@ impl Backend {
         }
     }
 
-    pub(crate) async fn rg_context(&self) -> (Option<PathBuf>, Option<Arc<IgnoreMatcher>>) {
+    pub(crate) async fn rg_context(
+        &self,
+    ) -> (Option<PathBuf>, Vec<String>, Option<Arc<IgnoreMatcher>>) {
         let root = self.indexer.workspace_root.read().unwrap().clone();
+        let source_paths = self.indexer.source_paths_raw.read().unwrap().clone();
         let ignore = self.indexer.ignore_matcher.read().unwrap().clone();
-        (root, ignore)
+        (root, source_paths, ignore)
     }
 
     /// Try `find_definition_qualified` with `rt.qualified`, falling back to `rt.leaf`

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -136,27 +136,9 @@ impl Backend {
         &self,
     ) -> (Option<PathBuf>, Vec<String>, Option<Arc<IgnoreMatcher>>) {
         let root = self.indexer.workspace_root.read().unwrap().clone();
-        let all_source_paths = self.indexer.source_paths_raw.read().unwrap().clone();
+        let source_roots = self.indexer.workspace_source_roots.read().unwrap().clone();
         let ignore = self.indexer.ignore_matcher.read().unwrap().clone();
-        // Only scope rg to paths under the workspace root (project source directories).
-        // External library paths (Android SDK, ~/.kotlin-lsp/sources) are for indexing
-        // only and must not be searched when resolving references.
-        let workspace_source_paths = match &root {
-            Some(root_path) => all_source_paths
-                .into_iter()
-                .filter(|p| {
-                    let path = std::path::Path::new(p);
-                    let abs = if path.is_absolute() {
-                        path.to_path_buf()
-                    } else {
-                        root_path.join(path)
-                    };
-                    abs.starts_with(root_path)
-                })
-                .collect(),
-            None => Vec::new(),
-        };
-        (root, workspace_source_paths, ignore)
+        (root, source_roots, ignore)
     }
 
     /// Try `find_definition_qualified` with `rt.qualified`, falling back to `rt.leaf`
@@ -288,63 +270,10 @@ impl Backend {
             }
         }
 
-        let mut all_source_paths: Vec<String> =
-            Self::collect_indexing_option_strings(initialization_options, "sourcePaths")
-                .unwrap_or_default();
-
-        // Auto-discover source roots from workspace.json (JetBrains Gradle/Maven format).
-        // Discovered paths are merged with any user-configured sourcePaths.
-        let workspace_json_paths = crate::workspace_json::load_source_paths(workspace_root);
-        for path in &workspace_json_paths {
-            let path_str = path.to_string_lossy().into_owned();
-            if !all_source_paths.contains(&path_str) {
-                all_source_paths.push(path_str);
-            }
-        }
-
-        // Fallback: if workspace.json wasn't present, probe standard Maven/Gradle layouts.
-        if workspace_json_paths.is_empty() {
-            for path in crate::workspace_json::detect_build_layout_source_paths(workspace_root) {
-                let path_str = path.to_string_lossy().into_owned();
-                if !all_source_paths.contains(&path_str) {
-                    all_source_paths.push(path_str);
-                }
-            }
-        }
-
-        // Auto-include ~/.kotlin-lsp/sources if present (default extract-sources output dir).
-        // Skipped when workspace.json declares an explicit `sourcePaths` key.
-        if let Some(configured) =
-            crate::workspace_json::load_configured_source_paths(workspace_root)
-        {
-            for p in configured {
-                let path_str = p.to_string_lossy().into_owned();
-                if !all_source_paths.contains(&path_str) {
-                    all_source_paths.push(path_str);
-                }
-            }
-        } else {
-            #[allow(deprecated)]
-            if let Some(home) = std::env::home_dir() {
-                let default_sources = home.join(".kotlin-lsp").join("sources");
-                if default_sources.is_dir() {
-                    let path_str = default_sources.to_string_lossy().into_owned();
-                    if !all_source_paths.contains(&path_str) {
-                        all_source_paths.push(path_str);
-                    }
-                }
-            }
-        }
-
-        // Auto-detect Android SDK sources from local.properties / $ANDROID_HOME.
-        // Added unconditionally — SDK sources are distinct from library sources and
-        // are always useful for Android projects regardless of other sourcePaths config.
-        for path in crate::workspace_json::detect_android_sdk_source_paths(workspace_root) {
-            let path_str = path.to_string_lossy().into_owned();
-            if !all_source_paths.contains(&path_str) {
-                all_source_paths.push(path_str);
-            }
-        }
+        let all_source_paths =
+            Self::collect_all_source_paths(initialization_options, workspace_root);
+        let rg_source_roots =
+            Self::collect_workspace_source_roots(initialization_options, workspace_root);
 
         if !all_source_paths.is_empty() {
             log::info!("sourcePaths (combined): {:?}", all_source_paths);
@@ -357,6 +286,119 @@ impl Backend {
                 }
             }
         }
+
+        if !rg_source_roots.is_empty() {
+            log::info!(
+                "workspace sourceRoots for rg scoping: {:?}",
+                rg_source_roots
+            );
+            match self.indexer.workspace_source_roots.write() {
+                Ok(mut roots) => {
+                    *roots = rg_source_roots;
+                }
+                Err(error) => {
+                    log::warn!("Failed to update workspace_source_roots: {error}");
+                }
+            }
+        }
+    }
+
+    /// Build the combined source-paths list used for indexing:
+    /// explicit `sourcePaths` + workspace.json modules + build-layout auto-detection
+    /// + external library directories (~/.kotlin-lsp/sources, Android SDK).
+    fn collect_all_source_paths(
+        initialization_options: Option<&serde_json::Value>,
+        workspace_root: &Path,
+    ) -> Vec<String> {
+        let mut paths: Vec<String> =
+            Self::collect_indexing_option_strings(initialization_options, "sourcePaths")
+                .unwrap_or_default();
+
+        let workspace_json_paths = crate::workspace_json::load_source_paths(workspace_root);
+        for path in &workspace_json_paths {
+            let s = path.to_string_lossy().into_owned();
+            if !paths.contains(&s) {
+                paths.push(s);
+            }
+        }
+
+        if workspace_json_paths.is_empty() {
+            for path in crate::workspace_json::detect_build_layout_source_paths(workspace_root) {
+                let s = path.to_string_lossy().into_owned();
+                if !paths.contains(&s) {
+                    paths.push(s);
+                }
+            }
+        }
+
+        if let Some(configured) =
+            crate::workspace_json::load_configured_source_paths(workspace_root)
+        {
+            for p in configured {
+                let s = p.to_string_lossy().into_owned();
+                if !paths.contains(&s) {
+                    paths.push(s);
+                }
+            }
+        } else {
+            #[allow(deprecated)]
+            if let Some(home) = std::env::home_dir() {
+                let default_sources = home.join(".kotlin-lsp").join("sources");
+                if default_sources.is_dir() {
+                    let s = default_sources.to_string_lossy().into_owned();
+                    if !paths.contains(&s) {
+                        paths.push(s);
+                    }
+                }
+            }
+        }
+
+        for path in crate::workspace_json::detect_android_sdk_source_paths(workspace_root) {
+            let s = path.to_string_lossy().into_owned();
+            if !paths.contains(&s) {
+                paths.push(s);
+            }
+        }
+
+        paths
+    }
+
+    /// Collect workspace source roots for rg scoping: only paths that the user explicitly
+    /// configured and that lie under the workspace root.
+    ///
+    /// - Includes workspace.json JetBrains module sourceRoots (`load_source_paths`).
+    /// - Includes LSP init `sourcePaths` entries that resolve under `workspace_root`.
+    /// - Excludes auto-detected build-layout paths, Android SDK, and library directories.
+    fn collect_workspace_source_roots(
+        initialization_options: Option<&serde_json::Value>,
+        workspace_root: &Path,
+    ) -> Vec<String> {
+        let mut roots: Vec<String> = Vec::new();
+
+        for path in crate::workspace_json::load_source_paths(workspace_root) {
+            let s = path.to_string_lossy().into_owned();
+            if !roots.contains(&s) {
+                roots.push(s);
+            }
+        }
+
+        if let Some(init_paths) =
+            Self::collect_indexing_option_strings(initialization_options, "sourcePaths")
+        {
+            for p_str in init_paths {
+                let path = std::path::Path::new(&p_str);
+                let abs = if path.is_absolute() {
+                    path.to_path_buf()
+                } else {
+                    workspace_root.join(path)
+                };
+                if abs.starts_with(workspace_root) && !roots.contains(&p_str) {
+                    roots.push(p_str);
+                }
+            }
+        }
+
+        roots
     }
 
     fn collect_indexing_option_strings(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -141,6 +141,28 @@ impl Backend {
         (root, source_roots, ignore)
     }
 
+    /// Return `(effective_root, scoped_source_paths, matcher)` for an rg search
+    /// originating from `file_path`.
+    ///
+    /// `effective_root` is computed via `effective_rg_root` (follows the file into its
+    /// own project root when it lives outside the configured workspace root).
+    /// `scoped_source_paths` is non-empty only when the effective root matches the
+    /// workspace root — when we've switched to a different project, source roots from
+    /// the workspace context don't apply and we fall back to a full-root search.
+    pub(crate) async fn rg_scope_for_file(
+        &self,
+        file_path: Option<&Path>,
+    ) -> (Option<PathBuf>, Vec<String>, Option<Arc<IgnoreMatcher>>) {
+        let (workspace_root, source_roots, matcher) = self.rg_context().await;
+        let effective_root = crate::rg::effective_rg_root(workspace_root.as_deref(), file_path);
+        let scoped_paths = if effective_root == workspace_root {
+            source_roots
+        } else {
+            Vec::new()
+        };
+        (effective_root, scoped_paths, matcher)
+    }
+
     /// Try `find_definition_qualified` with `rt.qualified`, falling back to `rt.leaf`
     /// when the first lookup is empty and the two names differ.
     pub(super) fn resolve_with_receiver_fallback(
@@ -272,8 +294,7 @@ impl Backend {
 
         let all_source_paths =
             Self::collect_all_source_paths(initialization_options, workspace_root);
-        let rg_source_roots =
-            Self::collect_workspace_source_roots(initialization_options, workspace_root);
+        let rg_source_roots = Self::collect_workspace_source_roots(workspace_root);
 
         if !all_source_paths.is_empty() {
             log::info!("sourcePaths (combined): {:?}", all_source_paths);
@@ -363,46 +384,29 @@ impl Backend {
         paths
     }
 
-    /// Collect workspace source roots for rg scoping: only paths that the user explicitly
-    /// configured and that lie under the workspace root.
+    /// Collect workspace source roots for rg scoping.
     ///
-    /// - Includes workspace.json JetBrains module sourceRoots (`load_source_paths`).
-    /// - Includes LSP init `sourcePaths` entries that resolve under `workspace_root`.
-    /// - Excludes auto-detected build-layout paths, Android SDK, and library directories.
-    fn collect_workspace_source_roots(
-        initialization_options: Option<&serde_json::Value>,
-        workspace_root: &Path,
-    ) -> Vec<String> {
-        let mut roots: Vec<String> = Vec::new();
+    /// Only workspace.json JetBrains module sourceRoots are included — these are paths
+    /// the user explicitly configured for the project layout. `initializationOptions.sourcePaths`
+    /// is intentionally excluded: it is an additive indexing override for stubs/generated code,
+    /// not a scope restriction, and including it would make references/rename skip the rest of
+    /// the workspace for any project that adds a single `buildSrc/src` to sourcePaths.
+    fn collect_workspace_source_roots(workspace_root: &Path) -> Vec<String> {
+        crate::workspace_json::load_source_paths(workspace_root)
+            .into_iter()
+            .map(|p| p.to_string_lossy().into_owned())
+            .collect()
+    }
 
-        for path in crate::workspace_json::load_source_paths(workspace_root) {
-            let s = path.to_string_lossy().into_owned();
-            if !roots.contains(&s) {
-                roots.push(s);
-            }
+    /// Reload workspace source roots from `workspace_root`'s workspace.json and store them.
+    /// Call whenever the active workspace root changes so stale source roots from the previous
+    /// project are not used for rg scoping in the new project.
+    fn reload_workspace_source_roots(&self, workspace_root: &Path) {
+        let roots = Self::collect_workspace_source_roots(workspace_root);
+        match self.indexer.workspace_source_roots.write() {
+            Ok(mut guard) => *guard = roots,
+            Err(e) => log::warn!("Failed to update workspace_source_roots: {e}"),
         }
-
-        if let Some(init_paths) =
-            Self::collect_indexing_option_strings(initialization_options, "sourcePaths")
-        {
-            for p_str in init_paths {
-                let path = std::path::Path::new(&p_str);
-                let abs = if path.is_absolute() {
-                    path.to_path_buf()
-                } else {
-                    workspace_root.join(path)
-                };
-                // Normalize before `starts_with` to resolve `..` components.
-                // A path like `"../escape"` lexically looks like a prefix match but
-                // canonicalizes outside the workspace root.
-                let normalized = Self::normalize_path(&abs);
-                if normalized.starts_with(workspace_root) && !roots.contains(&p_str) {
-                    roots.push(p_str);
-                }
-            }
-        }
-
-        roots
     }
 
     fn collect_indexing_option_strings(
@@ -534,27 +538,6 @@ impl Backend {
         std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
     }
 
-    /// Normalize `path` by resolving `..` and `.` components without requiring the path
-    /// to exist on disk. Uses `canonicalize` when the path exists (also resolves symlinks),
-    /// otherwise falls back to a lexical walk so that `../escape` traversals are caught
-    /// even for paths that have not been created yet.
-    fn normalize_path(path: &Path) -> PathBuf {
-        if let Ok(canonical) = std::fs::canonicalize(path) {
-            return canonical;
-        }
-        use std::path::Component;
-        path.components().fold(PathBuf::new(), |mut acc, comp| {
-            match comp {
-                Component::ParentDir => {
-                    acc.pop();
-                }
-                Component::CurDir => {}
-                c => acc.push(c),
-            }
-            acc
-        })
-    }
-
     fn switch_workspace_root_for_opened_document(
         &self,
         workspace_root: PathBuf,
@@ -564,6 +547,9 @@ impl Backend {
         self.indexer.workspace_pinned.store(true, Ordering::Relaxed);
         self.indexer.root_generation.fetch_add(1, Ordering::SeqCst);
         self.indexer.reset_index_state();
+        // Reload source roots for the new workspace so rg scoping doesn't use
+        // stale paths from the previous project.
+        self.reload_workspace_source_roots(&workspace_root);
         log::info!(
             "Auto-detected workspace root (now pinned): {}",
             workspace_root.display()

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -135,10 +135,7 @@ impl Backend {
     pub(crate) async fn rg_context(
         &self,
     ) -> (Option<PathBuf>, Vec<String>, Option<Arc<IgnoreMatcher>>) {
-        let root = self.indexer.workspace_root.read().unwrap().clone();
-        let source_roots = self.indexer.workspace_source_roots.read().unwrap().clone();
-        let ignore = self.indexer.ignore_matcher.read().unwrap().clone();
-        (root, source_roots, ignore)
+        self.indexer.rg_scope_for_path(None)
     }
 
     /// Return `(effective_root, scoped_source_paths, matcher)` for an rg search
@@ -153,14 +150,7 @@ impl Backend {
         &self,
         file_path: Option<&Path>,
     ) -> (Option<PathBuf>, Vec<String>, Option<Arc<IgnoreMatcher>>) {
-        let (workspace_root, source_roots, matcher) = self.rg_context().await;
-        let effective_root = crate::rg::effective_rg_root(workspace_root.as_deref(), file_path);
-        let scoped_paths = if effective_root == workspace_root {
-            source_roots
-        } else {
-            Vec::new()
-        };
-        (effective_root, scoped_paths, matcher)
+        self.indexer.rg_scope_for_path(file_path)
     }
 
     /// Try `find_definition_qualified` with `rt.qualified`, falling back to `rt.leaf`

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -392,7 +392,11 @@ impl Backend {
                 } else {
                     workspace_root.join(path)
                 };
-                if abs.starts_with(workspace_root) && !roots.contains(&p_str) {
+                // Normalize before `starts_with` to resolve `..` components.
+                // A path like `"../escape"` lexically looks like a prefix match but
+                // canonicalizes outside the workspace root.
+                let normalized = Self::normalize_path(&abs);
+                if normalized.starts_with(workspace_root) && !roots.contains(&p_str) {
                     roots.push(p_str);
                 }
             }
@@ -528,6 +532,27 @@ impl Backend {
 
     fn canonicalize_or_clone(path: &Path) -> PathBuf {
         std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    }
+
+    /// Normalize `path` by resolving `..` and `.` components without requiring the path
+    /// to exist on disk. Uses `canonicalize` when the path exists (also resolves symlinks),
+    /// otherwise falls back to a lexical walk so that `../escape` traversals are caught
+    /// even for paths that have not been created yet.
+    fn normalize_path(path: &Path) -> PathBuf {
+        if let Ok(canonical) = std::fs::canonicalize(path) {
+            return canonical;
+        }
+        use std::path::Component;
+        path.components().fold(PathBuf::new(), |mut acc, comp| {
+            match comp {
+                Component::ParentDir => {
+                    acc.pop();
+                }
+                Component::CurDir => {}
+                c => acc.push(c),
+            }
+            acc
+        })
     }
 
     fn switch_workspace_root_for_opened_document(

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -103,12 +103,17 @@ impl Backend {
         // Use effective_rg_root so searches use the open file's project root
         // when workspace_root points to a different project (e.g. android vs ios).
         let file_path = uri.to_file_path().ok();
-        let (workspace_root, matcher) = self.rg_context().await;
+        let (workspace_root, source_paths, matcher) = self.rg_context().await;
         let root_opt =
             crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
         let name_clone = ctx.word.clone();
         let rg_locs = tokio::task::spawn_blocking(move || {
-            crate::rg::rg_find_definition(&name_clone, root_opt.as_deref(), matcher.as_deref())
+            crate::rg::rg_find_definition(
+                &name_clone,
+                root_opt.as_deref(),
+                &source_paths,
+                matcher.as_deref(),
+            )
         })
         .await
         .unwrap_or_default();
@@ -139,7 +144,7 @@ impl Backend {
         // to find implementors quickly to avoid client timeouts in large projects.
         if locs.is_empty() {
             let file_path = uri.to_file_path().ok();
-            let (workspace_root, matcher) = self.rg_context().await;
+            let (workspace_root, _source_paths, matcher) = self.rg_context().await;
             let root_opt =
                 crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
             let word_clone = word.clone();
@@ -240,11 +245,16 @@ impl Backend {
     pub(super) async fn rg_resolve(&self, uri: &Url, name: &str) -> Vec<Location> {
         let name_clone = name.to_string();
         let file_path = uri.to_file_path().ok();
-        let (workspace_root, matcher) = self.rg_context().await;
+        let (workspace_root, source_paths, matcher) = self.rg_context().await;
         let root_opt =
             crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
         tokio::task::spawn_blocking(move || {
-            crate::rg::rg_find_definition(&name_clone, root_opt.as_deref(), matcher.as_deref())
+            crate::rg::rg_find_definition(
+                &name_clone,
+                root_opt.as_deref(),
+                &source_paths,
+                matcher.as_deref(),
+            )
         })
         .await
         .unwrap_or_default()

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -103,17 +103,7 @@ impl Backend {
         // Use effective_rg_root so searches use the open file's project root
         // when workspace_root points to a different project (e.g. android vs ios).
         let file_path = uri.to_file_path().ok();
-        let (workspace_root, source_paths, matcher) = self.rg_context().await;
-        let root_opt =
-            crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
-        // Only apply source_paths scoping when rg searches the workspace root itself.
-        // If effective_rg_root diverged (e.g. open file is in a different project),
-        // fall back to full-root search so nothing is missed.
-        let scoped_paths = if root_opt == workspace_root {
-            source_paths
-        } else {
-            Vec::new()
-        };
+        let (root_opt, scoped_paths, matcher) = self.rg_scope_for_file(file_path.as_deref()).await;
         let name_clone = ctx.word.clone();
         let rg_locs = tokio::task::spawn_blocking(move || {
             crate::rg::rg_find_definition(
@@ -152,14 +142,8 @@ impl Backend {
         // to find implementors quickly to avoid client timeouts in large projects.
         if locs.is_empty() {
             let file_path = uri.to_file_path().ok();
-            let (workspace_root, source_paths, matcher) = self.rg_context().await;
-            let root_opt =
-                crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
-            let scoped_paths = if root_opt == workspace_root {
-                source_paths
-            } else {
-                Vec::new()
-            };
+            let (root_opt, scoped_paths, matcher) =
+                self.rg_scope_for_file(file_path.as_deref()).await;
             let word_clone = word.clone();
             let rg_impls = tokio::task::spawn_blocking(move || {
                 crate::rg::rg_find_implementors(
@@ -259,14 +243,7 @@ impl Backend {
     pub(super) async fn rg_resolve(&self, uri: &Url, name: &str) -> Vec<Location> {
         let name_clone = name.to_string();
         let file_path = uri.to_file_path().ok();
-        let (workspace_root, source_paths, matcher) = self.rg_context().await;
-        let root_opt =
-            crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
-        let scoped_paths = if root_opt == workspace_root {
-            source_paths
-        } else {
-            Vec::new()
-        };
+        let (root_opt, scoped_paths, matcher) = self.rg_scope_for_file(file_path.as_deref()).await;
         tokio::task::spawn_blocking(move || {
             crate::rg::rg_find_definition(
                 &name_clone,

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -144,7 +144,7 @@ impl Backend {
         // to find implementors quickly to avoid client timeouts in large projects.
         if locs.is_empty() {
             let file_path = uri.to_file_path().ok();
-            let (workspace_root, _source_paths, matcher) = self.rg_context().await;
+            let (workspace_root, source_paths, matcher) = self.rg_context().await;
             let root_opt =
                 crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
             let word_clone = word.clone();
@@ -152,6 +152,7 @@ impl Backend {
                 crate::rg::rg_find_implementors(
                     &word_clone,
                     root_opt.as_deref(),
+                    &source_paths,
                     matcher.as_deref(),
                 )
             })

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -106,12 +106,20 @@ impl Backend {
         let (workspace_root, source_paths, matcher) = self.rg_context().await;
         let root_opt =
             crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
+        // Only apply source_paths scoping when rg searches the workspace root itself.
+        // If effective_rg_root diverged (e.g. open file is in a different project),
+        // fall back to full-root search so nothing is missed.
+        let scoped_paths = if root_opt == workspace_root {
+            source_paths
+        } else {
+            Vec::new()
+        };
         let name_clone = ctx.word.clone();
         let rg_locs = tokio::task::spawn_blocking(move || {
             crate::rg::rg_find_definition(
                 &name_clone,
                 root_opt.as_deref(),
-                &source_paths,
+                &scoped_paths,
                 matcher.as_deref(),
             )
         })
@@ -147,12 +155,17 @@ impl Backend {
             let (workspace_root, source_paths, matcher) = self.rg_context().await;
             let root_opt =
                 crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
+            let scoped_paths = if root_opt == workspace_root {
+                source_paths
+            } else {
+                Vec::new()
+            };
             let word_clone = word.clone();
             let rg_impls = tokio::task::spawn_blocking(move || {
                 crate::rg::rg_find_implementors(
                     &word_clone,
                     root_opt.as_deref(),
-                    &source_paths,
+                    &scoped_paths,
                     matcher.as_deref(),
                 )
             })
@@ -249,11 +262,16 @@ impl Backend {
         let (workspace_root, source_paths, matcher) = self.rg_context().await;
         let root_opt =
             crate::rg::effective_rg_root(workspace_root.as_deref(), file_path.as_deref());
+        let scoped_paths = if root_opt == workspace_root {
+            source_paths
+        } else {
+            Vec::new()
+        };
         tokio::task::spawn_blocking(move || {
             crate::rg::rg_find_definition(
                 &name_clone,
                 root_opt.as_deref(),
-                &source_paths,
+                &scoped_paths,
                 matcher.as_deref(),
             )
         })

--- a/src/backend/rename.rs
+++ b/src/backend/rename.rs
@@ -352,7 +352,7 @@ impl Backend {
             &rename_target.name,
             rename_target.parent_class.as_deref(),
         );
-        let (root, matcher) = self.rg_context().await;
+        let (root, source_paths, matcher) = self.rg_context().await;
         let uri_clone = uri.clone();
         let name = rename_target.name.clone();
         let parent_class = rename_target.parent_class.clone();
@@ -366,7 +366,8 @@ impl Backend {
                 true,
                 &uri_clone,
                 &decl_files,
-            );
+            )
+            .with_source_paths(&source_paths);
             crate::rg::rg_find_references(&request, matcher.as_deref())
         })
         .await

--- a/src/backend/rename.rs
+++ b/src/backend/rename.rs
@@ -352,7 +352,8 @@ impl Backend {
             &rename_target.name,
             rename_target.parent_class.as_deref(),
         );
-        let (root, source_paths, matcher) = self.rg_context().await;
+        let file_path = uri.to_file_path().ok();
+        let (root, source_paths, matcher) = self.rg_scope_for_file(file_path.as_deref()).await;
         let uri_clone = uri.clone();
         let name = rename_target.name.clone();
         let parent_class = rename_target.parent_class.clone();

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -248,7 +248,7 @@ fn smart_find(indexer: &Arc<Indexer>, name: &str, root: &Path) -> Vec<CliResult>
         return locs_to_results(locs, name, "");
     }
     // Fallback to rg so smart mode still covers edge cases (generics, type aliases).
-    let locs = rg_find_definition(name, Some(root), None);
+    let locs = rg_find_definition(name, Some(root), &[], None);
     locs_to_results(locs, name, "")
 }
 
@@ -273,7 +273,7 @@ fn smart_refs(indexer: &Arc<Indexer>, name: &str, root: &Path) -> Vec<CliResult>
 // ── Fast-mode find ────────────────────────────────────────────────────────────
 
 fn fast_find(name: &str, root: &Path) -> Vec<CliResult> {
-    let locs = rg_find_definition(name, Some(root), None);
+    let locs = rg_find_definition(name, Some(root), &[], None);
     locs_to_results(locs, name, "")
 }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -156,6 +156,15 @@ async fn build_index_inner(root: &Path, source_paths: Vec<String>) -> Arc<Indexe
     if !source_paths.is_empty() {
         *idx.source_paths_raw.write().unwrap() = source_paths;
     }
+    // Populate workspace source roots from workspace.json so resolver/infer rg fallbacks
+    // are scoped when the CLI is run in a project with configured module sourceRoots.
+    let workspace_roots: Vec<String> = crate::workspace_json::load_source_paths(root)
+        .into_iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect();
+    if !workspace_roots.is_empty() {
+        *idx.workspace_source_roots.write().unwrap() = workspace_roots;
+    }
     Arc::clone(&idx)
         .index_workspace_full(root, Arc::new(NoopReporter))
         .await;
@@ -294,7 +303,8 @@ fn fast_find(name: &str, root: &Path) -> Vec<CliResult> {
 // ── Fast-mode refs ────────────────────────────────────────────────────────────
 
 fn fast_refs(name: &str, root: &Path) -> Vec<CliResult> {
-    let locs = rg_word_search(name, root);
+    let source_roots = cli_workspace_source_roots(root);
+    let locs = rg_word_search(name, root, &source_roots);
     locs_to_results(locs, name, "")
 }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -239,6 +239,17 @@ fn locs_to_results(locs: Vec<Location>, name: &str, kind: &str) -> Vec<CliResult
         .collect()
 }
 
+// ── Workspace source roots for CLI ───────────────────────────────────────────
+
+/// Load workspace.json module sourceRoots to scope rg searches in the CLI.
+/// Mirrors the subset of `Backend::collect_workspace_source_roots` relevant for CLI.
+fn cli_workspace_source_roots(root: &Path) -> Vec<String> {
+    crate::workspace_json::load_source_paths(root)
+        .into_iter()
+        .map(|p| p.to_string_lossy().into_owned())
+        .collect()
+}
+
 // ── Smart-mode find ───────────────────────────────────────────────────────────
 
 fn smart_find(indexer: &Arc<Indexer>, name: &str, root: &Path) -> Vec<CliResult> {
@@ -247,11 +258,8 @@ fn smart_find(indexer: &Arc<Indexer>, name: &str, root: &Path) -> Vec<CliResult>
     if !locs.is_empty() {
         return locs_to_results(locs, name, "");
     }
-    // Fallback to rg so smart mode still covers edge cases (generics, type aliases).
-    // Pass &[] so rg searches the full workspace root — CLI source_paths_raw contains
-    // only external library paths (outside the workspace root) used for indexing, not
-    // workspace source roots suitable for scoping definition searches.
-    let locs = rg_find_definition(name, Some(root), &[], None);
+    let source_roots = cli_workspace_source_roots(root);
+    let locs = rg_find_definition(name, Some(root), &source_roots, None);
     locs_to_results(locs, name, "")
 }
 
@@ -268,7 +276,9 @@ fn smart_refs(indexer: &Arc<Indexer>, name: &str, root: &Path) -> Vec<CliResult>
     let dummy_uri: tower_lsp::lsp_types::Url = tower_lsp::lsp_types::Url::from_file_path(root)
         .unwrap_or_else(|_| "file:///".parse().unwrap());
 
-    let request = RgSearchRequest::new(name, None, None, Some(root), true, &dummy_uri, &decl_files);
+    let source_roots = cli_workspace_source_roots(root);
+    let request = RgSearchRequest::new(name, None, None, Some(root), true, &dummy_uri, &decl_files)
+        .with_source_paths(&source_roots);
     let locs = crate::rg::rg_find_references(&request, None);
     locs_to_results(locs, name, "")
 }
@@ -276,7 +286,8 @@ fn smart_refs(indexer: &Arc<Indexer>, name: &str, root: &Path) -> Vec<CliResult>
 // ── Fast-mode find ────────────────────────────────────────────────────────────
 
 fn fast_find(name: &str, root: &Path) -> Vec<CliResult> {
-    let locs = rg_find_definition(name, Some(root), &[], None);
+    let source_roots = cli_workspace_source_roots(root);
+    let locs = rg_find_definition(name, Some(root), &source_roots, None);
     locs_to_results(locs, name, "")
 }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -248,6 +248,9 @@ fn smart_find(indexer: &Arc<Indexer>, name: &str, root: &Path) -> Vec<CliResult>
         return locs_to_results(locs, name, "");
     }
     // Fallback to rg so smart mode still covers edge cases (generics, type aliases).
+    // Pass &[] so rg searches the full workspace root — CLI source_paths_raw contains
+    // only external library paths (outside the workspace root) used for indexing, not
+    // workspace source roots suitable for scoping definition searches.
     let locs = rg_find_definition(name, Some(root), &[], None);
     locs_to_results(locs, name, "")
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -357,9 +357,21 @@ impl Indexer {
         Vec<String>,
         Option<Arc<crate::rg::IgnoreMatcher>>,
     ) {
-        let workspace_root = self.workspace_root.read().unwrap().clone();
-        let source_roots = self.workspace_source_roots.read().unwrap().clone();
-        let matcher = self.ignore_matcher.read().unwrap().clone();
+        let workspace_root = self
+            .workspace_root
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let source_roots = self
+            .workspace_source_roots
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        let matcher = self
+            .ignore_matcher
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
         let effective_root = crate::rg::effective_rg_root(workspace_root.as_deref(), open_file);
         let scoped_paths = if effective_root == workspace_root {
             source_roots

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -191,6 +191,12 @@ pub(crate) struct Indexer {
     /// Raw source paths from `initializationOptions.indexingOptions.sourcePaths`.
     /// Stored unresolved; resolved against workspace root at indexing time.
     pub(crate) source_paths_raw: RwLock<Vec<String>>,
+    /// Workspace source roots explicitly configured by the user (workspace.json
+    /// JetBrains module sourceRoots or LSP init `sourcePaths` under the workspace root).
+    /// Used to scope rg searches to project source directories only.
+    /// Unlike `source_paths_raw`, this excludes external library sources (Android SDK,
+    /// ~/.kotlin-lsp/sources) and auto-detected build-layout paths.
+    pub(crate) workspace_source_roots: RwLock<Vec<String>>,
     /// URIs of files indexed from `sourcePaths` that lie outside the workspace root.
     /// These are treated as library sources: available for hover/definition/autocomplete
     /// but excluded from findReferences and rename.
@@ -269,6 +275,7 @@ impl Indexer {
             last_scan_complete: std::sync::atomic::AtomicBool::new(false),
             ignore_matcher: RwLock::new(None),
             source_paths_raw: RwLock::new(Vec::new()),
+            workspace_source_roots: RwLock::new(Vec::new()),
             library_uris: DashSet::new(),
             importable_fqns: std::sync::RwLock::new(std::collections::HashMap::new()),
             live_trees: DashMap::new(),

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -191,11 +191,12 @@ pub(crate) struct Indexer {
     /// Raw source paths from `initializationOptions.indexingOptions.sourcePaths`.
     /// Stored unresolved; resolved against workspace root at indexing time.
     pub(crate) source_paths_raw: RwLock<Vec<String>>,
-    /// Workspace source roots explicitly configured by the user (workspace.json
-    /// JetBrains module sourceRoots or LSP init `sourcePaths` under the workspace root).
-    /// Used to scope rg searches to project source directories only.
-    /// Unlike `source_paths_raw`, this excludes external library sources (Android SDK,
-    /// ~/.kotlin-lsp/sources) and auto-detected build-layout paths.
+    /// Workspace source roots for scoping rg searches to project source directories only.
+    /// Populated exclusively from workspace.json JetBrains module sourceRoots
+    /// (`workspace_json::load_source_paths`). LSP init `sourcePaths` is intentionally
+    /// excluded — it is an additive indexing override for stubs/generated code, not a
+    /// search-scope restriction. Auto-detected build-layout paths, Android SDK sources,
+    /// and ~/.kotlin-lsp/sources are also excluded.
     pub(crate) workspace_source_roots: RwLock<Vec<String>>,
     /// URIs of files indexed from `sourcePaths` that lie outside the workspace root.
     /// These are treated as library sources: available for hover/definition/autocomplete
@@ -334,6 +335,38 @@ impl Indexer {
 
     pub(crate) fn is_library_uri(&self, uri: &Url) -> bool {
         self.library_uris.contains(uri.as_str())
+    }
+
+    /// Return `(effective_root, scoped_source_paths, matcher)` for an rg search
+    /// whose context file is `open_file`.
+    ///
+    /// `effective_root` is derived via `effective_rg_root`: when `open_file` lives
+    /// outside the configured workspace root, it walks up to the nearest `.git` root
+    /// so rg searches the *actual* project of that file.
+    ///
+    /// `scoped_source_paths` is non-empty only when `effective_root` matches the
+    /// configured workspace root — when the file belongs to a different project,
+    /// workspace source roots don't apply and we fall back to a full-root search.
+    ///
+    /// Pass `None` for `open_file` to get workspace-level scope (no file context).
+    pub(crate) fn rg_scope_for_path(
+        &self,
+        open_file: Option<&std::path::Path>,
+    ) -> (
+        Option<std::path::PathBuf>,
+        Vec<String>,
+        Option<Arc<crate::rg::IgnoreMatcher>>,
+    ) {
+        let workspace_root = self.workspace_root.read().unwrap().clone();
+        let source_roots = self.workspace_source_roots.read().unwrap().clone();
+        let matcher = self.ignore_matcher.read().unwrap().clone();
+        let effective_root = crate::rg::effective_rg_root(workspace_root.as_deref(), open_file);
+        let scoped_paths = if effective_root == workspace_root {
+            source_roots
+        } else {
+            Vec::new()
+        };
+        (effective_root, scoped_paths, matcher)
     }
 
     pub(crate) fn remove_live_lines(&self, uri: &Url) {

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -920,9 +920,14 @@ fn lambda_receiver_type_named_arg_ml(
             locs.first().map(|l| l.uri.to_string()).or_else(|| {
                 // On-demand: use rg to find and index the outer class.
                 let root = idx.workspace_root.read().unwrap().clone();
+                let source_paths = idx.source_paths_raw.read().unwrap().clone();
                 let matcher = idx.ignore_matcher.read().unwrap().clone();
-                let rg_locs =
-                    crate::rg::rg_find_definition(outer, root.as_deref(), matcher.as_deref());
+                let rg_locs = crate::rg::rg_find_definition(
+                    outer,
+                    root.as_deref(),
+                    &source_paths,
+                    matcher.as_deref(),
+                );
                 for loc in &rg_locs {
                     if !idx.files.contains_key(loc.uri.as_str()) {
                         if let Ok(path) = loc.uri.to_file_path() {

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -920,12 +920,12 @@ fn lambda_receiver_type_named_arg_ml(
             locs.first().map(|l| l.uri.to_string()).or_else(|| {
                 // On-demand: use rg to find and index the outer class.
                 let root = idx.workspace_root.read().unwrap().clone();
-                let source_paths = idx.source_paths_raw.read().unwrap().clone();
+                let source_roots = idx.workspace_source_roots.read().unwrap().clone();
                 let matcher = idx.ignore_matcher.read().unwrap().clone();
                 let rg_locs = crate::rg::rg_find_definition(
                     outer,
                     root.as_deref(),
-                    &source_paths,
+                    &source_roots,
                     matcher.as_deref(),
                 );
                 for loc in &rg_locs {

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -919,9 +919,8 @@ fn lambda_receiver_type_named_arg_ml(
             let locs = idx.resolve_symbol_no_rg(outer, uri);
             locs.first().map(|l| l.uri.to_string()).or_else(|| {
                 // On-demand: use rg to find and index the outer class.
-                let root = idx.workspace_root.read().unwrap().clone();
-                let source_roots = idx.workspace_source_roots.read().unwrap().clone();
-                let matcher = idx.ignore_matcher.read().unwrap().clone();
+                let open_file = uri.to_file_path().ok();
+                let (root, source_roots, matcher) = idx.rg_scope_for_path(open_file.as_deref());
                 let rg_locs = crate::rg::rg_find_definition(
                     outer,
                     root.as_deref(),

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -105,9 +105,8 @@ pub(crate) fn find_fun_signature_full(fn_name: &str, idx: &Indexer, uri: &Url) -
         return Some(sig);
     }
     // Slow path: rg to locate the definition, index on-demand.
-    let root = idx.workspace_root.read().unwrap().clone();
-    let source_roots = idx.workspace_source_roots.read().unwrap().clone();
-    let matcher = idx.ignore_matcher.read().unwrap().clone();
+    let open_file = uri.to_file_path().ok();
+    let (root, source_roots, matcher) = idx.rg_scope_for_path(open_file.as_deref());
     let locs =
         crate::rg::rg_find_definition(fn_name, root.as_deref(), &source_roots, matcher.as_deref());
     for loc in &locs {

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -106,8 +106,10 @@ pub(crate) fn find_fun_signature_full(fn_name: &str, idx: &Indexer, uri: &Url) -
     }
     // Slow path: rg to locate the definition, index on-demand.
     let root = idx.workspace_root.read().unwrap().clone();
+    let source_paths = idx.source_paths_raw.read().unwrap().clone();
     let matcher = idx.ignore_matcher.read().unwrap().clone();
-    let locs = crate::rg::rg_find_definition(fn_name, root.as_deref(), matcher.as_deref());
+    let locs =
+        crate::rg::rg_find_definition(fn_name, root.as_deref(), &source_paths, matcher.as_deref());
     for loc in &locs {
         let file_uri_str = loc.uri.as_str();
         if !idx.files.contains_key(file_uri_str) {

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -106,10 +106,10 @@ pub(crate) fn find_fun_signature_full(fn_name: &str, idx: &Indexer, uri: &Url) -
     }
     // Slow path: rg to locate the definition, index on-demand.
     let root = idx.workspace_root.read().unwrap().clone();
-    let source_paths = idx.source_paths_raw.read().unwrap().clone();
+    let source_roots = idx.workspace_source_roots.read().unwrap().clone();
     let matcher = idx.ignore_matcher.read().unwrap().clone();
     let locs =
-        crate::rg::rg_find_definition(fn_name, root.as_deref(), &source_paths, matcher.as_deref());
+        crate::rg::rg_find_definition(fn_name, root.as_deref(), &source_roots, matcher.as_deref());
     for loc in &locs {
         let file_uri_str = loc.uri.as_str();
         if !idx.files.contains_key(file_uri_str) {

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -406,9 +406,8 @@ pub(crate) fn resolve_symbol_inner(
     }
 
     // 5 ── project-wide rg ───────────────────────────────────────────────────
-    let root = idx.workspace_root.read().unwrap().clone();
-    let source_roots = idx.workspace_source_roots.read().unwrap().clone();
-    let matcher = idx.ignore_matcher.read().unwrap().clone();
+    let open_file = from_uri.to_file_path().ok();
+    let (root, source_roots, matcher) = idx.rg_scope_for_path(open_file.as_deref());
     rg_find_definition(name, root.as_deref(), &source_roots, matcher.as_deref())
 }
 

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -407,8 +407,9 @@ pub(crate) fn resolve_symbol_inner(
 
     // 5 ── project-wide rg ───────────────────────────────────────────────────
     let root = idx.workspace_root.read().unwrap().clone();
+    let source_paths = idx.source_paths_raw.read().unwrap().clone();
     let matcher = idx.ignore_matcher.read().unwrap().clone();
-    rg_find_definition(name, root.as_deref(), matcher.as_deref())
+    rg_find_definition(name, root.as_deref(), &source_paths, matcher.as_deref())
 }
 
 /// Returns the first Location found by scanning star-import packages.

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -407,9 +407,9 @@ pub(crate) fn resolve_symbol_inner(
 
     // 5 ── project-wide rg ───────────────────────────────────────────────────
     let root = idx.workspace_root.read().unwrap().clone();
-    let source_paths = idx.source_paths_raw.read().unwrap().clone();
+    let source_roots = idx.workspace_source_roots.read().unwrap().clone();
     let matcher = idx.ignore_matcher.read().unwrap().clone();
-    rg_find_definition(name, root.as_deref(), &source_paths, matcher.as_deref())
+    rg_find_definition(name, root.as_deref(), &source_roots, matcher.as_deref())
 }
 
 /// Returns the first Location found by scanning star-import packages.

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -425,9 +425,20 @@ impl<'a> RgSearch<'a> {
             RgTarget::Root(root) => *root,
             RgTarget::Files(_) => return vec![],
             RgTarget::SourcePaths(_) => {
+                // Apply the same relative-path normalization as the Root branch so that
+                // a source root passed as relative (or rg run from a different cwd) doesn't
+                // produce relative filenames that later fail URI construction.
+                let parse_root = self.parse_root;
                 return String::from_utf8_lossy(&output.stdout)
                     .lines()
-                    .map(|line| line.to_owned())
+                    .map(|line| {
+                        let path = Path::new(line);
+                        if path.is_absolute() {
+                            line.to_owned()
+                        } else {
+                            parse_root.join(line).to_string_lossy().into_owned()
+                        }
+                    })
                     .collect();
             }
         };
@@ -582,9 +593,15 @@ fn scope_decl_files<'a>(
     if source_paths.is_empty() {
         return std::borrow::Cow::Borrowed(decl_files);
     }
+    // Use Path::starts_with (component-based) rather than str::starts_with to avoid
+    // sibling-path false positives: "/src/main/kotlin2" must not match "/src/main/kotlin".
+    let source_paths_buf: Vec<&Path> = source_paths.iter().map(|s| Path::new(s.as_str())).collect();
     let filtered: Vec<String> = decl_files
         .iter()
-        .filter(|f| source_paths.iter().any(|sp| f.starts_with(sp.as_str())))
+        .filter(|f| {
+            let fp = Path::new(f.as_str());
+            source_paths_buf.iter().any(|sp| fp.starts_with(sp))
+        })
         .cloned()
         .collect();
     std::borrow::Cow::Owned(filtered)
@@ -826,8 +843,11 @@ fn rg_word_in_files(safe_name: &str, files: &[String]) -> Vec<(Location, String)
 /// Used by the CLI `refs --fast` subcommand.  Less precise than
 /// `rg_find_references` (no package/class context) but zero-cost to run —
 /// no index required.
-pub(crate) fn rg_word_search(name: &str, root: &Path) -> Vec<Location> {
-    RgSearch::rooted(root)
+///
+/// When `source_paths` is non-empty, the search is scoped to those directories
+/// instead of `root`, mirroring the scoping behaviour of other rg search functions.
+pub(crate) fn rg_word_search(name: &str, root: &Path, source_paths: &[String]) -> Vec<Location> {
+    RgSearch::scoped(source_paths, root)
         .word_regexp()
         .with_pattern(regex_escape(name))
         .locations()

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -260,8 +260,9 @@ pub(crate) struct RgSearchRequest<'a> {
 
 enum RgTarget<'a> {
     Root(&'a Path),
-    /// Multiple source-root directories (from workspace.json `sourceRoots`).
+    /// Workspace source-root directories (paths under the workspace root).
     /// When set, rg searches only these directories instead of the full workspace root.
+    /// Relative paths are resolved against `parse_root` at command-build time.
     SourcePaths(&'a [String]),
     Files(&'a [String]),
 }
@@ -360,7 +361,14 @@ impl<'a> RgSearch<'a> {
                 command.arg(root);
             }
             RgTarget::SourcePaths(paths) => {
-                command.args(paths.iter().map(String::as_str));
+                for p in paths.iter() {
+                    let path = Path::new(p);
+                    if path.is_absolute() {
+                        command.arg(p.as_str());
+                    } else {
+                        command.arg(self.parse_root.join(path));
+                    }
+                }
             }
             RgTarget::Files(files) => {
                 command.arg("--");
@@ -674,6 +682,7 @@ pub(crate) fn rg_find_references(
 pub(crate) fn rg_find_implementors(
     name: &str,
     root: Option<&Path>,
+    source_paths: &[String],
     matcher: Option<&IgnoreMatcher>,
 ) -> Vec<Location> {
     let safe = name.to_string();
@@ -682,7 +691,7 @@ pub(crate) fn rg_find_implementors(
         None => return vec![],
     };
     // Search for the name in source files.
-    let locs: Vec<Location> = RgSearch::rooted(root)
+    let locs: Vec<Location> = RgSearch::scoped(source_paths, root)
         .with_pattern(safe)
         .locations_with_content()
         .into_iter()

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -217,6 +217,10 @@ pub(crate) fn effective_rg_root(
 /// Passing workspace root here is essential; without it rg would search
 /// from CWD which may not be the project when spawned by the editor.
 ///
+/// When `source_paths` is non-empty, rg searches only those directories instead
+/// of `root`. `root` is still used as the base for resolving relative entries in
+/// `source_paths` and as a fallback if every configured path is missing on disk.
+///
 /// Results in directories matched by `matcher` are filtered out.
 pub(crate) fn rg_find_definition(
     name: &str,
@@ -569,6 +573,23 @@ fn merge_decl_files(candidate_files: &mut Vec<String>, decl_files: &[String]) {
     }
 }
 
+/// When `source_paths` is non-empty, filter `decl_files` to only those within the
+/// configured source roots so declaration files outside the scope don't bypass scoping.
+fn scope_decl_files<'a>(
+    decl_files: &'a [String],
+    source_paths: &'a [String],
+) -> std::borrow::Cow<'a, [String]> {
+    if source_paths.is_empty() {
+        return std::borrow::Cow::Borrowed(decl_files);
+    }
+    let filtered: Vec<String> = decl_files
+        .iter()
+        .filter(|f| source_paths.iter().any(|sp| f.starts_with(sp.as_str())))
+        .cloned()
+        .collect();
+    std::borrow::Cow::Owned(filtered)
+}
+
 fn append_unique_reference_hits(
     locations: &mut Vec<Location>,
     hits: Vec<(Location, String)>,
@@ -615,7 +636,10 @@ fn parent_scoped_reference_locations(
         ),
         matcher,
     );
-    merge_decl_files(&mut candidate_files, request.decl_files);
+    merge_decl_files(
+        &mut candidate_files,
+        &scope_decl_files(request.decl_files, request.source_paths),
+    );
     if !candidate_files.is_empty() {
         let bare_hits = rg_word_in_files(&patterns[2], &candidate_files);
         append_unique_reference_hits(&mut locations, bare_hits, request);

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -221,18 +221,19 @@ pub(crate) fn effective_rg_root(
 pub(crate) fn rg_find_definition(
     name: &str,
     root: Option<&Path>,
+    source_paths: &[String],
     matcher: Option<&IgnoreMatcher>,
 ) -> Vec<Location> {
     let pattern = build_rg_pattern(name);
 
     // Use the provided root, or fall back to CWD (which editors like Helix
     // set to the workspace root when spawning the LSP server).
-    let search_root: std::borrow::Cow<Path> = match root {
+    let fallback_root: std::borrow::Cow<Path> = match root {
         Some(r) => std::borrow::Cow::Borrowed(r),
         None => std::borrow::Cow::Owned(std::env::current_dir().unwrap_or_default()),
     };
 
-    let locs = RgSearch::rooted(search_root.as_ref())
+    let locs = RgSearch::scoped(source_paths, fallback_root.as_ref())
         .with_pattern(pattern)
         .locations();
 
@@ -249,6 +250,9 @@ pub(crate) struct RgSearchRequest<'a> {
     parent_class: Option<&'a str>,
     declared_pkg: Option<&'a str>,
     search_root: std::borrow::Cow<'a, Path>,
+    /// Source-root directories from workspace config; when non-empty, rg is
+    /// scoped to these directories instead of the full workspace root.
+    source_paths: &'a [String],
     include_decl: bool,
     from_uri: &'a Url,
     decl_files: &'a [String],
@@ -256,6 +260,9 @@ pub(crate) struct RgSearchRequest<'a> {
 
 enum RgTarget<'a> {
     Root(&'a Path),
+    /// Multiple source-root directories (from workspace.json `sourceRoots`).
+    /// When set, rg searches only these directories instead of the full workspace root.
+    SourcePaths(&'a [String]),
     Files(&'a [String]),
 }
 
@@ -272,6 +279,21 @@ impl<'a> RgSearch<'a> {
         Self {
             parse_root: root,
             target: RgTarget::Root(root),
+            patterns: Vec::new(),
+            word_regexp: false,
+            list_files: false,
+        }
+    }
+
+    /// Search only within `source_paths` directories (when configured via `sourceRoots`).
+    /// Falls back to `fallback_root` when `source_paths` is empty.
+    fn scoped(source_paths: &'a [String], fallback_root: &'a Path) -> Self {
+        if source_paths.is_empty() {
+            return Self::rooted(fallback_root);
+        }
+        Self {
+            parse_root: fallback_root,
+            target: RgTarget::SourcePaths(source_paths),
             patterns: Vec::new(),
             word_regexp: false,
             list_files: false,
@@ -337,6 +359,9 @@ impl<'a> RgSearch<'a> {
             RgTarget::Root(root) => {
                 command.arg(root);
             }
+            RgTarget::SourcePaths(paths) => {
+                command.args(paths.iter().map(String::as_str));
+            }
             RgTarget::Files(files) => {
                 command.arg("--");
                 command.args(*files);
@@ -377,6 +402,12 @@ impl<'a> RgSearch<'a> {
         let root = match &self.target {
             RgTarget::Root(root) => *root,
             RgTarget::Files(_) => return vec![],
+            RgTarget::SourcePaths(_) => {
+                return String::from_utf8_lossy(&output.stdout)
+                    .lines()
+                    .map(|line| line.to_owned())
+                    .collect();
+            }
         };
         String::from_utf8_lossy(&output.stdout)
             .lines()
@@ -411,10 +442,16 @@ impl<'a> RgSearchRequest<'a> {
             parent_class,
             declared_pkg,
             search_root,
+            source_paths: &[],
             include_decl,
             from_uri,
             decl_files,
         }
+    }
+
+    pub(crate) fn with_source_paths(mut self, source_paths: &'a [String]) -> Self {
+        self.source_paths = source_paths;
+        self
     }
 }
 
@@ -473,8 +510,8 @@ fn should_skip_reference(loc: &Location, content: &str, request: &RgSearchReques
 }
 
 fn run_rg_search(request: &RgSearchRequest<'_>, patterns: &[String]) -> Vec<Location> {
-    let mut search =
-        RgSearch::rooted(request.search_root.as_ref()).with_patterns(patterns.iter().cloned());
+    let mut search = RgSearch::scoped(request.source_paths, request.search_root.as_ref())
+        .with_patterns(patterns.iter().cloned());
     if request.parent_class.is_none() && request.declared_pkg.is_none() {
         search = search.word_regexp();
     }
@@ -553,7 +590,11 @@ fn parent_scoped_reference_locations(
 ) -> Vec<Location> {
     let mut locations = run_rg_search(request, &patterns[..1]);
     let mut candidate_files = filter_candidate_files(
-        rg_files_with_matches(&patterns[1], request.search_root.as_ref()),
+        rg_files_with_matches_scoped(
+            &patterns[1],
+            request.source_paths,
+            request.search_root.as_ref(),
+        ),
         matcher,
     );
     merge_decl_files(&mut candidate_files, request.decl_files);
@@ -569,10 +610,18 @@ fn package_scoped_reference_locations(
     patterns: &[String],
     matcher: Option<&IgnoreMatcher>,
 ) -> Vec<Location> {
-    let mut candidate_files = rg_files_with_matches(&patterns[0], request.search_root.as_ref());
+    let mut candidate_files = rg_files_with_matches_scoped(
+        &patterns[0],
+        request.source_paths,
+        request.search_root.as_ref(),
+    );
     extend_unique_files(
         &mut candidate_files,
-        rg_files_with_matches(&patterns[1], request.search_root.as_ref()),
+        rg_files_with_matches_scoped(
+            &patterns[1],
+            request.source_paths,
+            request.search_root.as_ref(),
+        ),
     );
     let candidate_files = filter_candidate_files(candidate_files, matcher);
     if candidate_files.is_empty() {
@@ -707,9 +756,12 @@ pub(crate) fn regex_escape(s: &str) -> String {
         .collect()
 }
 
-/// Run `rg -l` to get the list of files matching a pattern.
-fn rg_files_with_matches(pattern: &str, root: &Path) -> Vec<String> {
-    RgSearch::rooted(root)
+fn rg_files_with_matches_scoped(
+    pattern: &str,
+    source_paths: &[String],
+    root: &Path,
+) -> Vec<String> {
+    RgSearch::scoped(source_paths, root)
         .list_files()
         .with_pattern(pattern.to_owned())
         .files_with_matches()

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -361,13 +361,23 @@ impl<'a> RgSearch<'a> {
                 command.arg(root);
             }
             RgTarget::SourcePaths(paths) => {
+                let mut any_added = false;
                 for p in paths.iter() {
                     let path = Path::new(p);
-                    if path.is_absolute() {
-                        command.arg(p.as_str());
+                    let abs = if path.is_absolute() {
+                        path.to_path_buf()
                     } else {
-                        command.arg(self.parse_root.join(path));
+                        self.parse_root.join(path)
+                    };
+                    if abs.is_dir() {
+                        command.arg(&abs);
+                        any_added = true;
                     }
+                }
+                // If all configured source paths are missing, fall back to workspace root
+                // so rg doesn't silently return zero results.
+                if !any_added {
+                    command.arg(self.parse_root);
                 }
             }
             RgTarget::Files(files) => {

--- a/src/rg_tests.rs
+++ b/src/rg_tests.rs
@@ -450,3 +450,57 @@ fn rg_find_references_filters_ignored_dirs() {
         "must not include buildSrc in references; got: {files:?}"
     );
 }
+
+/// `rg_find_definition` with non-empty `source_paths` must only return results
+/// from within those directories, not from the full workspace root.
+#[test]
+fn rg_find_definition_scoped_to_source_paths() {
+    let dir = tempfile::TempDir::new().expect("create tempdir");
+    let root = dir.path();
+
+    std::fs::create_dir_all(root.join("app/src/main/kotlin")).unwrap();
+    std::fs::write(root.join("app/src/main/kotlin/Foo.kt"), "class Foo\n").unwrap();
+
+    // A second directory that should NOT be searched when source_paths is set.
+    std::fs::create_dir_all(root.join("generated")).unwrap();
+    std::fs::write(root.join("generated/Foo.kt"), "class Foo\n").unwrap();
+
+    let source_path = root
+        .join("app/src/main/kotlin")
+        .to_string_lossy()
+        .into_owned();
+    let source_paths = vec![source_path.clone()];
+
+    let locs = rg_find_definition("Foo", Some(root), &source_paths, None);
+    let files: Vec<String> = locs
+        .iter()
+        .map(|l| l.uri.to_file_path().unwrap().to_string_lossy().into_owned())
+        .collect();
+
+    assert!(
+        files.iter().all(|f| f.contains("app/src/main/kotlin")),
+        "must only return results from source_paths; got: {files:?}"
+    );
+    assert!(
+        !files.iter().any(|f| f.contains("generated")),
+        "must not include files outside source_paths; got: {files:?}"
+    );
+}
+
+/// `rg_find_definition` with empty `source_paths` falls back to searching the
+/// entire workspace root (backward-compatible behavior).
+#[test]
+fn rg_find_definition_empty_source_paths_falls_back_to_root() {
+    let dir = tempfile::TempDir::new().expect("create tempdir");
+    let root = dir.path();
+
+    std::fs::create_dir_all(root.join("app/src/main/kotlin")).unwrap();
+    std::fs::write(root.join("app/src/main/kotlin/Bar.kt"), "class Bar\n").unwrap();
+
+    // With empty source_paths, should find via workspace root scan.
+    let locs = rg_find_definition("Bar", Some(root), &[], None);
+    assert!(
+        !locs.is_empty(),
+        "must find Bar when source_paths is empty (fallback to root)"
+    );
+}

--- a/src/rg_tests.rs
+++ b/src/rg_tests.rs
@@ -478,6 +478,10 @@ fn rg_find_definition_scoped_to_source_paths() {
         .collect();
 
     assert!(
+        !files.is_empty(),
+        "must find Foo inside the configured source_path; got nothing"
+    );
+    assert!(
         files.iter().all(|f| f.contains("app/src/main/kotlin")),
         "must only return results from source_paths; got: {files:?}"
     );
@@ -502,5 +506,74 @@ fn rg_find_definition_empty_source_paths_falls_back_to_root() {
     assert!(
         !locs.is_empty(),
         "must find Bar when source_paths is empty (fallback to root)"
+    );
+}
+
+/// `rg_find_references` with `with_source_paths` must limit candidate-file
+/// discovery and reference search to the configured source root.
+#[test]
+fn rg_find_references_scoped_to_source_paths() {
+    let dir = tempfile::TempDir::new().expect("create tempdir");
+    let root = dir.path();
+
+    // Source root: contains the declaration and a legitimate reference.
+    std::fs::create_dir_all(root.join("app/src/main/kotlin/com/example")).unwrap();
+    std::fs::write(
+        root.join("app/src/main/kotlin/com/example/Contract.kt"),
+        "package com.example\nclass Contract {\n  class Event\n}\n",
+    )
+    .unwrap();
+    std::fs::write(
+        root.join("app/src/main/kotlin/com/example/User.kt"),
+        "package com.example\nfun use(e: Contract.Event) {}\n",
+    )
+    .unwrap();
+
+    // Outside source root: should NOT appear in results.
+    std::fs::create_dir_all(root.join("generated/com/example")).unwrap();
+    std::fs::write(
+        root.join("generated/com/example/Contract.kt"),
+        "package com.example\nclass Contract {\n  class Event\n}\n",
+    )
+    .unwrap();
+
+    let source_path = root
+        .join("app/src/main/kotlin")
+        .to_string_lossy()
+        .into_owned();
+    let source_paths = vec![source_path];
+
+    let decl_uri =
+        Url::from_file_path(root.join("app/src/main/kotlin/com/example/Contract.kt")).unwrap();
+    let decl_file = root
+        .join("app/src/main/kotlin/com/example/Contract.kt")
+        .to_string_lossy()
+        .into_owned();
+    let decl_files = [decl_file];
+
+    let request = RgSearchRequest::new(
+        "Event",
+        Some("Contract"),
+        Some("com.example"),
+        Some(root),
+        true,
+        &decl_uri,
+        &decl_files,
+    )
+    .with_source_paths(&source_paths);
+
+    let locs = rg_find_references(&request, None);
+    let files: Vec<String> = locs
+        .iter()
+        .map(|l| l.uri.to_file_path().unwrap().to_string_lossy().into_owned())
+        .collect();
+
+    assert!(
+        !files.is_empty(),
+        "must find references inside configured source_paths; got nothing"
+    );
+    assert!(
+        !files.iter().any(|f| f.contains("generated")),
+        "must not include files outside source_paths; got: {files:?}"
     );
 }

--- a/src/rg_tests.rs
+++ b/src/rg_tests.rs
@@ -529,11 +529,12 @@ fn rg_find_references_scoped_to_source_paths() {
     )
     .unwrap();
 
-    // Outside source root: should NOT appear in results.
+    // Outside source root: has a usage of Contract.Event — must NOT appear in scoped results.
+    // Without scoping, rg_find_references would return this file; with scoping it must be excluded.
     std::fs::create_dir_all(root.join("generated/com/example")).unwrap();
     std::fs::write(
-        root.join("generated/com/example/Contract.kt"),
-        "package com.example\nclass Contract {\n  class Event\n}\n",
+        root.join("generated/com/example/OutsideUser.kt"),
+        "package com.example\nfun outsideUse(e: Contract.Event) {}\n",
     )
     .unwrap();
 
@@ -574,6 +575,6 @@ fn rg_find_references_scoped_to_source_paths() {
     );
     assert!(
         !files.iter().any(|f| f.contains("generated")),
-        "must not include files outside source_paths; got: {files:?}"
+        "must not include files outside source_paths (generated/); got: {files:?}"
     );
 }

--- a/src/rg_tests.rs
+++ b/src/rg_tests.rs
@@ -384,7 +384,7 @@ fn rg_find_definition_filters_ignored_dirs() {
     .unwrap();
 
     let matcher = IgnoreMatcher::new(vec!["buildSrc".to_owned()], root);
-    let locs = rg_find_definition("MyClass", Some(root), Some(&matcher));
+    let locs = rg_find_definition("MyClass", Some(root), &[], Some(&matcher));
     let files: Vec<String> = locs
         .iter()
         .map(|l| l.uri.to_file_path().unwrap().to_string_lossy().into_owned())


### PR DESCRIPTION
## Problem

When `sourceRoots` is set in `workspace.json`, all rg-based searches (go-to-definition, references, rename) still searched the entire workspace root, ignoring the configured source paths.

Fixes #78.

## Solution

- Added `RgTarget::SourcePaths` variant to `RgSearch`
- Added `RgSearch::scoped(source_paths, fallback_root)`: uses `SourcePaths` when non-empty, transparently falls back to `Root` when `sourceRoots` is not configured — zero behavior change for existing users
- `rg_find_definition`, `run_rg_search`, reference file discovery now all route through `RgSearch::scoped`
- `RgSearchRequest`: added `.with_source_paths()` builder method (avoids 8-arg constructor lint)
- All callers in `backend`, `resolver`, `indexer/infer`, and `cli` updated

## Testing

781 tests pass. No regressions.