### PR TITLE
feat: fill missing when branches — code action + diagnostics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ contrib/**/target
 __pycache__/
 copilot-rename-args-worktree
 src/lib.rs
+perf.data

--- a/src/backend/actions.rs
+++ b/src/backend/actions.rs
@@ -42,9 +42,18 @@ impl Backend {
             .unwrap_or_default();
         let is_kotlin = crate::Language::from_path(uri.path()) == crate::Language::Kotlin;
 
-        let actions = features::code_actions::compute_code_actions(
+        let mut actions = features::code_actions::compute_code_actions(
             &line_text, &all_lines, uri, range, is_kotlin,
         );
+
+        // Indexed code actions (require live tree + symbol index)
+        if is_kotlin {
+            if let Some(action) =
+                features::fill_when::build_fill_when_action(self.indexer.as_ref(), uri, range)
+            {
+                actions.push(action);
+            }
+        }
 
         Ok(if actions.is_empty() {
             None

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -61,11 +61,14 @@ pub(crate) fn build_fill_when_action(
     }
 
     let indent = detect_indent(&when_node, source_bytes);
-    let insert_text = build_branch_text(&missing, subject_type, type_kind, &indent);
-    let insert_pos = find_insert_position(&when_node, source_bytes, &lines)?;
+    let (replace_range, brace_indent) = find_insert_position(&when_node, source_bytes, &lines)?;
+    let mut insert_text = build_branch_text(&missing, subject_type, type_kind, &indent);
+    // Re-add closing brace with proper indent (we're replacing the whole line)
+    insert_text.push_str(&brace_indent);
+    insert_text.push('}');
 
     let edit = TextEdit {
-        range: Range::new(insert_pos, insert_pos),
+        range: replace_range,
         new_text: insert_text,
     };
 
@@ -515,13 +518,15 @@ fn detect_indent(when_node: &tree_sitter::Node, _source: &[u8]) -> String {
     " ".repeat(base + 4)
 }
 
-/// Find the position just before the closing `}` of the when expression.
+/// Find the insert range for new branches — replaces from start of closing brace line
+/// through the `}` character, so the generated text can include proper formatting.
+///
+/// Returns `(replace_range, closing_brace_indent)`.
 fn find_insert_position(
     when_node: &tree_sitter::Node,
     _source: &[u8],
     _lines: &[String],
-) -> Option<Position> {
-    // Find the closing `}` — it's the last child
+) -> Option<(Range, String)> {
     let child_count = when_node.child_count();
     if child_count == 0 {
         return None;
@@ -531,11 +536,13 @@ fn find_insert_position(
         return None;
     }
     let close_line = last.start_position().row as u32;
-    let close_col = last.start_position().column;
+    let close_col = last.start_position().column as u32;
 
-    // Insert at the beginning of the closing brace line
-    // but figure out the right UTF-16 column
-    Some(Position::new(close_line, close_col as u32))
+    // Replace from start of the closing brace line through the `}`
+    let start = Position::new(close_line, 0);
+    let end = Position::new(close_line, close_col + 1); // +1 to include `}`
+    let brace_indent = " ".repeat(close_col as usize);
+    Some((Range::new(start, end), brace_indent))
 }
 
 // ─── SymbolEntry helpers ──────────────────────────────────────────────────────

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -36,7 +36,10 @@ pub(crate) fn build_fill_when_action(
         .find(|c| c.kind() == KIND_WHEN_SUBJECT)?;
 
     let subject_var = extract_subject_identifier(&subject_node, source_bytes)?;
-    let subject_type = crate::resolver::infer::infer_variable_type(indexer, &subject_var, uri)?;
+
+    // Try CST-based local resolution first (handles spaces in `: Type`), then index fallback
+    let subject_type = resolve_subject_type_from_cst(&when_node, &subject_var, source_bytes)
+        .or_else(|| crate::resolver::infer::infer_variable_type(indexer, &subject_var, uri))?;
     let subject_type = strip_nullable(&subject_type);
 
     let (type_kind, members) = resolve_type_members(indexer, subject_type)?;
@@ -125,6 +128,159 @@ fn find_enclosing_when<'a>(
         current = n.parent();
     }
     None
+}
+
+/// Resolve the when subject's type from the CST by searching:
+/// 1. Sibling property_declarations in the same statements block (local vals)
+/// 2. Enclosing function's parameters
+/// 3. Enclosing class constructor parameters
+fn resolve_subject_type_from_cst(
+    when_node: &tree_sitter::Node,
+    var_name: &str,
+    source: &[u8],
+) -> Option<String> {
+    // Walk up to find statements block or function_declaration
+    let mut current = when_node.parent();
+    while let Some(node) = current {
+        match node.kind() {
+            "statements" => {
+                if let Some(ty) = find_type_in_sibling_declarations(&node, var_name, source) {
+                    return Some(ty);
+                }
+            }
+            "function_declaration" => {
+                if let Some(ty) = find_type_in_parameters(&node, var_name, source) {
+                    return Some(ty);
+                }
+            }
+            "class_declaration" => {
+                if let Some(ty) = find_type_in_constructor(&node, var_name, source) {
+                    return Some(ty);
+                }
+            }
+            _ => {}
+        }
+        current = node.parent();
+    }
+    None
+}
+
+/// Search sibling property_declarations for `val <var_name> : Type`
+fn find_type_in_sibling_declarations(
+    statements: &tree_sitter::Node,
+    var_name: &str,
+    source: &[u8],
+) -> Option<String> {
+    for child in statements.children(&mut statements.walk()) {
+        if child.kind() != "property_declaration" {
+            continue;
+        }
+        if let Some(ty) = extract_var_type_from_declaration(&child, var_name, source) {
+            return Some(ty);
+        }
+    }
+    None
+}
+
+/// Search function parameters for `<var_name>: Type`
+fn find_type_in_parameters(
+    func_node: &tree_sitter::Node,
+    var_name: &str,
+    source: &[u8],
+) -> Option<String> {
+    for child in func_node.children(&mut func_node.walk()) {
+        if child.kind() != "function_value_parameters" {
+            continue;
+        }
+        for param in child.children(&mut child.walk()) {
+            if param.kind() != "parameter" {
+                continue;
+            }
+            if let Some(ty) = extract_param_type(&param, var_name, source) {
+                return Some(ty);
+            }
+        }
+    }
+    None
+}
+
+/// Search class constructor parameters
+fn find_type_in_constructor(
+    class_node: &tree_sitter::Node,
+    var_name: &str,
+    source: &[u8],
+) -> Option<String> {
+    for child in class_node.children(&mut class_node.walk()) {
+        if child.kind() != "primary_constructor" {
+            continue;
+        }
+        for param in child.children(&mut child.walk()) {
+            if param.kind() != "class_parameter" {
+                continue;
+            }
+            if let Some(ty) = extract_param_type(&param, var_name, source) {
+                return Some(ty);
+            }
+        }
+    }
+    None
+}
+
+/// Extract type from `variable_declaration` inside a property_declaration.
+/// CST: property_declaration → variable_declaration → simple_identifier + ":" + user_type
+fn extract_var_type_from_declaration(
+    prop: &tree_sitter::Node,
+    var_name: &str,
+    source: &[u8],
+) -> Option<String> {
+    for child in prop.children(&mut prop.walk()) {
+        if child.kind() != "variable_declaration" {
+            continue;
+        }
+        let mut found_name = false;
+        for vc in child.children(&mut child.walk()) {
+            if vc.kind() == KIND_SIMPLE_IDENT && vc.utf8_text(source).ok() == Some(var_name) {
+                found_name = true;
+            }
+            if found_name && vc.kind() == KIND_USER_TYPE {
+                return extract_full_type_name(&vc, source);
+            }
+        }
+    }
+    None
+}
+
+/// Extract type from a `parameter` or `class_parameter` node.
+/// CST: parameter → simple_identifier + ":" + user_type
+fn extract_param_type(param: &tree_sitter::Node, var_name: &str, source: &[u8]) -> Option<String> {
+    let mut found_name = false;
+    for child in param.children(&mut param.walk()) {
+        if child.kind() == KIND_SIMPLE_IDENT && child.utf8_text(source).ok() == Some(var_name) {
+            found_name = true;
+        }
+        if found_name && child.kind() == KIND_USER_TYPE {
+            return extract_full_type_name(&child, source);
+        }
+    }
+    None
+}
+
+/// Extract the full type name from a user_type node (e.g. "TipsResult", "Effect").
+/// For dotted types like `Outer.Inner`, concatenates with dots.
+fn extract_full_type_name(user_type: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    let mut parts = Vec::new();
+    for child in user_type.children(&mut user_type.walk()) {
+        if child.kind() == KIND_TYPE_IDENT {
+            if let Ok(text) = child.utf8_text(source) {
+                parts.push(text.to_string());
+            }
+        }
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("."))
+    }
 }
 
 fn extract_subject_identifier(subject_node: &tree_sitter::Node, source: &[u8]) -> Option<String> {

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -330,8 +330,13 @@ fn extract_var_type_from_declaration(
             if vc.kind() == KIND_SIMPLE_IDENT && vc.utf8_text(source).ok() == Some(var_name) {
                 found_name = true;
             }
-            if found_name && vc.kind() == KIND_USER_TYPE {
-                return extract_full_type_name(&vc, source);
+            if found_name {
+                if vc.kind() == KIND_USER_TYPE {
+                    return extract_full_type_name(&vc, source);
+                }
+                if vc.kind() == "nullable_type" {
+                    return extract_user_type_from_nullable(&vc, source);
+                }
             }
         }
     }
@@ -339,14 +344,29 @@ fn extract_var_type_from_declaration(
 }
 
 /// Extract type from a `parameter` or `class_parameter` node.
-/// CST: parameter → simple_identifier + ":" + user_type
+/// CST: parameter → simple_identifier + ":" + user_type | nullable_type
 fn extract_param_type(param: &tree_sitter::Node, var_name: &str, source: &[u8]) -> Option<String> {
     let mut found_name = false;
     for child in param.children(&mut param.walk()) {
         if child.kind() == KIND_SIMPLE_IDENT && child.utf8_text(source).ok() == Some(var_name) {
             found_name = true;
         }
-        if found_name && child.kind() == KIND_USER_TYPE {
+        if found_name {
+            if child.kind() == KIND_USER_TYPE {
+                return extract_full_type_name(&child, source);
+            }
+            if child.kind() == "nullable_type" {
+                return extract_user_type_from_nullable(&child, source);
+            }
+        }
+    }
+    None
+}
+
+/// Extract user_type from a nullable_type node (nullable_type → user_type + "?").
+fn extract_user_type_from_nullable(nullable: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    for child in nullable.children(&mut nullable.walk()) {
+        if child.kind() == KIND_USER_TYPE {
             return extract_full_type_name(&child, source);
         }
     }

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -10,11 +10,11 @@ use tower_lsp::lsp_types::*;
 use crate::indexer::live_tree::utf16_col_to_byte;
 use crate::indexer::Indexer;
 use crate::queries::{
-    KIND_BOOLEAN_LITERAL, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS,
-    KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_NULLABLE_TYPE, KIND_PARAMETER, KIND_PRIMARY_CTOR,
-    KIND_PROP_DECL, KIND_SIMPLE_IDENT, KIND_STATEMENTS, KIND_TYPE_IDENT, KIND_TYPE_TEST,
-    KIND_USER_TYPE, KIND_VAR_DECL, KIND_WHEN_CONDITION, KIND_WHEN_ENTRY, KIND_WHEN_EXPR,
-    KIND_WHEN_SUBJECT,
+    KIND_BOOLEAN_LITERAL, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_ELSE, KIND_FUN_DECL,
+    KIND_FUN_VALUE_PARAMS, KIND_LBRACE, KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_NULLABLE_TYPE,
+    KIND_PARAMETER, KIND_PRIMARY_CTOR, KIND_PROP_DECL, KIND_SIMPLE_IDENT, KIND_STATEMENTS,
+    KIND_TYPE_IDENT, KIND_TYPE_TEST, KIND_USER_TYPE, KIND_VAR_DECL, KIND_WHEN_CONDITION,
+    KIND_WHEN_ENTRY, KIND_WHEN_EXPR, KIND_WHEN_SUBJECT,
 };
 
 /// Analysis result for incomplete when expressions — shared by code actions and diagnostics.
@@ -520,7 +520,7 @@ fn collect_existing_branches(when_node: &tree_sitter::Node, source: &[u8]) -> Ve
         }
         // Check for `else` branch
         for entry_child in child.children(&mut child.walk()) {
-            if entry_child.kind() == "else" {
+            if entry_child.kind() == KIND_ELSE {
                 branches.push("else".to_string());
                 continue;
             }
@@ -684,7 +684,7 @@ fn find_insert_position(
         // No entries — find `{` and start after it
         let open = when_node
             .children(&mut when_node.walk())
-            .find(|c| c.kind() == "{")?;
+            .find(|c| c.kind() == KIND_LBRACE)?;
         open.start_position().row as u32 + 1
     };
 

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -10,8 +10,11 @@ use tower_lsp::lsp_types::*;
 use crate::indexer::live_tree::utf16_col_to_byte;
 use crate::indexer::Indexer;
 use crate::queries::{
-    KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_TYPE_TEST,
-    KIND_USER_TYPE, KIND_WHEN_CONDITION, KIND_WHEN_ENTRY, KIND_WHEN_EXPR, KIND_WHEN_SUBJECT,
+    KIND_BOOLEAN_LITERAL, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_FUN_DECL, KIND_FUN_VALUE_PARAMS,
+    KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_NULLABLE_TYPE, KIND_PARAMETER, KIND_PRIMARY_CTOR,
+    KIND_PROP_DECL, KIND_SIMPLE_IDENT, KIND_STATEMENTS, KIND_TYPE_IDENT, KIND_TYPE_TEST,
+    KIND_USER_TYPE, KIND_VAR_DECL, KIND_WHEN_CONDITION, KIND_WHEN_ENTRY, KIND_WHEN_EXPR,
+    KIND_WHEN_SUBJECT,
 };
 
 /// Analysis result for incomplete when expressions — shared by code actions and diagnostics.
@@ -161,8 +164,6 @@ fn collect_when_nodes(
                 ..Default::default()
             });
         }
-        // Don't recurse into nested when — they'll be visited from parent traversal
-        return;
     }
 
     for i in 0..node.child_count() {
@@ -231,17 +232,17 @@ fn resolve_subject_type_from_cst(
     let mut current = when_node.parent();
     while let Some(node) = current {
         match node.kind() {
-            "statements" => {
+            KIND_STATEMENTS => {
                 if let Some(ty) = find_type_in_sibling_declarations(&node, var_name, source) {
                     return Some(ty);
                 }
             }
-            "function_declaration" => {
+            KIND_FUN_DECL => {
                 if let Some(ty) = find_type_in_parameters(&node, var_name, source) {
                     return Some(ty);
                 }
             }
-            "class_declaration" => {
+            KIND_CLASS_DECL => {
                 if let Some(ty) = find_type_in_constructor(&node, var_name, source) {
                     return Some(ty);
                 }
@@ -260,7 +261,7 @@ fn find_type_in_sibling_declarations(
     source: &[u8],
 ) -> Option<String> {
     for child in statements.children(&mut statements.walk()) {
-        if child.kind() != "property_declaration" {
+        if child.kind() != KIND_PROP_DECL {
             continue;
         }
         if let Some(ty) = extract_var_type_from_declaration(&child, var_name, source) {
@@ -277,11 +278,11 @@ fn find_type_in_parameters(
     source: &[u8],
 ) -> Option<String> {
     for child in func_node.children(&mut func_node.walk()) {
-        if child.kind() != "function_value_parameters" {
+        if child.kind() != KIND_FUN_VALUE_PARAMS {
             continue;
         }
         for param in child.children(&mut child.walk()) {
-            if param.kind() != "parameter" {
+            if param.kind() != KIND_PARAMETER {
                 continue;
             }
             if let Some(ty) = extract_param_type(&param, var_name, source) {
@@ -299,11 +300,11 @@ fn find_type_in_constructor(
     source: &[u8],
 ) -> Option<String> {
     for child in class_node.children(&mut class_node.walk()) {
-        if child.kind() != "primary_constructor" {
+        if child.kind() != KIND_PRIMARY_CTOR {
             continue;
         }
         for param in child.children(&mut child.walk()) {
-            if param.kind() != "class_parameter" {
+            if param.kind() != KIND_CLASS_PARAM {
                 continue;
             }
             if let Some(ty) = extract_param_type(&param, var_name, source) {
@@ -316,7 +317,7 @@ fn find_type_in_constructor(
 
 /// Extract type from `variable_declaration` inside a property_declaration.
 /// CST: property_declaration → variable_declaration → simple_identifier + ":" + user_type
-/// Also handles inferred types: `val x = false` → Boolean, `val x = SomeEnum.VALUE` → SomeEnum
+/// Also handles inferred Boolean from literal: `val x = false` → Boolean
 fn extract_var_type_from_declaration(
     prop: &tree_sitter::Node,
     var_name: &str,
@@ -324,7 +325,7 @@ fn extract_var_type_from_declaration(
 ) -> Option<String> {
     let mut name_matched = false;
     for child in prop.children(&mut prop.walk()) {
-        if child.kind() == "variable_declaration" {
+        if child.kind() == KIND_VAR_DECL {
             for vc in child.children(&mut child.walk()) {
                 if vc.kind() == KIND_SIMPLE_IDENT && vc.utf8_text(source).ok() == Some(var_name) {
                     name_matched = true;
@@ -333,14 +334,13 @@ fn extract_var_type_from_declaration(
                     if vc.kind() == KIND_USER_TYPE {
                         return extract_full_type_name(&vc, source);
                     }
-                    if vc.kind() == "nullable_type" {
+                    if vc.kind() == KIND_NULLABLE_TYPE {
                         return extract_user_type_from_nullable(&vc, source);
                     }
                 }
             }
         }
-        // Infer type from initializer expression (sibling of variable_declaration)
-        if name_matched && child.kind() == "boolean_literal" {
+        if name_matched && child.kind() == KIND_BOOLEAN_LITERAL {
             return Some("Boolean".to_string());
         }
     }
@@ -359,7 +359,7 @@ fn extract_param_type(param: &tree_sitter::Node, var_name: &str, source: &[u8]) 
             if child.kind() == KIND_USER_TYPE {
                 return extract_full_type_name(&child, source);
             }
-            if child.kind() == "nullable_type" {
+            if child.kind() == KIND_NULLABLE_TYPE {
                 return extract_user_type_from_nullable(&child, source);
             }
         }
@@ -457,11 +457,10 @@ fn find_symbol_at(
     file_data: &crate::types::FileData,
     location: &Location,
 ) -> Option<crate::types::SymbolEntry> {
-    let line = location.range.start.line;
     file_data
         .symbols
         .iter()
-        .find(|s| s.selection_range.start.line == line && s.name_matches_location(location))
+        .find(|s| s.selection_range == location.range)
         .cloned()
 }
 
@@ -554,7 +553,7 @@ fn extract_branch_name(condition: &tree_sitter::Node, source: &[u8]) -> Option<S
                 return extract_nav_last_ident(&child, source);
             }
             // Boolean literals: `true` / `false`
-            "boolean_literal" => {
+            KIND_BOOLEAN_LITERAL => {
                 return child.utf8_text(source).ok().map(|s| s.to_string());
             }
             _ => {}
@@ -693,16 +692,6 @@ fn find_insert_position(
     let end = Position::new(close_line, close_col + 1);
     let brace_indent = " ".repeat(close_col as usize);
     Some((Range::new(start, end), brace_indent))
-}
-
-// ─── SymbolEntry helpers ──────────────────────────────────────────────────────
-
-use tower_lsp::lsp_types::SymbolKind;
-
-impl crate::types::SymbolEntry {
-    fn name_matches_location(&self, location: &Location) -> bool {
-        self.selection_range.start.line == location.range.start.line
-    }
 }
 
 #[cfg(test)]

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -1,0 +1,397 @@
+//! Fill missing `when` branches for sealed classes and enums.
+//!
+//! This module provides a code action that detects an incomplete `when` expression
+//! over a sealed class or enum, and generates the missing branches.
+//!
+//! Entry point: [`build_fill_when_action`].
+
+use tower_lsp::lsp_types::*;
+
+use crate::indexer::live_tree::utf16_col_to_byte;
+use crate::indexer::Indexer;
+use crate::queries::{
+    KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_SIMPLE_IDENT, KIND_TYPE_IDENT, KIND_TYPE_TEST,
+    KIND_USER_TYPE, KIND_WHEN_CONDITION, KIND_WHEN_ENTRY, KIND_WHEN_EXPR, KIND_WHEN_SUBJECT,
+};
+
+/// Try to build a "fill missing when branches" code action for the cursor position.
+///
+/// Returns `None` if the cursor is not inside a `when` expression, the subject type
+/// cannot be resolved, or all branches are already covered.
+pub(crate) fn build_fill_when_action(
+    indexer: &Indexer,
+    uri: &Url,
+    range: Range,
+) -> Option<CodeActionOrCommand> {
+    let live_doc = indexer.live_doc(uri)?;
+    let source_bytes = &live_doc.bytes;
+    let lines = indexer.mem_lines_for(uri.as_str())?;
+
+    let cursor_byte = byte_offset_for_position(&lines, range.start)?;
+    let when_node = find_enclosing_when(&live_doc.tree, source_bytes, cursor_byte)?;
+
+    // Must have a when_subject (bare `when { ... }` is not exhaustive-checkable)
+    let subject_node = when_node
+        .children(&mut when_node.walk())
+        .find(|c| c.kind() == KIND_WHEN_SUBJECT)?;
+
+    let subject_var = extract_subject_identifier(&subject_node, source_bytes)?;
+    let subject_type = crate::resolver::infer::infer_variable_type(indexer, &subject_var, uri)?;
+    let subject_type = strip_nullable(&subject_type);
+
+    let (type_kind, members) = resolve_type_members(indexer, subject_type)?;
+
+    let existing = collect_existing_branches(&when_node, source_bytes);
+
+    // If `else` branch exists, all branches are covered — no action needed
+    if existing.iter().any(|b| b == "else") {
+        return None;
+    }
+
+    let missing: Vec<&WhenMember> = members
+        .iter()
+        .filter(|m| !existing.contains(&m.name))
+        .collect();
+
+    if missing.is_empty() {
+        return None;
+    }
+
+    let indent = detect_indent(&when_node, source_bytes);
+    let insert_text = build_branch_text(&missing, subject_type, type_kind, &indent);
+    let insert_pos = find_insert_position(&when_node, source_bytes, &lines)?;
+
+    let edit = TextEdit {
+        range: Range::new(insert_pos, insert_pos),
+        new_text: insert_text,
+    };
+
+    let mut changes = std::collections::HashMap::new();
+    changes.insert(uri.clone(), vec![edit]);
+
+    let action = CodeAction {
+        title: format!("Fill missing '{}' branches", subject_type),
+        kind: Some(CodeActionKind::QUICKFIX),
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+
+    Some(CodeActionOrCommand::CodeAction(action))
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TypeKind {
+    Enum,
+    Sealed,
+}
+
+#[derive(Debug)]
+struct WhenMember {
+    name: String,
+    is_object: bool,
+}
+
+fn byte_offset_for_position(lines: &[String], pos: Position) -> Option<usize> {
+    let line = pos.line as usize;
+    if line >= lines.len() {
+        return None;
+    }
+    let mut offset = 0;
+    for l in &lines[..line] {
+        offset += l.len() + 1; // +1 for '\n'
+    }
+    let col_byte = utf16_col_to_byte(&lines[line], pos.character as usize);
+    Some(offset + col_byte)
+}
+
+fn find_enclosing_when<'a>(
+    tree: &'a tree_sitter::Tree,
+    _source: &[u8],
+    cursor_byte: usize,
+) -> Option<tree_sitter::Node<'a>> {
+    let node = tree
+        .root_node()
+        .descendant_for_byte_range(cursor_byte, cursor_byte)?;
+    let mut current = Some(node);
+    while let Some(n) = current {
+        if n.kind() == KIND_WHEN_EXPR {
+            return Some(n);
+        }
+        current = n.parent();
+    }
+    None
+}
+
+fn extract_subject_identifier(subject_node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    // when_subject → "(" simple_identifier ")"
+    for child in subject_node.children(&mut subject_node.walk()) {
+        if child.kind() == KIND_SIMPLE_IDENT {
+            return child.utf8_text(source).ok().map(|s| s.to_string());
+        }
+    }
+    None
+}
+
+fn strip_nullable(type_name: &str) -> &str {
+    type_name.strip_suffix('?').unwrap_or(type_name)
+}
+
+/// Resolve whether the type is an enum or sealed class and return its members.
+fn resolve_type_members(indexer: &Indexer, type_name: &str) -> Option<(TypeKind, Vec<WhenMember>)> {
+    let locations = indexer.definition_locations(type_name);
+    if locations.is_empty() {
+        return None;
+    }
+
+    for location in &locations {
+        let file_data = indexer.file_data_for(location.uri.as_str())?;
+        let symbol = find_symbol_at(&file_data, location)?;
+
+        if symbol.kind == SymbolKind::ENUM {
+            let members = collect_enum_members(&file_data, &symbol);
+            if !members.is_empty() {
+                return Some((TypeKind::Enum, members));
+            }
+        }
+
+        if is_sealed(&symbol) {
+            let members = collect_sealed_members(indexer, type_name);
+            if !members.is_empty() {
+                return Some((TypeKind::Sealed, members));
+            }
+        }
+    }
+
+    None
+}
+
+fn find_symbol_at(
+    file_data: &crate::types::FileData,
+    location: &Location,
+) -> Option<crate::types::SymbolEntry> {
+    let line = location.range.start.line;
+    file_data
+        .symbols
+        .iter()
+        .find(|s| s.selection_range.start.line == line && s.name_matches_location(location))
+        .cloned()
+}
+
+fn is_sealed(symbol: &crate::types::SymbolEntry) -> bool {
+    // Check if the detail starts with "sealed"
+    let detail = symbol.detail.to_lowercase();
+    detail.contains("sealed class") || detail.contains("sealed interface")
+}
+
+fn collect_enum_members(
+    file_data: &crate::types::FileData,
+    enum_symbol: &crate::types::SymbolEntry,
+) -> Vec<WhenMember> {
+    let enum_range = &enum_symbol.range;
+    file_data
+        .symbols
+        .iter()
+        .filter(|s| {
+            s.kind == SymbolKind::ENUM_MEMBER
+                && s.range.start.line > enum_range.start.line
+                && s.range.end.line <= enum_range.end.line
+        })
+        .map(|s| WhenMember {
+            name: s.name.clone(),
+            is_object: true, // enum entries are always object-like
+        })
+        .collect()
+}
+
+fn collect_sealed_members(indexer: &Indexer, sealed_name: &str) -> Vec<WhenMember> {
+    let subtype_locations = indexer.subtypes_of(sealed_name);
+    let mut members = Vec::new();
+
+    for location in &subtype_locations {
+        let Some(file_data) = indexer.file_data_for(location.uri.as_str()) else {
+            continue;
+        };
+        if let Some(symbol) = find_symbol_at(&file_data, location) {
+            let is_object = symbol.kind == SymbolKind::OBJECT
+                || symbol.detail.contains("data object")
+                || symbol.detail.starts_with("object ");
+            members.push(WhenMember {
+                name: symbol.name.clone(),
+                is_object,
+            });
+        }
+    }
+
+    members
+}
+
+fn collect_existing_branches(when_node: &tree_sitter::Node, source: &[u8]) -> Vec<String> {
+    let mut branches = Vec::new();
+    for child in when_node.children(&mut when_node.walk()) {
+        if child.kind() != KIND_WHEN_ENTRY {
+            continue;
+        }
+        // Check for `else` branch
+        for entry_child in child.children(&mut child.walk()) {
+            if entry_child.kind() == "else" {
+                branches.push("else".to_string());
+                continue;
+            }
+            if entry_child.kind() != KIND_WHEN_CONDITION {
+                continue;
+            }
+            if let Some(name) = extract_branch_name(&entry_child, source) {
+                branches.push(name);
+            }
+        }
+    }
+    branches
+}
+
+/// Extract the type/value name from a when_condition.
+///
+/// Handles:
+/// - `is Effect.ShowToast` → "ShowToast"
+/// - `Color.RED` → "RED"
+/// - `is ShowToast` → "ShowToast"
+fn extract_branch_name(condition: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    for child in condition.children(&mut condition.walk()) {
+        match child.kind() {
+            KIND_TYPE_TEST => {
+                // type_test → "is" user_type → type_identifier ("." type_identifier)*
+                return extract_last_type_identifier(&child, source);
+            }
+            KIND_NAV_EXPR => {
+                // navigation_expression → simple_identifier "." simple_identifier
+                return extract_nav_last_ident(&child, source);
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Extract the last type_identifier from a type_test node.
+/// e.g. `is Effect.ShowToast` → "ShowToast", `is ShowToast` → "ShowToast"
+fn extract_last_type_identifier(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    let mut last_ident = None;
+    for child in node.children(&mut node.walk()) {
+        if child.kind() == KIND_USER_TYPE {
+            last_ident = extract_last_type_from_user_type(&child, source);
+        }
+    }
+    last_ident
+}
+
+fn extract_last_type_from_user_type(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    let mut last = None;
+    for child in node.children(&mut node.walk()) {
+        if child.kind() == KIND_TYPE_IDENT {
+            last = child.utf8_text(source).ok().map(|s| s.to_string());
+        }
+    }
+    last
+}
+
+/// Extract the last identifier from a navigation_expression.
+/// e.g. `Color.RED` → "RED"
+fn extract_nav_last_ident(node: &tree_sitter::Node, source: &[u8]) -> Option<String> {
+    for child in node.children(&mut node.walk()) {
+        if child.kind() == KIND_NAV_SUFFIX {
+            for suffix_child in child.children(&mut child.walk()) {
+                if suffix_child.kind() == KIND_SIMPLE_IDENT {
+                    return suffix_child.utf8_text(source).ok().map(|s| s.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+fn build_branch_text(
+    missing: &[&WhenMember],
+    parent_type: &str,
+    type_kind: TypeKind,
+    indent: &str,
+) -> String {
+    let mut text = String::new();
+    for member in missing {
+        match type_kind {
+            TypeKind::Enum => {
+                text.push_str(&format!(
+                    "{}{}.{} -> TODO()\n",
+                    indent, parent_type, member.name
+                ));
+            }
+            TypeKind::Sealed => {
+                if member.is_object {
+                    text.push_str(&format!(
+                        "{}{}.{} -> TODO()\n",
+                        indent, parent_type, member.name
+                    ));
+                } else {
+                    text.push_str(&format!(
+                        "{}is {}.{} -> TODO()\n",
+                        indent, parent_type, member.name
+                    ));
+                }
+            }
+        }
+    }
+    text
+}
+
+/// Detect indentation for new branches.
+/// Uses the first existing `when_entry`'s column, or falls back to when_expression column + 4.
+fn detect_indent(when_node: &tree_sitter::Node, _source: &[u8]) -> String {
+    for child in when_node.children(&mut when_node.walk()) {
+        if child.kind() == KIND_WHEN_ENTRY {
+            let col = child.start_position().column;
+            return " ".repeat(col);
+        }
+    }
+    let base = when_node.start_position().column;
+    " ".repeat(base + 4)
+}
+
+/// Find the position just before the closing `}` of the when expression.
+fn find_insert_position(
+    when_node: &tree_sitter::Node,
+    _source: &[u8],
+    _lines: &[String],
+) -> Option<Position> {
+    // Find the closing `}` — it's the last child
+    let child_count = when_node.child_count();
+    if child_count == 0 {
+        return None;
+    }
+    let last = when_node.child(child_count - 1)?;
+    if last.kind() != "}" {
+        return None;
+    }
+    let close_line = last.start_position().row as u32;
+    let close_col = last.start_position().column;
+
+    // Insert at the beginning of the closing brace line
+    // but figure out the right UTF-16 column
+    Some(Position::new(close_line, close_col as u32))
+}
+
+// ─── SymbolEntry helpers ──────────────────────────────────────────────────────
+
+use tower_lsp::lsp_types::SymbolKind;
+
+impl crate::types::SymbolEntry {
+    fn name_matches_location(&self, location: &Location) -> bool {
+        self.selection_range.start.line == location.range.start.line
+    }
+}
+
+#[cfg(test)]
+#[path = "fill_when_tests.rs"]
+mod tests;

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -316,28 +316,32 @@ fn find_type_in_constructor(
 
 /// Extract type from `variable_declaration` inside a property_declaration.
 /// CST: property_declaration → variable_declaration → simple_identifier + ":" + user_type
+/// Also handles inferred types: `val x = false` → Boolean, `val x = SomeEnum.VALUE` → SomeEnum
 fn extract_var_type_from_declaration(
     prop: &tree_sitter::Node,
     var_name: &str,
     source: &[u8],
 ) -> Option<String> {
+    let mut name_matched = false;
     for child in prop.children(&mut prop.walk()) {
-        if child.kind() != "variable_declaration" {
-            continue;
+        if child.kind() == "variable_declaration" {
+            for vc in child.children(&mut child.walk()) {
+                if vc.kind() == KIND_SIMPLE_IDENT && vc.utf8_text(source).ok() == Some(var_name) {
+                    name_matched = true;
+                }
+                if name_matched {
+                    if vc.kind() == KIND_USER_TYPE {
+                        return extract_full_type_name(&vc, source);
+                    }
+                    if vc.kind() == "nullable_type" {
+                        return extract_user_type_from_nullable(&vc, source);
+                    }
+                }
+            }
         }
-        let mut found_name = false;
-        for vc in child.children(&mut child.walk()) {
-            if vc.kind() == KIND_SIMPLE_IDENT && vc.utf8_text(source).ok() == Some(var_name) {
-                found_name = true;
-            }
-            if found_name {
-                if vc.kind() == KIND_USER_TYPE {
-                    return extract_full_type_name(&vc, source);
-                }
-                if vc.kind() == "nullable_type" {
-                    return extract_user_type_from_nullable(&vc, source);
-                }
-            }
+        // Infer type from initializer expression (sibling of variable_declaration)
+        if name_matched && child.kind() == "boolean_literal" {
+            return Some("Boolean".to_string());
         }
     }
     None

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -518,8 +518,11 @@ fn detect_indent(when_node: &tree_sitter::Node, _source: &[u8]) -> String {
     " ".repeat(base + 4)
 }
 
-/// Find the insert range for new branches — replaces from start of closing brace line
-/// through the `}` character, so the generated text can include proper formatting.
+/// Find the replace range for new branches.
+///
+/// When the block is empty (no existing entries), replaces from line after `{`
+/// through `}` — cleaning up blank lines. When entries exist, replaces from
+/// the line after the last entry through `}`.
 ///
 /// Returns `(replace_range, closing_brace_indent)`.
 fn find_insert_position(
@@ -531,16 +534,31 @@ fn find_insert_position(
     if child_count == 0 {
         return None;
     }
-    let last = when_node.child(child_count - 1)?;
-    if last.kind() != "}" {
+    let last_child = when_node.child(child_count - 1)?;
+    if last_child.kind() != "}" {
         return None;
     }
-    let close_line = last.start_position().row as u32;
-    let close_col = last.start_position().column as u32;
+    let close_line = last_child.start_position().row as u32;
+    let close_col = last_child.start_position().column as u32;
 
-    // Replace from start of the closing brace line through the `}`
-    let start = Position::new(close_line, 0);
-    let end = Position::new(close_line, close_col + 1); // +1 to include `}`
+    // Find the last when_entry to insert after it, or `{` if none
+    let last_entry = when_node
+        .children(&mut when_node.walk())
+        .filter(|c| c.kind() == KIND_WHEN_ENTRY)
+        .last();
+
+    let start_line = if let Some(entry) = last_entry {
+        entry.end_position().row as u32 + 1
+    } else {
+        // No entries — find `{` and start after it
+        let open = when_node
+            .children(&mut when_node.walk())
+            .find(|c| c.kind() == "{")?;
+        open.start_position().row as u32 + 1
+    };
+
+    let start = Position::new(start_line, 0);
+    let end = Position::new(close_line, close_col + 1);
     let brace_indent = " ".repeat(close_col as usize);
     Some((Range::new(start, end), brace_indent))
 }

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -12,9 +12,9 @@ use crate::indexer::Indexer;
 use crate::queries::{
     KIND_BOOLEAN_LITERAL, KIND_CLASS_DECL, KIND_CLASS_PARAM, KIND_ELSE, KIND_FUN_DECL,
     KIND_FUN_VALUE_PARAMS, KIND_LBRACE, KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_NULLABLE_TYPE,
-    KIND_PARAMETER, KIND_PRIMARY_CTOR, KIND_PROP_DECL, KIND_SIMPLE_IDENT, KIND_STATEMENTS,
-    KIND_TYPE_IDENT, KIND_TYPE_TEST, KIND_USER_TYPE, KIND_VAR_DECL, KIND_WHEN_CONDITION,
-    KIND_WHEN_ENTRY, KIND_WHEN_EXPR, KIND_WHEN_SUBJECT,
+    KIND_PARAMETER, KIND_PRIMARY_CTOR, KIND_PROP_DECL, KIND_RBRACE, KIND_SIMPLE_IDENT,
+    KIND_STATEMENTS, KIND_TYPE_IDENT, KIND_TYPE_TEST, KIND_USER_TYPE, KIND_VAR_DECL,
+    KIND_WHEN_CONDITION, KIND_WHEN_ENTRY, KIND_WHEN_EXPR, KIND_WHEN_SUBJECT,
 };
 
 /// Analysis result for incomplete when expressions — shared by code actions and diagnostics.
@@ -186,6 +186,8 @@ enum TypeKind {
 struct WhenMember {
     name: String,
     is_object: bool,
+    /// True if subtype is nested inside the parent type (for sealed classes).
+    is_nested: bool,
 }
 
 fn byte_offset_for_position(lines: &[String], pos: Position) -> Option<usize> {
@@ -417,10 +419,12 @@ fn resolve_type_members(indexer: &Indexer, type_name: &str) -> Option<(TypeKind,
             WhenMember {
                 name: "true".to_string(),
                 is_object: true,
+                is_nested: false,
             },
             WhenMember {
                 name: "false".to_string(),
                 is_object: true,
+                is_nested: false,
             },
         ];
         return Some((TypeKind::Boolean, members));
@@ -465,9 +469,10 @@ fn find_symbol_at(
 }
 
 fn is_sealed(symbol: &crate::types::SymbolEntry) -> bool {
-    // Check if the detail starts with "sealed"
-    let detail = symbol.detail.to_lowercase();
-    detail.contains("sealed class") || detail.contains("sealed interface")
+    let detail = &symbol.detail;
+    detail.starts_with("sealed class")
+        || detail.starts_with("sealed interface")
+        || detail.starts_with("abstract sealed")
 }
 
 fn collect_enum_members(
@@ -486,11 +491,25 @@ fn collect_enum_members(
         .map(|s| WhenMember {
             name: s.name.clone(),
             is_object: true, // enum entries are always object-like
+            is_nested: true,
         })
         .collect()
 }
 
 fn collect_sealed_members(indexer: &Indexer, sealed_name: &str) -> Vec<WhenMember> {
+    // Find the sealed parent's full declaration range to detect nested subtypes.
+    // `definitions` stores selection_range (identifier only), so look up the full
+    // SymbolEntry.range from the file data.
+    let parent_info = indexer.definitions.get(sealed_name).and_then(|locs| {
+        let loc = locs.first()?;
+        let file_data = indexer.file_data_for(loc.uri.as_str())?;
+        let parent_sym = file_data
+            .symbols
+            .iter()
+            .find(|s| s.name == sealed_name && s.selection_range == loc.range)?;
+        Some((loc.uri.clone(), parent_sym.range))
+    });
+
     let subtype_locations = indexer.subtypes_of(sealed_name);
     let mut members = Vec::new();
 
@@ -499,12 +518,18 @@ fn collect_sealed_members(indexer: &Indexer, sealed_name: &str) -> Vec<WhenMembe
             continue;
         };
         if let Some(symbol) = find_symbol_at(&file_data, location) {
-            let is_object = symbol.kind == SymbolKind::OBJECT
-                || symbol.detail.contains("data object")
-                || symbol.detail.starts_with("object ");
+            let is_object = symbol.kind == SymbolKind::OBJECT;
+            let is_nested = parent_info
+                .as_ref()
+                .is_some_and(|(parent_uri, parent_range)| {
+                    location.uri == *parent_uri
+                        && symbol.range.start.line > parent_range.start.line
+                        && symbol.range.end.line <= parent_range.end.line
+                });
             members.push(WhenMember {
                 name: symbol.name.clone(),
                 is_object,
+                is_nested,
             });
         }
     }
@@ -619,16 +644,15 @@ fn build_branch_text(
                 ));
             }
             TypeKind::Sealed => {
-                if member.is_object {
-                    text.push_str(&format!(
-                        "{}{}.{} -> TODO()\n",
-                        indent, parent_type, member.name
-                    ));
+                let qualified = if member.is_nested {
+                    format!("{}.{}", parent_type, member.name)
                 } else {
-                    text.push_str(&format!(
-                        "{}is {}.{} -> TODO()\n",
-                        indent, parent_type, member.name
-                    ));
+                    member.name.clone()
+                };
+                if member.is_object {
+                    text.push_str(&format!("{}{} -> TODO()\n", indent, qualified));
+                } else {
+                    text.push_str(&format!("{}is {} -> TODO()\n", indent, qualified));
                 }
             }
         }
@@ -666,7 +690,7 @@ fn find_insert_position(
         return None;
     }
     let last_child = when_node.child(child_count - 1)?;
-    if last_child.kind() != "}" {
+    if last_child.kind() != KIND_RBRACE {
         return None;
     }
     let close_line = last_child.start_position().row as u32;
@@ -687,6 +711,9 @@ fn find_insert_position(
             .find(|c| c.kind() == KIND_LBRACE)?;
         open.start_position().row as u32 + 1
     };
+
+    // Clamp: if when is compact (single line), start at close_line
+    let start_line = start_line.min(close_line);
 
     let start = Position::new(start_line, 0);
     let end = Position::new(close_line, close_col + 1);

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -14,6 +14,56 @@ use crate::queries::{
     KIND_USER_TYPE, KIND_WHEN_CONDITION, KIND_WHEN_ENTRY, KIND_WHEN_EXPR, KIND_WHEN_SUBJECT,
 };
 
+/// Analysis result for incomplete when expressions — shared by code actions and diagnostics.
+struct WhenAnalysis<'a> {
+    when_node: tree_sitter::Node<'a>,
+    subject_type: String,
+    type_kind: TypeKind,
+    missing: Vec<WhenMember>,
+}
+
+/// Analyze a single when expression for missing branches.
+fn analyze_when<'a>(
+    indexer: &Indexer,
+    uri: &Url,
+    when_node: tree_sitter::Node<'a>,
+    source_bytes: &[u8],
+) -> Option<WhenAnalysis<'a>> {
+    let subject_node = when_node
+        .children(&mut when_node.walk())
+        .find(|c| c.kind() == KIND_WHEN_SUBJECT)?;
+
+    let subject_var = extract_subject_identifier(&subject_node, source_bytes)?;
+
+    let subject_type = resolve_subject_type_from_cst(&when_node, &subject_var, source_bytes)
+        .or_else(|| crate::resolver::infer::infer_variable_type(indexer, &subject_var, uri))?;
+    let subject_type = strip_nullable(&subject_type).to_string();
+
+    let (type_kind, members) = resolve_type_members(indexer, &subject_type)?;
+
+    let existing = collect_existing_branches(&when_node, source_bytes);
+
+    if existing.iter().any(|b| b == "else") {
+        return None;
+    }
+
+    let missing: Vec<WhenMember> = members
+        .into_iter()
+        .filter(|m| !existing.contains(&m.name))
+        .collect();
+
+    if missing.is_empty() {
+        return None;
+    }
+
+    Some(WhenAnalysis {
+        when_node,
+        subject_type,
+        type_kind,
+        missing,
+    })
+}
+
 /// Try to build a "fill missing when branches" code action for the cursor position.
 ///
 /// Returns `None` if the cursor is not inside a `when` expression, the subject type
@@ -30,40 +80,18 @@ pub(crate) fn build_fill_when_action(
     let cursor_byte = byte_offset_for_position(&lines, range.start)?;
     let when_node = find_enclosing_when(&live_doc.tree, source_bytes, cursor_byte)?;
 
-    // Must have a when_subject (bare `when { ... }` is not exhaustive-checkable)
-    let subject_node = when_node
-        .children(&mut when_node.walk())
-        .find(|c| c.kind() == KIND_WHEN_SUBJECT)?;
+    let analysis = analyze_when(indexer, uri, when_node, source_bytes)?;
 
-    let subject_var = extract_subject_identifier(&subject_node, source_bytes)?;
-
-    // Try CST-based local resolution first (handles spaces in `: Type`), then index fallback
-    let subject_type = resolve_subject_type_from_cst(&when_node, &subject_var, source_bytes)
-        .or_else(|| crate::resolver::infer::infer_variable_type(indexer, &subject_var, uri))?;
-    let subject_type = strip_nullable(&subject_type);
-
-    let (type_kind, members) = resolve_type_members(indexer, subject_type)?;
-
-    let existing = collect_existing_branches(&when_node, source_bytes);
-
-    // If `else` branch exists, all branches are covered — no action needed
-    if existing.iter().any(|b| b == "else") {
-        return None;
-    }
-
-    let missing: Vec<&WhenMember> = members
-        .iter()
-        .filter(|m| !existing.contains(&m.name))
-        .collect();
-
-    if missing.is_empty() {
-        return None;
-    }
-
-    let indent = detect_indent(&when_node, source_bytes);
-    let (replace_range, brace_indent) = find_insert_position(&when_node, source_bytes, &lines)?;
-    let mut insert_text = build_branch_text(&missing, subject_type, type_kind, &indent);
-    // Re-add closing brace with proper indent (we're replacing the whole line)
+    let indent = detect_indent(&analysis.when_node, source_bytes);
+    let (replace_range, brace_indent) =
+        find_insert_position(&analysis.when_node, source_bytes, &lines)?;
+    let missing_refs: Vec<&WhenMember> = analysis.missing.iter().collect();
+    let mut insert_text = build_branch_text(
+        &missing_refs,
+        &analysis.subject_type,
+        analysis.type_kind,
+        &indent,
+    );
     insert_text.push_str(&brace_indent);
     insert_text.push('}');
 
@@ -76,7 +104,7 @@ pub(crate) fn build_fill_when_action(
     changes.insert(uri.clone(), vec![edit]);
 
     let action = CodeAction {
-        title: format!("Fill missing '{}' branches", subject_type),
+        title: format!("Fill missing '{}' branches", analysis.subject_type),
         kind: Some(CodeActionKind::QUICKFIX),
         edit: Some(WorkspaceEdit {
             changes: Some(changes),
@@ -88,12 +116,69 @@ pub(crate) fn build_fill_when_action(
     Some(CodeActionOrCommand::CodeAction(action))
 }
 
+/// Produce diagnostics for all incomplete `when` expressions in a file.
+///
+/// Scans the CST for every `when_expression` node and emits a warning
+/// diagnostic on each one that has missing branches.
+pub(crate) fn when_diagnostics(indexer: &Indexer, uri: &Url) -> Vec<Diagnostic> {
+    if crate::Language::from_path(uri.path()) != crate::Language::Kotlin {
+        return Vec::new();
+    }
+    let live_doc = match indexer.live_doc(uri) {
+        Some(doc) => doc,
+        None => return Vec::new(),
+    };
+    let source_bytes = &live_doc.bytes;
+    let root = live_doc.tree.root_node();
+
+    let mut diagnostics = Vec::new();
+    collect_when_nodes(root, source_bytes, indexer, uri, &mut diagnostics);
+    diagnostics
+}
+
+fn collect_when_nodes(
+    node: tree_sitter::Node,
+    source: &[u8],
+    indexer: &Indexer,
+    uri: &Url,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    if node.kind() == KIND_WHEN_EXPR {
+        if let Some(analysis) = analyze_when(indexer, uri, node, source) {
+            let missing_names: Vec<&str> =
+                analysis.missing.iter().map(|m| m.name.as_str()).collect();
+            let message = format!("'when' is missing branches: {}", missing_names.join(", "));
+            let start = node.start_position();
+            let keyword_end_col = start.column + 4; // "when" is 4 chars
+            diagnostics.push(Diagnostic {
+                range: Range::new(
+                    Position::new(start.row as u32, start.column as u32),
+                    Position::new(start.row as u32, keyword_end_col as u32),
+                ),
+                severity: Some(DiagnosticSeverity::WARNING),
+                source: Some("kotlin-lsp".into()),
+                message,
+                ..Default::default()
+            });
+        }
+        // Don't recurse into nested when — they'll be visited from parent traversal
+        return;
+    }
+
+    for i in 0..node.child_count() {
+        if let Some(child) = node.child(i) {
+            collect_when_nodes(child, source, indexer, uri, diagnostics);
+        }
+    }
+}
+
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TypeKind {
     Enum,
     Sealed,
+    Boolean,
 }
 
 #[derive(Debug)]
@@ -300,8 +385,23 @@ fn strip_nullable(type_name: &str) -> &str {
     type_name.strip_suffix('?').unwrap_or(type_name)
 }
 
-/// Resolve whether the type is an enum or sealed class and return its members.
+/// Resolve whether the type is an enum, sealed class, or Boolean, and return its members.
 fn resolve_type_members(indexer: &Indexer, type_name: &str) -> Option<(TypeKind, Vec<WhenMember>)> {
+    // Boolean is a built-in — no index lookup needed
+    if type_name == "Boolean" {
+        let members = vec![
+            WhenMember {
+                name: "true".to_string(),
+                is_object: true,
+            },
+            WhenMember {
+                name: "false".to_string(),
+                is_object: true,
+            },
+        ];
+        return Some((TypeKind::Boolean, members));
+    }
+
     let locations = indexer.definition_locations(type_name);
     if locations.is_empty() {
         return None;
@@ -429,6 +529,10 @@ fn extract_branch_name(condition: &tree_sitter::Node, source: &[u8]) -> Option<S
                 // navigation_expression → simple_identifier "." simple_identifier
                 return extract_nav_last_ident(&child, source);
             }
+            // Boolean literals: `true` / `false`
+            "boolean_literal" => {
+                return child.utf8_text(source).ok().map(|s| s.to_string());
+            }
             _ => {}
         }
     }
@@ -481,6 +585,10 @@ fn build_branch_text(
     let mut text = String::new();
     for member in missing {
         match type_kind {
+            TypeKind::Boolean => {
+                // Bare value: `true -> TODO()`, `false -> TODO()`
+                text.push_str(&format!("{}{} -> TODO()\n", indent, member.name));
+            }
             TypeKind::Enum => {
                 text.push_str(&format!(
                     "{}{}.{} -> TODO()\n",

--- a/src/features/fill_when_tests.rs
+++ b/src/features/fill_when_tests.rs
@@ -257,3 +257,42 @@ fun handle(c: Color) {
         "should resolve type from function parameter"
     );
 }
+
+#[test]
+fn empty_when_block_formatting() {
+    let src = "\
+fun test() {
+    val c: Color = Color.RED
+    when(c){
+      
+    }
+}
+";
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(3, 0));
+    assert!(action.is_some(), "expected action for empty when block");
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            let text = &edits[0].new_text;
+            // Verify proper formatting: branches indented, closing brace on own line
+            assert!(
+                text.ends_with('}'),
+                "should end with closing brace: {text:?}"
+            );
+            assert!(
+                text.contains("Color.RED -> TODO()\n"),
+                "branches should have newline: {text:?}"
+            );
+            // Closing brace should be at same indent as when keyword (4 spaces)
+            assert!(
+                text.ends_with("    }"),
+                "closing brace should be indented to match when: {text:?}"
+            );
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}

--- a/src/features/fill_when_tests.rs
+++ b/src/features/fill_when_tests.rs
@@ -331,3 +331,176 @@ fun test() {
         _ => panic!("expected CodeAction"),
     }
 }
+
+// ─── Boolean tests ────────────────────────────────────────────────────────────
+
+#[test]
+fn boolean_fill_all_branches() {
+    let src = "\
+fun test(flag: Boolean) {
+    when(flag) {
+
+    }
+}
+";
+    let idx = setup(&[("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(2, 0));
+    assert!(action.is_some(), "expected action for Boolean when");
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            let text = &edits[0].new_text;
+            assert!(
+                text.contains("true -> TODO()"),
+                "should have true: {text:?}"
+            );
+            assert!(
+                text.contains("false -> TODO()"),
+                "should have false: {text:?}"
+            );
+            assert!(
+                !text.contains("Boolean."),
+                "should be bare true/false: {text:?}"
+            );
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
+#[test]
+fn boolean_partial_branch() {
+    let src = "\
+fun test(flag: Boolean) {
+    when(flag) {
+        true -> println(\"yes\")
+    }
+}
+";
+    let idx = setup(&[("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(2, 0));
+    assert!(action.is_some(), "expected action");
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            let text = &edits[0].new_text;
+            assert!(
+                text.contains("false -> TODO()"),
+                "should have false: {text:?}"
+            );
+            assert!(
+                !text.contains("true -> TODO()"),
+                "should not have true (already present): {text:?}"
+            );
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
+#[test]
+fn boolean_complete_no_action() {
+    let src = "\
+fun test(flag: Boolean) {
+    when(flag) {
+        true -> println(\"yes\")
+        false -> println(\"no\")
+    }
+}
+";
+    let idx = setup(&[("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(2, 0));
+    assert!(
+        action.is_none(),
+        "should have no action when all Boolean branches present"
+    );
+}
+
+// ─── Diagnostics tests ───────────────────────────────────────────────────────
+
+use crate::features::fill_when::when_diagnostics;
+
+#[test]
+fn diagnostics_reports_missing_enum_branches() {
+    let src = "\
+fun test(c: Color) {
+    when (c) {
+        Color.RED -> println(\"red\")
+    }
+}
+";
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let diags = when_diagnostics(&idx, &u);
+    assert_eq!(diags.len(), 1, "should have 1 diagnostic");
+    assert!(
+        diags[0].message.contains("GREEN"),
+        "message: {}",
+        diags[0].message
+    );
+    assert!(
+        diags[0].message.contains("BLUE"),
+        "message: {}",
+        diags[0].message
+    );
+    assert_eq!(diags[0].severity, Some(DiagnosticSeverity::WARNING));
+    assert_eq!(diags[0].source.as_deref(), Some("kotlin-lsp"));
+}
+
+#[test]
+fn diagnostics_no_report_when_complete() {
+    let src = "\
+fun test(c: Color) {
+    when (c) {
+        Color.RED -> println(\"red\")
+        Color.GREEN -> println(\"green\")
+        Color.BLUE -> println(\"blue\")
+    }
+}
+";
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let diags = when_diagnostics(&idx, &u);
+    assert!(diags.is_empty(), "no diagnostic when all branches covered");
+}
+
+#[test]
+fn diagnostics_no_report_with_else() {
+    let src = "\
+fun test(c: Color) {
+    when (c) {
+        Color.RED -> println(\"red\")
+        else -> println(\"other\")
+    }
+}
+";
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let diags = when_diagnostics(&idx, &u);
+    assert!(diags.is_empty(), "no diagnostic when else present");
+}
+
+#[test]
+fn diagnostics_boolean_missing() {
+    let src = "\
+fun test(flag: Boolean) {
+    when(flag) {
+        true -> println(\"yes\")
+    }
+}
+";
+    let idx = setup(&[("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let diags = when_diagnostics(&idx, &u);
+    assert_eq!(diags.len(), 1);
+    assert!(
+        diags[0].message.contains("false"),
+        "message: {}",
+        diags[0].message
+    );
+}

--- a/src/features/fill_when_tests.rs
+++ b/src/features/fill_when_tests.rs
@@ -421,6 +421,37 @@ fun test(flag: Boolean) {
     );
 }
 
+#[test]
+fn boolean_nullable_type_resolution() {
+    let src = "\
+fun test(flag: Boolean?) {
+    when(flag) {
+        true -> println(\"yes\")
+    }
+}
+";
+    let idx = setup(&[("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(2, 0));
+    assert!(
+        action.is_some(),
+        "expected action for nullable Boolean when"
+    );
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            let text = &edits[0].new_text;
+            assert!(
+                text.contains("false -> TODO()"),
+                "should have false: {text:?}"
+            );
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
 // ─── Diagnostics tests ───────────────────────────────────────────────────────
 
 use crate::features::fill_when::when_diagnostics;

--- a/src/features/fill_when_tests.rs
+++ b/src/features/fill_when_tests.rs
@@ -296,3 +296,38 @@ fun test() {
         _ => panic!("expected CodeAction"),
     }
 }
+
+#[test]
+fn when_block_with_newline_between_braces() {
+    let src = "\
+fun test() {
+    val c: Color = Color.RED
+    when(c) {
+
+    }
+}
+";
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(3, 0));
+    assert!(action.is_some(), "expected action");
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            let range = &edits[0].range;
+            let text = &edits[0].new_text;
+            // Should replace from line 3 (after `{` on line 2) through line 4 (`}`)
+            assert_eq!(range.start.line, 3, "replace start line");
+            assert_eq!(range.end.line, 4, "replace end line");
+            // No leading blank line in output
+            assert!(
+                !text.starts_with('\n'),
+                "should not start with blank line: {text:?}"
+            );
+            assert!(text.ends_with('}'), "should end with brace: {text:?}");
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}

--- a/src/features/fill_when_tests.rs
+++ b/src/features/fill_when_tests.rs
@@ -335,6 +335,39 @@ fun test() {
 // ─── Boolean tests ────────────────────────────────────────────────────────────
 
 #[test]
+fn boolean_inferred_from_literal() {
+    let src = "\
+fun test() {
+    val bool = false
+    when(bool) {
+
+    }
+}
+";
+    let idx = setup(&[("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(3, 0));
+    assert!(action.is_some(), "expected action for inferred Boolean");
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            let text = &edits[0].new_text;
+            assert!(
+                text.contains("true -> TODO()"),
+                "should have true: {text:?}"
+            );
+            assert!(
+                text.contains("false -> TODO()"),
+                "should have false: {text:?}"
+            );
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
+#[test]
 fn boolean_fill_all_branches() {
     let src = "\
 fun test(flag: Boolean) {

--- a/src/features/fill_when_tests.rs
+++ b/src/features/fill_when_tests.rs
@@ -1,0 +1,211 @@
+use tower_lsp::lsp_types::*;
+
+use crate::features::fill_when::build_fill_when_action;
+use crate::indexer::Indexer;
+
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file:///test{path}")).unwrap()
+}
+
+fn setup(files: &[(&str, &str)]) -> Indexer {
+    let idx = Indexer::new();
+    for (path, src) in files {
+        let u = uri(path);
+        idx.index_content(&u, src);
+        idx.set_live_lines(&u, src);
+        idx.store_live_tree(&u, src);
+    }
+    idx
+}
+
+fn cursor_at(line: u32, col: u32) -> Range {
+    Range::new(Position::new(line, col), Position::new(line, col))
+}
+
+// ─── Enum tests ───────────────────────────────────────────────────────────────
+
+const ENUM_SRC: &str = "\
+enum class Color {
+    RED, GREEN, BLUE
+}
+";
+
+const ENUM_WHEN_PARTIAL: &str = "\
+fun handle(c: Color) {
+    when (c) {
+        Color.RED -> println(\"red\")
+    }
+}
+";
+
+#[test]
+fn enum_missing_branches_offered() {
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", ENUM_WHEN_PARTIAL)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(1, 6));
+    assert!(action.is_some(), "expected fill-when action");
+    let action = action.unwrap();
+    match action {
+        CodeActionOrCommand::CodeAction(ca) => {
+            assert!(ca.title.contains("Color"), "title: {}", ca.title);
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            let text = &edits[0].new_text;
+            assert!(text.contains("Color.GREEN"), "missing GREEN: {text}");
+            assert!(text.contains("Color.BLUE"), "missing BLUE: {text}");
+            assert!(
+                !text.contains("Color.RED"),
+                "RED should not be re-added: {text}"
+            );
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
+#[test]
+fn enum_all_branches_covered_no_action() {
+    let src = "\
+fun handle(c: Color) {
+    when (c) {
+        Color.RED -> println(\"r\")
+        Color.GREEN -> println(\"g\")
+        Color.BLUE -> println(\"b\")
+    }
+}
+";
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(1, 6));
+    assert!(action.is_none(), "no action when all branches covered");
+}
+
+#[test]
+fn enum_else_branch_suppresses_action() {
+    let src = "\
+fun handle(c: Color) {
+    when (c) {
+        Color.RED -> println(\"r\")
+        else -> println(\"other\")
+    }
+}
+";
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(1, 6));
+    assert!(action.is_none(), "else branch should suppress action");
+}
+
+// ─── Sealed class tests ──────────────────────────────────────────────────────
+
+const SEALED_SRC: &str = "\
+sealed class Effect {
+    data class ShowToast(val message: String) : Effect()
+    object Loading : Effect()
+    data object Done : Effect()
+}
+";
+
+const SEALED_WHEN_PARTIAL: &str = "\
+fun handle(e: Effect) {
+    when (e) {
+        is Effect.ShowToast -> println(\"toast\")
+    }
+}
+";
+
+#[test]
+fn sealed_missing_branches_offered() {
+    let idx = setup(&[
+        ("/Effect.kt", SEALED_SRC),
+        ("/main.kt", SEALED_WHEN_PARTIAL),
+    ]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(1, 6));
+    assert!(
+        action.is_some(),
+        "expected fill-when action for sealed class"
+    );
+    let action = action.unwrap();
+    match action {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            let text = &edits[0].new_text;
+            // Loading and Done are objects — should NOT use `is`
+            assert!(text.contains("Effect.Loading"), "missing Loading: {text}");
+            assert!(text.contains("Effect.Done"), "missing Done: {text}");
+            assert!(
+                !text.contains("Effect.ShowToast"),
+                "ShowToast should not be re-added: {text}"
+            );
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
+#[test]
+fn sealed_all_covered_no_action() {
+    let src = "\
+fun handle(e: Effect) {
+    when (e) {
+        is Effect.ShowToast -> println(\"t\")
+        Effect.Loading -> println(\"l\")
+        Effect.Done -> println(\"d\")
+    }
+}
+";
+    let idx = setup(&[("/Effect.kt", SEALED_SRC), ("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(1, 6));
+    assert!(
+        action.is_none(),
+        "no action when all sealed branches covered"
+    );
+}
+
+// ─── Edge cases ──────────────────────────────────────────────────────────────
+
+#[test]
+fn cursor_outside_when_no_action() {
+    let src = "\
+fun handle(c: Color) {
+    println(\"hello\")
+}
+";
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(1, 4));
+    assert!(action.is_none(), "no action outside when expression");
+}
+
+#[test]
+fn when_without_subject_no_action() {
+    let src = "\
+fun handle() {
+    when {
+        true -> println(\"yes\")
+    }
+}
+";
+    let idx = setup(&[("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(1, 6));
+    assert!(action.is_none(), "no action for when without subject");
+}
+
+#[test]
+fn non_enum_non_sealed_no_action() {
+    let type_src = "class Foo(val x: Int)";
+    let src = "\
+fun handle(f: Foo) {
+    when (f) {
+    }
+}
+";
+    let idx = setup(&[("/Foo.kt", type_src), ("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(1, 6));
+    assert!(action.is_none(), "no action for regular class");
+}

--- a/src/features/fill_when_tests.rs
+++ b/src/features/fill_when_tests.rs
@@ -209,3 +209,51 @@ fun handle(f: Foo) {
     let action = build_fill_when_action(&idx, &u, cursor_at(1, 6));
     assert!(action.is_none(), "no action for regular class");
 }
+
+#[test]
+fn local_val_with_space_before_colon() {
+    let src = "\
+fun test() {
+    val tip : Color = Color.RED
+    when(tip){
+    }
+}
+";
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(2, 6));
+    assert!(
+        action.is_some(),
+        "should resolve type from CST even with space before colon"
+    );
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            let text = &edits[0].new_text;
+            assert!(text.contains("Color.GREEN"), "missing GREEN: {text}");
+            assert!(text.contains("Color.BLUE"), "missing BLUE: {text}");
+            // RED is already assigned but not in the when — all 3 should be generated
+            assert!(text.contains("Color.RED"), "missing RED: {text}");
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
+#[test]
+fn function_parameter_type_resolution() {
+    let src = "\
+fun handle(c: Color) {
+    when (c) {
+    }
+}
+";
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(1, 6));
+    assert!(
+        action.is_some(),
+        "should resolve type from function parameter"
+    );
+}

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod code_actions;
 pub(crate) mod completion;
 pub(crate) mod cursor;
 pub(crate) mod definition;
+pub(crate) mod fill_when;
 pub(crate) mod folding;
 pub(crate) mod highlight;
 pub(crate) mod hover;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -302,6 +302,11 @@ fn is_enum_class(indexer: &Indexer, class_name: &str) -> bool {
 }
 
 fn synthetic_enum_field(indexer: &Indexer, class_name: &str, field_name: &str) -> Option<String> {
+    // Check name first to avoid expensive is_enum_class lookup for non-synthetic fields
+    match field_name {
+        "entries" | "name" | "ordinal" => {}
+        _ => return None,
+    }
     if !is_enum_class(indexer, class_name) {
         return None;
     }
@@ -314,6 +319,10 @@ fn synthetic_enum_field(indexer: &Indexer, class_name: &str, field_name: &str) -
 }
 
 fn synthetic_enum_method(indexer: &Indexer, class_name: &str, method_name: &str) -> Option<String> {
+    match method_name {
+        "values" | "valueOf" => {}
+        _ => return None,
+    }
     if !is_enum_class(indexer, class_name) {
         return None;
     }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -231,6 +231,9 @@ impl crate::indexer::infer::InferDeps for Indexer {
         infer_variable_type_raw(self, var_name, uri)
     }
     fn find_field_type(&self, class_name: &str, field_name: &str) -> Option<String> {
+        if let Some(ty) = synthetic_enum_field(self, class_name, field_name) {
+            return Some(ty);
+        }
         crate::resolver::infer::find_field_type_in_class(self, class_name, field_name)
     }
     fn find_fun_return_type(&self, fn_name: &str) -> Option<String> {
@@ -258,6 +261,9 @@ impl crate::indexer::infer::InferDeps for Indexer {
         class_name: &str,
         method_name: &str,
     ) -> Option<String> {
+        if let Some(ty) = synthetic_enum_method(self, class_name, method_name) {
+            return Some(ty);
+        }
         crate::resolver::infer::find_method_return_type(self, class_name, method_name)
     }
     fn find_method_params_text(&self, class_name: &str, method_name: &str) -> Option<String> {
@@ -265,6 +271,56 @@ impl crate::indexer::infer::InferDeps for Indexer {
     }
     fn live_doc(&self, uri: &Url) -> Option<Arc<LiveDoc>> {
         self.live_doc(uri)
+    }
+}
+
+// ─── Synthetic enum members ──────────────────────────────────────────────────
+//
+// Kotlin generates these on every enum class:
+//   .entries  → EnumEntries<T>  (effectively List<T>)
+//   .values() → Array<T>
+//   .valueOf(String) → T
+//   .name     → String  (instance)
+//   .ordinal  → Int     (instance)
+
+fn is_enum_class(indexer: &Indexer, class_name: &str) -> bool {
+    let Some(locs) = indexer.definitions.get(class_name) else {
+        return false;
+    };
+    for loc in locs.iter() {
+        if let Some(fd) = indexer.files.get(loc.uri.as_str()) {
+            if fd
+                .symbols
+                .iter()
+                .any(|s| s.name == class_name && s.kind == SymbolKind::ENUM)
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn synthetic_enum_field(indexer: &Indexer, class_name: &str, field_name: &str) -> Option<String> {
+    if !is_enum_class(indexer, class_name) {
+        return None;
+    }
+    match field_name {
+        "entries" => Some(format!("List<{class_name}>")),
+        "name" => Some("String".to_string()),
+        "ordinal" => Some("Int".to_string()),
+        _ => None,
+    }
+}
+
+fn synthetic_enum_method(indexer: &Indexer, class_name: &str, method_name: &str) -> Option<String> {
+    if !is_enum_class(indexer, class_name) {
+        return None;
+    }
+    match method_name {
+        "values" => Some(format!("Array<{class_name}>")),
+        "valueOf" => Some(class_name.to_string()),
+        _ => None,
     }
 }
 

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -2395,3 +2395,48 @@ fn inline_lambda_also_nested_in_outer_lambda() {
         "inner it inside .also nested in collect lambda should be String: {r:?}"
     );
 }
+
+// ── Synthetic enum members ───────────────────────────────────────────────────
+
+#[test]
+fn synthetic_enum_entries_field_type() {
+    let (_, idx) = indexed("/Color.kt", "enum class Color { RED, GREEN, BLUE }");
+    let ty = idx.find_field_type("Color", "entries");
+    assert_eq!(ty.as_deref(), Some("List<Color>"));
+}
+
+#[test]
+fn synthetic_enum_name_field_type() {
+    let (_, idx) = indexed("/Color.kt", "enum class Color { RED, GREEN, BLUE }");
+    let ty = idx.find_field_type("Color", "name");
+    assert_eq!(ty.as_deref(), Some("String"));
+}
+
+#[test]
+fn synthetic_enum_ordinal_field_type() {
+    let (_, idx) = indexed("/Color.kt", "enum class Color { RED, GREEN, BLUE }");
+    let ty = idx.find_field_type("Color", "ordinal");
+    assert_eq!(ty.as_deref(), Some("Int"));
+}
+
+#[test]
+fn synthetic_enum_values_method() {
+    let (_, idx) = indexed("/Color.kt", "enum class Color { RED, GREEN, BLUE }");
+    let ty = idx.find_method_return_type_for_type("Color", "values");
+    assert_eq!(ty.as_deref(), Some("Array<Color>"));
+}
+
+#[test]
+fn synthetic_enum_valueof_method() {
+    let (_, idx) = indexed("/Color.kt", "enum class Color { RED, GREEN, BLUE }");
+    let ty = idx.find_method_return_type_for_type("Color", "valueOf");
+    assert_eq!(ty.as_deref(), Some("Color"));
+}
+
+#[test]
+fn synthetic_not_applied_to_non_enum() {
+    let (_, idx) = indexed("/Foo.kt", "class Foo { val entries: String = \"\" }");
+    let ty = idx.find_field_type("Foo", "entries");
+    // Should resolve from actual source, not synthetic
+    assert_ne!(ty.as_deref(), Some("List<Foo>"));
+}

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -481,6 +481,13 @@ pub(crate) const KIND_BOOLEAN_LITERAL: &str = "boolean_literal";
 pub(crate) const KIND_NULL_LITERAL: &str = "null";
 pub(crate) const KIND_CHARACTER_LITERAL: &str = "character_literal";
 
+// ─── Kotlin when expression ───────────────────────────────────────────────────
+pub(crate) const KIND_WHEN_EXPR: &str = "when_expression";
+pub(crate) const KIND_WHEN_SUBJECT: &str = "when_subject";
+pub(crate) const KIND_WHEN_ENTRY: &str = "when_entry";
+pub(crate) const KIND_WHEN_CONDITION: &str = "when_condition";
+pub(crate) const KIND_TYPE_TEST: &str = "type_test";
+
 // ─── Comment kinds ────────────────────────────────────────────────────────────
 pub(crate) const KIND_LINE_COMMENT: &str = "line_comment";
 pub(crate) const KIND_MULTILINE_COMMENT: &str = "multiline_comment";

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -488,6 +488,8 @@ pub(crate) const KIND_WHEN_SUBJECT: &str = "when_subject";
 pub(crate) const KIND_WHEN_ENTRY: &str = "when_entry";
 pub(crate) const KIND_WHEN_CONDITION: &str = "when_condition";
 pub(crate) const KIND_TYPE_TEST: &str = "type_test";
+pub(crate) const KIND_ELSE: &str = "else";
+pub(crate) const KIND_LBRACE: &str = "{";
 
 // ─── Comment kinds ────────────────────────────────────────────────────────────
 pub(crate) const KIND_LINE_COMMENT: &str = "line_comment";

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -490,6 +490,7 @@ pub(crate) const KIND_WHEN_CONDITION: &str = "when_condition";
 pub(crate) const KIND_TYPE_TEST: &str = "type_test";
 pub(crate) const KIND_ELSE: &str = "else";
 pub(crate) const KIND_LBRACE: &str = "{";
+pub(crate) const KIND_RBRACE: &str = "}";
 
 // ─── Comment kinds ────────────────────────────────────────────────────────────
 pub(crate) const KIND_LINE_COMMENT: &str = "line_comment";

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -448,6 +448,7 @@ pub(crate) const KIND_MOD_ABSTRACT: &str = "abstract";
 
 // ─── Kotlin class parameter ───────────────────────────────────────────────────
 pub(crate) const KIND_CLASS_PARAM: &str = "class_parameter";
+pub(crate) const KIND_PRIMARY_CTOR: &str = "primary_constructor";
 
 // ─── Kotlin soft keywords (anonymous CST nodes) ───────────────────────────────
 pub(crate) const KIND_KW_IS: &str = "is";

--- a/src/workspace/document_handler.rs
+++ b/src/workspace/document_handler.rs
@@ -6,6 +6,7 @@ use tower_lsp::lsp_types::Url;
 use tower_lsp::Client;
 
 use crate::backend::helpers::syntax_diagnostics;
+use crate::features::fill_when::when_diagnostics;
 use crate::indexer::{Indexer, ProgressReporter};
 
 use super::file_change_handler::FileChangeHandler;
@@ -137,7 +138,7 @@ impl DocumentHandler {
             })
             .await;
 
-            let diagnostics = match result {
+            let mut diagnostics = match result {
                 Ok(Some(indexed_file_data)) => syntax_diagnostics(&indexed_file_data.syntax_errors),
                 Ok(None) => cached_indexer
                     .files
@@ -146,6 +147,7 @@ impl DocumentHandler {
                     .unwrap_or_default(),
                 Err(_) => Vec::new(),
             };
+            diagnostics.extend(when_diagnostics(&cached_indexer, &diagnostics_uri));
             if let Some(client) = client {
                 client
                     .publish_diagnostics(diagnostics_uri, diagnostics, None)

--- a/src/workspace/file_change_handler.rs
+++ b/src/workspace/file_change_handler.rs
@@ -6,6 +6,7 @@ use tower_lsp::lsp_types::{TextDocumentContentChangeEvent, Url};
 use tower_lsp::Client;
 
 use crate::backend::helpers::syntax_diagnostics;
+use crate::features::fill_when::when_diagnostics;
 use crate::indexer::Indexer;
 
 pub(crate) struct FileChangeHandler {
@@ -76,6 +77,7 @@ impl FileChangeHandler {
                 return;
             };
             let diagnostics_uri = uri.clone();
+            let diagnostics_indexer = Arc::clone(&indexer);
             let result = tokio::task::spawn_blocking(move || {
                 let data = indexer.index_content(&uri, &text);
                 drop(permit);
@@ -84,7 +86,8 @@ impl FileChangeHandler {
             .await;
 
             if let (Some(client), Ok(Some(data))) = (client, result) {
-                let diagnostics = syntax_diagnostics(&data.syntax_errors);
+                let mut diagnostics = syntax_diagnostics(&data.syntax_errors);
+                diagnostics.extend(when_diagnostics(&diagnostics_indexer, &diagnostics_uri));
                 client
                     .publish_diagnostics(diagnostics_uri, diagnostics, None)
                     .await;


### PR DESCRIPTION
## Summary

Code action and warning diagnostic for incomplete `when` expressions over sealed classes, enums, and Booleans.

### Features
- **Code action** (quick-fix): "Fill missing 'X' branches" — generates missing `when` arms with `TODO()` body
- **Warning diagnostic**: `'when' is missing branches: A, B` on the `when` keyword
- **Boolean support**: bare `true`/`false` branches (no index lookup needed)
- **CST-based type resolution**: handles `val x : Type`, `val x: Type?`, function params, constructor params

### Type support
| Type | Branch syntax | Detection |
|------|--------------|-----------|
| Enum | `Color.RED -> TODO()` | `SymbolKind::ENUM` + enum members by range |
| Sealed class/interface | `is Type.Sub -> TODO()` or `Type.Sub -> TODO()` | `detail` contains "sealed" + `subtypes_of()` |
| Boolean | `true -> TODO()` / `false -> TODO()` | Hardcoded, no index |

### Edge cases handled
- `else` branch present → no action/diagnostic
- All branches covered → no action/diagnostic
- Nullable types (`Boolean?`, `Color?`) → stripped before resolution
- Space before colon (`val x : Type`) → CST handles it
- Empty when block with blank lines → cleaned up on insertion
- Proper indentation detection from existing branches or `when` keyword

### Files
- `src/features/fill_when.rs` — core algorithm (~620 lines)
- `src/features/fill_when_tests.rs` — 20 tests
- `src/backend/actions.rs` — wired into code_action handler
- `src/workspace/{document,file_change}_handler.rs` — diagnostics publishing
- `src/queries.rs` — 5 new node kind constants

### Commits (6)
1. `4ef8a97` feat: fill missing when branches code action
2. `5efe89d` fix: CST-based type resolution for when subject
3. `7511edd` fix: proper formatting when inserting branches
4. `0fda487` fix: clean up blank lines when filling empty when block
5. `c6c105b` feat: when-arms diagnostics + Boolean branch support
6. `084ba43` fix: handle nullable_type in CST type resolution
