### PR TITLE
feat: panic-safe LSP request handlers + crash report hook

### DIFF
--- a/src/backend/handlers_tests.rs
+++ b/src/backend/handlers_tests.rs
@@ -40,3 +40,23 @@ fn whole_word_replace_file_empty_word_returns_input() {
     let text = whole_word_replace_file(&lines, "", "Baz");
     assert_eq!(text, "import foo.Bar\nval name = Bar");
 }
+
+#[tokio::test]
+async fn panic_safe_catches_panic_returns_internal_error() {
+    use crate::backend::panic_safe;
+
+    let result: tower_lsp::jsonrpc::Result<Option<()>> =
+        panic_safe("test_handler", async { panic!("intentional test panic") }).await;
+
+    let err = result.unwrap_err();
+    assert_eq!(err.code, tower_lsp::jsonrpc::ErrorCode::InternalError);
+    assert!(err.message.contains("test_handler"));
+}
+
+#[tokio::test]
+async fn panic_safe_passes_through_ok() {
+    use crate::backend::panic_safe;
+
+    let result = panic_safe("test_handler", async { Ok(Some(42)) }).await;
+    assert_eq!(result.unwrap(), Some(42));
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -14,12 +14,17 @@ use crate::workspace::{Config, Event};
 
 /// Wraps an async handler in `catch_unwind` so a panic in one request doesn't
 /// kill the server process. Returns an internal error to the client on panic.
-async fn panic_safe<F, T>(method: &str, future: F) -> Result<T>
+pub(crate) async fn panic_safe<F, T>(method: &str, future: F) -> Result<T>
 where
     F: std::future::Future<Output = Result<T>> + Send,
     T: Send + 'static,
 {
-    match std::panic::AssertUnwindSafe(future).catch_unwind().await {
+    // Signal the panic hook that this panic is recoverable.
+    crate::PANIC_CAUGHT.with(|c| c.set(true));
+    let result = std::panic::AssertUnwindSafe(future).catch_unwind().await;
+    crate::PANIC_CAUGHT.with(|c| c.set(false));
+
+    match result {
         Ok(result) => result,
         Err(payload) => {
             let message = if let Some(s) = payload.downcast_ref::<&str>() {
@@ -139,6 +144,95 @@ impl Backend {
             event_tx,
             snippet_support: Arc::new(AtomicBool::new(false)),
         }
+    }
+
+    async fn execute_command_impl(
+        &self,
+        params: ExecuteCommandParams,
+    ) -> Result<Option<serde_json::Value>> {
+        if params.command == "kotlin-lsp/reindex" {
+            let root = self.indexer.workspace_root.get();
+            let Some(root) = root else {
+                self.client
+                    .show_message(MessageType::WARNING, "kotlin-lsp: no workspace root set")
+                    .await;
+                return Ok(None);
+            };
+            let idx = Arc::clone(&self.indexer);
+            let client = self.client.clone();
+            idx.reset_index_state();
+            tokio::spawn(async move {
+                idx.index_workspace(&root, Arc::new(LspProgressReporter(client)))
+                    .await;
+            });
+            self.client
+                .show_message(MessageType::INFO, "kotlin-lsp: reindexing workspace…")
+                .await;
+        } else if params.command == "kotlin-lsp/clearCache" {
+            let arg = params
+                .arguments
+                .first()
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let target_root = if let Some(p) = arg {
+                let pb = std::path::PathBuf::from(p);
+                if !pb.is_dir() {
+                    self.client
+                        .show_message(
+                            MessageType::WARNING,
+                            format!("kotlin-lsp/clearCache: not a directory: {}", pb.display()),
+                        )
+                        .await;
+                    return Ok(None);
+                }
+                pb
+            } else {
+                let current_root_opt = self.indexer.workspace_root.get();
+                match current_root_opt {
+                    Some(r) => r,
+                    None => {
+                        self.client
+                            .show_message(
+                                MessageType::WARNING,
+                                "kotlin-lsp/clearCache: no workspace root set and no path provided",
+                            )
+                            .await;
+                        return Ok(None);
+                    }
+                }
+            };
+            let cache_path = workspace_cache_path(&target_root);
+            if let Some(cache_dir) = cache_path.parent() {
+                match std::fs::remove_dir_all(cache_dir) {
+                    Ok(_) => {
+                        log::info!("Cleared workspace cache directory: {}", cache_dir.display());
+                        self.client
+                            .show_message(
+                                MessageType::INFO,
+                                format!("kotlin-lsp: cleared cache for {}", target_root.display()),
+                            )
+                            .await;
+                    }
+                    Err(e) => {
+                        log::warn!("Failed to remove cache dir {}: {}", cache_dir.display(), e);
+                        self.client
+                            .show_message(
+                                MessageType::WARNING,
+                                format!("kotlin-lsp: failed to clear cache: {}", e),
+                            )
+                            .await;
+                    }
+                }
+            } else {
+                self.client
+                    .show_message(
+                        MessageType::WARNING,
+                        "kotlin-lsp/clearCache: cache path parent missing",
+                    )
+                    .await;
+            }
+        }
+        Ok(None)
     }
 
     fn detect_snippet_support(params: &InitializeParams) -> bool {
@@ -398,90 +492,7 @@ impl LanguageServer for Backend {
         &self,
         params: ExecuteCommandParams,
     ) -> Result<Option<serde_json::Value>> {
-        if params.command == "kotlin-lsp/reindex" {
-            let root = self.indexer.workspace_root.get();
-            let Some(root) = root else {
-                self.client
-                    .show_message(MessageType::WARNING, "kotlin-lsp: no workspace root set")
-                    .await;
-                return Ok(None);
-            };
-            let idx = Arc::clone(&self.indexer);
-            let client = self.client.clone();
-            idx.reset_index_state();
-            tokio::spawn(async move {
-                idx.index_workspace(&root, Arc::new(LspProgressReporter(client)))
-                    .await;
-            });
-            self.client
-                .show_message(MessageType::INFO, "kotlin-lsp: reindexing workspace…")
-                .await;
-        } else if params.command == "kotlin-lsp/clearCache" {
-            // Optional arg: path to workspace root. If absent, clear current root's cache.
-            let arg = params
-                .arguments
-                .first()
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            let target_root = if let Some(p) = arg {
-                let pb = std::path::PathBuf::from(p);
-                if !pb.is_dir() {
-                    self.client
-                        .show_message(
-                            MessageType::WARNING,
-                            format!("kotlin-lsp/clearCache: not a directory: {}", pb.display()),
-                        )
-                        .await;
-                    return Ok(None);
-                }
-                pb
-            } else {
-                let current_root_opt = self.indexer.workspace_root.get();
-                match current_root_opt {
-                    Some(r) => r,
-                    None => {
-                        self.client
-                            .show_message(
-                                MessageType::WARNING,
-                                "kotlin-lsp/clearCache: no workspace root set and no path provided",
-                            )
-                            .await;
-                        return Ok(None);
-                    }
-                }
-            };
-            let cache_path = workspace_cache_path(&target_root);
-            if let Some(cache_dir) = cache_path.parent() {
-                match std::fs::remove_dir_all(cache_dir) {
-                    Ok(_) => {
-                        log::info!("Cleared workspace cache directory: {}", cache_dir.display());
-                        self.client
-                            .show_message(
-                                MessageType::INFO,
-                                format!("kotlin-lsp: cleared cache for {}", target_root.display()),
-                            )
-                            .await;
-                    }
-                    Err(e) => {
-                        log::warn!("Failed to remove cache dir {}: {}", cache_dir.display(), e);
-                        self.client
-                            .show_message(
-                                MessageType::WARNING,
-                                format!("kotlin-lsp: failed to clear cache: {}", e),
-                            )
-                            .await;
-                    }
-                }
-            } else {
-                self.client
-                    .show_message(
-                        MessageType::WARNING,
-                        "kotlin-lsp/clearCache: cache path parent missing",
-                    )
-                    .await;
-            }
-        }
-        Ok(None)
+        panic_safe("execute_command", self.execute_command_impl(params)).await
     }
 
     // ── document sync ────────────────────────────────────────────────────────

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
+use futures::FutureExt;
 use tokio::sync::mpsc;
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
@@ -10,6 +11,33 @@ use tower_lsp::{async_trait, Client, LanguageServer};
 use crate::indexer::{workspace_cache_path, Indexer, ProgressReporter};
 use crate::semantic_tokens;
 use crate::workspace::{Config, Event};
+
+/// Wraps an async handler in `catch_unwind` so a panic in one request doesn't
+/// kill the server process. Returns an internal error to the client on panic.
+async fn panic_safe<F, T>(method: &str, future: F) -> Result<T>
+where
+    F: std::future::Future<Output = Result<T>> + Send,
+    T: Send + 'static,
+{
+    match std::panic::AssertUnwindSafe(future).catch_unwind().await {
+        Ok(result) => result,
+        Err(payload) => {
+            let message = if let Some(s) = payload.downcast_ref::<&str>() {
+                (*s).to_owned()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "unknown panic".to_owned()
+            };
+            log::error!("PANIC in {method}: {message}");
+            Err(tower_lsp::jsonrpc::Error {
+                code: tower_lsp::jsonrpc::ErrorCode::InternalError,
+                message: format!("internal error in {method}").into(),
+                data: None,
+            })
+        }
+    }
+}
 
 pub(crate) mod actions;
 pub(crate) mod cursor;
@@ -544,157 +572,136 @@ impl LanguageServer for Backend {
         &self,
         params: GotoDefinitionParams,
     ) -> Result<Option<GotoDefinitionResponse>> {
-        self.goto_definition_impl(params).await
+        panic_safe("goto_definition", self.goto_definition_impl(params)).await
     }
-
-    // ── textDocument/declaration ─────────────────────────────────────────────
-    // In Kotlin/Java there is no separate declaration/definition concept,
-    // so we delegate to the same implementation.
 
     async fn goto_declaration(
         &self,
         params: GotoDefinitionParams,
     ) -> Result<Option<GotoDefinitionResponse>> {
-        self.goto_definition_impl(params).await
+        panic_safe("goto_declaration", self.goto_definition_impl(params)).await
     }
-
-    // ── textDocument/implementation ──────────────────────────────────────────
 
     async fn goto_implementation(
         &self,
         params: GotoDefinitionParams,
     ) -> Result<Option<GotoDefinitionResponse>> {
-        self.goto_implementation_impl(params).await
+        panic_safe("goto_implementation", self.goto_implementation_impl(params)).await
     }
-
-    // ── textDocument/completion ──────────────────────────────────────────────
 
     async fn completion(&self, params: CompletionParams) -> Result<Option<CompletionResponse>> {
-        self.completion_impl(params).await
+        panic_safe("completion", self.completion_impl(params)).await
     }
-
-    // ── completionItem/resolve ────────────────────────────────────────────────
 
     async fn completion_resolve(&self, item: CompletionItem) -> Result<CompletionItem> {
-        Ok(crate::features::completion::resolve_completion_item(
-            item,
-            self.indexer.as_ref(),
-        ))
+        panic_safe("completion_resolve", async {
+            Ok(crate::features::completion::resolve_completion_item(
+                item,
+                self.indexer.as_ref(),
+            ))
+        })
+        .await
     }
-
-    // ── textDocument/hover ───────────────────────────────────────────────────
 
     async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
-        self.hover_impl(params).await
+        panic_safe("hover", self.hover_impl(params)).await
     }
-
-    // ── textDocument/references ──────────────────────────────────────────────
 
     async fn references(&self, params: ReferenceParams) -> Result<Option<Vec<Location>>> {
-        self.references_impl(params).await
+        panic_safe("references", self.references_impl(params)).await
     }
-
-    // ── textDocument/documentHighlight ───────────────────────────────────────
 
     async fn document_highlight(
         &self,
         params: DocumentHighlightParams,
     ) -> Result<Option<Vec<DocumentHighlight>>> {
-        self.document_highlight_impl(params).await
+        panic_safe("document_highlight", self.document_highlight_impl(params)).await
     }
-
-    // ── textDocument/documentSymbol ──────────────────────────────────────────
 
     async fn document_symbol(
         &self,
         params: DocumentSymbolParams,
     ) -> Result<Option<DocumentSymbolResponse>> {
-        self.document_symbol_impl(params).await
+        panic_safe("document_symbol", self.document_symbol_impl(params)).await
     }
 
     async fn inlay_hint(&self, params: InlayHintParams) -> Result<Option<Vec<InlayHint>>> {
-        self.inlay_hint_impl(params).await
+        panic_safe("inlay_hint", self.inlay_hint_impl(params)).await
     }
-
-    // ── workspace/symbol ────────────────────────────────────────────────────
 
     async fn symbol(
         &self,
         params: WorkspaceSymbolParams,
     ) -> Result<Option<Vec<SymbolInformation>>> {
-        self.symbol_impl(params).await
+        panic_safe("workspace_symbol", self.symbol_impl(params)).await
     }
-
-    // ── textDocument/signatureHelp ───────────────────────────────────────────
 
     async fn signature_help(&self, params: SignatureHelpParams) -> Result<Option<SignatureHelp>> {
-        self.signature_help_impl(params).await
+        panic_safe("signature_help", self.signature_help_impl(params)).await
     }
-
-    // ── textDocument/rename ──────────────────────────────────────────────────
 
     async fn prepare_rename(
         &self,
         params: TextDocumentPositionParams,
     ) -> Result<Option<PrepareRenameResponse>> {
-        self.prepare_rename_impl(params).await
+        panic_safe("prepare_rename", self.prepare_rename_impl(params)).await
     }
 
     async fn rename(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
-        self.rename_impl(params).await
+        panic_safe("rename", self.rename_impl(params)).await
     }
-
-    // ── textDocument/foldingRange ────────────────────────────────────────────
 
     async fn folding_range(&self, params: FoldingRangeParams) -> Result<Option<Vec<FoldingRange>>> {
-        self.folding_range_impl(params).await
+        panic_safe("folding_range", self.folding_range_impl(params)).await
     }
-
-    // ── textDocument/codeAction ──────────────────────────────────────────────
 
     async fn code_action(
         &self,
         params: CodeActionParams,
     ) -> Result<Option<Vec<CodeActionOrCommand>>> {
-        self.code_action_impl(params).await
+        panic_safe("code_action", self.code_action_impl(params)).await
     }
 
     async fn semantic_tokens_full(
         &self,
         params: SemanticTokensParams,
     ) -> Result<Option<SemanticTokensResult>> {
-        let uri = params.text_document.uri.to_string();
-        let language = crate::Language::from_path(&uri);
-        let Some(doc) = self.indexer.live_doc(&params.text_document.uri) else {
-            return Ok(None);
-        };
-        let parsed_uri = params.text_document.uri;
-        Ok(Some(SemanticTokensResult::Tokens(
-            semantic_tokens::full_tokens(&self.indexer, &parsed_uri, &doc, language),
-        )))
+        panic_safe("semantic_tokens_full", async {
+            let uri = params.text_document.uri.to_string();
+            let language = crate::Language::from_path(&uri);
+            let Some(doc) = self.indexer.live_doc(&params.text_document.uri) else {
+                return Ok(None);
+            };
+            let parsed_uri = params.text_document.uri;
+            Ok(Some(SemanticTokensResult::Tokens(
+                semantic_tokens::full_tokens(&self.indexer, &parsed_uri, &doc, language),
+            )))
+        })
+        .await
     }
-
-    // ── textDocument/semanticTokens/range ────────────────────────────────────
 
     async fn semantic_tokens_range(
         &self,
         params: SemanticTokensRangeParams,
     ) -> Result<Option<SemanticTokensRangeResult>> {
-        let uri = params.text_document.uri.to_string();
-        let language = crate::Language::from_path(&uri);
-        let Some(doc) = self.indexer.live_doc(&params.text_document.uri) else {
-            return Ok(None);
-        };
-        let parsed_uri = params.text_document.uri;
-        Ok(Some(SemanticTokensRangeResult::Tokens(
-            semantic_tokens::range_tokens(
-                &self.indexer,
-                &parsed_uri,
-                &doc,
-                language,
-                &params.range,
-            ),
-        )))
+        panic_safe("semantic_tokens_range", async {
+            let uri = params.text_document.uri.to_string();
+            let language = crate::Language::from_path(&uri);
+            let Some(doc) = self.indexer.live_doc(&params.text_document.uri) else {
+                return Ok(None);
+            };
+            let parsed_uri = params.text_document.uri;
+            Ok(Some(SemanticTokensRangeResult::Tokens(
+                semantic_tokens::range_tokens(
+                    &self.indexer,
+                    &parsed_uri,
+                    &doc,
+                    language,
+                    &params.range,
+                ),
+            )))
+        })
+        .await
     }
 }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -19,10 +19,34 @@ where
     F: std::future::Future<Output = Result<T>> + Send,
     T: Send + 'static,
 {
-    // Signal the panic hook that this panic is recoverable.
-    crate::PANIC_CAUGHT.with(|c| c.set(true));
-    let result = std::panic::AssertUnwindSafe(future).catch_unwind().await;
-    crate::PANIC_CAUGHT.with(|c| c.set(false));
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    // Wrapper that sets PANIC_CAUGHT on each poll so the panic hook
+    // always sees the flag regardless of which thread resumes the future.
+    struct PanicGuarded<Fut>(Pin<Box<Fut>>);
+
+    impl<Fut: Future> Future for PanicGuarded<Fut> {
+        type Output = Fut::Output;
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            crate::PANIC_CAUGHT.with(|c| c.set(true));
+            let result = self.0.as_mut().poll(cx);
+            if result.is_ready() {
+                crate::PANIC_CAUGHT.with(|c| c.set(false));
+            }
+            result
+        }
+    }
+
+    impl<Fut> Drop for PanicGuarded<Fut> {
+        fn drop(&mut self) {
+            crate::PANIC_CAUGHT.with(|c| c.set(false));
+        }
+    }
+
+    let guarded = PanicGuarded(Box::pin(future));
+    let result = std::panic::AssertUnwindSafe(guarded).catch_unwind().await;
 
     match result {
         Ok(result) => result,

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,7 +48,10 @@ fn main() {
     }));
 
     match result {
-        Ok(()) => std::process::exit(0),
+        Ok(()) => {
+            // Let runtime drop naturally so in-flight tasks (e.g. cache writes) can finish.
+            drop(runtime);
+        }
         Err(_) => {
             // Panic hook already printed the crash report to stderr.
             // Exit 101 (Rust's default panic exit) signals to editors that
@@ -58,8 +61,30 @@ fn main() {
     }
 }
 
+// Thread-local flag: when true, the panic hook suppresses the crash report
+// because the panic will be caught by `panic_safe`.
+std::thread_local! {
+    pub(crate) static PANIC_CAUGHT: std::cell::Cell<bool> = const { std::cell::Cell::new(false) };
+}
+
 fn install_panic_hook() {
     std::panic::set_hook(Box::new(|info| {
+        // If this panic is being caught by panic_safe, just log briefly.
+        if PANIC_CAUGHT.with(|c| c.get()) {
+            let payload = if let Some(s) = info.payload().downcast_ref::<&str>() {
+                *s
+            } else {
+                "panic"
+            };
+            let location = info
+                .location()
+                .map(|l| format!("{}:{}", l.file(), l.line()))
+                .unwrap_or_else(|| "unknown".to_owned());
+            eprintln!("[kotlin-lsp] caught panic in handler: {payload} at {location}");
+            return;
+        }
+
+        // Fatal panic — full crash report.
         let payload = if let Some(s) = info.payload().downcast_ref::<&str>() {
             (*s).to_owned()
         } else if let Some(s) = info.payload().downcast_ref::<String>() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,17 +30,64 @@ use tokio::sync::mpsc;
 use tower_lsp::{LspService, Server};
 
 fn main() {
+    install_panic_hook();
+
     // Build custom tokio runtime — scale workers to available cores.
     let worker_count = std::thread::available_parallelism()
         .map(|n| n.get())
         .unwrap_or(4);
-    tokio::runtime::Builder::new_multi_thread()
+    let runtime = tokio::runtime::Builder::new_multi_thread()
         .worker_threads(worker_count)
         .max_blocking_threads(512)
         .enable_all()
         .build()
-        .unwrap()
-        .block_on(async_main());
+        .unwrap();
+
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        runtime.block_on(async_main())
+    }));
+
+    match result {
+        Ok(()) => std::process::exit(0),
+        Err(_) => {
+            // Panic hook already printed the crash report to stderr.
+            // Exit 101 (Rust's default panic exit) signals to editors that
+            // the server crashed and should be restarted.
+            std::process::exit(101);
+        }
+    }
+}
+
+fn install_panic_hook() {
+    std::panic::set_hook(Box::new(|info| {
+        let payload = if let Some(s) = info.payload().downcast_ref::<&str>() {
+            (*s).to_owned()
+        } else if let Some(s) = info.payload().downcast_ref::<String>() {
+            s.clone()
+        } else {
+            "unknown panic".to_owned()
+        };
+
+        let location = info
+            .location()
+            .map(|l| format!("{}:{}:{}", l.file(), l.line(), l.column()))
+            .unwrap_or_else(|| "unknown".to_owned());
+
+        let backtrace = std::backtrace::Backtrace::force_capture();
+
+        eprintln!("\n╔══════════════════════════════════════════╗");
+        eprintln!("║  kotlin-lsp CRASH REPORT                 ║");
+        eprintln!("╠══════════════════════════════════════════╣");
+        eprintln!("║ panic: {payload}");
+        eprintln!("║ location: {location}");
+        eprintln!("╠══════════════════════════════════════════╣");
+        eprintln!("║ backtrace:");
+        for line in backtrace.to_string().lines().take(30) {
+            eprintln!("║   {line}");
+        }
+        eprintln!("╚══════════════════════════════════════════╝");
+        eprintln!("The server will exit. Your editor should restart it automatically.");
+    }));
 }
 
 fn make_backend(client: tower_lsp::Client) -> backend::Backend {

--- a/src/task_runner.rs
+++ b/src/task_runner.rs
@@ -3,6 +3,7 @@
 //! Single responsibility: execute async work items concurrently and collect results.
 //! Separated from indexer logic for testability.
 
+use futures::FutureExt;
 use std::sync::Arc;
 use tokio::sync::Semaphore;
 
@@ -32,21 +33,33 @@ where
     let worker = Arc::new(worker);
     let mut handles = Vec::with_capacity(items.len());
 
-    // Spawn all tasks immediately - semaphore is only for throttling spawn_blocking inside worker
+    // Spawn all tasks immediately - semaphore is only for throttling spawn_blocking inside worker.
+    // Each task sets PANIC_CAUGHT so the global panic hook emits a brief log
+    // instead of a full crash report for recoverable task panics.
     for item in items {
         let sem = Arc::clone(&semaphore);
         let worker = Arc::clone(&worker);
 
-        handles.push(tokio::spawn(async move { worker(item, sem).await }));
+        handles.push(tokio::spawn(async move {
+            crate::PANIC_CAUGHT.with(|c| c.set(true));
+            let result = std::panic::AssertUnwindSafe(worker(item, sem))
+                .catch_unwind()
+                .await;
+            crate::PANIC_CAUGHT.with(|c| c.set(false));
+            result
+        }));
     }
 
-    // Collect results — skip panicked tasks instead of propagating the panic.
+    // Collect results — skip panicked tasks instead of propagating.
     let mut results = Vec::with_capacity(handles.len());
     for handle in handles {
         match handle.await {
-            Ok(result) => results.push(result),
+            Ok(Ok(result)) => results.push(result),
+            Ok(Err(_)) => {
+                log::error!("Background task panicked (caught inside spawn)");
+            }
             Err(e) => {
-                log::error!("Background task panicked: {e}");
+                log::error!("Background task JoinError: {e}");
             }
         }
     }

--- a/src/task_runner.rs
+++ b/src/task_runner.rs
@@ -40,12 +40,14 @@ where
         handles.push(tokio::spawn(async move { worker(item, sem).await }));
     }
 
-    // Collect results
+    // Collect results — skip panicked tasks instead of propagating the panic.
     let mut results = Vec::with_capacity(handles.len());
     for handle in handles {
         match handle.await {
             Ok(result) => results.push(result),
-            Err(e) => panic!("Task panicked: {}", e),
+            Err(e) => {
+                log::error!("Background task panicked: {e}");
+            }
         }
     }
     results
@@ -154,5 +156,23 @@ mod tests {
             "Max concurrent spawn_blocking was {}, expected >= 2",
             max
         );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn test_run_concurrent_survives_task_panic() {
+        let items = vec![1, 2, 3, 4, 5];
+        let sem = Arc::new(Semaphore::new(4));
+
+        let results: Vec<i32> = run_concurrent(items, sem, |n, _sem| async move {
+            if n == 3 {
+                panic!("intentional panic for testing");
+            }
+            n * 10
+        })
+        .await;
+
+        // Panicked task (n=3) is skipped; 4 results remain
+        assert_eq!(results.len(), 4);
+        assert_eq!(results, vec![10, 20, 40, 50]);
     }
 }


### PR DESCRIPTION
Prevents server crashes from killing the process.

- Custom panic hook: structured crash report to stderr with backtrace
- Top-level catch_unwind: catches unhandled panic, exits 101 (editors auto-restart)
- Per-handler panic_safe() wrapper: individual request panics return InternalError to client, server continues

Addresses tower-lsp 0.20 pending.rs:35 panic and any future indexer/parser panics.