### PR TITLE
fix(call_arg_diagnostics): eliminate false positives from nested-class resolution

### DIFF
--- a/contrib/zed-extension/Cargo.lock
+++ b/contrib/zed-extension/Cargo.lock
@@ -3,10 +3,28 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "auditable-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7bf8143dfc3c0258df908843e169b5cc5fcf76c7718bd66135ef4a9cd558c5"
+dependencies = [
+ "semver",
+ "serde",
+ "serde_json",
+ "topological-sort",
+]
 
 [[package]]
 name = "bitflags"
@@ -15,10 +33,158 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -28,11 +194,90 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
- "unicode-segmentation",
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
 ]
 
 [[package]]
@@ -42,13 +287,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -67,10 +333,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "leb128"
-version = "0.2.6"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cc46bac87ef8093eed6f272babb833b6443374399985ac8ed28471ee0918545"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "log"
@@ -83,6 +355,53 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -107,6 +426,10 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+dependencies = [
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "serde"
@@ -152,6 +475,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -178,16 +519,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "topological-sort"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
-
-[[package]]
-name = "unicode-segmentation"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"
@@ -196,77 +558,107 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "wasm-encoder"
-version = "0.201.0"
+name = "url"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c7d2731df60006819b013f64ccc2019691deccf6e11a1804bc850cd6748f1a"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
- "leb128",
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "wasm-encoder"
+version = "0.227.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80bb72f02e7fbf07183443b27b0f3d4144abf8c114189f2e088ed95b696a7822"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
 ]
 
 [[package]]
 name = "wasm-metadata"
-version = "0.201.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fd83062c17b9f4985d438603cde0a5e8c5c8198201a6937f778b607924c7da2"
+checksum = "ce1ef0faabbbba6674e97a56bee857ccddf942785a336c8b47b42373c922a91d"
 dependencies = [
  "anyhow",
+ "auditable-serde",
+ "flate2",
  "indexmap",
  "serde",
  "serde_derive",
  "serde_json",
  "spdx",
+ "url",
  "wasm-encoder",
  "wasmparser",
 ]
 
 [[package]]
 name = "wasmparser"
-version = "0.201.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e5df6dba6c0d7fafc63a450f1738451ed7a0b52295d83e868218fa286bf708"
+checksum = "0f51cad774fb3c9461ab9bccc9c62dfb7388397b5deda31bf40e8108ccd678b2"
 dependencies = [
  "bitflags",
+ "hashbrown 0.15.5",
  "indexmap",
  "semver",
 ]
 
 [[package]]
 name = "wit-bindgen"
-version = "0.22.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "288f992ea30e6b5c531b52cdd5f3be81c148554b09ea416f058d16556ba92c27"
+checksum = "10fb6648689b3929d56bbc7eb1acf70c9a42a29eb5358c67c10f54dbd5d695de"
 dependencies = [
- "bitflags",
  "wit-bindgen-rt",
  "wit-bindgen-rust-macro",
 ]
 
 [[package]]
 name = "wit-bindgen-core"
-version = "0.22.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e85e72719ffbccf279359ad071497e47eb0675fe22106dea4ed2d8a7fcb60ba4"
+checksum = "92fa781d4f2ff6d3f27f3cc9b74a73327b31ca0dc4a3ef25a0ce2983e0e5af9b"
 dependencies = [
  "anyhow",
+ "heck",
  "wit-parser",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.22.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb8738270f32a2d6739973cbbb7c1b6dd8959ce515578a6e19165853272ee64"
+checksum = "c4db52a11d4dfb0a59f194c064055794ee6564eb1ced88c25da2cf76e50c5621"
+dependencies = [
+ "bitflags",
+ "futures",
+ "once_cell",
+]
 
 [[package]]
 name = "wit-bindgen-rust"
-version = "0.22.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a39a15d1ae2077688213611209849cad40e9e5cccf6e61951a425850677ff3"
+checksum = "9d0809dc5ba19e2e98661bf32fc0addc5a3ca5bf3a6a7083aa6ba484085ff3ce"
 dependencies = [
  "anyhow",
  "heck",
  "indexmap",
+ "prettyplease",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -274,11 +666,12 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen-rust-macro"
-version = "0.22.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d376d3ae5850526dfd00d937faea0d81a06fa18f7ac1e26f386d760f241a8f4b"
+checksum = "ad19eec017904e04c60719592a803ee5da76cb51c81e3f6fbf9457f59db49799"
 dependencies = [
  "anyhow",
+ "prettyplease",
  "proc-macro2",
  "quote",
  "syn",
@@ -288,9 +681,9 @@ dependencies = [
 
 [[package]]
 name = "wit-component"
-version = "0.201.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "421c0c848a0660a8c22e2fd217929a0191f14476b68962afd2af89fd22e39825"
+checksum = "635c3adc595422cbf2341a17fb73a319669cc8d33deed3a48368a841df86b676"
 dependencies = [
  "anyhow",
  "bitflags",
@@ -307,9 +700,9 @@ dependencies = [
 
 [[package]]
 name = "wit-parser"
-version = "0.201.0"
+version = "0.227.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "196d3ecfc4b759a8573bf86a9b3f8996b304b3732e4c7de81655f875f6efdca6"
+checksum = "ddf445ed5157046e4baf56f9138c124a0824d4d1657e7204d71886ad8ce2fc11"
 dependencies = [
  "anyhow",
  "id-arena",
@@ -324,14 +717,97 @@ dependencies = [
 ]
 
 [[package]]
-name = "zed_extension_api"
-version = "0.3.0"
+name = "writeable"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e580c3ea59a92fc876756f3b4612f7a47ec86a34a1b9be099a24bd55401ff31"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zed_extension_api"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ef88a8e5aeff67b0996b1795d56338f04c02de95f1f147577944aa37b801d6"
 dependencies = [
  "serde",
  "serde_json",
  "wit-bindgen",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/contrib/zed-extension/Cargo.toml
+++ b/contrib/zed-extension/Cargo.toml
@@ -9,4 +9,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.3"
+zed_extension_api = "0.5"

--- a/src/features/call_arg_diagnostics.rs
+++ b/src/features/call_arg_diagnostics.rs
@@ -16,7 +16,10 @@ use crate::indexer::{
     collect_all_fun_params_texts, find_fun_signature_with_receiver, live_tree::LiveDoc,
     split_params_at_depth_zero, Indexer, NodeExt,
 };
-use crate::queries::{KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_LAMBDA_LIT, KIND_VALUE_ARG};
+use crate::queries::{
+    KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_FUN_DECL, KIND_LAMBDA_LIT, KIND_SIMPLE_IDENT,
+    KIND_VALUE_ARG,
+};
 use crate::util::is_test_file;
 
 /// Scan a file for call-argument count mismatches and return diagnostics.
@@ -118,6 +121,12 @@ fn check_call_args(
     }
 
     if provided_count > total {
+        // Skip if this is a delegation to a parent overload:
+        // `fun foo() { foo(extraArg) }` — local has 0 params, call has 1 arg.
+        // Only suppress for unqualified calls inside a same-named function.
+        if qualifier.is_none() && is_inside_same_named_function(call_node, bytes, &fn_name) {
+            return None;
+        }
         let range = diagnostic_range(call_node, value_arguments.as_ref());
         let message =
             format!("{fn_name}: expected at most {total} argument(s), found {provided_count}");
@@ -292,6 +301,33 @@ fn has_named_args(value_arguments: Option<&tree_sitter::Node>, bytes: &[u8]) -> 
     false
 }
 
+/// Return `true` if `node` is nested inside a `function_declaration` whose name
+/// matches `fn_name`.
+///
+/// This catches the "delegation override" pattern where a no-arg local override
+/// calls the same-named SDK function with arguments:
+/// ```kotlin
+/// fun setHomeAsUpEnabled() { setHomeAsUpEnabled(true) }
+/// ```
+/// Without this guard the 1-arg call would be flagged as "expected 0, found 1".
+fn is_inside_same_named_function(node: &tree_sitter::Node, bytes: &[u8], fn_name: &str) -> bool {
+    let mut cur = *node;
+    for _ in 0..25 {
+        let Some(parent) = cur.parent() else { break };
+        if parent.kind() == KIND_FUN_DECL {
+            let matches = parent
+                .first_child_of_kind(KIND_SIMPLE_IDENT)
+                .and_then(|n| n.utf8_text_owned(bytes))
+                .is_some_and(|name| name == fn_name);
+            if matches {
+                return true;
+            }
+        }
+        cur = parent;
+    }
+    false
+}
+
 /// Resolve `(required, total)` param counts directly from `SymbolEntry::param_counts`.
 /// Returns `None` if no matching symbol found or if the symbol was never indexed
 /// with param_counts (non-callable symbols like interfaces/fields).
@@ -421,7 +457,7 @@ fn resolve_signatures(
     // lookup across the whole workspace would match hundreds of unrelated
     // same-name overrides (e.g. 945 `loadData` implementations) causing
     // a false "overloaded — skip" result.
-    let current_sigs = collect_all_fun_params_texts(fn_name, uri.as_str(), indexer);
+    let current_sigs = collect_all_fun_params_texts(fn_name, uri.as_str(), indexer, false);
     if qualifier.is_none() && !current_sigs.is_empty() {
         // For unqualified calls, don't use receiver_sig — it comes from a global
         // name scan that may find only one overload, masking same-file overloads.
@@ -441,7 +477,8 @@ fn resolve_signatures(
             if is_test_file(loc.uri.as_str()) {
                 continue;
             }
-            let sigs = collect_all_fun_params_texts(fn_name, loc.uri.as_str(), indexer);
+            // skip_nested=true: unqualified calls can't refer to nested classes from other files
+            let sigs = collect_all_fun_params_texts(fn_name, loc.uri.as_str(), indexer, true);
             all_sigs.extend(sigs);
         }
     }
@@ -462,10 +499,17 @@ fn resolve_signatures(
         return all_sigs; // caller sees len > 1 → skip
     }
 
-    // Return the receiver-aware signature if available, else first from all_sigs
-    if let Some(sig) = receiver_sig {
-        vec![sig]
-    } else if let Some(sig) = all_sigs.into_iter().next() {
+    // For qualified calls, prefer the receiver-resolved signature (it's type-accurate).
+    // For unqualified calls, skip receiver_sig: it comes from find_fun_signature_full which
+    // does NOT apply skip_nested filtering, so it would pick up nested classes (e.g.
+    // `data class Date(val value: Long)` inside a sealed interface) as false positives.
+    // Unqualified calls rely on the definitions-map path above (which does apply skip_nested).
+    if qualifier.is_some() {
+        if let Some(sig) = receiver_sig {
+            return vec![sig];
+        }
+    }
+    if let Some(sig) = all_sigs.into_iter().next() {
         vec![sig]
     } else {
         Vec::new()

--- a/src/features/call_arg_diagnostics.rs
+++ b/src/features/call_arg_diagnostics.rs
@@ -17,6 +17,7 @@ use crate::indexer::{
     split_params_at_depth_zero, Indexer, NodeExt,
 };
 use crate::queries::{KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_LAMBDA_LIT, KIND_VALUE_ARG};
+use crate::util::is_test_file;
 
 /// Scan a file for call-argument count mismatches and return diagnostics.
 ///
@@ -63,6 +64,13 @@ fn check_call_args(
 
     let (fn_name, qualifier) = call_node.call_fn_and_qualifier(bytes)?;
 
+    // Skip unqualified calls inside scope-function lambdas (apply/run/with/let/also).
+    // These have an implicit `this` receiver that we cannot resolve, so global lookup
+    // would match the wrong overload.
+    if qualifier.is_none() && is_inside_scope_function_lambda(call_node, bytes) {
+        return None;
+    }
+
     // Skip calls with named arguments — positional counting is invalid
     let value_arguments = call_node.find_value_arguments();
     let provided_count = count_provided_args(value_arguments.as_ref(), bytes);
@@ -81,8 +89,11 @@ fn check_call_args(
 
     let params_text = &signatures[0];
 
-    // Skip vararg functions
-    if params_text.contains("vararg ") || params_text.contains("vararg\t") {
+    // Skip vararg functions (Kotlin `vararg` or Java `...`)
+    if params_text.contains("vararg ")
+        || params_text.contains("vararg\t")
+        || params_text.contains("...")
+    {
         return None;
     }
 
@@ -119,6 +130,52 @@ fn check_call_args(
         });
     }
 
+    None
+}
+
+/// Check if the call is inside a lambda that belongs to a scope function
+/// (apply, run, with, let, also). Unqualified calls inside these lambdas
+/// have an implicit `this` receiver we cannot resolve.
+fn is_inside_scope_function_lambda(call_node: &tree_sitter::Node, bytes: &[u8]) -> bool {
+    const SCOPE_FUNCTIONS: &[&str] = &[
+        "apply",
+        "run",
+        "with",
+        "let",
+        "also",
+        "takeIf",
+        "takeUnless",
+    ];
+
+    let mut node = *call_node;
+    for _ in 0..15 {
+        let Some(parent) = node.parent() else {
+            return false;
+        };
+        if parent.kind() == KIND_LAMBDA_LIT {
+            // Walk up from the lambda to find the enclosing call_expression
+            if let Some(call_ancestor) = find_enclosing_call(&parent) {
+                if let Some((name, _)) = call_ancestor.call_fn_and_qualifier(bytes) {
+                    if SCOPE_FUNCTIONS.contains(&name.as_str()) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+        node = parent;
+    }
+    false
+}
+
+fn find_enclosing_call<'a>(node: &tree_sitter::Node<'a>) -> Option<tree_sitter::Node<'a>> {
+    let mut current = node.parent()?;
+    for _ in 0..5 {
+        if current.kind() == KIND_CALL_EXPR {
+            return Some(current);
+        }
+        current = current.parent()?;
+    }
     None
 }
 
@@ -264,6 +321,29 @@ fn resolve_param_counts(
     }
     // Unqualified: check definitions and current file
     let mut found: Option<(u8, u8)> = None;
+
+    // For unqualified calls, prefer same-file definitions to avoid false
+    // "overloaded" results from hundreds of same-name functions across the workspace.
+    if qualifier.is_none() {
+        if let Some(data) = indexer.files.get(uri.as_str()) {
+            for sym in data
+                .symbols
+                .iter()
+                .filter(|s| s.name == fn_name && is_callable_kind(s.kind))
+            {
+                if let Some(prev) = found {
+                    if prev != sym.param_counts {
+                        return None;
+                    }
+                }
+                found = Some(sym.param_counts);
+            }
+        }
+        if found.is_some() {
+            return found.map(|(r, t)| (r as usize, t as usize));
+        }
+    }
+
     if let Some(locs) = indexer.definitions.get(fn_name) {
         for loc in locs.iter() {
             if is_test_file(loc.uri.as_str()) {
@@ -336,6 +416,25 @@ fn resolve_signatures(
     // Also collect all same-name signatures across indexed files for overload detection
     let mut all_sigs: Vec<String> = Vec::new();
 
+    // For unqualified calls (no receiver), check the current file first.
+    // If the function is defined here, use only those definitions — global
+    // lookup across the whole workspace would match hundreds of unrelated
+    // same-name overrides (e.g. 945 `loadData` implementations) causing
+    // a false "overloaded — skip" result.
+    let current_sigs = collect_all_fun_params_texts(fn_name, uri.as_str(), indexer);
+    if qualifier.is_none() && !current_sigs.is_empty() {
+        // For unqualified calls, don't use receiver_sig — it comes from a global
+        // name scan that may find only one overload, masking same-file overloads.
+        // Check arity diversity first; if ambiguous, return all so caller skips.
+        let arities: Vec<(usize, usize)> = current_sigs.iter().map(|s| count_params(s)).collect();
+        let unique: std::collections::HashSet<_> = arities.into_iter().collect();
+        return if unique.len() > 1 {
+            current_sigs // caller sees len > 1 → skip
+        } else {
+            current_sigs.into_iter().take(1).collect()
+        };
+    }
+
     // Check definitions map for the function name
     if let Some(locs) = indexer.definitions.get(fn_name) {
         for loc in locs.iter() {
@@ -347,8 +446,7 @@ fn resolve_signatures(
         }
     }
 
-    // Also check current file
-    let current_sigs = collect_all_fun_params_texts(fn_name, uri.as_str(), indexer);
+    // Also include current file (may already be in definitions, but ensure coverage)
     for sig in &current_sigs {
         if !all_sigs.contains(sig) {
             all_sigs.push(sig.clone());
@@ -372,15 +470,6 @@ fn resolve_signatures(
     } else {
         Vec::new()
     }
-}
-
-/// Heuristic: a file path likely belongs to a test source set.
-fn is_test_file(uri_str: &str) -> bool {
-    // Common Android/Gradle test source sets
-    uri_str.contains("/src/test/")
-        || uri_str.contains("/src/androidTest/")
-        || uri_str.contains("/src/commonTest/")
-        || uri_str.contains("/src/iosTest/")
 }
 
 /// Parse a parameter list and return `(required_count, total_count)`.

--- a/src/features/call_arg_diagnostics_tests.rs
+++ b/src/features/call_arg_diagnostics_tests.rs
@@ -549,3 +549,223 @@ fn trailing_lambda_same_line_three_args_skipped() {
         "trailing lambda same line should be skipped: {diags:?}"
     );
 }
+
+#[test]
+fn same_file_diagnostic_retype_cycle() {
+    // Regression: type loadData() → delete → retype should still emit diagnostic.
+    // Tests that index_content + call_arg_diagnostics work correctly on re-index
+    // when content returns to a previously-seen state.
+    let idx = Indexer::new();
+    let u = uri("/a.kt");
+
+    let with_call = concat!(
+        "fun loadData(arg: String) {}\n",
+        "fun main() {\n",
+        "    loadData()\n",
+        "}\n",
+    );
+    let without_call = concat!("fun loadData(arg: String) {}\n", "fun main() {\n", "}\n",);
+
+    // Step 1: type the call → should get diagnostic
+    idx.index_content(&u, with_call);
+    let diags1 = run_diagnostics(&idx, &u, with_call);
+    assert!(!diags1.is_empty(), "step1: expected diagnostic, got none");
+
+    // Step 2: delete the call → should be clear
+    idx.index_content(&u, without_call);
+    let diags2 = run_diagnostics(&idx, &u, without_call);
+    assert!(
+        diags2.is_empty(),
+        "step2: expected no diagnostic after delete"
+    );
+
+    // Step 3: retype the call → should get diagnostic again
+    idx.index_content(&u, with_call);
+    let diags3 = run_diagnostics(&idx, &u, with_call);
+    assert!(
+        !diags3.is_empty(),
+        "step3: expected diagnostic after retype, got none"
+    );
+}
+
+#[test]
+fn same_file_diagnostic_with_live_lines_cycle() {
+    // Mirrors production: set_live_lines called before index_content.
+    // Tests that even when index_content returns None (hash-cache hit),
+    // call_arg_diagnostics still fires using diag_indexer.files.
+    let idx = Indexer::new();
+    let u = uri("/a.kt");
+
+    let with_call = concat!(
+        "fun loadData(arg: String) {}\n",
+        "fun main() {\n",
+        "    loadData()\n",
+        "}\n",
+    );
+    let without_call = concat!("fun loadData(arg: String) {}\n", "fun main() {\n", "}\n",);
+
+    // Step 1: type the call (production: set_live_lines THEN index_content)
+    idx.set_live_lines(&u, with_call);
+    idx.index_content(&u, with_call);
+    let diags1 = run_diagnostics(&idx, &u, with_call);
+    assert!(!diags1.is_empty(), "step1: expected diagnostic");
+
+    // Step 2: delete call
+    idx.set_live_lines(&u, without_call);
+    idx.index_content(&u, without_call);
+    let diags2 = run_diagnostics(&idx, &u, without_call);
+    assert!(diags2.is_empty(), "step2: expected no diagnostic");
+
+    // Step 3: simulate save from disk (re-indexes H1) — mimics handle_file_saved
+    // racing with or preceding the debounce task
+    idx.index_content(&u, with_call); // ← now content_hash = H1 again
+
+    // Step 4: retype — index_content called with H1, but content_hash already H1
+    // (from step 3), so it returns None. Diagnostics must still work via files.
+    idx.set_live_lines(&u, with_call);
+    let none_result = idx.index_content(&u, with_call); // should be None = hash-cache hit
+                                                        // We still need diagnostics to fire using stale diag_indexer.files (set in step 3)
+    let diags3 = if none_result.is_none() {
+        // Production code: use diag_indexer.files when index_content returned None
+        let doc = crate::indexer::live_tree::parse_live(with_call, tree_sitter_kotlin::language())
+            .unwrap();
+        call_arg_diagnostics(&idx, &u, &doc)
+    } else {
+        run_diagnostics(&idx, &u, with_call)
+    };
+    assert!(
+        !diags3.is_empty(),
+        "step4: expected diagnostic after retype (hash-cache hit path)"
+    );
+}
+
+/// Regression: method call with wrong args inside a coroutine lambda (withContext)
+/// should still produce a diagnostic. The function is defined in the same class.
+#[test]
+fn method_call_wrong_args_inside_coroutine_lambda() {
+    let (uri, idx, src) = setup(&[(
+        "/Interactor.kt",
+        concat!(
+            "class Interactor {\n",
+            "  suspend fun loadData(args: String): String {\n",
+            "    return withContext(Dispatchers.IO) {\n",
+            "      loadData()\n",
+            "    }\n",
+            "  }\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_diagnostics(&idx, &uri, &src);
+    assert!(
+        !diags.is_empty(),
+        "expected diagnostic for loadData() inside withContext lambda: {diags:?}"
+    );
+}
+
+/// Regression: override with base class also indexed — both define loadData with 1 arg.
+/// The override in the derived class should still produce a diagnostic for loadData().
+#[test]
+fn method_call_wrong_args_with_base_class_indexed() {
+    let idx = Indexer::new();
+    let base_uri = uri("/LoadingInteractor.kt");
+    let base_src = concat!(
+        "abstract class LoadingInteractor<Args : Any, Result : Any> {\n",
+        "  abstract suspend fun loadData(args: Args): Result\n",
+        "}\n",
+    );
+    idx.index_content(&base_uri, base_src);
+    idx.store_live_tree(&base_uri, base_src);
+
+    let impl_src = concat!(
+        "class ShowChildNewTipsInteractor : LoadingInteractor<String, String>() {\n",
+        "  override suspend fun loadData(args: String): String {\n",
+        "    return withContext(ioDispatcher) {\n",
+        "      loadData()\n", // ← 0 args — should fire diagnostic
+        "      \"\"\n",
+        "    }\n",
+        "  }\n",
+        "}\n",
+    );
+    let impl_uri = uri("/ShowChildNewTipsInteractor.kt");
+    idx.index_content(&impl_uri, impl_src);
+    idx.store_live_tree(&impl_uri, impl_src);
+
+    let doc = parse_live(impl_src, tree_sitter_kotlin::language()).unwrap();
+    let diags = call_arg_diagnostics(&idx, &impl_uri, &doc);
+    assert!(
+        !diags.is_empty(),
+        "expected diagnostic for loadData() with base class indexed: {diags:?}"
+    );
+}
+
+/// Regression: workspace has many same-name functions with different arities.
+/// Unqualified call should be resolved against the CURRENT FILE only,
+/// not skipped because of 945+ same-name functions in the workspace.
+#[test]
+fn method_call_same_file_wins_over_workspace_overloads() {
+    let idx = Indexer::new();
+
+    // Simulate 3 other files with different arities for "loadData"
+    for i in 0..3 {
+        let other_uri = uri(&format!("/Other{i}.kt"));
+        // Each has loadData with a different number of args
+        let other_src = format!(
+            "class Other{i} {{\n  fun loadData({}) {{}}\n}}\n",
+            std::iter::repeat("x: Int")
+                .take(i + 2)
+                .collect::<Vec<_>>()
+                .join(", ")
+        );
+        idx.index_content(&other_uri, &other_src);
+    }
+
+    // Current file has loadData with 1 required arg — call with 0 should diagnose
+    let src = concat!(
+        "class MyClass {\n",
+        "  fun loadData(arg: String) {}\n",
+        "  fun test() {\n",
+        "    loadData()\n",
+        "  }\n",
+        "}\n",
+    );
+    let u = uri("/MyClass.kt");
+    idx.index_content(&u, src);
+    let doc = parse_live(src, tree_sitter_kotlin::language()).unwrap();
+    let diags = call_arg_diagnostics(&idx, &u, &doc);
+    assert!(
+        !diags.is_empty(),
+        "expected diagnostic even with many workspace overloads: {diags:?}"
+    );
+}
+
+/// Regression: same as above but with multiple chained lambdas inside withContext,
+/// mirroring the actual production file shape that was showing 0 diagnostics.
+#[test]
+fn method_call_wrong_args_inside_complex_coroutine_lambda() {
+    let (uri, idx, src) = setup(&[(
+        "/Interactor.kt",
+        concat!(
+            "class ShowChildNewTipsInteractor {\n",
+            "  sealed interface TipsResult {\n",
+            "    data object No : TipsResult\n",
+            "  }\n",
+            "  override suspend fun loadData(args: String): TipsResult {\n",
+            "    return withContext(ioDispatcher) {\n",
+            "      loadData()\n", // ← the call under test
+            "      val x = settings?.let {\n",
+            "        if (it == 0L) System.currentTimeMillis().also {\n",
+            "          settings = it\n",
+            "        } else it\n",
+            "      }?.let { it > 0L } ?: false\n",
+            "      TipsResult.No\n",
+            "    }\n",
+            "  }\n",
+            "}\n",
+        ),
+    )]);
+    let diags = run_diagnostics(&idx, &uri, &src);
+    assert!(
+        !diags.is_empty(),
+        "expected diagnostic for loadData() in complex coroutine context: {diags:?}"
+    );
+}

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -511,32 +511,34 @@ fn collect_sealed_members(indexer: &Indexer, sealed_name: &str) -> Vec<WhenMembe
             .symbols
             .iter()
             .find(|s| s.name == sealed_name && s.selection_range == loc.range)?;
-        Some((loc.uri.clone(), parent_sym.range))
+        Some((loc.uri.clone(), parent_sym.range, file_data.package.clone()))
     });
 
-    // Sealed subtypes must be in the same file or same package as the sealed class.
-    // Filter to same file to avoid false positives from identically-named sealed
-    // classes in different packages.
-    let parent_uri = parent_info.as_ref().map(|(uri, _)| uri.as_str());
+    // Sealed subtypes must be in the same package as the sealed class.
+    // Keep same-file nested classes too, but reject identically-named sealed
+    // classes from other packages.
+    let parent_uri = parent_info.as_ref().map(|(uri, _, _)| uri.as_str());
+    let parent_package = parent_info
+        .as_ref()
+        .and_then(|(_, _, package_name)| package_name.as_deref());
 
     let subtype_locations = indexer.subtypes_of(sealed_name);
     let mut members = Vec::new();
 
     for location in &subtype_locations {
-        // Only consider subtypes in the same file as the sealed parent
-        if let Some(p_uri) = parent_uri {
-            if location.uri.as_str() != p_uri {
-                continue;
-            }
-        }
         let Some(file_data) = indexer.file_data_for(location.uri.as_str()) else {
             continue;
         };
+        let same_parent_file = parent_uri.is_some_and(|p_uri| location.uri.as_str() == p_uri);
+        let same_package = parent_package == file_data.package.as_deref();
+        if !same_parent_file && !same_package {
+            continue;
+        }
         if let Some(symbol) = find_symbol_at(&file_data, location) {
             let is_object = symbol.kind == SymbolKind::OBJECT;
             let is_nested = parent_info
                 .as_ref()
-                .is_some_and(|(parent_uri, parent_range)| {
+                .is_some_and(|(parent_uri, parent_range, _)| {
                     location.uri == *parent_uri
                         && symbol.range.start.line > parent_range.start.line
                         && symbol.range.end.line <= parent_range.end.line

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -436,8 +436,12 @@ fn resolve_type_members(indexer: &Indexer, type_name: &str) -> Option<(TypeKind,
     }
 
     for location in &locations {
-        let file_data = indexer.file_data_for(location.uri.as_str())?;
-        let symbol = find_symbol_at(&file_data, location)?;
+        let Some(file_data) = indexer.file_data_for(location.uri.as_str()) else {
+            continue;
+        };
+        let Some(symbol) = find_symbol_at(&file_data, location) else {
+            continue;
+        };
 
         if symbol.kind == SymbolKind::ENUM {
             let members = collect_enum_members(&file_data, &symbol);
@@ -510,10 +514,21 @@ fn collect_sealed_members(indexer: &Indexer, sealed_name: &str) -> Vec<WhenMembe
         Some((loc.uri.clone(), parent_sym.range))
     });
 
+    // Sealed subtypes must be in the same file or same package as the sealed class.
+    // Filter to same file to avoid false positives from identically-named sealed
+    // classes in different packages.
+    let parent_uri = parent_info.as_ref().map(|(uri, _)| uri.as_str());
+
     let subtype_locations = indexer.subtypes_of(sealed_name);
     let mut members = Vec::new();
 
     for location in &subtype_locations {
+        // Only consider subtypes in the same file as the sealed parent
+        if let Some(p_uri) = parent_uri {
+            if location.uri.as_str() != p_uri {
+                continue;
+            }
+        }
         let Some(file_data) = indexer.file_data_for(location.uri.as_str()) else {
             continue;
         };

--- a/src/features/fill_when_tests.rs
+++ b/src/features/fill_when_tests.rs
@@ -165,6 +165,44 @@ fun handle(e: Effect) {
     );
 }
 
+#[test]
+fn sealed_same_package_subclasses_in_other_files_offered() {
+    let idx = setup(&[
+        ("/pkg/Effect.kt", "package com.example\nsealed class Effect"),
+        (
+            "/pkg/EffectMembers.kt",
+            "package com.example\nobject Loading : Effect()\ndata class ShowToast(val message: String) : Effect()",
+        ),
+        (
+            "/pkg/main.kt",
+            "package com.example\nfun handle(e: Effect) {\n    when (e) {\n        Loading -> println(\"loading\")\n    }\n}",
+        ),
+    ]);
+    let u = uri("/pkg/main.kt");
+    let action = build_fill_when_action(&idx, &u, cursor_at(2, 6));
+    assert!(
+        action.is_some(),
+        "expected fill-when action for same-package sealed subclasses"
+    );
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            let text = &edits[0].new_text;
+            assert!(
+                text.contains("is ShowToast -> TODO()"),
+                "missing ShowToast: {text}"
+            );
+            assert!(
+                text.contains("Loading -> TODO()"),
+                "missing Loading: {text}"
+            );
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
 // ─── Edge cases ──────────────────────────────────────────────────────────────
 
 #[test]

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -500,12 +500,9 @@ impl Indexer {
             .unwrap_or_else(|e| e.into_inner())
             .clone();
         let effective_root = crate::rg::effective_rg_root(workspace_root.as_deref(), open_file);
-        let scoped_paths = if effective_root == workspace_root {
-            source_roots
-        } else {
-            Vec::new()
-        };
-        (effective_root, scoped_paths, matcher)
+        // Always pass source_roots through — RgSearch::scoped will use them when
+        // non-empty, and fall back to effective_root when empty.
+        (effective_root, source_roots, matcher)
     }
 
     pub(crate) fn remove_live_lines(&self, uri: &Url) {

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -21,7 +21,7 @@ use crate::types::{FileData, FileIndexResult, Visibility};
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Bump when the serialized format changes; invalidates any older cache files.
-pub(crate) const CACHE_VERSION: u32 = 15;
+pub(crate) const CACHE_VERSION: u32 = 16;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -21,7 +21,7 @@ use crate::types::{FileData, FileIndexResult, Visibility};
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Bump when the serialized format changes; invalidates any older cache files.
-pub(crate) const CACHE_VERSION: u32 = 14;
+pub(crate) const CACHE_VERSION: u32 = 15;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -1161,7 +1161,7 @@ fn lambda_receiver_type_named_arg_ml(
             // Try ALL symbols named `fn_name` in the outer-class file — the file
             // may have multiple same-named nested classes (e.g. two `SheetReloadActions`
             // in different reducers).  Pick the first one whose params contain `named_arg`.
-            let sigs = collect_all_fun_params_texts(fn_name, &file_uri, idx);
+            let sigs = collect_all_fun_params_texts(fn_name, &file_uri, idx, false);
             let found = sigs
                 .into_iter()
                 .find_map(|s| find_named_param_type_in_sig(&s, named_arg).map(|ty| (s, ty)));

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -262,6 +262,10 @@ pub(crate) fn collect_params_from_line(lines: &[String], start_line: usize) -> O
         let chars = line.char_indices().peekable();
         for (_, ch) in chars {
             match ch {
+                // If we hit '{' before finding any '(', the class has no constructor params
+                '{' if !found_open && found_keyword => {
+                    return Some(String::new());
+                }
                 '(' => {
                     paren_depth += 1;
                     if paren_depth == 1 {

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -149,30 +149,43 @@ pub(crate) fn collect_fun_params_text(
     uri_str: &str,
     idx: &Indexer,
 ) -> Option<String> {
-    collect_all_fun_params_texts(fn_name, uri_str, idx)
+    collect_all_fun_params_texts(fn_name, uri_str, idx, false)
         .into_iter()
         .next()
 }
 
 /// Like `collect_fun_params_text` but returns ALL params texts for every symbol
 /// named `fn_name` in the file (a file may have multiple same-named nested classes).
+///
+/// For Java files, CLASS symbols are excluded because Java class nodes never carry
+/// constructor params — use the indexed CONSTRUCTOR symbols instead.
+///
+/// When `skip_nested` is `true`, symbols with a non-`None` `container` are excluded.
+/// Use this for cross-file lookups: an unqualified `Foo()` call in another file
+/// cannot refer to a nested class `Outer.Foo` — those require a qualifier.
 pub(crate) fn collect_all_fun_params_texts(
     fn_name: &str,
     uri_str: &str,
     idx: &Indexer,
+    skip_nested: bool,
 ) -> Vec<String> {
     let data = match idx.files.get(uri_str) {
         Some(d) => d,
         None => return vec![],
     };
+    let is_java = uri_str.ends_with(".java");
     data.symbols
         .iter()
         .filter(|s| {
             s.name == fn_name
+                && !(skip_nested
+                    && s.container.is_some()
+                    && matches!(s.kind, SymbolKind::CLASS | SymbolKind::STRUCT))
                 && (s.kind == SymbolKind::FUNCTION
                     || s.kind == SymbolKind::METHOD
-                    || s.kind == SymbolKind::CLASS
-                    || s.kind == SymbolKind::STRUCT)
+                    || s.kind == SymbolKind::CONSTRUCTOR
+                    || s.kind == SymbolKind::STRUCT
+                    || (s.kind == SymbolKind::CLASS && !is_java))
         })
         .filter_map(|s| {
             // Prefer pre-computed params from CST (populated at index time)
@@ -191,11 +204,23 @@ pub(crate) fn collect_all_fun_params_texts(
 /// Given `"fun foo(x: Int, y: String): Boolean"`, returns `"x: Int, y: String"`.
 /// Given `"fun bar()"`, returns `None` (empty params = no required args).
 /// Returns `None` if the detail is truncated (no matching `)` found).
+///
+/// Skips any leading annotation arguments (e.g., `@Deprecated("x") class Foo(params)`)
+/// by starting the search for `(` only AFTER a declaration keyword is found.
 pub(crate) fn extract_params_from_detail(detail: &str) -> Option<String> {
     if detail.is_empty() {
         return None;
     }
-    let open_pos = detail.find('(')?;
+    // Skip annotation preamble by finding the first declaration keyword and
+    // searching for `(` only after it.  This prevents `@Deprecated("x")` from
+    // being mistaken for the constructor parameter list.
+    const KEYWORDS: &[&str] = &["fun ", "fun<", "class ", "constructor"];
+    let search_from = KEYWORDS
+        .iter()
+        .filter_map(|kw| detail.find(kw).map(|p| p + kw.len()))
+        .min()
+        .unwrap_or(0);
+    let open_pos = detail[search_from..].find('(').map(|p| search_from + p)?;
     let mut depth: i32 = 0;
     let mut end_pos = None;
     for (i, ch) in detail[open_pos..].char_indices() {
@@ -303,9 +328,11 @@ pub(crate) fn collect_params_from_line(lines: &[String], start_line: usize) -> O
 
 // ─── Parameter type accessors ─────────────────────────────────────────────────
 
-/// Split `text` at top-level commas (depth 0), skipping commas inside `()`, `<>`, `[]`.
+/// Split `text` at top-level commas (depth 0), skipping commas inside `()`, `<>`, `[]`, `{}`.
 /// The `->` Kotlin function-type arrow is handled: `>` preceded by `-` is NOT a closing
 /// generic delimiter.
+/// `{}` are tracked so that lambda defaults like `= { a, b -> a }` are not split at
+/// the comma inside the lambda body.
 ///
 /// Returns the raw slices between commas; does NOT trim or filter empty parts.
 pub(crate) fn split_params_at_depth_zero(text: &str) -> Vec<&str> {
@@ -315,8 +342,8 @@ pub(crate) fn split_params_at_depth_zero(text: &str) -> Vec<&str> {
     let mut prev = '\0';
     for (i, ch) in text.char_indices() {
         match ch {
-            '(' | '<' | '[' => depth += 1,
-            ')' | ']' => depth -= 1,
+            '(' | '<' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
             '>' if prev != '-' && depth > 0 => depth -= 1,
             ',' if depth == 0 => {
                 parts.push(&text[start..i]);

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -517,6 +517,8 @@ async fn run_parse_phase<R: ProgressReporter + 'static>(
     .await;
 
     progress_handle.abort();
+    // Send final 100% so editors never get stuck at <100% before the End.
+    reporter.report(token, parse_count, parse_count).await;
     counters.log_summary(results.len());
     (results, aborted)
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -984,19 +984,41 @@ fn extract_params_and_counts(root: Node, bytes: &[u8], range: &Range) -> (String
     (String::new(), (0, 0))
 }
 
-/// Extract text between `(` and `)` of a params container node.
+/// Extract text between the first `(` and its matching `)` inside a params container node.
+///
+/// Handles annotated nodes like `@JvmOverloads constructor(...)` where the node does
+/// not start directly with `(`. Uses depth-tracked matching to find the correct `)`.
 fn extract_inner_text(node: &Node, bytes: &[u8]) -> String {
-    let start = node.start_byte();
-    let end = node.end_byte();
-    if end > start + 2 {
-        if let Ok(s) = std::str::from_utf8(&bytes[start + 1..end - 1]) {
-            return s
-                .lines()
-                .map(|l| l.trim())
-                .filter(|l| !l.is_empty())
-                .collect::<Vec<_>>()
-                .join(" ");
+    let node_bytes = &bytes[node.start_byte()..node.end_byte()];
+    let Some(open) = node_bytes.iter().position(|&b| b == b'(') else {
+        return String::new();
+    };
+    // Find the matching ')' using depth tracking.
+    let mut depth: i32 = 0;
+    let mut close = None;
+    for (i, &b) in node_bytes[open..].iter().enumerate() {
+        match b {
+            b'(' => depth += 1,
+            b')' => {
+                depth -= 1;
+                if depth == 0 {
+                    close = Some(open + i);
+                    break;
+                }
+            }
+            _ => {}
         }
+    }
+    let Some(close) = close else {
+        return String::new();
+    };
+    if let Ok(s) = std::str::from_utf8(&node_bytes[open + 1..close]) {
+        return s
+            .lines()
+            .map(|l| l.trim())
+            .filter(|l| !l.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
     }
     String::new()
 }
@@ -1874,6 +1896,12 @@ impl crate::types::FileData {
             let type_params = node.extract_type_params(bytes);
             // Java extension methods (static methods in a class annotated with @JvmName etc.)
             // are not real Kotlin extensions; leave extension_receiver empty for Java.
+            let (params, param_counts) =
+                if matches!(kind, SymbolKind::METHOD | SymbolKind::CONSTRUCTOR) {
+                    java_params_and_counts(node, bytes)
+                } else {
+                    (String::new(), (0, 0))
+                };
             self.symbols.push(SymbolEntry {
                 name,
                 kind,
@@ -1884,8 +1912,8 @@ impl crate::types::FileData {
                 type_params,
                 extension_receiver: String::new(),
                 container: None,
-                params: String::new(),
-                param_counts: (0, 0),
+                params,
+                param_counts,
             });
         }
     }
@@ -1941,7 +1969,21 @@ impl crate::types::FileData {
     }
 }
 
-// ─── tests ───────────────────────────────────────────────────────────────────
+// ─── Java extraction helpers ──────────────────────────────────────────────────
+
+/// Extract `(params_text, (required, total))` from the `formal_parameters` child
+/// of a Java method or constructor declaration node.
+fn java_params_and_counts(node: &Node, bytes: &[u8]) -> (String, (u8, u8)) {
+    for i in 0..node.child_count() {
+        let Some(child) = node.child(i) else { continue };
+        if child.kind() == KIND_FORMAL_PARAMS {
+            let text = extract_inner_text(&child, bytes);
+            let counts = count_params_from_node(&child);
+            return (text, counts);
+        }
+    }
+    (String::new(), (0, 0))
+}
 
 #[cfg(test)]
 #[path = "parser_tests.rs"]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -16,10 +16,10 @@ use crate::queries::{
     KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_METHOD_DECL, KIND_MODIFIERS, KIND_MOD_FINAL,
     KIND_MOD_STATIC, KIND_NAV_EXPR, KIND_NULLABLE_TYPE, KIND_OBJECT_DECL, KIND_PACKAGE_DECL,
     KIND_PACKAGE_HEADER, KIND_PARAMETER, KIND_PRIMARY_CTOR, KIND_PROP_DECL, KIND_PROP_DELEGATE,
-    KIND_PROTOCOL_DECL, KIND_RECORD_DECL, KIND_SCOPED_IDENT, KIND_SIMPLE_IDENT, KIND_SOURCE_FILE,
-    KIND_STATEMENTS, KIND_SUPERCLASS, KIND_SUPER_INTERFACES, KIND_TYPE_IDENT, KIND_USER_TYPE,
-    KIND_VALUE_ARG, KIND_VALUE_ARGS, KIND_VAR_DECL, KIND_VAR_DECLARATOR, KIND_WILDCARD_IMPORT,
-    KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
+    KIND_PROTOCOL_DECL, KIND_RECORD_DECL, KIND_SCOPED_IDENT, KIND_SECONDARY_CTOR,
+    KIND_SIMPLE_IDENT, KIND_SOURCE_FILE, KIND_STATEMENTS, KIND_SUPERCLASS, KIND_SUPER_INTERFACES,
+    KIND_TYPE_IDENT, KIND_USER_TYPE, KIND_VALUE_ARG, KIND_VALUE_ARGS, KIND_VAR_DECL,
+    KIND_VAR_DECLARATOR, KIND_WILDCARD_IMPORT, KOTLIN_DEFINITIONS, SWIFT_DEFINITIONS,
 };
 use crate::StrExt;
 
@@ -173,6 +173,9 @@ pub(crate) fn parse_kotlin(content: &str) -> FileData {
 
         // ── fun interface (tree-sitter parses these as ERROR + lambda_literal) ─
         data.extract_fun_interfaces(root, bytes);
+
+        // ── secondary constructors (no @name in tree-sitter patterns) ────────
+        data.extract_secondary_constructors(root, bytes);
 
         // ── supertype relationships (delegation specifiers) ────────────────────
         data.extract_supers_kotlin(root, bytes);
@@ -754,9 +757,61 @@ fn extract_fun_interfaces(root: Node, bytes: &[u8], data: &mut FileData) {
     }
 }
 
-/// Returns true if `node` or any of its (error-containing) descendants is a
-/// `fun interface` misparse — either the ERROR shape or the function_declaration shape.
-/// Prunes clean subtrees (`!has_error()`) for efficiency.
+/// Walk the Kotlin AST and emit CONSTRUCTOR symbols for all `secondary_constructor`
+/// nodes, using the enclosing `class_declaration` name as the symbol name.
+///
+/// Kotlin secondary constructors are not captured by the tree-sitter query patterns
+/// (they have no `name` node — the class name is the constructor name). This function
+/// fills that gap so that call-arg diagnostics can detect multi-constructor classes
+/// and avoid false positives.
+fn extract_secondary_constructors(root: Node, bytes: &[u8], data: &mut FileData) {
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if node.kind() == KIND_SECONDARY_CTOR {
+            // Structure: class_declaration → class_body → secondary_constructor
+            let class_name = node
+                .parent()
+                .and_then(|body| body.parent())
+                .filter(|n| n.kind() == KIND_CLASS_DECL)
+                .and_then(|class| class.extract_type_name(bytes));
+            if let Some(name) = class_name {
+                let params_node = node.first_child_of_kind(KIND_FUN_VALUE_PARAMS);
+                let (params, param_counts) = params_node
+                    .map_or((String::new(), (0u8, 0u8)), |pn| {
+                        (extract_inner_text(&pn, bytes), count_params_from_node(&pn))
+                    });
+                let range = ts_to_lsp(node.range());
+                let sel = Range::new(
+                    range.start,
+                    Position::new(
+                        range.start.line,
+                        range.start.character + "constructor".len() as u32,
+                    ),
+                );
+                let detail = extract_detail(&data.lines, range.start.line, range.end.line);
+                let visibility = visibility_at_line(&data.lines, range.start.line as usize);
+                data.symbols.push(SymbolEntry {
+                    name,
+                    kind: SymbolKind::CONSTRUCTOR,
+                    visibility,
+                    range,
+                    selection_range: sel,
+                    detail,
+                    type_params: Vec::new(),
+                    extension_receiver: String::new(),
+                    container: None,
+                    params,
+                    param_counts,
+                });
+            }
+        }
+        let mut cur = node.walk();
+        for child in node.children(&mut cur) {
+            stack.push(child);
+        }
+    }
+}
+
 fn has_fun_interface_descendant(root: &Node, bytes: &[u8]) -> bool {
     let mut stack = vec![*root];
     while let Some(node) = stack.pop() {
@@ -1697,6 +1752,9 @@ impl crate::types::FileData {
     }
     fn extract_fun_interfaces(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
         extract_fun_interfaces(root, bytes, self)
+    }
+    fn extract_secondary_constructors(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
+        extract_secondary_constructors(root, bytes, self)
     }
     fn extract_swift_imports(&mut self, root: tree_sitter::Node, bytes: &[u8]) {
         extract_swift_imports(root, bytes, self)

--- a/src/queries.rs
+++ b/src/queries.rs
@@ -374,6 +374,7 @@ pub(crate) const KIND_EXPLICIT_DELEGATION: &str = "explicit_delegation";
 pub(crate) const KIND_RECORD_DECL: &str = "record_declaration";
 pub(crate) const KIND_METHOD_DECL: &str = "method_declaration";
 pub(crate) const KIND_CTOR_DECL: &str = "constructor_declaration";
+pub(crate) const KIND_SECONDARY_CTOR: &str = "secondary_constructor";
 pub(crate) const KIND_FIELD_DECL: &str = "field_declaration";
 pub(crate) const KIND_IMPORT_DECL: &str = "import_declaration";
 pub(crate) const KIND_PACKAGE_DECL: &str = "package_declaration";

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -934,12 +934,13 @@ impl<'a> BareCompletionWalk<'a> {
         let Some(package_uris) = self.indexer.packages.get(&package_name) else {
             return;
         };
+        let from_test_file = crate::util::is_test_file(self.from_uri.as_str());
 
         for package_uri in package_uris.iter() {
             if package_uri == self.from_uri.as_str() {
                 continue;
             }
-            if crate::util::is_test_file(package_uri.as_str()) {
+            if !from_test_file && crate::util::is_test_file(package_uri.as_str()) {
                 continue;
             }
             let Some(file) = self.indexer.files.get(package_uri.as_str()) else {

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -939,6 +939,9 @@ impl<'a> BareCompletionWalk<'a> {
             if package_uri == self.from_uri.as_str() {
                 continue;
             }
+            if crate::util::is_test_file(package_uri.as_str()) {
+                continue;
+            }
             let Some(file) = self.indexer.files.get(package_uri.as_str()) else {
                 continue;
             };

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -1340,6 +1340,21 @@ fn auto_import_skipped_same_package() {
 }
 
 #[test]
+fn same_package_test_helpers_appear_when_completing_from_test_file() {
+    let idx = Indexer::new();
+    let helper_uri = uri("/src/test/kotlin/com/example/TestHelpers.kt");
+    idx.index_content(&helper_uri, "package com.example\nfun helperThing() = Unit");
+    let cur_uri = uri("/src/test/kotlin/com/example/CurrentTest.kt");
+    idx.index_content(&cur_uri, "package com.example\nclass CurrentTest");
+
+    let (items, _) = complete_symbol(&idx, "hel", None, &cur_uri, false, None);
+    assert!(
+        items.iter().any(|item| item.label == "helperThing"),
+        "expected same-package helper from sibling test file in completions"
+    );
+}
+
+#[test]
 fn auto_import_two_packages_two_items() {
     let idx = Indexer::new();
     idx.index_content(

--- a/src/rg_tests.rs
+++ b/src/rg_tests.rs
@@ -491,6 +491,50 @@ fn rg_find_definition_scoped_to_source_paths() {
     );
 }
 
+/// `rg_find_definition` with multiple source_paths searches ALL of them.
+/// Regression test for GitHub issue #78: rg only searched one source root.
+#[test]
+fn rg_find_definition_searches_all_source_paths() {
+    let dir = tempfile::TempDir::new().expect("create tempdir");
+    let root = dir.path();
+
+    // Two separate source roots
+    std::fs::create_dir_all(root.join("frameworks/base/src")).unwrap();
+    std::fs::write(
+        root.join("frameworks/base/src/PolicyHandle.kt"),
+        "class PolicyHandle\n",
+    )
+    .unwrap();
+
+    std::fs::create_dir_all(root.join("cts/src")).unwrap();
+    std::fs::write(
+        root.join("cts/src/PolicyIdentifier.kt"),
+        "class PolicyIdentifier\n",
+    )
+    .unwrap();
+
+    let source_paths = vec![
+        root.join("frameworks/base/src")
+            .to_string_lossy()
+            .into_owned(),
+        root.join("cts/src").to_string_lossy().into_owned(),
+    ];
+
+    // Search for a symbol in source root #1
+    let locs = rg_find_definition("PolicyHandle", Some(root), &source_paths, None);
+    assert!(
+        !locs.is_empty(),
+        "must find PolicyHandle in frameworks/base"
+    );
+
+    // Search for a symbol in source root #2
+    let locs = rg_find_definition("PolicyIdentifier", Some(root), &source_paths, None);
+    assert!(
+        !locs.is_empty(),
+        "must find PolicyIdentifier in cts (second source root)"
+    );
+}
+
 /// `rg_find_definition` with empty `source_paths` falls back to searching the
 /// entire workspace root (backward-compatible behavior).
 #[test]

--- a/src/util.rs
+++ b/src/util.rs
@@ -8,3 +8,11 @@ use std::path::PathBuf;
 pub(crate) fn home_dir() -> Option<PathBuf> {
     std::env::home_dir()
 }
+
+/// Heuristic: a file path likely belongs to a test source set.
+pub(crate) fn is_test_file(uri_str: &str) -> bool {
+    uri_str.contains("/src/test/")
+        || uri_str.contains("/src/androidTest/")
+        || uri_str.contains("/src/commonTest/")
+        || uri_str.contains("/src/iosTest/")
+}

--- a/src/workspace/file_change_handler.rs
+++ b/src/workspace/file_change_handler.rs
@@ -121,13 +121,13 @@ impl FileChangeHandler {
             // If a newer edit arrived while we were working, skip publishing
             // — a newer debounce task will handle it.
             let current_gen = generation.load(Ordering::Acquire);
-            log::warn!(
+            log::debug!(
                 "diag[gen={}]: generation check — current={current_gen} path={}",
                 my_generation,
                 diagnostics_uri.path(),
             );
             if current_gen != my_generation {
-                log::warn!(
+                log::debug!(
                     "diag[gen={}]: generation mismatch (current={current_gen}) — skipping publish",
                     my_generation
                 );
@@ -140,7 +140,7 @@ impl FileChangeHandler {
                 .and_then(|lang| parse_live(&diagnostics_text, lang));
 
             let index_hit_cache = matches!(result, Ok(None));
-            log::warn!(
+            log::debug!(
                 "diag[gen={}]: index_content returned {} for {}",
                 my_generation,
                 if index_hit_cache {
@@ -162,14 +162,14 @@ impl FileChangeHandler {
             diagnostics.extend(when_diagnostics(&diag_indexer, &diagnostics_uri));
             if let Some(ref doc) = live_doc {
                 let arg_diags = call_arg_diagnostics(&diag_indexer, &diagnostics_uri, doc);
-                log::warn!(
+                log::debug!(
                     "diag[gen={}]: call_arg_diagnostics returned {} items",
                     my_generation,
                     arg_diags.len(),
                 );
                 diagnostics.extend(arg_diags);
             } else {
-                log::warn!(
+                log::debug!(
                     "diag[gen={}]: live_doc is None — no call-arg diagnostics",
                     my_generation,
                 );

--- a/src/workspace/file_change_handler.rs
+++ b/src/workspace/file_change_handler.rs
@@ -120,7 +120,17 @@ impl FileChangeHandler {
 
             // If a newer edit arrived while we were working, skip publishing
             // — a newer debounce task will handle it.
-            if generation.load(Ordering::Acquire) != my_generation {
+            let current_gen = generation.load(Ordering::Acquire);
+            log::warn!(
+                "diag[gen={}]: generation check — current={current_gen} path={}",
+                my_generation,
+                diagnostics_uri.path(),
+            );
+            if current_gen != my_generation {
+                log::warn!(
+                    "diag[gen={}]: generation mismatch (current={current_gen}) — skipping publish",
+                    my_generation
+                );
                 return;
             }
 
@@ -129,6 +139,17 @@ impl FileChangeHandler {
             let live_doc = lang_for_path(diagnostics_uri.path())
                 .and_then(|lang| parse_live(&diagnostics_text, lang));
 
+            let index_hit_cache = matches!(result, Ok(None));
+            log::warn!(
+                "diag[gen={}]: index_content returned {} for {}",
+                my_generation,
+                if index_hit_cache {
+                    "None (hash-cache hit)"
+                } else {
+                    "Some (reindexed)"
+                },
+                diagnostics_uri.path(),
+            );
             let mut diagnostics = match result {
                 Ok(Some(data)) => syntax_diagnostics(&data.syntax_errors),
                 Ok(None) => diag_indexer
@@ -140,7 +161,18 @@ impl FileChangeHandler {
             };
             diagnostics.extend(when_diagnostics(&diag_indexer, &diagnostics_uri));
             if let Some(ref doc) = live_doc {
-                diagnostics.extend(call_arg_diagnostics(&diag_indexer, &diagnostics_uri, doc));
+                let arg_diags = call_arg_diagnostics(&diag_indexer, &diagnostics_uri, doc);
+                log::warn!(
+                    "diag[gen={}]: call_arg_diagnostics returned {} items",
+                    my_generation,
+                    arg_diags.len(),
+                );
+                diagnostics.extend(arg_diags);
+            } else {
+                log::warn!(
+                    "diag[gen={}]: live_doc is None — no call-arg diagnostics",
+                    my_generation,
+                );
             }
 
             // Final generation check before publishing — prevents stale

--- a/src/workspace/file_change_handler_tests.rs
+++ b/src/workspace/file_change_handler_tests.rs
@@ -2,9 +2,19 @@ use std::sync::Arc;
 
 use tower_lsp::lsp_types::{TextDocumentContentChangeEvent, Url};
 
+use crate::features::call_arg_diagnostics::call_arg_diagnostics;
+use crate::indexer::live_tree::parse_live;
 use crate::indexer::Indexer;
 
 use super::FileChangeHandler;
+
+fn change(text: &str) -> Vec<TextDocumentContentChangeEvent> {
+    vec![TextDocumentContentChangeEvent {
+        range: None,
+        range_length: None,
+        text: text.to_string(),
+    }]
+}
 
 #[tokio::test]
 async fn handle_file_changed_stores_live_lines() {
@@ -13,18 +23,92 @@ async fn handle_file_changed_stores_live_lines() {
     let uri = Url::parse("file:///workspace/Main.kt").unwrap();
 
     handler
-        .handle_file_changed(
-            uri.clone(),
-            vec![TextDocumentContentChangeEvent {
-                range: None,
-                range_length: None,
-                text: "fun main() = Unit".to_string(),
-            }],
-        )
+        .handle_file_changed(uri.clone(), change("fun main() = Unit"))
         .await;
 
     let live_lines = indexer.live_lines.get(uri.as_str()).unwrap();
     assert_eq!(live_lines.as_ref(), &vec!["fun main() = Unit".to_string()]);
 
     handler.cancel_pending_reindex(&uri);
+}
+
+/// Regression: type loadData() → delete → retype should leave the indexer in a
+/// state where call_arg_diagnostics fires on the final content.
+///
+/// This tests the FULL ASYNC PIPELINE (FileChangeHandler debounce + index_content)
+/// rather than the unit-level logic already covered in call_arg_diagnostics_tests.rs.
+/// It catches bugs where the debounce task or generation counter leaves indexer.files
+/// in a stale state after the retype cycle.
+#[tokio::test]
+async fn retype_cycle_indexer_state_supports_diagnostics() {
+    // Use a temp workspace dir so workspace.json scan doesn't pick up host sources.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::write(tmp.path().join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();
+    let file_path = tmp.path().join("Foo.kt");
+
+    let indexer = Arc::new(Indexer::new());
+    // Set workspace root so the file is treated as a workspace file.
+    indexer.workspace_root.set(tmp.path().to_path_buf());
+
+    let mut handler = FileChangeHandler::new(Arc::clone(&indexer), None);
+    let uri = Url::parse(&format!("file://{}", file_path.display())).unwrap();
+
+    let with_call = concat!(
+        "fun loadData(arg: String) {}\n",
+        "fun main() {\n",
+        "    loadData()\n",
+        "}\n",
+    );
+    let without_call = concat!("fun loadData(arg: String) {}\n", "fun main() {\n", "}\n",);
+
+    // Step 1: type the call.
+    handler
+        .handle_file_changed(uri.clone(), change(with_call))
+        .await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
+
+    // Indexer should have the file with `loadData` defined.
+    assert!(
+        indexer.files.contains_key(uri.as_str()),
+        "step1: indexer.files should have uri after debounce"
+    );
+    let diags1 = {
+        let doc = parse_live(with_call, tree_sitter_kotlin::language()).unwrap();
+        call_arg_diagnostics(&indexer, &uri, &doc)
+    };
+    assert!(
+        !diags1.is_empty(),
+        "step1: expected diagnostic from indexer state"
+    );
+
+    // Step 2: delete the call.
+    handler
+        .handle_file_changed(uri.clone(), change(without_call))
+        .await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
+
+    let diags2 = {
+        let doc = parse_live(without_call, tree_sitter_kotlin::language()).unwrap();
+        call_arg_diagnostics(&indexer, &uri, &doc)
+    };
+    assert!(
+        diags2.is_empty(),
+        "step2: expected no diagnostic after delete"
+    );
+
+    // Step 3: retype the call.
+    handler
+        .handle_file_changed(uri.clone(), change(with_call))
+        .await;
+    tokio::time::sleep(tokio::time::Duration::from_millis(400)).await;
+
+    // The indexer state must support diagnostics on the retyped content.
+    let diags3 = {
+        let doc = parse_live(with_call, tree_sitter_kotlin::language()).unwrap();
+        call_arg_diagnostics(&indexer, &uri, &doc)
+    };
+    assert!(
+        !diags3.is_empty(),
+        "step3: expected diagnostic after retype — indexer state is stale"
+    );
 }


### PR DESCRIPTION
## Summary

Eliminates 7 categories of false-positive `call_arg_diagnostics` warnings found by auditing the top-21 largest Kotlin files in a real-world Android codebase (Moneta).

## Fixes

### 1. Lambda-default commas
`split_params_at_depth_zero` now tracks `{}` depth. Default values like `= { a, b -> a }` contain commas that were incorrectly treated as parameter separators.

### 2. Annotation args in signatures
`extract_params_from_detail` now anchors the `(` search after the first `fun`/`class`/`constructor` keyword, skipping annotation argument lists like `@Deprecated("msg")`.

### 3. Java CLASS exclusion + CONSTRUCTOR indexing
`collect_all_fun_params_texts` skips CLASS symbols for `.java` files (they carry no constructor params). The companion fix in `parser.rs` properly indexes Java CONSTRUCTOR symbols.

### 4. Kotlin secondary constructors
`parser.rs` now indexes `secondary_constructor` AST nodes as CONSTRUCTOR symbols using `NodeExt` helpers (`first_child_of_kind`, `extract_type_name`). Previously they were invisible to the resolver.

### 5. Same-name override delegation
When `provided > total`, skip the diagnostic if the call site is inside a function with the same name (e.g. a 0-arg override delegating to a 1-arg parent version).

### 6. Nested class cross-file pollution
`collect_all_fun_params_texts` with `skip_nested=true` now filters `CLASS|STRUCT` symbols whose `container` is non-None. Prevents nested data classes from matching unqualified constructor calls in other files.

### 7. `receiver_sig` bypass for unqualified calls
`resolve_signatures` no longer falls back to `receiver_sig` (from `find_fun_signature_full`) for unqualified calls. That path bypasses `skip_nested` filtering and was picking up nested classes like `AllowanceFormUseCase.StartPayment.Date` or `LoanListContract.Loan`.

## Validation

- ✅ Zero diagnostics across top-21 largest Kotlin files in Moneta/android
- ✅ All 1002 tests pass
- ✅ Clippy clean (`-D warnings`)