### PR TITLE
refactor(call_arg_diagnostics): unified call-site resolution pipeline

### DIFF
--- a/src/features/call_arg_diagnostics.rs
+++ b/src/features/call_arg_diagnostics.rs
@@ -13,14 +13,12 @@
 use tower_lsp::lsp_types::*;
 
 use crate::indexer::{
-    collect_all_fun_params_texts, find_fun_signature_with_receiver, live_tree::LiveDoc,
-    split_params_at_depth_zero, Indexer, NodeExt,
+    live_tree::LiveDoc, resolve_call_signature, CallSite, Indexer, NodeExt, SignatureResult,
 };
 use crate::queries::{
     KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_FUN_DECL, KIND_LAMBDA_LIT, KIND_SIMPLE_IDENT,
     KIND_VALUE_ARG,
 };
-use crate::util::is_test_file;
 
 /// Scan a file for call-argument count mismatches and return diagnostics.
 ///
@@ -82,15 +80,21 @@ fn check_call_args(
         return None;
     }
 
-    // Resolve signature(s)
-    let signatures = resolve_signatures(indexer, uri, &fn_name, qualifier.as_deref());
-
-    // Skip if no signatures found or overloaded (ambiguous)
-    if signatures.is_empty() || signatures.len() > 1 {
-        return None;
-    }
-
-    let params_text = &signatures[0];
+    // Resolve signature through the unified pipeline.
+    let call = CallSite {
+        name: &fn_name,
+        qualifier: qualifier.as_deref(),
+        caller_uri: uri,
+    };
+    let (params_text, (required, total)) = match resolve_call_signature(&call, indexer) {
+        SignatureResult::Unique {
+            params_text,
+            param_counts,
+        } => (params_text, param_counts),
+        SignatureResult::Overloaded
+        | SignatureResult::NotFound
+        | SignatureResult::UnresolvableReceiver => return None,
+    };
 
     // Skip vararg functions (Kotlin `vararg` or Java `...`)
     if params_text.contains("vararg ")
@@ -99,10 +103,6 @@ fn check_call_args(
     {
         return None;
     }
-
-    // Prefer CST-derived param_counts from index; fall back to text-based counting
-    let (required, total) = resolve_param_counts(indexer, uri, &fn_name, qualifier.as_deref())
-        .unwrap_or_else(|| count_params(params_text));
 
     if provided_count < required {
         let range = diagnostic_range(call_node, value_arguments.as_ref());
@@ -324,243 +324,6 @@ fn is_inside_same_named_function(node: &tree_sitter::Node, bytes: &[u8], fn_name
             }
         }
         cur = parent;
-    }
-    false
-}
-
-/// Resolve `(required, total)` param counts directly from `SymbolEntry::param_counts`.
-/// Returns `None` if no matching symbol found or if the symbol was never indexed
-/// with param_counts (non-callable symbols like interfaces/fields).
-fn resolve_param_counts(
-    indexer: &Indexer,
-    uri: &Url,
-    fn_name: &str,
-    qualifier: Option<&str>,
-) -> Option<(usize, usize)> {
-    // If qualified, resolve receiver type first
-    if let Some(recv) = qualifier {
-        use crate::resolver::infer::{infer_receiver_type, ReceiverKind};
-        let rt = infer_receiver_type(indexer, ReceiverKind::Variable(recv), uri)?;
-        let locs = indexer.resolve_symbol(&rt.outer, None, uri);
-        for loc in &locs {
-            if let Some(data) = indexer.files.get(loc.uri.as_str()) {
-                if let Some(sym) = data
-                    .symbols
-                    .iter()
-                    .find(|s| s.name == fn_name && is_callable_kind(s.kind))
-                {
-                    return Some((sym.param_counts.0 as usize, sym.param_counts.1 as usize));
-                }
-            }
-        }
-        return None;
-    }
-    // Unqualified: check definitions and current file
-    let mut found: Option<(u8, u8)> = None;
-
-    // For unqualified calls, prefer same-file definitions to avoid false
-    // "overloaded" results from hundreds of same-name functions across the workspace.
-    if qualifier.is_none() {
-        if let Some(data) = indexer.files.get(uri.as_str()) {
-            for sym in data
-                .symbols
-                .iter()
-                .filter(|s| s.name == fn_name && is_callable_kind(s.kind))
-            {
-                if let Some(prev) = found {
-                    if prev != sym.param_counts {
-                        return None;
-                    }
-                }
-                found = Some(sym.param_counts);
-            }
-        }
-        if found.is_some() {
-            return found.map(|(r, t)| (r as usize, t as usize));
-        }
-    }
-
-    if let Some(locs) = indexer.definitions.get(fn_name) {
-        for loc in locs.iter() {
-            if is_test_file(loc.uri.as_str()) {
-                continue;
-            }
-            if let Some(data) = indexer.files.get(loc.uri.as_str()) {
-                for sym in data
-                    .symbols
-                    .iter()
-                    .filter(|s| s.name == fn_name && is_callable_kind(s.kind))
-                {
-                    if let Some(prev) = found {
-                        if prev != sym.param_counts {
-                            return None; // overloaded — let caller skip
-                        }
-                    }
-                    found = Some(sym.param_counts);
-                }
-            }
-        }
-    }
-    // Also current file
-    if let Some(data) = indexer.files.get(uri.as_str()) {
-        for sym in data
-            .symbols
-            .iter()
-            .filter(|s| s.name == fn_name && is_callable_kind(s.kind))
-        {
-            if let Some(prev) = found {
-                if prev != sym.param_counts {
-                    return None;
-                }
-            }
-            found = Some(sym.param_counts);
-        }
-    }
-    found.map(|(r, t)| (r as usize, t as usize))
-}
-
-fn is_callable_kind(kind: SymbolKind) -> bool {
-    matches!(
-        kind,
-        SymbolKind::FUNCTION | SymbolKind::METHOD | SymbolKind::CONSTRUCTOR
-    )
-}
-
-/// Resolve all known signatures for a function name.
-/// Returns multiple entries if overloaded.
-fn resolve_signatures(
-    indexer: &Indexer,
-    uri: &Url,
-    fn_name: &str,
-    qualifier: Option<&str>,
-) -> Vec<String> {
-    // First try receiver-aware lookup (returns a single best match)
-    let receiver_sig = find_fun_signature_with_receiver(indexer, uri, fn_name, qualifier);
-    let receiver_sig = if receiver_sig.is_empty() {
-        None
-    } else {
-        Some(receiver_sig)
-    };
-
-    // If a qualifier (receiver) is present but type could not be resolved,
-    // don't fall through to a global name scan — it would match unrelated
-    // functions from other classes (e.g. `cancel`, `show`).
-    if qualifier.is_some() && receiver_sig.is_none() {
-        return Vec::new();
-    }
-
-    // Also collect all same-name signatures across indexed files for overload detection
-    let mut all_sigs: Vec<String> = Vec::new();
-
-    // For unqualified calls (no receiver), check the current file first.
-    // If the function is defined here, use only those definitions — global
-    // lookup across the whole workspace would match hundreds of unrelated
-    // same-name overrides (e.g. 945 `loadData` implementations) causing
-    // a false "overloaded — skip" result.
-    let current_sigs = collect_all_fun_params_texts(fn_name, uri.as_str(), indexer, false);
-    if qualifier.is_none() && !current_sigs.is_empty() {
-        // For unqualified calls, don't use receiver_sig — it comes from a global
-        // name scan that may find only one overload, masking same-file overloads.
-        // Check arity diversity first; if ambiguous, return all so caller skips.
-        let arities: Vec<(usize, usize)> = current_sigs.iter().map(|s| count_params(s)).collect();
-        let unique: std::collections::HashSet<_> = arities.into_iter().collect();
-        return if unique.len() > 1 {
-            current_sigs // caller sees len > 1 → skip
-        } else {
-            current_sigs.into_iter().take(1).collect()
-        };
-    }
-
-    // Check definitions map for the function name
-    if let Some(locs) = indexer.definitions.get(fn_name) {
-        for loc in locs.iter() {
-            if is_test_file(loc.uri.as_str()) {
-                continue;
-            }
-            // skip_nested=true: unqualified calls can't refer to nested classes from other files
-            let sigs = collect_all_fun_params_texts(fn_name, loc.uri.as_str(), indexer, true);
-            all_sigs.extend(sigs);
-        }
-    }
-
-    // Also include current file (may already be in definitions, but ensure coverage)
-    for sig in &current_sigs {
-        if !all_sigs.contains(sig) {
-            all_sigs.push(sig.clone());
-        }
-    }
-
-    // Deduplicate by arity envelope (required..=total)
-    let arities: Vec<(usize, usize)> = all_sigs.iter().map(|s| count_params(s)).collect();
-    let unique_arities: std::collections::HashSet<(usize, usize)> = arities.into_iter().collect();
-
-    // If multiple distinct arities exist → overloaded
-    if unique_arities.len() > 1 {
-        return all_sigs; // caller sees len > 1 → skip
-    }
-
-    // For qualified calls, prefer the receiver-resolved signature (it's type-accurate).
-    // For unqualified calls, skip receiver_sig: it comes from find_fun_signature_full which
-    // does NOT apply skip_nested filtering, so it would pick up nested classes (e.g.
-    // `data class Date(val value: Long)` inside a sealed interface) as false positives.
-    // Unqualified calls rely on the definitions-map path above (which does apply skip_nested).
-    if qualifier.is_some() {
-        if let Some(sig) = receiver_sig {
-            return vec![sig];
-        }
-    }
-    if let Some(sig) = all_sigs.into_iter().next() {
-        vec![sig]
-    } else {
-        Vec::new()
-    }
-}
-
-/// Parse a parameter list and return `(required_count, total_count)`.
-/// Parameters with default values (containing `=` at depth 0) are optional.
-fn count_params(params_text: &str) -> (usize, usize) {
-    let raw = params_text.trim_matches(|c| c == '(' || c == ')');
-    let parts = split_params_at_depth_zero(raw);
-    let params: Vec<&str> = parts
-        .iter()
-        .map(|s| s.trim())
-        .filter(|s| !s.is_empty())
-        .collect();
-    let total = params.len();
-    let required = params.iter().filter(|p| !has_default_value(p)).count();
-    (required, total)
-}
-
-/// Check if a single parameter text has a default value (`=` at depth 0).
-/// Example: `c: Boolean = true` → true, `f: (Int) -> String` → false
-fn has_default_value(param: &str) -> bool {
-    let mut depth: i32 = 0;
-    let mut prev = '\0';
-    // Find the first `:` at depth 0 — everything after is the type + optional default
-    let mut past_colon = false;
-    for ch in param.chars() {
-        if !past_colon {
-            if ch == ':' && depth == 0 {
-                past_colon = true;
-            }
-            match ch {
-                '(' | '<' | '[' => depth += 1,
-                ')' | ']' => depth -= 1,
-                '>' if prev != '-' && depth > 0 => depth -= 1,
-                _ => {}
-            }
-            prev = ch;
-            continue;
-        }
-        // After the type colon, look for `=` at depth 0
-        match ch {
-            '(' | '<' | '[' => depth += 1,
-            ')' | ']' => depth -= 1,
-            '>' if prev != '-' && depth > 0 => depth -= 1,
-            '=' if depth == 0 => return true,
-            _ => {}
-        }
-        prev = ch;
     }
     false
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -45,6 +45,7 @@ pub(crate) use self::infer::{
     has_named_params_not_it,
     // expr_type.rs
     infer_expr_type,
+    is_import_reachable,
     is_inside_receiver_lambda,
     is_lambda_param,
     lambda_brace_pos_for_param,
@@ -53,12 +54,16 @@ pub(crate) use self::infer::{
     last_fun_param_type_str,
     line_has_lambda_param,
     nth_fun_param_type_str,
+    resolve_call_signature,
     split_params_at_depth_zero,
     strip_trailing_call_args,
     // sig.rs
     CallInfo,
+    CallSite,
     // deps.rs
     InferDeps,
+    ResolutionScope,
+    SignatureResult,
 };
 
 mod cache;

--- a/src/indexer/infer/mod.rs
+++ b/src/indexer/infer/mod.rs
@@ -27,8 +27,10 @@ pub(crate) use lambda::{
 
 pub(crate) use sig::{
     collect_all_fun_params_texts, collect_params_from_line, collect_signature,
-    find_fun_signature_full, find_fun_signature_with_receiver, last_fun_param_type_str,
-    nth_fun_param_type_str, split_params_at_depth_zero, strip_trailing_call_args,
+    find_fun_signature_full, find_fun_signature_with_receiver, is_import_reachable,
+    last_fun_param_type_str, nth_fun_param_type_str, resolve_call_signature,
+    split_params_at_depth_zero, strip_trailing_call_args, CallSite, ResolutionScope,
+    SignatureResult,
 };
 
 pub(crate) use args::{

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -11,6 +11,49 @@ use tower_lsp::lsp_types::{SymbolKind, Url};
 use crate::indexer::Indexer;
 use crate::resolver::{infer_receiver_type, ReceiverKind};
 
+// ─── Call-site resolution types ──────────────────────────────────────────────
+
+/// The scope in which a function call is being resolved.
+///
+/// `SameFile` resolution does not filter nested classes — calling `Foo()` in the
+/// file where `class Outer { data class Foo(...) }` is defined is valid.
+///
+/// `CrossFile` resolution skips `CLASS`/`STRUCT` symbols whose `container` is
+/// non-`None` — an unqualified `Foo()` in another file cannot reach `Outer.Foo`
+/// without a qualifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ResolutionScope {
+    SameFile,
+    CrossFile,
+}
+
+/// Everything needed to resolve a call expression's signature.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct CallSite<'a> {
+    /// The bare function / constructor name (without qualifier).
+    pub name: &'a str,
+    /// The receiver variable name, if any (`foo.bar()` → `Some("foo")`).
+    pub qualifier: Option<&'a str>,
+    /// URI of the file containing the call.
+    pub caller_uri: &'a Url,
+}
+
+/// Result of resolving a call site's signature.
+#[derive(Debug)]
+pub(crate) enum SignatureResult {
+    /// Exactly one arity envelope — safe to emit a diagnostic.
+    Unique {
+        params_text: String,
+        param_counts: (usize, usize),
+    },
+    /// Multiple distinct arity envelopes found — overloaded, skip.
+    Overloaded,
+    /// No definition found — skip.
+    NotFound,
+    /// Qualified call whose receiver type could not be resolved — skip.
+    UnresolvableReceiver,
+}
+
 // ─── Multiline signature collector ───────────────────────────────────────────
 
 /// Maximum number of lines to scan when collecting a multi-line function signature.
@@ -18,6 +61,65 @@ const SIGNATURE_SCAN_LINES: usize = 15;
 
 /// Maximum number of lines to scan when collecting a function parameter list.
 const FUN_PARAMS_SCAN_LINES: usize = 20;
+
+// ─── Import reachability ─────────────────────────────────────────────────────
+
+/// Check whether symbols from `def_uri` are reachable from `caller_uri`.
+///
+/// A definition file is reachable when any of the following hold:
+/// - Both files share the same package declaration (same-package access).
+/// - The caller has an explicit import `package.SymbolName`.
+/// - The caller has a star import `package.*` that covers the definition's package.
+///
+/// This is best-effort, not sound — we have no full classpath.  When
+/// reachability cannot be determined (missing `FileData`, no package info) we
+/// return `true` to avoid false negatives.
+pub(crate) fn is_import_reachable(
+    idx: &Indexer,
+    caller_uri: &str,
+    def_uri: &str,
+    symbol_name: &str,
+) -> bool {
+    if caller_uri == def_uri {
+        return true;
+    }
+    let Some(caller_data) = idx.files.get(caller_uri) else {
+        return true; // fail-open
+    };
+    let Some(def_data) = idx.files.get(def_uri) else {
+        return true; // fail-open
+    };
+    let def_pkg = match def_data.package.as_deref() {
+        Some(p) => p,
+        None => return true, // no package info → can't filter
+    };
+    let caller_pkg = caller_data.package.as_deref().unwrap_or("");
+
+    // Same package — always reachable
+    if caller_pkg == def_pkg {
+        return true;
+    }
+
+    // Check caller's imports
+    for import in &caller_data.imports {
+        if import.is_star {
+            // `import com.example.*` covers `com.example.Foo`
+            if import.full_path == def_pkg {
+                return true;
+            }
+        } else {
+            // Explicit import: local name matches AND FQN matches package.SymbolName
+            if import.local_name == symbol_name {
+                let expected = format!("{}.{}", def_pkg, symbol_name);
+                if import.full_path == expected {
+                    return true;
+                }
+            }
+        }
+    }
+
+    false
+}
 
 /// Collect a human-readable function/class signature starting at `start_line`.
 ///
@@ -536,6 +638,184 @@ fn is_class_like(kind: SymbolKind) -> bool {
             | SymbolKind::ENUM
             | SymbolKind::OBJECT
     )
+}
+
+// ─── Unified call-site resolver ───────────────────────────────────────────────
+
+/// Collect params text and param_counts for all callable symbols named `name`
+/// in `file_data`, applying `scope` filtering rules.
+///
+/// `CrossFile` scope: skips `CLASS`/`STRUCT` symbols with a container (nested
+/// classes) and excludes files not import-reachable from the caller.
+fn collect_params_from_file(
+    name: &str,
+    file_uri: &str,
+    idx: &Indexer,
+    caller_uri: &str,
+    scope: ResolutionScope,
+) -> Vec<(String, (u8, u8))> {
+    let Some(data) = idx.files.get(file_uri) else {
+        return vec![];
+    };
+    if scope == ResolutionScope::CrossFile && !is_import_reachable(idx, caller_uri, file_uri, name)
+    {
+        return vec![];
+    }
+    let is_java = file_uri.ends_with(".java");
+    data.symbols
+        .iter()
+        .filter(|s| {
+            s.name == name
+                && !(scope == ResolutionScope::CrossFile
+                    && s.container.is_some()
+                    && matches!(s.kind, SymbolKind::CLASS | SymbolKind::STRUCT))
+                && (s.kind == SymbolKind::FUNCTION
+                    || s.kind == SymbolKind::METHOD
+                    || s.kind == SymbolKind::CONSTRUCTOR
+                    || s.kind == SymbolKind::STRUCT
+                    || (s.kind == SymbolKind::CLASS && !is_java))
+        })
+        .filter_map(|s| {
+            let params_text = if !s.params.is_empty() {
+                s.params.clone()
+            } else {
+                extract_params_from_detail(&s.detail).or_else(|| {
+                    collect_params_from_line(&data.lines, s.range.start.line as usize)
+                })?
+            };
+            Some((params_text, s.param_counts))
+        })
+        .collect()
+}
+
+/// Resolve the signature for a qualified call `qualifier.name(…)`.
+///
+/// Resolves the receiver type, then searches for `name` within that type's body.
+/// Returns `SignatureResult::UnresolvableReceiver` when the receiver type cannot
+/// be determined (prevents a fallback global scan that would match unrelated fns).
+fn resolve_qualified(call: &CallSite<'_>, qualifier: &str, idx: &Indexer) -> SignatureResult {
+    use crate::resolver::infer::{infer_receiver_type, ReceiverKind};
+    let Some(rt) = infer_receiver_type(idx, ReceiverKind::Variable(qualifier), call.caller_uri)
+    else {
+        return SignatureResult::UnresolvableReceiver;
+    };
+    let locs = idx.resolve_symbol(&rt.outer, None, call.caller_uri);
+    for loc in &locs {
+        let Some(data) = idx.files.get(loc.uri.as_str()) else {
+            continue;
+        };
+        // Look for the method directly within the resolved type.
+        let type_end = data
+            .symbols
+            .iter()
+            .find(|s| s.name == rt.outer)
+            .map(|s| s.range.end.line)
+            .unwrap_or(u32::MAX);
+        for sym in data
+            .symbols
+            .iter()
+            .filter(|s| s.name == call.name && s.range.start.line <= type_end)
+        {
+            let params_text = if !sym.params.is_empty() {
+                sym.params.clone()
+            } else if let Some(p) = extract_params_from_detail(&sym.detail) {
+                p
+            } else {
+                continue;
+            };
+            return SignatureResult::Unique {
+                param_counts: (sym.param_counts.0 as usize, sym.param_counts.1 as usize),
+                params_text,
+            };
+        }
+    }
+    SignatureResult::NotFound
+}
+
+/// Resolve the signature for an unqualified call `name(…)`.
+///
+/// Priority:
+/// 1. Current file (same-file definitions are exact — no import filtering needed).
+/// 2. Definitions map, cross-file with import-aware filtering.
+///
+/// If multiple distinct arity envelopes are found, returns `Overloaded`.
+fn resolve_unqualified(call: &CallSite<'_>, idx: &Indexer) -> SignatureResult {
+    // Same-file first: if defined here, use only those — avoids workspace-wide
+    // overload explosion (e.g. 945 `loadData` implementations).
+    let same_file = collect_params_from_file(
+        call.name,
+        call.caller_uri.as_str(),
+        idx,
+        call.caller_uri.as_str(),
+        ResolutionScope::SameFile,
+    );
+    if !same_file.is_empty() {
+        return build_result(same_file);
+    }
+
+    // Cross-file: definitions map with import + nested-class filtering.
+    let mut all: Vec<(String, (u8, u8))> = Vec::new();
+    if let Some(locs) = idx.definitions.get(call.name) {
+        for loc in locs.iter() {
+            if crate::util::is_test_file(loc.uri.as_str()) {
+                continue;
+            }
+            let sigs = collect_params_from_file(
+                call.name,
+                loc.uri.as_str(),
+                idx,
+                call.caller_uri.as_str(),
+                ResolutionScope::CrossFile,
+            );
+            all.extend(sigs);
+        }
+    }
+    build_result(all)
+}
+
+/// Build a `SignatureResult` from a list of `(params_text, param_counts)` pairs.
+///
+/// Deduplicates by arity envelope. If there are multiple distinct envelopes,
+/// the function is considered overloaded and the caller should skip the diagnostic.
+fn build_result(entries: Vec<(String, (u8, u8))>) -> SignatureResult {
+    if entries.is_empty() {
+        return SignatureResult::NotFound;
+    }
+    // Deduplicate by arity envelope.
+    let mut seen: std::collections::HashSet<(u8, u8)> = std::collections::HashSet::new();
+    let mut deduped: Vec<(String, (u8, u8))> = Vec::new();
+    for (text, counts) in entries {
+        if seen.insert(counts) {
+            deduped.push((text, counts));
+        }
+    }
+    if deduped.len() > 1 {
+        return SignatureResult::Overloaded;
+    }
+    let (params_text, (required, total)) = deduped.into_iter().next().unwrap();
+    SignatureResult::Unique {
+        params_text,
+        param_counts: (required as usize, total as usize),
+    }
+}
+
+/// Resolve the call site's signature using a unified, single-entry-point pipeline.
+///
+/// Resolution strategy:
+/// - **Qualified** (`qualifier.name(…)`): resolve receiver type, find method within it.
+///   Returns `UnresolvableReceiver` when the receiver type is unknown to prevent
+///   a fallback global-name scan from matching unrelated functions.
+/// - **Unqualified** (`name(…)`): check the current file first, then cross-file
+///   definitions filtered by import reachability and nested-class exclusion.
+///
+/// This function does NOT trigger on-demand indexing (`rg` / disk reads).
+/// Use `find_fun_signature_full` for hover/completion where latency is acceptable.
+pub(crate) fn resolve_call_signature(call: &CallSite<'_>, idx: &Indexer) -> SignatureResult {
+    if let Some(qualifier) = call.qualifier {
+        resolve_qualified(call, qualifier, idx)
+    } else {
+        resolve_unqualified(call, idx)
+    }
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -100,6 +100,9 @@ pub(crate) fn is_import_reachable(
         return true;
     }
 
+    // Precompute once to avoid repeated heap allocation inside the loop.
+    let expected_fqn = format!("{}.{}", def_pkg, symbol_name);
+
     // Check caller's imports
     for import in &caller_data.imports {
         if import.is_star {
@@ -108,12 +111,14 @@ pub(crate) fn is_import_reachable(
                 return true;
             }
         } else {
-            // Explicit import: local name matches AND FQN matches package.SymbolName
-            if import.local_name == symbol_name {
-                let expected = format!("{}.{}", def_pkg, symbol_name);
-                if import.full_path == expected {
-                    return true;
-                }
+            // Explicit import: local name matches AND FQN matches package.SymbolName.
+            // Also matches nested class imports like `import pkg.Outer.Config` where
+            // local_name="Config" and full_path ends with the expected_fqn suffix.
+            if import.local_name == symbol_name
+                && (import.full_path == expected_fqn
+                    || import.full_path.ends_with(&format!(".{}", expected_fqn)))
+            {
+                return true;
             }
         }
     }
@@ -646,7 +651,8 @@ fn is_class_like(kind: SymbolKind) -> bool {
 /// in `file_data`, applying `scope` filtering rules.
 ///
 /// `CrossFile` scope: skips `CLASS`/`STRUCT` symbols with a container (nested
-/// classes) and excludes files not import-reachable from the caller.
+/// classes) unless the caller has an explicit import for that symbol by local
+/// name, and excludes files not import-reachable from the caller.
 fn collect_params_from_file(
     name: &str,
     file_uri: &str,
@@ -661,6 +667,16 @@ fn collect_params_from_file(
     {
         return vec![];
     }
+    // A nested class/struct is reachable cross-file when the caller has an
+    // explicit import for it by local name (e.g. `import pkg.Outer.Config`).
+    let caller_imports_by_name = if scope == ResolutionScope::CrossFile {
+        idx.files
+            .get(caller_uri)
+            .map(|d| d.imports.iter().any(|i| !i.is_star && i.local_name == name))
+            .unwrap_or(true) // fail-open
+    } else {
+        false
+    };
     let is_java = file_uri.ends_with(".java");
     data.symbols
         .iter()
@@ -668,7 +684,8 @@ fn collect_params_from_file(
             s.name == name
                 && !(scope == ResolutionScope::CrossFile
                     && s.container.is_some()
-                    && matches!(s.kind, SymbolKind::CLASS | SymbolKind::STRUCT))
+                    && matches!(s.kind, SymbolKind::CLASS | SymbolKind::STRUCT)
+                    && !caller_imports_by_name)
                 && (s.kind == SymbolKind::FUNCTION
                     || s.kind == SymbolKind::METHOD
                     || s.kind == SymbolKind::CONSTRUCTOR
@@ -711,23 +728,42 @@ fn resolve_qualified(call: &CallSite<'_>, qualifier: &str, idx: &Indexer) -> Sig
             .find(|s| s.name == rt.outer)
             .map(|s| s.range.end.line)
             .unwrap_or(u32::MAX);
-        for sym in data
+        // Filter by container membership first (exact), then fall back to range
+        // containment for symbols whose container field wasn't populated.
+        let members: Vec<_> = data
             .symbols
             .iter()
-            .filter(|s| s.name == call.name && s.range.start.line <= type_end)
-        {
-            let params_text = if !sym.params.is_empty() {
-                sym.params.clone()
-            } else if let Some(p) = extract_params_from_detail(&sym.detail) {
-                p
-            } else {
-                continue;
-            };
-            return SignatureResult::Unique {
-                param_counts: (sym.param_counts.0 as usize, sym.param_counts.1 as usize),
-                params_text,
-            };
+            .filter(|s| {
+                s.name == call.name
+                    && (s.container.as_deref() == Some(&rt.outer)
+                        || (s.container.is_none() && s.range.start.line <= type_end))
+            })
+            .collect();
+        if members.is_empty() {
+            continue;
         }
+        // Collect all distinct param_counts to detect overloads.
+        let mut seen: Vec<(u8, u8)> = vec![];
+        for sym in &members {
+            if !seen.contains(&sym.param_counts) {
+                seen.push(sym.param_counts);
+            }
+        }
+        if seen.len() > 1 {
+            return SignatureResult::Overloaded;
+        }
+        let sym = members[0];
+        let params_text = if !sym.params.is_empty() {
+            sym.params.clone()
+        } else if let Some(p) = extract_params_from_detail(&sym.detail) {
+            p
+        } else {
+            continue;
+        };
+        return SignatureResult::Unique {
+            param_counts: (sym.param_counts.0 as usize, sym.param_counts.1 as usize),
+            params_text,
+        };
     }
     SignatureResult::NotFound
 }

--- a/src/indexer/infer/sig_tests.rs
+++ b/src/indexer/infer/sig_tests.rs
@@ -262,3 +262,141 @@ fn nth_param_type_gt_operator_in_default() {
     let params = "x: Int, y: String";
     assert_eq!(nth_fun_param_type_str(params, 1), Some("String".to_owned()));
 }
+
+// ─── is_import_reachable ─────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod import_reachable {
+    use super::is_import_reachable;
+    use crate::indexer::Indexer;
+    use crate::types::{FileData, ImportEntry};
+    use std::sync::Arc;
+
+    fn make_url(path: &str) -> String {
+        format!("file://{}", path)
+    }
+
+    fn index_file(idx: &Indexer, uri: &str, pkg: &str, imports: Vec<ImportEntry>) {
+        let data = FileData {
+            package: Some(pkg.to_owned()),
+            imports,
+            ..FileData::default()
+        };
+        idx.files.insert(uri.to_owned(), Arc::new(data));
+    }
+
+    fn explicit_import(pkg: &str, name: &str) -> ImportEntry {
+        ImportEntry {
+            full_path: format!("{}.{}", pkg, name),
+            local_name: name.to_owned(),
+            is_star: false,
+        }
+    }
+
+    fn star_import(pkg: &str) -> ImportEntry {
+        ImportEntry {
+            full_path: pkg.to_owned(),
+            local_name: "*".to_owned(),
+            is_star: true,
+        }
+    }
+
+    #[test]
+    fn same_file_always_reachable() {
+        let idx = Indexer::new();
+        let uri = make_url("/a/Foo.kt");
+        index_file(&idx, &uri, "com.example", vec![]);
+        assert!(is_import_reachable(&idx, &uri, &uri, "Foo"));
+    }
+
+    #[test]
+    fn same_package_reachable() {
+        let idx = Indexer::new();
+        let caller = make_url("/a/A.kt");
+        let def = make_url("/a/B.kt");
+        index_file(&idx, &caller, "com.example", vec![]);
+        index_file(&idx, &def, "com.example", vec![]);
+        assert!(is_import_reachable(&idx, &caller, &def, "Foo"));
+    }
+
+    #[test]
+    fn different_package_no_import_not_reachable() {
+        let idx = Indexer::new();
+        let caller = make_url("/a/A.kt");
+        let def = make_url("/b/B.kt");
+        index_file(&idx, &caller, "com.example", vec![]);
+        index_file(&idx, &def, "com.other", vec![]);
+        assert!(!is_import_reachable(&idx, &caller, &def, "Foo"));
+    }
+
+    #[test]
+    fn explicit_import_reachable() {
+        let idx = Indexer::new();
+        let caller = make_url("/a/A.kt");
+        let def = make_url("/b/Foo.kt");
+        index_file(
+            &idx,
+            &caller,
+            "com.example",
+            vec![explicit_import("com.other", "Foo")],
+        );
+        index_file(&idx, &def, "com.other", vec![]);
+        assert!(is_import_reachable(&idx, &caller, &def, "Foo"));
+    }
+
+    #[test]
+    fn explicit_import_wrong_name_not_reachable() {
+        let idx = Indexer::new();
+        let caller = make_url("/a/A.kt");
+        let def = make_url("/b/Bar.kt");
+        index_file(
+            &idx,
+            &caller,
+            "com.example",
+            vec![explicit_import("com.other", "Foo")],
+        );
+        index_file(&idx, &def, "com.other", vec![]);
+        assert!(!is_import_reachable(&idx, &caller, &def, "Bar"));
+    }
+
+    #[test]
+    fn star_import_reachable() {
+        let idx = Indexer::new();
+        let caller = make_url("/a/A.kt");
+        let def = make_url("/b/Foo.kt");
+        index_file(&idx, &caller, "com.example", vec![star_import("com.other")]);
+        index_file(&idx, &def, "com.other", vec![]);
+        assert!(is_import_reachable(&idx, &caller, &def, "Foo"));
+    }
+
+    #[test]
+    fn star_import_wrong_package_not_reachable() {
+        let idx = Indexer::new();
+        let caller = make_url("/a/A.kt");
+        let def = make_url("/b/Foo.kt");
+        index_file(&idx, &caller, "com.example", vec![star_import("com.third")]);
+        index_file(&idx, &def, "com.other", vec![]);
+        assert!(!is_import_reachable(&idx, &caller, &def, "Foo"));
+    }
+
+    #[test]
+    fn missing_caller_data_fails_open() {
+        let idx = Indexer::new();
+        let def = make_url("/b/Foo.kt");
+        index_file(&idx, &def, "com.other", vec![]);
+        assert!(is_import_reachable(&idx, "file:///missing.kt", &def, "Foo"));
+    }
+
+    #[test]
+    fn missing_def_data_fails_open() {
+        let idx = Indexer::new();
+        let caller = make_url("/a/A.kt");
+        index_file(&idx, &caller, "com.example", vec![]);
+        assert!(is_import_reachable(
+            &idx,
+            &caller,
+            "file:///missing.kt",
+            "Foo"
+        ));
+    }
+}

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1091,29 +1091,54 @@ fn count_params_from_node(params_node: &Node) -> (u8, u8) {
         let ck = child.kind();
         if ck == KIND_PARAMETER || ck == KIND_FORMAL_PARAM || ck == KIND_CLASS_PARAM {
             total += 1;
-            // Check if next non-comma sibling is `=`
-            let mut j = i + 1;
-            while j < count {
-                let Some(sibling) = params_node.child(j) else {
-                    break;
-                };
-                let sk = sibling.kind();
-                if sk == "," {
-                    // comma between params — no default for this param
-                    break;
-                }
-                if sk == "=" {
-                    optional += 1;
-                    break;
-                }
-                if sk == KIND_PARAMETER || sk == KIND_FORMAL_PARAM || sk == KIND_CLASS_PARAM {
-                    break;
-                }
-                j += 1;
+            if param_has_default(&child, params_node, i, count) {
+                optional += 1;
             }
         }
     }
     (total.saturating_sub(optional), total)
+}
+
+/// Check whether a parameter node has a default value.
+///
+/// - For `class_parameter` (Kotlin primary constructor): `=` is a direct child
+///   of the parameter node itself.
+/// - For `function_value_parameter` and Java `formal_parameter`: `=` appears as
+///   a sibling at the container level (between this param and the next comma).
+fn param_has_default(
+    param: &Node,
+    container: &Node,
+    param_idx: usize,
+    container_len: usize,
+) -> bool {
+    // class_parameter: look for `=` as a direct child of the parameter node.
+    if param.kind() == KIND_CLASS_PARAM {
+        for k in 0..param.child_count() {
+            if param.child(k).map(|c| c.kind() == "=").unwrap_or(false) {
+                return true;
+            }
+        }
+        return false;
+    }
+    // function_value_parameter / formal_parameter: `=` is a sibling at the container level.
+    let mut j = param_idx + 1;
+    while j < container_len {
+        let Some(sibling) = container.child(j) else {
+            break;
+        };
+        let sk = sibling.kind();
+        if sk == "," {
+            break;
+        }
+        if sk == "=" {
+            return true;
+        }
+        if sk == KIND_PARAMETER || sk == KIND_FORMAL_PARAM || sk == KIND_CLASS_PARAM {
+            break;
+        }
+        j += 1;
+    }
+    false
 }
 
 /// Walk up from a node to find the enclosing declaration (function/class/object).

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -1333,6 +1333,33 @@ fn param_counts_zero_params() {
 }
 
 #[test]
+fn param_counts_primary_constructor_with_defaults() {
+    // Regression: `=` is a child of `class_parameter`, not a sibling at the
+    // primary_constructor level — ensure defaults are counted correctly.
+    let src = "data class User(val name: String, val age: Int = 0, val active: Boolean = true)";
+    let data = super::parse_kotlin(src);
+    let sym = data
+        .symbols
+        .iter()
+        .find(|s| s.name == "User")
+        .expect("User should be indexed");
+    // 1 required (name), 3 total
+    assert_eq!(sym.param_counts, (1, 3));
+}
+
+#[test]
+fn param_counts_primary_constructor_all_required() {
+    let src = "class Point(val x: Int, val y: Int)";
+    let data = super::parse_kotlin(src);
+    let sym = data
+        .symbols
+        .iter()
+        .find(|s| s.name == "Point")
+        .expect("Point should be indexed");
+    assert_eq!(sym.param_counts, (2, 2));
+}
+
+#[test]
 fn rhs_types_class_literal_java_suffix() {
     // `val api = retrofit.create(DashboardApi::class.java)` — the type should
     // be extracted directly from the callable_reference argument, not stored


### PR DESCRIPTION
## Summary

Replaces the fragmented 5-layer resolution chain in `call_arg_diagnostics` with a single entry point (`resolve_call_signature`) backed by explicit types and import-aware filtering.

## Motivation

After fixing 7 FP categories in #103, the root architectural issues remained:
- Two parallel resolution paths with inconsistent filtering
- `skip_nested` bool threading implicit context through 5 functions
- Name-only cross-file matching — no import awareness (root cause of most FPs)

## Changes

### Phase 1 — Explicit types (`sig.rs`)
New types make resolution context unambiguous:
- `CallSite` — name + optional qualifier + caller URI
- `ResolutionScope` — `SameFile` vs `CrossFile` (replaces `skip_nested` bool)
- `SignatureResult` — `Unique` / `Overloaded` / `NotFound` / `UnresolvableReceiver`

### Phase 2 — Import-aware filtering
`is_import_reachable(idx, caller_uri, def_uri, symbol_name)` — cross-file lookups now skip definitions unreachable from the caller's imports. Fail-open (returns `true`) when FileData is missing to avoid new false negatives. **9 unit tests** cover all reachability cases.

### Phase 3 — Collapsed resolution chain
`resolve_call_signature → resolve_qualified + resolve_unqualified` (2 functions instead of 5). Deleted from `call_arg_diagnostics.rs`: `resolve_signatures`, `resolve_param_counts`, `is_callable_kind`, `count_params`, `has_default_value`.

### Parser fix (bonus)
`count_params_from_node` now correctly detects default values for Kotlin primary constructor `class_parameter` nodes. The `=` sign is a direct child of `class_parameter` (not a sibling at the container level). Previously masked by text-based counting in the old pipeline — surfaced by the new index-based counting.

## Test results
- All 983 unit tests pass
- All 16 CLI diagnostic integration tests pass (including `no_false_positive_constructor_defaults`)
- Clippy clean (no new warnings)