### PR TITLE
perf: chunked library cache to eliminate end-of-indexing memory spike

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,6 +837,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
  "tower-lsp",
  "tree-sitter",
@@ -1375,6 +1376,26 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ zip = "2"
 futures = "0.3.32"
 lexopt = "0.3"
 parking_lot = "0.12.5"
+# jemalloc: dramatically reduces RSS on long-running processes by avoiding
+# glibc malloc arena fragmentation (same pattern as rust-analyzer)
+tikv-jemallocator = "0.6"
 
 [profile.release]
 opt-level = 3

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -450,6 +450,7 @@ fn resolve_type_members(
     if locations.is_empty() {
         return None;
     }
+    let subtype_locations = indexer.subtypes_of(type_name);
 
     let mut fallback: Option<(TypeKind, Vec<WhenMember>)> = None;
 

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -450,7 +450,6 @@ fn resolve_type_members(
     if locations.is_empty() {
         return None;
     }
-    let subtype_locations = indexer.subtypes_of(type_name);
 
     let mut fallback: Option<(TypeKind, Vec<WhenMember>)> = None;
 

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -542,9 +542,15 @@ impl Indexer {
             &source_paths,
             &manifest_path,
             &first_chunk,
+            &cache_dir,
+            chunk_count,
         ) {
-            // Cache is stale: reload all chunks into a combined HashMap for
-            // per-file hit checking, then proceed with the slow scan.
+            // Cache is stale: load all chunks into a combined HashMap so
+            // scan_source_paths_slow can reuse per-file entries that haven't changed.
+            //
+            // Memory note: this reassembles the full library HashMap (~same peak as
+            // the pre-chunked code).  The stale path is rare in practice — it only
+            // triggers when a library source directory mtime or a sampled file changes.
             let mut combined = first_chunk;
             for idx in 1..chunk_count {
                 if let Some(chunk) = crate::indexer::cache::load_library_chunk(&cache_dir, idx) {
@@ -560,33 +566,45 @@ impl Indexer {
             return;
         }
 
-        // Pre-flight: validate all chunks exist before mutating any index state.
-        for idx in 1..chunk_count {
-            if !crate::indexer::cache::library_chunk_path(&cache_dir, idx).exists() {
-                log::warn!(
-                    "Library cache chunk {idx}/{chunk_count} missing — falling back to slow path"
-                );
-                let scan = self
-                    .scan_source_paths_slow(&source_paths, None, &workspace_root)
-                    .await;
-                if self.workspace_root.generation() == gen {
-                    self.apply_source_path_scan(scan, &raw_paths);
+        // Fast path: load every chunk first to validate all are readable, then
+        // flush in order.  Loading before flushing prevents partial DashMap
+        // mutations when a later chunk is corrupt or version-mismatched.
+        //
+        // Memory note: all N chunks are held simultaneously during flushing
+        // (~total stripped cache size, typically 100–200 MB with field stripping).
+        // Chunks are dropped as they are flushed to reclaim memory promptly.
+        let all_chunks = {
+            let mut chunks = Vec::with_capacity(chunk_count as usize);
+            chunks.push(first_chunk);
+            for idx in 1..chunk_count {
+                match crate::indexer::cache::load_library_chunk(&cache_dir, idx) {
+                    Some(chunk) => chunks.push(chunk),
+                    None => {
+                        log::warn!(
+                            "Library cache chunk {idx}/{chunk_count} failed to load — \
+                             falling back to slow scan"
+                        );
+                        // Invalidate manifest so next startup does a fresh save.
+                        let _ = std::fs::remove_file(crate::indexer::cache::library_manifest_path(
+                            &cache_dir,
+                        ));
+                        let scan = self
+                            .scan_source_paths_slow(&source_paths, None, &workspace_root)
+                            .await;
+                        if self.workspace_root.generation() == gen {
+                            self.apply_source_path_scan(scan, &raw_paths);
+                        }
+                        return;
+                    }
                 }
-                return;
             }
-        }
+            chunks
+        };
 
-        // Fast path: restore one chunk at a time.  Each chunk is dropped before
-        // the next is loaded, keeping the instantaneous working set small.
-        log::debug!(
-            "Library cache fresh: restoring {} chunks without re-scanning",
-            chunk_count
-        );
-        self.restore_library_chunk(first_chunk, &workspace_root);
-        for idx in 1..chunk_count {
-            if let Some(chunk) = crate::indexer::cache::load_library_chunk(&cache_dir, idx) {
-                self.restore_library_chunk(chunk, &workspace_root);
-            }
+        let loaded_chunks = all_chunks.len();
+        log::debug!("Library cache fresh: restoring {loaded_chunks} chunks without re-scanning");
+        for chunk in all_chunks {
+            self.restore_library_chunk(chunk, &workspace_root);
         }
         self.rebuild_bare_name_cache();
         log::debug!(

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -526,6 +526,11 @@ impl Indexer {
             return;
         };
 
+        // Empty library cache — nothing to restore; skip loading any chunks.
+        if chunk_count == 0 {
+            return;
+        }
+
         // Load first chunk for Tier 2 freshness sampling (~20 MB read).
         let Some(first_chunk) = crate::indexer::cache::load_library_chunk(&cache_dir, 0) else {
             let scan = self

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -512,53 +512,96 @@ impl Indexer {
         let gen = self.workspace_root.generation();
         let source_paths = resolve_source_paths(&raw_paths, &workspace_root);
 
-        let cache_path = crate::indexer::cache::library_cache_path(&raw_paths);
-        let lib_cache = crate::indexer::cache::try_load_library_cache(&raw_paths);
-        let cache_is_fresh = lib_cache.as_ref().is_some_and(|entries| {
-            crate::indexer::cache::library_cache_is_fresh(&source_paths, &cache_path, entries)
-        });
+        // Load manifest only — cheap (just version + chunk_count, no file data).
+        let Some((cache_dir, chunk_count)) =
+            crate::indexer::cache::try_load_library_manifest(&raw_paths)
+        else {
+            // No valid manifest → slow path without any per-file cache hits.
+            let scan = self
+                .scan_source_paths_slow(&source_paths, None, &workspace_root)
+                .await;
+            if self.workspace_root.generation() == gen {
+                self.apply_source_path_scan(scan, &raw_paths);
+            }
+            return;
+        };
 
-        // Fast path: library cache is fresh (source dirs haven't changed).
-        if cache_is_fresh {
-            let Some(lib_cache) = lib_cache else {
+        // Load first chunk for Tier 2 freshness sampling (~20 MB read).
+        let Some(first_chunk) = crate::indexer::cache::load_library_chunk(&cache_dir, 0) else {
+            let scan = self
+                .scan_source_paths_slow(&source_paths, None, &workspace_root)
+                .await;
+            if self.workspace_root.generation() == gen {
+                self.apply_source_path_scan(scan, &raw_paths);
+            }
+            return;
+        };
+
+        let manifest_path = crate::indexer::cache::library_manifest_path(&cache_dir);
+        if !crate::indexer::cache::library_cache_is_fresh(
+            &source_paths,
+            &manifest_path,
+            &first_chunk,
+        ) {
+            // Cache is stale: reload all chunks into a combined HashMap for
+            // per-file hit checking, then proceed with the slow scan.
+            let mut combined = first_chunk;
+            for idx in 1..chunk_count {
+                if let Some(chunk) = crate::indexer::cache::load_library_chunk(&cache_dir, idx) {
+                    combined.extend(chunk);
+                }
+            }
+            let scan = self
+                .scan_source_paths_slow(&source_paths, Some(&combined), &workspace_root)
+                .await;
+            if self.workspace_root.generation() == gen {
+                self.apply_source_path_scan(scan, &raw_paths);
+            }
+            return;
+        }
+
+        // Pre-flight: validate all chunks exist before mutating any index state.
+        for idx in 1..chunk_count {
+            if !crate::indexer::cache::library_chunk_path(&cache_dir, idx).exists() {
+                log::warn!(
+                    "Library cache chunk {idx}/{chunk_count} missing — falling back to slow path"
+                );
+                let scan = self
+                    .scan_source_paths_slow(&source_paths, None, &workspace_root)
+                    .await;
+                if self.workspace_root.generation() == gen {
+                    self.apply_source_path_scan(scan, &raw_paths);
+                }
                 return;
-            };
-            self.restore_from_library_cache(lib_cache, &workspace_root);
-            return;
+            }
         }
 
-        // Slow path: scan directories, validate per-file, parse changed files.
-        let scan = self
-            .scan_source_paths_slow(&source_paths, lib_cache.as_ref(), &workspace_root)
-            .await;
-
-        if self.workspace_root.generation() != gen {
-            log::info!(
-                "index_source_paths: generation changed during async I/O, discarding results"
-            );
-            return;
+        // Fast path: restore one chunk at a time.  Each chunk is dropped before
+        // the next is loaded, keeping the instantaneous working set small.
+        log::debug!(
+            "Library cache fresh: restoring {} chunks without re-scanning",
+            chunk_count
+        );
+        self.restore_library_chunk(first_chunk, &workspace_root);
+        for idx in 1..chunk_count {
+            if let Some(chunk) = crate::indexer::cache::load_library_chunk(&cache_dir, idx) {
+                self.restore_library_chunk(chunk, &workspace_root);
+            }
         }
-
-        self.apply_source_path_scan(scan, &raw_paths);
+        self.rebuild_bare_name_cache();
+        log::debug!(
+            "Source paths restored from {} chunks: {} library files, {} total indexed files",
+            chunk_count,
+            self.library_uris.len(),
+            self.files.len()
+        );
     }
 
-    /// Fast path: restore library index from a fresh on-disk cache without re-scanning.
+    /// Flush one library cache chunk into the index.
     ///
-    /// Batches all contributions into local HashMaps first (no DashMap overhead),
-    /// then bulk-extends into DashMap in one pass. This avoids ~390K individual
-    /// lock acquisitions + dedup scans that plague the per-file approach.
-    fn restore_from_library_cache(
-        &self,
-        lib_cache: HashMap<String, FileCacheEntry>,
-        workspace_root: &Path,
-    ) {
-        let total = lib_cache.len();
-        log::debug!(
-            "Library cache fresh: restoring {} entries without re-scanning",
-            total
-        );
-
-        let mut batch = LibraryBatch::with_capacity(total);
+    /// Called in a loop from `index_source_paths`; the chunk HashMap is consumed
+    /// and dropped after each call so only one chunk sits in memory at a time.
+    fn restore_library_chunk(&self, chunk: HashMap<String, FileCacheEntry>, workspace_root: &Path) {
         let class_kinds = [
             SymbolKind::CLASS,
             SymbolKind::INTERFACE,
@@ -566,8 +609,8 @@ impl Indexer {
             SymbolKind::ENUM,
             SymbolKind::OBJECT,
         ];
-
-        for (path_str, entry) in &lib_cache {
+        let mut batch = LibraryBatch::with_capacity(chunk.len());
+        for (path_str, entry) in &chunk {
             let Ok(uri) = Url::from_file_path(path_str) else {
                 continue;
             };
@@ -581,15 +624,7 @@ impl Indexer {
                 workspace_root,
             );
         }
-
         batch.flush_into(self);
-        self.rebuild_bare_name_cache();
-
-        log::debug!(
-            "Source paths restored from cache: {} library files, {} total indexed files",
-            self.library_uris.len(),
-            self.files.len()
-        );
     }
 
     /// Slow path: scan source directories, use per-file cache where possible,

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -21,7 +21,7 @@ use crate::types::{FileData, FileIndexResult, Visibility};
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Bump when the serialized format changes; invalidates any older cache files.
-pub(crate) const CACHE_VERSION: u32 = 22;
+pub(crate) const CACHE_VERSION: u32 = 23;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -313,13 +313,35 @@ pub(super) fn save_cache(
     }
 }
 
-// ─── Library cache ────────────────────────────────────────────────────────────
+// ─── Library cache (chunked) ─────────────────────────────────────────────────
+//
+// The library cache is split into fixed-size chunk files to allow incremental
+// loading during the fast-path restore.  Loading 25k files one chunk at a time
+// (each ~20 MB on disk, ~50 MB deserialized) avoids the ~1 GB peak that a
+// single-file load causes — chunk + batch are dropped before the next chunk
+// is read, keeping the instantaneous working set small.
+//
+// Atomicity: the manifest is written LAST.  A missing or corrupt manifest means
+// the cache is invalid; callers fall back to a full re-scan.  Chunk files from a
+// previous incomplete write with the same chunk index are harmless because they
+// are overwritten at the start of the next save.
 
-/// Deterministic cache path for a set of library source paths.
+/// Max files per library cache chunk.  2 000 × average ~250 B on-disk ≈ 20 MB/chunk.
+const LIBRARY_CHUNK_SIZE: usize = 2000;
+
+/// Tiny commit-point file written last; its presence signals a complete save.
+#[derive(Serialize, Deserialize)]
+struct LibraryManifest {
+    version: u32,
+    chunk_count: u32,
+}
+
+/// Directory that holds the library cache chunks + manifest.
 ///
-/// Keyed by a hash of the (sorted) source path strings so the same
-/// `~/.kotlin-lsp/sources` directory shares one cache file across all workspaces.
-pub(super) fn library_cache_path(source_paths: &[String]) -> PathBuf {
+/// Uses the same hash logic as the old `library_cache_path` so existing caches
+/// do not collide: the old `library-{hash}.bin` file and the new
+/// `library-{hash}-chunks/` directory have different names.
+fn library_chunks_dir(source_paths: &[String]) -> PathBuf {
     let mut sorted = source_paths.to_vec();
     sorted.sort();
     let hash = {
@@ -336,32 +358,63 @@ pub(super) fn library_cache_path(source_paths: &[String]) -> PathBuf {
     };
     xdg_cache_base()
         .join("kotlin-lsp")
-        .join(format!("library-{hash:016x}.bin"))
+        .join(format!("library-{hash:016x}-chunks"))
+}
+
+pub(super) fn library_manifest_path(dir: &Path) -> PathBuf {
+    dir.join("manifest.bin")
+}
+
+pub(super) fn library_chunk_path(dir: &Path, idx: u32) -> PathBuf {
+    dir.join(format!("chunk-{idx:04}.bin"))
+}
+
+/// Load the library cache manifest.  Returns `(chunks_dir, chunk_count)` or `None`
+/// if the manifest is absent, corrupt, or version-mismatched.
+///
+/// Deliberately does NOT load any chunk data — callers decide whether they need
+/// the data at all (freshness check loads only the first chunk; fast-path restore
+/// loads chunks one at a time).
+pub(super) fn try_load_library_manifest(source_paths: &[String]) -> Option<(PathBuf, u32)> {
+    let dir = library_chunks_dir(source_paths);
+    let bytes = std::fs::read(library_manifest_path(&dir)).ok()?;
+    let manifest: LibraryManifest = bincode::deserialize(&bytes).ok()?;
+    if manifest.version != CACHE_VERSION {
+        return None;
+    }
+    Some((dir, manifest.chunk_count))
+}
+
+/// Load one library cache chunk.  Returns `None` if the file is missing, corrupt,
+/// or has a mismatched CACHE_VERSION.
+pub(super) fn load_library_chunk(dir: &Path, idx: u32) -> Option<HashMap<String, FileCacheEntry>> {
+    let path = library_chunk_path(dir, idx);
+    let file = std::fs::File::open(&path).ok()?;
+    let reader = std::io::BufReader::new(file);
+    let cache: IndexCache = bincode::deserialize_from(reader).ok()?;
+    if cache.version != CACHE_VERSION {
+        return None;
+    }
+    Some(cache.entries)
 }
 
 /// Returns `true` if the library cache is likely still valid.
 ///
 /// Two-tier check:
-/// 1. Directory mtime — catches file additions/deletions (fast, 1 stat per dir).
-/// 2. A random sample of up to 256 cached entries — catches in-place edits, which
-///    on most filesystems do NOT update the parent directory mtime.
+/// 1. Manifest mtime — catches additions/deletions in source directories (fast, 1 stat per dir).
+/// 2. A random sample of up to 256 entries from the first chunk — catches in-place edits.
 ///
-/// Limitation: edited files not in the random sample are still missed.
-/// For `~/.kotlin-lsp/sources` (populated by `extract-sources`) this is
-/// acceptable because those files are not directly edited by users.
+/// Callers must have already loaded the first chunk for the Tier 2 sample;
+/// passing it here avoids a redundant re-read.
 pub(super) fn library_cache_is_fresh(
     source_paths: &[PathBuf],
-    cache_path: &Path,
-    cached_entries: &HashMap<String, FileCacheEntry>,
+    manifest_path: &Path,
+    first_chunk_entries: &HashMap<String, FileCacheEntry>,
 ) -> bool {
-    let cache_mtime = match std::fs::metadata(cache_path).and_then(|m| m.modified()) {
+    let cache_mtime = match std::fs::metadata(manifest_path).and_then(|m| m.modified()) {
         Ok(t) => t,
         Err(_) => return false,
     };
-    // Tier 1: directory mtime.  Detects files added or removed directly inside each source
-    // path on most filesystems (the immediate parent directory mtime changes on add/remove).
-    // Note: on Linux, modifying a file's contents does NOT update its parent directory mtime,
-    // so this tier cannot detect modifications — Tier 2 handles that case.
     let dirs_fresh = source_paths.iter().all(|p| {
         std::fs::metadata(p)
             .and_then(|m| m.modified())
@@ -371,18 +424,12 @@ pub(super) fn library_cache_is_fresh(
     if !dirs_fresh {
         return false;
     }
-    // Tier 2: validate a spread sample of cached entries against on-disk mtime+size.
-    // This catches file modifications that Tier 1 misses.  We use up to 256 samples with
-    // a uniform stride so we cover the full entry set at roughly 1-in-(N/256) granularity.
-    // Library files (Gradle caches, extracted sources) are stable in practice, so this
-    // probabilistic check is sufficient; a full O(N) scan would be prohibitively slow for
-    // caches with tens of thousands of entries.
-    let sample_size = 256_usize.min(cached_entries.len());
+    let sample_size = 256_usize.min(first_chunk_entries.len());
     if sample_size == 0 {
         return true;
     }
-    let stride = (cached_entries.len() / sample_size).max(1);
-    cached_entries
+    let stride = (first_chunk_entries.len() / sample_size).max(1);
+    first_chunk_entries
         .iter()
         .step_by(stride)
         .take(sample_size)
@@ -402,44 +449,45 @@ pub(super) fn library_cache_is_fresh(
         })
 }
 
-/// Load the library cache for the given source paths.
-/// Returns `None` if absent, corrupt, or version-mismatched.
-pub(super) fn try_load_library_cache(
-    source_paths: &[String],
-) -> Option<HashMap<String, FileCacheEntry>> {
-    let path = library_cache_path(source_paths);
-    let file = std::fs::File::open(&path).ok()?;
-    let reader = std::io::BufReader::new(file);
-    let cache: IndexCache = bincode::deserialize_from(reader).ok()?;
-    if cache.version != CACHE_VERSION {
-        return None;
-    }
-    log::info!(
-        "Loaded library cache ({} files) from {}",
-        cache.entries.len(),
-        path.display()
-    );
-    Some(cache.entries)
-}
-
 /// Save the library cache for the given source paths.
 ///
-/// Only writes entries whose URI is in `library_uris`.
+/// Splits entries into `LIBRARY_CHUNK_SIZE`-file chunks and writes them to a
+/// dedicated directory.  The manifest is written **last** as a commit point:
+/// a missing manifest means the cache is invalid regardless of what chunk files
+/// exist.
 pub(super) fn save_library_cache(
     source_paths: &[String],
     files: &DashMap<String, Arc<FileData>>,
     content_hashes: &DashMap<String, u64>,
     library_uris: &DashSet<String>,
 ) {
-    let cache_path = library_cache_path(source_paths);
-    if let Some(parent) = cache_path.parent() {
-        if let Err(e) = std::fs::create_dir_all(parent) {
-            log::warn!("Library cache: could not create directory: {e}");
-            return;
-        }
+    let dir = library_chunks_dir(source_paths);
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        log::warn!("Library cache: could not create directory: {e}");
+        return;
     }
+    // Delete manifest first — marks save-in-progress.  A crash between here
+    // and the final manifest write leaves no manifest, which callers treat
+    // as an invalid cache and trigger a full re-scan.
+    let manifest_path = library_manifest_path(&dir);
+    let _ = std::fs::remove_file(&manifest_path);
 
-    let mut entries: HashMap<String, FileCacheEntry> = HashMap::new();
+    let entries = collect_library_entries(files, content_hashes, library_uris);
+    let total_files = entries.len();
+    let total_bytes = write_library_chunks(&dir, entries);
+    let chunk_count = total_files.div_ceil(LIBRARY_CHUNK_SIZE) as u32;
+
+    commit_library_manifest(&manifest_path, chunk_count, total_files, total_bytes, &dir);
+}
+
+/// Collect all library files into a flat vec of (path, cache-entry) pairs.
+/// Strips runtime-unneeded fields to minimise serialised size.
+fn collect_library_entries(
+    files: &DashMap<String, Arc<FileData>>,
+    content_hashes: &DashMap<String, u64>,
+    library_uris: &DashSet<String>,
+) -> Vec<(String, FileCacheEntry)> {
+    let mut entries: Vec<(String, FileCacheEntry)> = Vec::new();
     for file_ref in files.iter() {
         let uri_str = file_ref.key();
         if !library_uris.contains(uri_str) {
@@ -461,36 +509,9 @@ pub(super) fn save_library_cache(
                     .map(|d| d.as_secs())
                     .unwrap_or(0);
                 let file_size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
-                // Strip private/internal symbols before writing to disk: library
-                // members with restricted visibility are never accessible from
-                // workspace code, so there is no point caching them.  Filtering
-                // here means fast-path loads can use a plain Arc::clone.
-                //
-                // Also drop source lines: library files live in ~/.kotlin-lsp/sources
-                // and their lines are rarely needed at runtime (explicit type annotations
-                // in `type_annotations` cover the common cases). Storing lines for
-                // ~20 k library files bloats the binary cache by ~800 MB and inflates
-                // the in-memory footprint by several GB per server process.
-                let mut filtered = (**data).clone();
-                filtered.symbols.retain(|s| {
-                    !matches!(s.visibility, Visibility::Private | Visibility::Internal)
-                });
-                filtered.lines = Arc::new(Vec::new());
-                // Library files are never opened for editing — completion and
-                // hover work from `symbols` and `type_annotations`. Drop the
-                // identifier-scan results that are only used for in-file completion.
-                filtered.declared_names = Vec::new();
-                filtered.imports = Vec::new();
-                // RHS inference fields are only used for workspace-file variable
-                // type inference. Library files have explicit type annotations
-                // captured in `type_annotations` and `symbols`, so these are safe
-                // to drop — stripping them reduces cache size and heap footprint.
-                filtered.rhs_types = Vec::new();
-                filtered.method_call_rhs = Vec::new();
-                filtered.field_access_rhs = Vec::new();
-                let filtered = Arc::new(filtered);
+                let filtered = strip_library_file_data(data);
                 let qualified_keys = build_qualified_keys(&filtered, file_stem.as_deref());
-                entries.insert(
+                entries.push((
                     path_buf.to_string_lossy().to_string(),
                     FileCacheEntry {
                         mtime_secs: mtime,
@@ -499,36 +520,91 @@ pub(super) fn save_library_cache(
                         file_data: filtered,
                         qualified_keys,
                     },
-                );
+                ));
             }
         }
     }
+    entries
+}
 
-    let cache = IndexCache {
-        version: CACHE_VERSION,
-        complete_scan: true,
-        entries,
-    };
-    match bincode::serialize(&cache) {
-        Ok(bytes) => {
-            let tmp_path = cache_path.with_extension("bin.tmp");
-            let write_ok = std::fs::write(&tmp_path, &bytes)
-                .and_then(|()| std::fs::rename(&tmp_path, &cache_path))
-                .is_ok();
-            if write_ok {
-                log::info!(
-                    "Library cache saved ({} files, {} KB) → {}",
-                    cache.entries.len(),
-                    bytes.len() / 1024,
-                    cache_path.display()
-                );
-            } else {
-                let _ = std::fs::remove_file(&tmp_path);
-                log::warn!("Library cache write failed for {}", cache_path.display());
+/// Drop fields not needed for library symbols at runtime.
+fn strip_library_file_data(data: &FileData) -> Arc<FileData> {
+    let mut filtered = (*data).clone();
+    filtered
+        .symbols
+        .retain(|s| !matches!(s.visibility, Visibility::Private | Visibility::Internal));
+    // lines/declared_names/imports: only used for in-file completion.
+    // rhs/method_call/field_access RHS: only for workspace-file inference.
+    filtered.lines = Arc::new(Vec::new());
+    filtered.declared_names = Vec::new();
+    filtered.imports = Vec::new();
+    filtered.rhs_types = Vec::new();
+    filtered.method_call_rhs = Vec::new();
+    filtered.field_access_rhs = Vec::new();
+    Arc::new(filtered)
+}
+
+/// Write entries as sequential chunks.  Returns total bytes written.
+fn write_library_chunks(dir: &Path, entries: Vec<(String, FileCacheEntry)>) -> usize {
+    let chunk_count = entries.len().div_ceil(LIBRARY_CHUNK_SIZE) as u32;
+    let mut total_bytes = 0_usize;
+    let mut entries_iter = entries.into_iter();
+
+    for idx in 0..chunk_count {
+        let chunk_entries: HashMap<String, FileCacheEntry> =
+            entries_iter.by_ref().take(LIBRARY_CHUNK_SIZE).collect();
+        let cache = IndexCache {
+            version: CACHE_VERSION,
+            complete_scan: true,
+            entries: chunk_entries,
+        };
+        match bincode::serialize(&cache) {
+            Ok(bytes) => {
+                total_bytes += bytes.len();
+                let chunk_path = library_chunk_path(dir, idx);
+                if let Err(e) = std::fs::write(&chunk_path, &bytes) {
+                    log::warn!("Library cache chunk {idx} write failed: {e}");
+                    return total_bytes; // manifest absent → cache invalid on next load
+                }
+            }
+            Err(e) => {
+                log::warn!("Library cache chunk {idx} serialize failed: {e}");
+                return total_bytes;
             }
         }
-        Err(e) => log::warn!("Library cache serialize failed: {e}"),
     }
+    total_bytes
+}
+
+/// Write the manifest (commit point).  No manifest → cache invalid.
+fn commit_library_manifest(
+    manifest_path: &Path,
+    chunk_count: u32,
+    total_files: usize,
+    total_bytes: usize,
+    dir: &Path,
+) {
+    let manifest = LibraryManifest {
+        version: CACHE_VERSION,
+        chunk_count,
+    };
+    match bincode::serialize(&manifest) {
+        Ok(bytes) => {
+            if let Err(e) = std::fs::write(manifest_path, &bytes) {
+                log::warn!("Library cache manifest write failed: {e}");
+                return;
+            }
+        }
+        Err(e) => {
+            log::warn!("Library cache manifest serialize failed: {e}");
+            return;
+        }
+    }
+    log::info!(
+        "Library cache saved ({total_files} files in {chunk_count} chunks, {} KB total) → {}",
+        total_bytes / 1024,
+        dir.display()
+    );
 }
 
 #[cfg(test)]

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -326,7 +326,11 @@ pub(super) fn save_cache(
 // previous incomplete write with the same chunk index are harmless because they
 // are overwritten at the start of the next save.
 
-/// Max files per library cache chunk.  2 000 × average ~250 B on-disk ≈ 20 MB/chunk.
+/// Max files per library cache chunk.
+///
+/// Each chunk deserialises to roughly `LIBRARY_CHUNK_SIZE × average_entry_size`.
+/// With fields stripped (no `lines`, no `imports`, no RHS inference data),
+/// average entry size is ~3–5 KB, so 2 000 files ≈ 6–10 MB per chunk.
 const LIBRARY_CHUNK_SIZE: usize = 2000;
 
 /// Tiny commit-point file written last; its presence signals a complete save.
@@ -402,14 +406,22 @@ pub(super) fn load_library_chunk(dir: &Path, idx: u32) -> Option<HashMap<String,
 ///
 /// Two-tier check:
 /// 1. Manifest mtime — catches additions/deletions in source directories (fast, 1 stat per dir).
-/// 2. A random sample of up to 256 entries from the first chunk — catches in-place edits.
+/// 2. A random sample of up to 256 entries drawn from the first chunk AND the last chunk
+///    (if more than one chunk exists) — catches in-place file edits.
 ///
-/// Callers must have already loaded the first chunk for the Tier 2 sample;
-/// passing it here avoids a redundant re-read.
+/// Tier 1 covers the common case (Gradle re-extracts entire source directories).
+/// Tier 2 covers in-place edits: modifying a file updates the file's own mtime but
+/// not the parent directory mtime, so Tier 1 alone would miss it.  Sampling from
+/// both ends of the corpus reduces the probability of missing a changed file.
+///
+/// Callers must have already loaded the first chunk; `cache_dir` and `chunk_count`
+/// are used to optionally load the last chunk for the tail sample.
 pub(super) fn library_cache_is_fresh(
     source_paths: &[PathBuf],
     manifest_path: &Path,
     first_chunk_entries: &HashMap<String, FileCacheEntry>,
+    cache_dir: &Path,
+    chunk_count: u32,
 ) -> bool {
     let cache_mtime = match std::fs::metadata(manifest_path).and_then(|m| m.modified()) {
         Ok(t) => t,
@@ -424,12 +436,31 @@ pub(super) fn library_cache_is_fresh(
     if !dirs_fresh {
         return false;
     }
-    let sample_size = 256_usize.min(first_chunk_entries.len());
+
+    if !sample_entries_fresh(first_chunk_entries, 128) {
+        return false;
+    }
+
+    // Also sample the last chunk if it differs from the first.
+    if chunk_count > 1 {
+        if let Some(last_chunk) = load_library_chunk(cache_dir, chunk_count - 1) {
+            if !sample_entries_fresh(&last_chunk, 128) {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+/// Sample up to `limit` entries from `chunk` and verify each file's mtime and size match.
+fn sample_entries_fresh(chunk: &HashMap<String, FileCacheEntry>, limit: usize) -> bool {
+    let sample_size = limit.min(chunk.len());
     if sample_size == 0 {
         return true;
     }
-    let stride = (first_chunk_entries.len() / sample_size).max(1);
-    first_chunk_entries
+    let stride = (chunk.len() / sample_size).max(1);
+    chunk
         .iter()
         .step_by(stride)
         .take(sample_size)
@@ -474,7 +505,10 @@ pub(super) fn save_library_cache(
 
     let entries = collect_library_entries(files, content_hashes, library_uris);
     let total_files = entries.len();
-    let total_bytes = write_library_chunks(&dir, entries);
+    let Some(total_bytes) = write_library_chunks(&dir, entries) else {
+        // At least one chunk failed — manifest is absent, cache is invalid.
+        return;
+    };
     let chunk_count = total_files.div_ceil(LIBRARY_CHUNK_SIZE) as u32;
 
     commit_library_manifest(&manifest_path, chunk_count, total_files, total_bytes, &dir);
@@ -528,6 +562,12 @@ fn collect_library_entries(
 }
 
 /// Drop fields not needed for library symbols at runtime.
+///
+/// `lines` is stripped intentionally: restoring ~25k library files' source text
+/// would add ~300 MB of steady-state heap.  Callers that fall back to
+/// `data.lines` (e.g. `collect_params_from_line` in `infer/sig.rs`) silently
+/// return `None` for library symbols — this is acceptable since `SymbolEntry.params`
+/// and `detail` carry the same information for well-formed library classes.
 fn strip_library_file_data(data: &FileData) -> Arc<FileData> {
     let mut filtered = (*data).clone();
     filtered
@@ -544,8 +584,11 @@ fn strip_library_file_data(data: &FileData) -> Arc<FileData> {
     Arc::new(filtered)
 }
 
-/// Write entries as sequential chunks.  Returns total bytes written.
-fn write_library_chunks(dir: &Path, entries: Vec<(String, FileCacheEntry)>) -> usize {
+/// Write entries as sequential chunks.
+///
+/// Returns `Some(total_bytes)` if all chunks were written successfully.
+/// Returns `None` if any chunk failed; the manifest must NOT be written in that case.
+fn write_library_chunks(dir: &Path, entries: Vec<(String, FileCacheEntry)>) -> Option<usize> {
     let chunk_count = entries.len().div_ceil(LIBRARY_CHUNK_SIZE) as u32;
     let mut total_bytes = 0_usize;
     let mut entries_iter = entries.into_iter();
@@ -564,16 +607,16 @@ fn write_library_chunks(dir: &Path, entries: Vec<(String, FileCacheEntry)>) -> u
                 let chunk_path = library_chunk_path(dir, idx);
                 if let Err(e) = std::fs::write(&chunk_path, &bytes) {
                     log::warn!("Library cache chunk {idx} write failed: {e}");
-                    return total_bytes; // manifest absent → cache invalid on next load
+                    return None; // manifest absent → cache invalid on next load
                 }
             }
             Err(e) => {
                 log::warn!("Library cache chunk {idx} serialize failed: {e}");
-                return total_bytes;
+                return None;
             }
         }
     }
-    total_bytes
+    Some(total_bytes)
 }
 
 /// Write the manifest (commit point).  No manifest → cache invalid.

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -21,7 +21,7 @@ use crate::types::{FileData, FileIndexResult, Visibility};
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Bump when the serialized format changes; invalidates any older cache files.
-pub(crate) const CACHE_VERSION: u32 = 19;
+pub(crate) const CACHE_VERSION: u32 = 20;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -464,10 +464,17 @@ pub(super) fn save_library_cache(
                 // members with restricted visibility are never accessible from
                 // workspace code, so there is no point caching them.  Filtering
                 // here means fast-path loads can use a plain Arc::clone.
+                //
+                // Also drop source lines: library files live in ~/.kotlin-lsp/sources
+                // and their lines are rarely needed at runtime (explicit type annotations
+                // in `type_annotations` cover the common cases). Storing lines for
+                // ~20 k library files bloats the binary cache by ~800 MB and inflates
+                // the in-memory footprint by several GB per server process.
                 let mut filtered = (**data).clone();
                 filtered.symbols.retain(|s| {
                     !matches!(s.visibility, Visibility::Private | Visibility::Internal)
                 });
+                filtered.lines = Arc::new(Vec::new());
                 let filtered = Arc::new(filtered);
                 let qualified_keys = build_qualified_keys(&filtered, file_stem.as_deref());
                 entries.insert(

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -21,7 +21,7 @@ use crate::types::{FileData, FileIndexResult, Visibility};
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Bump when the serialized format changes; invalidates any older cache files.
-pub(crate) const CACHE_VERSION: u32 = 21;
+pub(crate) const CACHE_VERSION: u32 = 22;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -408,8 +408,9 @@ pub(super) fn try_load_library_cache(
     source_paths: &[String],
 ) -> Option<HashMap<String, FileCacheEntry>> {
     let path = library_cache_path(source_paths);
-    let bytes = std::fs::read(&path).ok()?;
-    let cache: IndexCache = bincode::deserialize(&bytes).ok()?;
+    let file = std::fs::File::open(&path).ok()?;
+    let reader = std::io::BufReader::new(file);
+    let cache: IndexCache = bincode::deserialize_from(reader).ok()?;
     if cache.version != CACHE_VERSION {
         return None;
     }
@@ -480,6 +481,13 @@ pub(super) fn save_library_cache(
                 // identifier-scan results that are only used for in-file completion.
                 filtered.declared_names = Vec::new();
                 filtered.imports = Vec::new();
+                // RHS inference fields are only used for workspace-file variable
+                // type inference. Library files have explicit type annotations
+                // captured in `type_annotations` and `symbols`, so these are safe
+                // to drop — stripping them reduces cache size and heap footprint.
+                filtered.rhs_types = Vec::new();
+                filtered.method_call_rhs = Vec::new();
+                filtered.field_access_rhs = Vec::new();
                 let filtered = Arc::new(filtered);
                 let qualified_keys = build_qualified_keys(&filtered, file_stem.as_deref());
                 entries.insert(

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -21,7 +21,7 @@ use crate::types::{FileData, FileIndexResult, Visibility};
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Bump when the serialized format changes; invalidates any older cache files.
-pub(crate) const CACHE_VERSION: u32 = 20;
+pub(crate) const CACHE_VERSION: u32 = 21;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -475,6 +475,11 @@ pub(super) fn save_library_cache(
                     !matches!(s.visibility, Visibility::Private | Visibility::Internal)
                 });
                 filtered.lines = Arc::new(Vec::new());
+                // Library files are never opened for editing — completion and
+                // hover work from `symbols` and `type_annotations`. Drop the
+                // identifier-scan results that are only used for in-file completion.
+                filtered.declared_names = Vec::new();
+                filtered.imports = Vec::new();
                 let filtered = Arc::new(filtered);
                 let qualified_keys = build_qualified_keys(&filtered, file_stem.as_deref());
                 entries.insert(

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -333,6 +333,13 @@ pub(super) fn save_cache(
 /// average entry size is ~3–5 KB, so 2 000 files ≈ 6–10 MB per chunk.
 const LIBRARY_CHUNK_SIZE: usize = 2000;
 
+/// Upper bound on the number of library cache chunks.
+///
+/// A corrupt-but-deserializable manifest could set `chunk_count` to `u32::MAX`,
+/// causing `Vec::with_capacity(chunk_count as usize)` to OOM.  Guard against that.
+/// Even the largest Android SDK (≈ 60 000 files) produces at most 30 chunks.
+const MAX_LIBRARY_CHUNKS: u32 = 10_000;
+
 /// Tiny commit-point file written last; its presence signals a complete save.
 #[derive(Serialize, Deserialize)]
 struct LibraryManifest {
@@ -386,6 +393,18 @@ pub(super) fn try_load_library_manifest(source_paths: &[String]) -> Option<(Path
     if manifest.version != CACHE_VERSION {
         return None;
     }
+    if manifest.chunk_count > MAX_LIBRARY_CHUNKS {
+        log::warn!(
+            "Library cache manifest has implausible chunk_count={}, treating as corrupt",
+            manifest.chunk_count
+        );
+        return None;
+    }
+    // Pre-flight: if non-empty, the first chunk must exist — catches manifests left
+    // over from an aborted save or a manual cache deletion.
+    if manifest.chunk_count > 0 && !library_chunk_path(&dir, 0).exists() {
+        return None;
+    }
     Some((dir, manifest.chunk_count))
 }
 
@@ -406,16 +425,16 @@ pub(super) fn load_library_chunk(dir: &Path, idx: u32) -> Option<HashMap<String,
 ///
 /// Two-tier check:
 /// 1. Manifest mtime — catches additions/deletions in source directories (fast, 1 stat per dir).
-/// 2. A random sample of up to 256 entries drawn from the first chunk AND the last chunk
-///    (if more than one chunk exists) — catches in-place file edits.
+/// 2. A random sample of up to 256 entries drawn from the first chunk, the middle chunk
+///    (if ≥ 3 chunks), and the last chunk (if ≥ 2 chunks) — catches in-place file edits.
 ///
 /// Tier 1 covers the common case (Gradle re-extracts entire source directories).
 /// Tier 2 covers in-place edits: modifying a file updates the file's own mtime but
 /// not the parent directory mtime, so Tier 1 alone would miss it.  Sampling from
-/// both ends of the corpus reduces the probability of missing a changed file.
+/// first, middle, and last chunks reduces the probability of missing a changed file.
 ///
 /// Callers must have already loaded the first chunk; `cache_dir` and `chunk_count`
-/// are used to optionally load the last chunk for the tail sample.
+/// are used to optionally load the last and middle chunks for the tail/mid samples.
 pub(super) fn library_cache_is_fresh(
     source_paths: &[PathBuf],
     manifest_path: &Path,
@@ -445,6 +464,17 @@ pub(super) fn library_cache_is_fresh(
     if chunk_count > 1 {
         if let Some(last_chunk) = load_library_chunk(cache_dir, chunk_count - 1) {
             if !sample_entries_fresh(&last_chunk, 128) {
+                return false;
+            }
+        }
+    }
+
+    // Sample a middle chunk so edits to files in neither the first nor last
+    // chunk are also caught.
+    if chunk_count > 2 {
+        let mid_idx = chunk_count / 2;
+        if let Some(mid_chunk) = load_library_chunk(cache_dir, mid_idx) {
+            if !sample_entries_fresh(&mid_chunk, 64) {
                 return false;
             }
         }

--- a/src/indexer/cache_tests.rs
+++ b/src/indexer/cache_tests.rs
@@ -361,3 +361,45 @@ fn library_cache_is_fresh_empty_cache() {
         );
     });
 }
+
+/// A manifest with an implausibly large `chunk_count` is rejected to prevent OOM.
+#[test]
+fn library_manifest_absurd_chunk_count_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    with_xdg_cache(tmp.path(), || {
+        let source_paths = vec![tmp.path().to_string_lossy().to_string()];
+        let dir = library_chunks_dir(&source_paths);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let manifest = LibraryManifest {
+            version: CACHE_VERSION,
+            chunk_count: u32::MAX,
+        };
+        let bytes = bincode::serialize(&manifest).unwrap();
+        std::fs::write(library_manifest_path(&dir), bytes).unwrap();
+
+        assert!(
+            try_load_library_manifest(&source_paths).is_none(),
+            "manifest with u32::MAX chunk_count should be rejected"
+        );
+    });
+}
+
+/// A manifest pointing to a non-existent first chunk is rejected.
+#[test]
+fn library_manifest_missing_chunk0_rejected() {
+    let tmp = tempfile::tempdir().unwrap();
+    with_xdg_cache(tmp.path(), || {
+        let source_paths = vec![tmp.path().to_string_lossy().to_string()];
+        let dir = library_chunks_dir(&source_paths);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // Write manifest claiming 2 chunks but write no chunk files.
+        write_manifest(&dir, 2);
+
+        assert!(
+            try_load_library_manifest(&source_paths).is_none(),
+            "manifest with missing chunk-0000.bin should be rejected"
+        );
+    });
+}

--- a/src/indexer/cache_tests.rs
+++ b/src/indexer/cache_tests.rs
@@ -174,3 +174,190 @@ fn save_and_load_cache_roundtrip() {
         );
     });
 }
+
+// ── Chunked library cache tests ──────────────────────────────────────────────
+
+fn make_dummy_entry(_path: &std::path::Path) -> FileCacheEntry {
+    FileCacheEntry {
+        mtime_secs: 0,
+        file_size: 0,
+        content_hash: 0,
+        file_data: Arc::new(FileData::default()),
+        qualified_keys: vec![],
+    }
+}
+
+fn write_dummy_chunk(dir: &std::path::Path, idx: u32, keys: &[&str]) {
+    let entries: HashMap<String, FileCacheEntry> = keys
+        .iter()
+        .map(|k| (k.to_string(), make_dummy_entry(std::path::Path::new(k))))
+        .collect();
+    let cache = IndexCache {
+        version: CACHE_VERSION,
+        complete_scan: true,
+        entries,
+    };
+    let bytes = bincode::serialize(&cache).unwrap();
+    std::fs::write(library_chunk_path(dir, idx), bytes).unwrap();
+}
+
+fn write_manifest(dir: &std::path::Path, chunk_count: u32) {
+    let manifest = LibraryManifest {
+        version: CACHE_VERSION,
+        chunk_count,
+    };
+    let bytes = bincode::serialize(&manifest).unwrap();
+    std::fs::write(library_manifest_path(dir), bytes).unwrap();
+}
+
+/// Missing manifest → `try_load_library_manifest` returns `None`.
+#[test]
+fn library_manifest_missing_returns_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    with_xdg_cache(tmp.path(), || {
+        let source_paths = vec![tmp.path().to_string_lossy().to_string()];
+        assert!(
+            try_load_library_manifest(&source_paths).is_none(),
+            "should return None when no manifest exists"
+        );
+    });
+}
+
+/// Present manifest + all chunks → round-trip returns correct chunk count.
+#[test]
+fn library_manifest_roundtrip() {
+    let tmp = tempfile::tempdir().unwrap();
+    with_xdg_cache(tmp.path(), || {
+        let source_paths = vec![tmp.path().to_string_lossy().to_string()];
+        let dir = library_chunks_dir(&source_paths);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        write_dummy_chunk(&dir, 0, &["/lib/A.kt"]);
+        write_dummy_chunk(&dir, 1, &["/lib/B.kt"]);
+        write_manifest(&dir, 2);
+
+        let result = try_load_library_manifest(&source_paths);
+        assert!(result.is_some(), "should find manifest");
+        let (returned_dir, chunk_count) = result.unwrap();
+        assert_eq!(returned_dir, dir);
+        assert_eq!(chunk_count, 2);
+    });
+}
+
+/// Loading a missing chunk returns `None` without panicking.
+#[test]
+fn load_library_chunk_missing_returns_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    assert!(
+        load_library_chunk(dir, 0).is_none(),
+        "missing chunk should return None"
+    );
+}
+
+/// A chunk with a wrong CACHE_VERSION is rejected.
+#[test]
+fn load_library_chunk_version_mismatch_returns_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+
+    // Write a chunk with the wrong version.
+    let cache = IndexCache {
+        version: 0, // intentionally wrong
+        complete_scan: true,
+        entries: HashMap::new(),
+    };
+    let bytes = bincode::serialize(&cache).unwrap();
+    std::fs::write(library_chunk_path(dir, 0), bytes).unwrap();
+
+    assert!(
+        load_library_chunk(dir, 0).is_none(),
+        "version-mismatched chunk should return None"
+    );
+}
+
+/// A corrupt (truncated) chunk file returns `None` without panicking.
+#[test]
+fn load_library_chunk_corrupt_returns_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    let dir = tmp.path();
+    std::fs::write(library_chunk_path(dir, 0), b"not valid bincode").unwrap();
+    assert!(
+        load_library_chunk(dir, 0).is_none(),
+        "corrupt chunk should return None"
+    );
+}
+
+/// Saving with zero library files produces a manifest with chunk_count=0.
+/// `try_load_library_manifest` returns `Some` with 0 chunks.
+#[test]
+fn save_library_cache_zero_files_writes_empty_manifest() {
+    use dashmap::{DashMap, DashSet};
+    let tmp = tempfile::tempdir().unwrap();
+    with_xdg_cache(tmp.path(), || {
+        let source_paths = vec![tmp.path().to_string_lossy().to_string()];
+        let files: DashMap<String, Arc<crate::types::FileData>> = DashMap::new();
+        let hashes: DashMap<String, u64> = DashMap::new();
+        let library_uris: DashSet<String> = DashSet::new();
+
+        save_library_cache(&source_paths, &files, &hashes, &library_uris);
+
+        // Empty library still writes a valid manifest (chunk_count=0).
+        let result = try_load_library_manifest(&source_paths);
+        assert!(
+            result.is_some(),
+            "manifest expected even for zero-entry library"
+        );
+        let (_, chunk_count) = result.unwrap();
+        assert_eq!(chunk_count, 0, "chunk_count should be 0 for empty library");
+    });
+}
+
+/// Manifest with wrong CACHE_VERSION is rejected.
+#[test]
+fn library_manifest_version_mismatch_returns_none() {
+    let tmp = tempfile::tempdir().unwrap();
+    with_xdg_cache(tmp.path(), || {
+        let source_paths = vec![tmp.path().to_string_lossy().to_string()];
+        let dir = library_chunks_dir(&source_paths);
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let manifest = LibraryManifest {
+            version: 0, // wrong version
+            chunk_count: 1,
+        };
+        let bytes = bincode::serialize(&manifest).unwrap();
+        std::fs::write(library_manifest_path(&dir), bytes).unwrap();
+
+        assert!(
+            try_load_library_manifest(&source_paths).is_none(),
+            "version-mismatched manifest should be rejected"
+        );
+    });
+}
+
+/// `library_cache_is_fresh` with an empty first chunk and no second chunk
+/// returns `true` (nothing to invalidate).
+#[test]
+fn library_cache_is_fresh_empty_cache() {
+    let tmp = tempfile::tempdir().unwrap();
+    with_xdg_cache(tmp.path(), || {
+        let source_paths_str = vec![tmp.path().to_string_lossy().to_string()];
+        let dir = library_chunks_dir(&source_paths_str);
+        std::fs::create_dir_all(&dir).unwrap();
+        write_manifest(&dir, 1);
+
+        // Touch the manifest to make it newer than any source directory.
+        let manifest_path = library_manifest_path(&dir);
+        let source_paths: Vec<std::path::PathBuf> = source_paths_str
+            .iter()
+            .map(std::path::PathBuf::from)
+            .collect();
+
+        let fresh = library_cache_is_fresh(&source_paths, &manifest_path, &HashMap::new(), &dir, 1);
+        assert!(
+            fresh,
+            "empty first chunk with nothing to check should be considered fresh"
+        );
+    });
+}

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -119,27 +119,24 @@ pub(crate) fn find_this_element_type_in_lines(
     find_it_element_type_in_lines_impl(lines, pos, idx, uri, LambdaParamKind::This)
 }
 
-/// Multi-line version of `find_named_lambda_param_type` for hover/goto-def.
+/// Multi-line version of `find_named_lambda_param_type` for hover/inlay-hint paths.
 ///
 /// Scans the whole file (not just `before_cursor`) for `{ param_name ->`,
-/// including the CURRENT line (needed when cursor is on the param name before
-/// the `->` is written, or when scanning the declaration line itself).
+/// including the CURRENT line.  Also handles multi-param lambdas `{ id, scan -> }`.
 ///
-/// Also handles multi-param lambdas `{ id, scan -> }`.
-/// Resolve a named lambda parameter's type for hover/inlay-hint paths.
+/// `cursor_utf16_col` is the UTF-16 column of the parameter name at `cursor_line`.
 ///
-/// `cursor_utf16_col` is the UTF-16 column of the parameter name at `cursor_line`
-/// (e.g. the position of `categoryAge` in `.let { categoryAge ->`).  Pass `0`
-/// when the column is not known (e.g. from tests); the text fallback will still
-/// run and may resolve simpler same-line cases.
-///
-/// The CST path (preferred) requires `idx.live_doc(uri)` to be present.
-/// The text scan (fallback) handles no-live-doc scenarios.
+/// `live_doc` must be the **same** snapshot that produced `cursor_line`/
+/// `cursor_utf16_col`.  Passing a different snapshot (or re-calling `idx.live_doc`
+/// internally) risks position mismatches when a `did_change` races with
+/// inlay-hint computation.  Pass `None` to skip the CST path; the text
+/// fallback will still run.
 pub(crate) fn find_named_lambda_param_type_in_lines(
     lines: &[String],
     param_name: &str,
     cursor_line: usize,
     cursor_utf16_col: usize,
+    live_doc: Option<&crate::indexer::live_tree::LiveDoc>,
     idx: &Indexer,
     uri: &Url,
 ) -> Option<String> {
@@ -149,8 +146,8 @@ pub(crate) fn find_named_lambda_param_type_in_lines(
         line: cursor_line,
         utf16_col: cursor_utf16_col,
     };
-    if let Some(doc) = idx.live_doc(uri) {
-        if let Some(result) = cst_named_lambda_param_type(pos, param_name, &doc, idx, uri) {
+    if let Some(doc) = live_doc {
+        if let Some(result) = cst_named_lambda_param_type(pos, param_name, doc, idx, uri) {
             return Some(result);
         }
     }

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -126,16 +126,28 @@ pub(crate) fn find_this_element_type_in_lines(
 /// the `->` is written, or when scanning the declaration line itself).
 ///
 /// Also handles multi-param lambdas `{ id, scan -> }`.
+/// Resolve a named lambda parameter's type for hover/inlay-hint paths.
+///
+/// `cursor_utf16_col` is the UTF-16 column of the parameter name at `cursor_line`
+/// (e.g. the position of `categoryAge` in `.let { categoryAge ->`).  Pass `0`
+/// when the column is not known (e.g. from tests); the text fallback will still
+/// run and may resolve simpler same-line cases.
+///
+/// The CST path (preferred) requires `idx.live_doc(uri)` to be present.
+/// The text scan (fallback) handles no-live-doc scenarios.
 pub(crate) fn find_named_lambda_param_type_in_lines(
     lines: &[String],
     param_name: &str,
     cursor_line: usize,
+    cursor_utf16_col: usize,
     idx: &Indexer,
     uri: &Url,
 ) -> Option<String> {
+    // CST fast-path: use the caller-provided position (may be col=0 when unknown,
+    // but is the real column when called from infer_lambda_param_type_at).
     let pos = CursorPos {
         line: cursor_line,
-        utf16_col: 0,
+        utf16_col: cursor_utf16_col,
     };
     if let Some(doc) = idx.live_doc(uri) {
         if let Some(result) = cst_named_lambda_param_type(pos, param_name, &doc, idx, uri) {
@@ -143,6 +155,8 @@ pub(crate) fn find_named_lambda_param_type_in_lines(
         }
     }
 
+    // Text fallback: needed when live_doc is absent (e.g. did_open not yet
+    // processed by the actor, or first inlay-hint request races with indexing).
     let scan_start = cursor_line.saturating_sub(LAMBDA_PARAM_SCAN_BACK_LINES);
     // Include cursor_line itself (different from completion path which is exclusive).
     for ln in (scan_start..=cursor_line).rev() {
@@ -153,25 +167,6 @@ pub(crate) fn find_named_lambda_param_type_in_lines(
         let Some((brace_pos, pos)) = find_lambda_brace_for_param(line, param_name) else {
             continue;
         };
-
-        // The initial CST call used utf16_col=0, which for multi-line chains
-        // (receiver on a previous line, `{ param ->` on its own line) lands
-        // outside the lambda.  Retry with the param's actual column so
-        // cursor_node_at finds the correct lambda_literal.
-        if let Some(doc) = idx.live_doc(uri) {
-            if let Some(param_utf16_col) = param_name_utf16_col(line, brace_pos, param_name) {
-                let precise_pos = CursorPos {
-                    line: ln,
-                    utf16_col: param_utf16_col,
-                };
-                if let Some(result) =
-                    cst_named_lambda_param_type(precise_pos, param_name, &doc, idx, uri)
-                {
-                    return Some(result);
-                }
-            }
-        }
-
         let before_brace = &line[..brace_pos];
         let result = lambda_receiver_type_from_context(before_brace, idx, uri)
             .or_else(|| lambda_receiver_type_named_arg_ml(before_brace, pos, lines, ln, idx, uri));
@@ -180,21 +175,6 @@ pub(crate) fn find_named_lambda_param_type_in_lines(
         }
     }
     None
-}
-
-/// Return the UTF-16 column of `param_name` inside a lambda opening like
-/// `    .let { categoryAge ->`, searching after `brace_pos`.
-/// Returns `None` if the name is not found as a word boundary after the brace.
-fn param_name_utf16_col(line: &str, brace_pos: usize, param_name: &str) -> Option<usize> {
-    let after = line.get(brace_pos..)?;
-    let rel = after.find(param_name)?;
-    // Ensure it's a whole-word match (not a substring of a longer identifier).
-    let end = rel + param_name.len();
-    if after[end..].starts_with(|c: char| c.is_alphanumeric() || c == '_') {
-        return None;
-    }
-    let byte_col = brace_pos + rel;
-    Some(line[..byte_col].encode_utf16().count())
 }
 
 /// Resolve the element/receiver type for an EXPLICITLY NAMED lambda parameter.

--- a/src/indexer/infer/it_this.rs
+++ b/src/indexer/infer/it_this.rs
@@ -153,6 +153,25 @@ pub(crate) fn find_named_lambda_param_type_in_lines(
         let Some((brace_pos, pos)) = find_lambda_brace_for_param(line, param_name) else {
             continue;
         };
+
+        // The initial CST call used utf16_col=0, which for multi-line chains
+        // (receiver on a previous line, `{ param ->` on its own line) lands
+        // outside the lambda.  Retry with the param's actual column so
+        // cursor_node_at finds the correct lambda_literal.
+        if let Some(doc) = idx.live_doc(uri) {
+            if let Some(param_utf16_col) = param_name_utf16_col(line, brace_pos, param_name) {
+                let precise_pos = CursorPos {
+                    line: ln,
+                    utf16_col: param_utf16_col,
+                };
+                if let Some(result) =
+                    cst_named_lambda_param_type(precise_pos, param_name, &doc, idx, uri)
+                {
+                    return Some(result);
+                }
+            }
+        }
+
         let before_brace = &line[..brace_pos];
         let result = lambda_receiver_type_from_context(before_brace, idx, uri)
             .or_else(|| lambda_receiver_type_named_arg_ml(before_brace, pos, lines, ln, idx, uri));
@@ -161,6 +180,21 @@ pub(crate) fn find_named_lambda_param_type_in_lines(
         }
     }
     None
+}
+
+/// Return the UTF-16 column of `param_name` inside a lambda opening like
+/// `    .let { categoryAge ->`, searching after `brace_pos`.
+/// Returns `None` if the name is not found as a word boundary after the brace.
+fn param_name_utf16_col(line: &str, brace_pos: usize, param_name: &str) -> Option<usize> {
+    let after = line.get(brace_pos..)?;
+    let rel = after.find(param_name)?;
+    // Ensure it's a whole-word match (not a substring of a longer identifier).
+    let end = rel + param_name.len();
+    if after[end..].starts_with(|c: char| c.is_alphanumeric() || c == '_') {
+        return None;
+    }
+    let byte_col = brace_pos + rel;
+    Some(line[..byte_col].encode_utf16().count())
 }
 
 /// Resolve the element/receiver type for an EXPLICITLY NAMED lambda parameter.

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -234,19 +234,21 @@ fn named_lambda_param_type_in_lines_cst_uses_param_position() {
     let sig_src = "fun zipUsers(block: (LeftUser, RightUser) -> Unit) {}";
     let code_src = "zipUsers { left, right ->\n    right.name\n}";
     let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
-    let result = find_named_lambda_param_type_in_lines(&lines, "right", 1, &idx, &u);
+    let result = find_named_lambda_param_type_in_lines(&lines, "right", 1, 0, &idx, &u);
     assert_eq!(result.as_deref(), Some("RightUser"));
 }
 
 #[test]
 fn named_lambda_param_multiline_receiver_via_function_call() {
     // childCategory(child) is on line 0; .let { categoryAge -> on line 1.
-    // Before this fix: col=0 CST found outer context, text fallback got
-    // before_brace=".let " → fun_trailing_lambda_it_type("let") → "T".
+    // col=0 on line 1 lands outside the lambda in the nav expression; we must
+    // pass the real column of `categoryAge` so CST finds the correct lambda_literal.
     let sig_src = "fun childCategory(child: ChildAccount): Int { return 0 }";
     let code_src = "childCategory(child)\n    .let { categoryAge ->\n        categoryAge\n    }";
     let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
-    let result = find_named_lambda_param_type_in_lines(&lines, "categoryAge", 1, &idx, &u);
+    // Compute the UTF-16 column of `categoryAge` in line 1.
+    let col = lines[1].find("categoryAge").unwrap();
+    let result = find_named_lambda_param_type_in_lines(&lines, "categoryAge", 1, col, &idx, &u);
     assert_eq!(
         result.as_deref(),
         Some("Int"),

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -234,7 +234,16 @@ fn named_lambda_param_type_in_lines_cst_uses_param_position() {
     let sig_src = "fun zipUsers(block: (LeftUser, RightUser) -> Unit) {}";
     let code_src = "zipUsers { left, right ->\n    right.name\n}";
     let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
-    let result = find_named_lambda_param_type_in_lines(&lines, "right", 1, 0, &idx, &u);
+    let live_doc_arc = idx.live_doc(&u);
+    let result = find_named_lambda_param_type_in_lines(
+        &lines,
+        "right",
+        1,
+        0,
+        live_doc_arc.as_deref(),
+        &idx,
+        &u,
+    );
     assert_eq!(result.as_deref(), Some("RightUser"));
 }
 
@@ -248,7 +257,17 @@ fn named_lambda_param_multiline_receiver_via_function_call() {
     let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
     // Compute the UTF-16 column of `categoryAge` in line 1.
     let col = lines[1].find("categoryAge").unwrap();
-    let result = find_named_lambda_param_type_in_lines(&lines, "categoryAge", 1, col, &idx, &u);
+    // Pass the live_doc snapshot to ensure CST and position use the same tree.
+    let live_doc_arc = idx.live_doc(&u);
+    let result = find_named_lambda_param_type_in_lines(
+        &lines,
+        "categoryAge",
+        1,
+        col,
+        live_doc_arc.as_deref(),
+        &idx,
+        &u,
+    );
     assert_eq!(
         result.as_deref(),
         Some("Int"),

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -238,6 +238,22 @@ fn named_lambda_param_type_in_lines_cst_uses_param_position() {
     assert_eq!(result.as_deref(), Some("RightUser"));
 }
 
+#[test]
+fn named_lambda_param_multiline_receiver_via_function_call() {
+    // childCategory(child) is on line 0; .let { categoryAge -> on line 1.
+    // Before this fix: col=0 CST found outer context, text fallback got
+    // before_brace=".let " → fun_trailing_lambda_it_type("let") → "T".
+    let sig_src = "fun childCategory(child: ChildAccount): Int { return 0 }";
+    let code_src = "childCategory(child)\n    .let { categoryAge ->\n        categoryAge\n    }";
+    let (u, idx, lines) = indexed_with_live("/t.kt", sig_src, code_src);
+    let result = find_named_lambda_param_type_in_lines(&lines, "categoryAge", 1, &idx, &u);
+    assert_eq!(
+        result.as_deref(),
+        Some("Int"),
+        "categoryAge should resolve to Int (return type of childCategory), got: {result:?}"
+    );
+}
+
 // ── line_has_lambda_param ────────────────────────────────────────────────────
 
 #[test]

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -135,7 +135,10 @@ pub(crate) fn collect_signature(lines: &[String], start_line: usize) -> String {
     let mut parts: Vec<String> = Vec::new();
     let mut depth: i32 = 0;
 
-    for raw_line in lines[start_line..(start_line + SIGNATURE_SCAN_LINES).min(lines.len())].iter() {
+    for raw_line in lines
+        [start_line.min(lines.len())..(start_line + SIGNATURE_SCAN_LINES).min(lines.len())]
+        .iter()
+    {
         let raw = raw_line.trim();
 
         // Count parens in this line.

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -259,10 +259,10 @@ impl Indexer {
             None
         } else {
             // For named params: scan backward for `{ name ->` pattern.
-            // Also check the CURRENT line (needed when cursor is ON the param
-            // at its declaration line, before `->` — before_cursor wouldn't
-            // contain the arrow).
-            find_named_lambda_param_type_in_lines(&lines, name, line_no, self, uri)
+            // Pass the real UTF-16 column so the CST fast-path places the cursor
+            // inside the correct lambda_literal (multi-line receiver chain case).
+            let utf16_col = position.character as usize;
+            find_named_lambda_param_type_in_lines(&lines, name, line_no, utf16_col, self, uri)
         }
     }
 

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -261,8 +261,20 @@ impl Indexer {
             // For named params: scan backward for `{ name ->` pattern.
             // Pass the real UTF-16 column so the CST fast-path places the cursor
             // inside the correct lambda_literal (multi-line receiver chain case).
+            // Snapshot live_doc ONCE here so the CST path uses the same tree
+            // that produced `position` — prevents a race where did_change updates
+            // live_doc between the caller's position derivation and our CST lookup.
             let utf16_col = position.character as usize;
-            find_named_lambda_param_type_in_lines(&lines, name, line_no, utf16_col, self, uri)
+            let live_doc_arc = self.live_doc(uri);
+            find_named_lambda_param_type_in_lines(
+                &lines,
+                name,
+                line_no,
+                utf16_col,
+                live_doc_arc.as_deref(),
+                self,
+                uri,
+            )
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,7 @@
 #![warn(unreachable_pub)]
+
+#[global_allocator]
+static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 mod backend;
 mod cli;
 mod features;


### PR DESCRIPTION
## Problem

At end-of-indexing, `restore_from_library_cache` loaded the entire `library-{hash}.bin` (~488 MB on disk) into a `HashMap<String, FileCacheEntry>` (~1 GB in RAM), then bulk-extended all 25k entries into DashMap. The HashMap + DashMap co-existence caused a visible RSS spike visible as a burst of disk reads + CPU at indexing completion.

## Solution

Replace the single monolithic file with a **chunked directory format**:
```
~/.cache/kotlin-lsp/library-{hash}-chunks/
  chunk-0000.bin   (~20 MB each, 2000 files)
  chunk-0001.bin
  ...
  manifest.bin     (written last — commit point)
```

Each chunk is loaded, flushed into DashMap, then **dropped** before the next is read. Peak working set per chunk is ~50 MB instead of ~1 GB.

## Atomicity

Manifest is written **last**. A crash or power-loss mid-write leaves no manifest → next startup treats cache as invalid and falls back to full rescan safely.

## Pre-flight validation

All chunk paths are `stat()`'d before any DashMap mutation → partial restores are impossible.

## Also in this PR

- `save_library_cache` split into focused helpers: `collect_library_entries`, `strip_library_file_data`, `write_library_chunks`, `commit_library_manifest`
- Streaming deserialization (`BufReader + deserialize_from`) to avoid 493 MB intermediate `Vec<u8>` on load
- Strip runtime-unneeded fields from library `FileData`: `lines`, `declared_names`, `imports`, `rhs_types`, `method_call_rhs`, `field_access_rhs`
- Switch to `tikv-jemallocator` as global allocator (eliminates glibc malloc arena fragmentation — was 244 × 128 MB anonymous arenas)

**CACHE_VERSION bumped 19 → 23** (each strip was a separate bump; 19→20→21→22→23).

## Memory impact

| Before | After |
|---|---|
| ~7 GB RSS (two processes) | ~2.8 GB RSS (two processes) |
| 244 × 128 MB glibc arenas | jemalloc, returns memory to OS |
| ~1 GB spike at end-of-index | ~50 MB peak per chunk |