### PR TITLE
fix(references): filter sibling-qualifier bleed and scope lowercase decl-site

### DIFF
--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -26,12 +26,13 @@ impl Backend {
     ) -> Result<Option<Vec<Location>>> {
         let uri = &params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
-        let Some((name, _)) = self.indexer.word_and_qualifier_at(uri, position) else {
+        let Some((name, qualifier)) = self.indexer.word_and_qualifier_at(uri, position) else {
             return Ok(None);
         };
 
-        let locations = crate::features::references::find_references(
+        let locations = crate::features::references::find_references_with_qualifier(
             &name,
+            qualifier.as_deref(),
             uri,
             position.line,
             params.context.include_declaration,

--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -26,6 +26,11 @@ impl Backend {
     ) -> Result<Option<Vec<Location>>> {
         let uri = &params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
+
+        // Ensure the file is in the index before scope resolution — `did_open`
+        // is async (actor-queued), so the index may not have it yet.
+        self.indexer.ensure_indexed(uri);
+
         let Some((name, qualifier)) = self.indexer.word_and_qualifier_at(uri, position) else {
             return Ok(None);
         };

--- a/src/backend/helpers_tests.rs
+++ b/src/backend/helpers_tests.rs
@@ -180,16 +180,22 @@ fn make_indexer_with(src: &str, uri: &tower_lsp::lsp_types::Url) -> crate::index
 
 /// Lowercase member names must always yield (None, None) regardless of context.
 /// This prevents the caller from injecting a parent_class derived from this/it
-/// type inference, which would scope rg to `ClassName.fieldName` qualified
-/// patterns that almost never appear in real Kotlin code.
+/// Lowercase names at the declaration site should get package scope (not parent_class).
+/// This narrows rg search to same-package files rather than the whole codebase,
+/// without wrongly attempting to qualify with a class name (which would produce
+/// `ClassName.methodName` patterns that almost never appear in real Kotlin code).
 #[test]
-fn scope_lowercase_name_always_none() {
+fn scope_lowercase_decl_gets_package_scope() {
     let uri = tower_lsp::lsp_types::Url::parse("file:///t.kt").unwrap();
     let src = "package demo\nclass Foo { val descriptiveNumber: String = \"\" }";
     let idx = make_indexer_with(src, &uri);
     let (parent, pkg) = resolve_scope(&idx, &uri, 1, "descriptiveNumber");
     assert_eq!(parent, None, "lowercase member must not get a parent_class");
-    assert_eq!(pkg, None, "lowercase member must not get a declared_pkg");
+    assert_eq!(
+        pkg.as_deref(),
+        Some("demo"),
+        "declaration site: lowercase member gets package scope"
+    );
 }
 
 /// Uppercase names on the declaration line should use enclosing class + package.

--- a/src/backend/helpers_tests.rs
+++ b/src/backend/helpers_tests.rs
@@ -178,12 +178,11 @@ fn make_indexer_with(src: &str, uri: &tower_lsp::lsp_types::Url) -> crate::index
     idx
 }
 
-/// Lowercase member names must always yield (None, None) regardless of context.
-/// This prevents the caller from injecting a parent_class derived from this/it
 /// Lowercase names at the declaration site should get package scope (not parent_class).
 /// This narrows rg search to same-package files rather than the whole codebase,
 /// without wrongly attempting to qualify with a class name (which would produce
 /// `ClassName.methodName` patterns that almost never appear in real Kotlin code).
+/// Off-declaration-site lowercase names still return `(None, None)`.
 #[test]
 fn scope_lowercase_decl_gets_package_scope() {
     let uri = tower_lsp::lsp_types::Url::parse("file:///t.kt").unwrap();

--- a/src/backend/rename.rs
+++ b/src/backend/rename.rs
@@ -15,12 +15,15 @@ impl Backend {
         params: TextDocumentPositionParams,
     ) -> Result<Option<PrepareRenameResponse>> {
         let uri = &params.text_document.uri;
+        // Same async did_open race as references — file may not be indexed yet.
+        self.indexer.ensure_indexed(uri);
         crate::features::rename::prepare_rename_impl(&self.indexer, uri, params.position).await
     }
 
     pub(super) async fn rename_impl(&self, params: RenameParams) -> Result<Option<WorkspaceEdit>> {
         let position = params.text_document_position.position;
         let uri = &params.text_document_position.text_document.uri;
+        self.indexer.ensure_indexed(uri);
         crate::features::rename::rename_impl(&self.indexer, uri, position, &params.new_name).await
     }
 }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -14,6 +14,13 @@ use super::hover::hover_at;
 use super::output::{print_results, CliResult};
 use super::tokens::{dump_tree, print_token_rows, token_rows, token_rows_phases};
 
+/// Severity label strings used when printing diagnostics in text mode.
+const SEVERITY_ERROR: &str = "error";
+const SEVERITY_WARNING: &str = "warning";
+const SEVERITY_INFO: &str = "info";
+const SEVERITY_HINT: &str = "hint";
+const SEVERITY_DIAG: &str = "diag";
+
 // ── Root resolution ───────────────────────────────────────────────────────────
 
 /// Resolve the workspace root: explicit --root, then nearest .git ancestor, then cwd.
@@ -601,7 +608,7 @@ async fn run_diagnose(root: &Path, file: &Path, _verbose: bool) {
     });
 
     let path_str = abs_path.to_string_lossy();
-    // Validate the extension before spending time reading the file.
+    // Validate the extension now that the path is resolved.
     if crate::indexer::live_tree::lang_for_path(&path_str).is_none() {
         eprintln!("error: unsupported file extension");
         std::process::exit(1);
@@ -627,13 +634,13 @@ async fn run_diagnose(root: &Path, file: &Path, _verbose: bool) {
             let severity = diag
                 .severity
                 .map(|s| match s {
-                    tower_lsp::lsp_types::DiagnosticSeverity::ERROR => "error",
-                    tower_lsp::lsp_types::DiagnosticSeverity::WARNING => "warning",
-                    tower_lsp::lsp_types::DiagnosticSeverity::INFORMATION => "info",
-                    tower_lsp::lsp_types::DiagnosticSeverity::HINT => "hint",
-                    _ => "diag",
+                    tower_lsp::lsp_types::DiagnosticSeverity::ERROR => SEVERITY_ERROR,
+                    tower_lsp::lsp_types::DiagnosticSeverity::WARNING => SEVERITY_WARNING,
+                    tower_lsp::lsp_types::DiagnosticSeverity::INFORMATION => SEVERITY_INFO,
+                    tower_lsp::lsp_types::DiagnosticSeverity::HINT => SEVERITY_HINT,
+                    _ => SEVERITY_DIAG,
                 })
-                .unwrap_or("diag");
+                .unwrap_or(SEVERITY_DIAG);
             println!("{}:{} [{}]: {}", line, col, severity, diag.message);
         }
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -575,9 +575,7 @@ fn run_tree(file: &Path) {
 async fn run_diagnose(root: &Path, file: &Path, _verbose: bool) {
     use crate::features::call_arg_diagnostics::call_arg_diagnostics;
     use crate::features::fill_when::when_diagnostics;
-    use crate::indexer::live_tree::{lang_for_path, LiveDoc};
     use tower_lsp::lsp_types::Url;
-    use tree_sitter::Parser;
 
     eprintln!("Indexing {}...", root.display());
     let index = build_index(root, true).await;
@@ -603,25 +601,19 @@ async fn run_diagnose(root: &Path, file: &Path, _verbose: bool) {
     });
 
     let path_str = abs_path.to_string_lossy();
-    let lang = lang_for_path(&path_str).unwrap_or_else(|| {
+    // Validate the extension before spending time reading the file.
+    if crate::indexer::live_tree::lang_for_path(&path_str).is_none() {
         eprintln!("error: unsupported file extension");
         std::process::exit(1);
-    });
+    }
 
-    let mut parser = Parser::new();
-    parser.set_language(&lang).unwrap();
-    let tree = parser.parse(source.as_bytes(), None).unwrap_or_else(|| {
+    // store_live_tree parses the file once; retrieve the result via live_doc()
+    // so call_arg_diagnostics can use the same tree without a second parse.
+    index.store_live_tree(&uri, &source);
+    let doc = index.live_doc(&uri).unwrap_or_else(|| {
         eprintln!("error: failed to parse file");
         std::process::exit(1);
     });
-
-    // Register the file as a live doc so when_diagnostics can read the CST.
-    index.store_live_tree(&uri, &source);
-
-    let doc = LiveDoc {
-        bytes: source.into_bytes(),
-        tree,
-    };
 
     let mut diagnostics = call_arg_diagnostics(&index, &uri, &doc);
     diagnostics.extend(when_diagnostics(&index, &uri));

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -574,6 +574,7 @@ fn run_tree(file: &Path) {
 
 async fn run_diagnose(root: &Path, file: &Path, _verbose: bool) {
     use crate::features::call_arg_diagnostics::call_arg_diagnostics;
+    use crate::features::fill_when::when_diagnostics;
     use crate::indexer::live_tree::{lang_for_path, LiveDoc};
     use tower_lsp::lsp_types::Url;
     use tree_sitter::Parser;
@@ -614,19 +615,34 @@ async fn run_diagnose(root: &Path, file: &Path, _verbose: bool) {
         std::process::exit(1);
     });
 
+    // Register the file as a live doc so when_diagnostics can read the CST.
+    index.store_live_tree(&uri, &source);
+
     let doc = LiveDoc {
         bytes: source.into_bytes(),
         tree,
     };
 
-    let diagnostics = call_arg_diagnostics(&index, &uri, &doc);
+    let mut diagnostics = call_arg_diagnostics(&index, &uri, &doc);
+    diagnostics.extend(when_diagnostics(&index, &uri));
+
     if diagnostics.is_empty() {
         println!("No diagnostics.");
     } else {
         for diag in &diagnostics {
             let line = diag.range.start.line + 1;
             let col = diag.range.start.character + 1;
-            println!("{}:{}: {}", line, col, diag.message);
+            let severity = diag
+                .severity
+                .map(|s| match s {
+                    tower_lsp::lsp_types::DiagnosticSeverity::ERROR => "error",
+                    tower_lsp::lsp_types::DiagnosticSeverity::WARNING => "warning",
+                    tower_lsp::lsp_types::DiagnosticSeverity::INFORMATION => "info",
+                    tower_lsp::lsp_types::DiagnosticSeverity::HINT => "hint",
+                    _ => "diag",
+                })
+                .unwrap_or("diag");
+            println!("{}:{} [{}]: {}", line, col, severity, diag.message);
         }
     }
 }

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -147,22 +147,27 @@ fn collect_when_nodes(
     diagnostics: &mut Vec<Diagnostic>,
 ) {
     if node.kind() == KIND_WHEN_EXPR {
-        if let Some(analysis) = analyze_when(indexer, uri, node, source) {
-            let missing_names: Vec<&str> =
-                analysis.missing.iter().map(|m| m.name.as_str()).collect();
-            let message = format!("'when' is missing branches: {}", missing_names.join(", "));
-            let start = node.start_position();
-            let keyword_end_col = start.column + 4; // "when" is 4 chars
-            diagnostics.push(Diagnostic {
-                range: Range::new(
-                    Position::new(start.row as u32, start.column as u32),
-                    Position::new(start.row as u32, keyword_end_col as u32),
-                ),
-                severity: Some(DiagnosticSeverity::WARNING),
-                source: Some("kotlin-lsp".into()),
-                message,
-                ..Default::default()
-            });
+        // Statement-form `when` (parent is `statements`) is not required to be
+        // exhaustive in Kotlin — only expression-form is.  Skip to avoid FPs.
+        let is_statement = node.parent().is_some_and(|p| p.kind() == KIND_STATEMENTS);
+        if !is_statement {
+            if let Some(analysis) = analyze_when(indexer, uri, node, source) {
+                let missing_names: Vec<&str> =
+                    analysis.missing.iter().map(|m| m.name.as_str()).collect();
+                let message = format!("'when' is missing branches: {}", missing_names.join(", "));
+                let start = node.start_position();
+                let keyword_end_col = start.column + 4; // "when" is 4 chars
+                diagnostics.push(Diagnostic {
+                    range: Range::new(
+                        Position::new(start.row as u32, start.column as u32),
+                        Position::new(start.row as u32, keyword_end_col as u32),
+                    ),
+                    severity: Some(DiagnosticSeverity::WARNING),
+                    source: Some("kotlin-lsp".into()),
+                    message,
+                    ..Default::default()
+                });
+            }
         }
     }
 

--- a/src/features/fill_when.rs
+++ b/src/features/fill_when.rs
@@ -149,6 +149,12 @@ fn collect_when_nodes(
     if node.kind() == KIND_WHEN_EXPR {
         // Statement-form `when` (parent is `statements`) is not required to be
         // exhaustive in Kotlin — only expression-form is.  Skip to avoid FPs.
+        //
+        // Known limitation: a `when` that is the last expression in a lambda body
+        // (e.g. `run { when(c) { ... } }`) also has `statements` as its parent
+        // but IS expression-form.  Detecting that case requires knowing whether
+        // the enclosing block's value is used, which needs type inference beyond
+        // what tree-sitter provides.  Such cases produce false negatives.
         let is_statement = node.parent().is_some_and(|p| p.kind() == KIND_STATEMENTS);
         if !is_statement {
             if let Some(analysis) = analyze_when(indexer, uri, node, source) {

--- a/src/features/fill_when_tests.rs
+++ b/src/features/fill_when_tests.rs
@@ -534,10 +534,8 @@ use crate::features::fill_when::when_diagnostics;
 #[test]
 fn diagnostics_reports_missing_enum_branches() {
     let src = "\
-fun test(c: Color) {
-    when (c) {
-        Color.RED -> println(\"red\")
-    }
+fun test(c: Color): String = when (c) {
+    Color.RED -> \"red\"
 }
 ";
     let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
@@ -594,10 +592,8 @@ fun test(c: Color) {
 #[test]
 fn diagnostics_boolean_missing() {
     let src = "\
-fun test(flag: Boolean) {
-    when(flag) {
-        true -> println(\"yes\")
-    }
+fun test(flag: Boolean): String = when(flag) {
+    true -> \"yes\"
 }
 ";
     let idx = setup(&[("/main.kt", src)]);
@@ -701,9 +697,7 @@ sealed class Event {
     let src = "\
 package main
 import b.Event
-fun test(e: Event) {
-    when (e) {
-    }
+fun test(e: Event): String = when (e) {
 }
 ";
     let idx = setup(&[
@@ -752,9 +746,7 @@ sealed class Event {
 ";
     let src = "\
 package b
-fun test(e: Event) {
-    when (e) {
-    }
+fun test(e: Event): String = when (e) {
 }
 ";
     let idx = setup(&[
@@ -779,5 +771,27 @@ fun test(e: Event) {
         !diags[0].message.contains("A"),
         "should NOT report a.Event members; got: {}",
         diags[0].message
+    );
+}
+
+#[test]
+fn diagnostics_no_report_for_statement_form_when() {
+    // Statement-form `when` (parent = statements block) is not exhaustive
+    // in Kotlin — only expression-form is.  Must not emit a diagnostic even
+    // when branches are missing.
+    let src = "\
+fun test(c: Color) {
+    when (c) {
+        Color.RED -> println(\"red\")
+    }
+}
+";
+    let idx = setup(&[("/Color.kt", ENUM_SRC), ("/main.kt", src)]);
+    let u = uri("/main.kt");
+    let diags = when_diagnostics(&idx, &u);
+    assert!(
+        diags.is_empty(),
+        "statement-form when must not produce diagnostics; got: {:?}",
+        diags
     );
 }

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -127,8 +127,8 @@ pub(crate) fn resolve_scope_with_qualifier(
     //
     // `word_and_qualifier_at` returns the full dot-chain (e.g. "Outer.Inner" for
     // "Outer.Inner.Factory").  We preserve the full chain as `parent_class` so
-    // `has_wrong_qualifier` can match it against the full extracted chain on each
-    // line, rather than just the immediate token.
+    // `has_wrong_qualifier_at_col` can match it against the full extracted chain on each
+    // hit, rather than just the immediate token.
     if let Some(q) = qualifier.filter(|q| q.starts_with_uppercase()) {
         let parent_pkg = index
             .declared_package_of(q)
@@ -247,12 +247,25 @@ fn add_current_file_locations(
         if has_reference_line(locations, uri, line_number) {
             continue;
         }
-        if let Some(parent) = parent_class {
-            if crate::rg::has_wrong_qualifier(line, name, parent) {
+        // Check qualifier per-occurrence so that a line containing both a valid
+        // and an invalid qualified reference (e.g. `ReducerA.Factory, ReducerC.Factory`)
+        // keeps the valid hit instead of dropping the whole line.
+        for loc in line_reference_locations(uri, name, line_number, line) {
+            if has_reference_start(locations, &loc) {
                 continue;
             }
+            if let Some(parent) = parent_class {
+                if crate::rg::has_wrong_qualifier_at_col(
+                    line,
+                    name,
+                    parent,
+                    loc.range.start.character,
+                ) {
+                    continue;
+                }
+            }
+            locations.push(loc);
         }
-        append_line_reference_locations(uri, name, line_number, line, locations);
     }
 }
 
@@ -260,20 +273,6 @@ fn has_reference_line(locations: &[Location], uri: &Url, line_number: u32) -> bo
     locations
         .iter()
         .any(|loc| loc.uri == *uri && loc.range.start.line == line_number)
-}
-
-fn append_line_reference_locations(
-    uri: &Url,
-    name: &str,
-    line_number: u32,
-    line: &str,
-    locations: &mut Vec<Location>,
-) {
-    for loc in line_reference_locations(uri, name, line_number, line) {
-        if !has_reference_start(locations, &loc) {
-            locations.push(loc);
-        }
-    }
 }
 
 fn line_reference_locations(uri: &Url, name: &str, line_number: u32, line: &str) -> Vec<Location> {

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -22,6 +22,11 @@ use crate::StrExt;
 /// with the same name (e.g. every class defines a `Factory` or `Builder`).
 ///
 /// When `qualifier` is `None`, scope is inferred from imports and the index.
+/// For lowercase methods at their declaration site that are declared inside a
+/// doubly-nested class (e.g. `create` inside `Factory` inside `RegularReducer`),
+/// the outer class is used for file discovery so callers that reference the outer
+/// class via a variable name (`factory.create()`) are found while sibling
+/// factories in the same package are excluded.
 pub(crate) async fn find_references_with_qualifier(
     name: &str,
     qualifier: Option<&str>,
@@ -32,6 +37,18 @@ pub(crate) async fn find_references_with_qualifier(
 ) -> Vec<Location> {
     let (parent_class, declared_pkg) =
         resolve_scope_with_qualifier(index, uri, line, name, qualifier);
+
+    // For lowercase methods at their declaration site, check if they are declared
+    // inside a doubly-nested class (e.g. `create` inside `Factory` inside `Reducer`).
+    // `declared_pkg.is_some()` is the on_decl proxy for lowercase names: resolve_scope
+    // returns (None, Some(pkg)) on_decl and (None, None) off-decl for lowercase names.
+    let owner_class =
+        if !name.starts_with_uppercase() && declared_pkg.is_some() && qualifier.is_none() {
+            outer_class_for_decl_site(index, uri, line)
+        } else {
+            None
+        };
+
     let decl_files = declaration_files_for(index, name, parent_class.as_deref());
 
     let search = ReferenceSearch {
@@ -41,6 +58,7 @@ pub(crate) async fn find_references_with_qualifier(
         parent_class,
         declared_pkg,
         decl_files,
+        owner_class,
     };
 
     let mut locations = rg_locations(&search, index).await;
@@ -152,6 +170,22 @@ fn declaration_files_for(
         .collect()
 }
 
+/// For a lowercase method at its declaration site, returns the outer-outer class
+/// if the method is inside a doubly-nested class
+/// (e.g. `create` inside `Factory` inside `RegularReducer` → `"RegularReducer"`).
+///
+/// Returns `None` if the method has only one level of nesting or none.
+/// Uses `enclosing_class_at` (line-specific CST walk) for the direct parent, then
+/// `declared_parent_class_of` (preferred-URI-first index lookup) for the outer parent.
+fn outer_class_for_decl_site(
+    index: &(impl SymbolIndex + ScopeQuery),
+    uri: &Url,
+    line: u32,
+) -> Option<String> {
+    let direct_parent = index.enclosing_class_at(uri, line)?;
+    index.declared_parent_class_of(&direct_parent, uri)
+}
+
 fn reference_matches_parent_class(
     index: &impl SymbolIndex,
     location: &Location,
@@ -186,6 +220,10 @@ async fn rg_locations(
             &request.decl_files,
         )
         .with_source_paths(&source_roots);
+        let rg_req = match request.owner_class.as_deref() {
+            Some(owner) => rg_req.with_owner_class(owner),
+            None => rg_req,
+        };
         crate::rg::rg_find_references(&rg_req, matcher.as_deref())
     })
     .await
@@ -278,6 +316,8 @@ struct ReferenceSearch {
     parent_class: Option<String>,
     declared_pkg: Option<String>,
     decl_files: Vec<String>,
+    /// Outer-outer class for owner-scoped file discovery; see [`outer_class_for_decl_site`].
+    owner_class: Option<String>,
 }
 
 #[cfg(test)]

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -272,6 +272,11 @@ fn add_current_file_locations(
             if has_reference_start(locations, &loc) {
                 continue;
             }
+            // Respect include_decl: if the caller asked to exclude the declaration,
+            // skip lines that declare this name (mirrors the rg path behaviour).
+            if !include_decl && crate::rg::is_declaration_of(line, name) {
+                continue;
+            }
             if let Some(parent) = parent_class {
                 if crate::rg::has_wrong_qualifier_at_col(
                     line,

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -13,14 +13,25 @@ use crate::StrExt;
 
 // ─── Public entry point ───────────────────────────────────────────────────────
 
-pub(crate) async fn find_references(
+/// Finds all references to `name`, optionally scoped by `qualifier`.
+///
+/// When `qualifier` is `Some("ReducerA")` (cursor was on `ReducerA.Factory`),
+/// the qualifier is used directly as the `parent_class` scope, bypassing the
+/// fallible index-lookup that `resolve_scope` uses for unresolved nested types.
+/// This prevents false positives when multiple classes define an inner class
+/// with the same name (e.g. every class defines a `Factory` or `Builder`).
+///
+/// When `qualifier` is `None`, scope is inferred from imports and the index.
+pub(crate) async fn find_references_with_qualifier(
     name: &str,
+    qualifier: Option<&str>,
     uri: &Url,
     line: u32,
     include_decl: bool,
     index: &(impl SymbolIndex + DocumentAccess + ScopeQuery + SearchAccess + Send + Sync),
 ) -> Vec<Location> {
-    let (parent_class, declared_pkg) = resolve_scope(index, uri, line, name);
+    let (parent_class, declared_pkg) =
+        resolve_scope_with_qualifier(index, uri, line, name, qualifier);
     let decl_files = declaration_files_for(index, name, parent_class.as_deref());
 
     let search = ReferenceSearch {
@@ -52,9 +63,38 @@ pub(crate) fn resolve_scope(
     line: u32,
     name: &str,
 ) -> (Option<String>, Option<String>) {
+    resolve_scope_with_qualifier(index, uri, line, name, None)
+}
+
+/// Like [`resolve_scope`] but accepts a dot-qualifier (the segment immediately
+/// preceding `name` at the cursor, e.g. `"ReducerA"` for `ReducerA.Factory`).
+///
+/// An uppercase qualifier is used directly as the `parent_class`, which avoids
+/// the index-lookup fallback that picks an arbitrary definition when multiple
+/// classes define an inner class with the same name.
+pub(crate) fn resolve_scope_with_qualifier(
+    index: &(impl SymbolIndex + ScopeQuery),
+    uri: &Url,
+    line: u32,
+    name: &str,
+    qualifier: Option<&str>,
+) -> (Option<String>, Option<String>) {
     if !name.starts_with_uppercase() {
         return (None, None);
     }
+
+    // Fast path: an uppercase dot-qualifier (e.g. "ReducerA" in "ReducerA.Factory")
+    // unambiguously identifies the parent class — use it directly rather than
+    // guessing from the index (which is non-deterministic when multiple classes
+    // share the same inner-class name).
+    if let Some(q) = qualifier.filter(|q| q.starts_with_uppercase()) {
+        let parent_pkg = index
+            .declared_package_of(q)
+            .map(|p| format!("{p}.{q}"))
+            .or_else(|| index.declared_package_of(name));
+        return (Some(q.to_string()), parent_pkg);
+    }
+
     let on_decl = index.is_declared_in(uri, name)
         && index
             .definition_locations(name)

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -68,6 +68,8 @@ pub(crate) async fn find_references_with_qualifier(
         uri,
         name,
         search.parent_class.as_deref(),
+        search.owner_class.as_deref(),
+        include_decl,
         &mut locations,
     );
 
@@ -237,6 +239,8 @@ fn add_current_file_locations(
     uri: &Url,
     name: &str,
     parent_class: Option<&str>,
+    owner_class: Option<&str>,
+    include_decl: bool,
     locations: &mut Vec<Location>,
 ) {
     let Some(lines) = index.mem_lines_for(uri.as_str()) else {
@@ -245,6 +249,20 @@ fn add_current_file_locations(
     for (line_idx, line) in lines.iter().enumerate() {
         let line_number = line_idx as u32;
         if has_reference_line(locations, uri, line_number) {
+            continue;
+        }
+        // When owner_class is set the caller is using variable-name call syntax
+        // (e.g. `reducerFactory.create()`). The only legitimate hit in the declaring
+        // file is the declaration itself; all other create() calls here are to OTHER
+        // injected factory instances and must be excluded.
+        if owner_class.is_some() {
+            if include_decl && crate::rg::is_declaration_of(line, name) {
+                for loc in line_reference_locations(uri, name, line_number, line) {
+                    if !has_reference_start(locations, &loc) {
+                        locations.push(loc);
+                    }
+                }
+            }
             continue;
         }
         // Check qualifier per-occurrence so that a line containing both a valid

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -104,6 +104,11 @@ pub(crate) fn resolve_scope_with_qualifier(
     // unambiguously identifies the parent class — use it directly rather than
     // guessing from the index (which is non-deterministic when multiple classes
     // share the same inner-class name).
+    //
+    // `word_and_qualifier_at` returns the full dot-chain (e.g. "Outer.Inner" for
+    // "Outer.Inner.Factory").  We preserve the full chain as `parent_class` so
+    // `has_wrong_qualifier` can match it against the full extracted chain on each
+    // line, rather than just the immediate token.
     if let Some(q) = qualifier.filter(|q| q.starts_with_uppercase()) {
         let parent_pkg = index
             .declared_package_of(q)

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -62,7 +62,9 @@ pub(crate) async fn find_references_with_qualifier(
 ///
 /// Uppercase symbols are narrowed via import analysis or declaration-site lookup
 /// so that rg can restrict to the specific class variant.
-/// Lowercase symbols return `(None, None)` — bare-word search via rg.
+/// Lowercase symbols at the **declaration site** return `(None, Some(package))` —
+/// rg is scoped to same-package files.  Off-declaration-site lowercase names
+/// return `(None, None)` — codebase-wide bare-word search via rg.
 pub(crate) fn resolve_scope(
     index: &(impl SymbolIndex + ScopeQuery),
     uri: &Url,

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -45,7 +45,13 @@ pub(crate) async fn find_references_with_qualifier(
 
     let mut locations = rg_locations(&search, index).await;
     locations.retain(|loc| !index.is_library_uri(&loc.uri));
-    add_current_file_locations(index, uri, name, &mut locations);
+    add_current_file_locations(
+        index,
+        uri,
+        name,
+        search.parent_class.as_deref(),
+        &mut locations,
+    );
 
     locations
 }
@@ -79,8 +85,19 @@ pub(crate) fn resolve_scope_with_qualifier(
     name: &str,
     qualifier: Option<&str>,
 ) -> (Option<String>, Option<String>) {
+    // Lowercase names: only scope if we're on the declaration — restrict to the
+    // declaring file's package so the bare-word search doesn't scan the whole codebase.
     if !name.starts_with_uppercase() {
-        return (None, None);
+        let on_decl = index.is_declared_in(uri, name)
+            && index
+                .definition_locations(name)
+                .iter()
+                .any(|l| l.uri == *uri && l.range.start.line == line);
+        return if on_decl {
+            (None, index.package_of(uri))
+        } else {
+            (None, None)
+        };
     }
 
     // Fast path: an uppercase dot-qualifier (e.g. "ReducerA" in "ReducerA.Factory")
@@ -174,6 +191,7 @@ fn add_current_file_locations(
     index: &impl DocumentAccess,
     uri: &Url,
     name: &str,
+    parent_class: Option<&str>,
     locations: &mut Vec<Location>,
 ) {
     let Some(lines) = index.mem_lines_for(uri.as_str()) else {
@@ -183,6 +201,11 @@ fn add_current_file_locations(
         let line_number = line_idx as u32;
         if has_reference_line(locations, uri, line_number) {
             continue;
+        }
+        if let Some(parent) = parent_class {
+            if crate::rg::has_wrong_qualifier(line, name, parent) {
+                continue;
+            }
         }
         append_line_reference_locations(uri, name, line_number, line, locations);
     }

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -209,3 +209,7 @@ struct ReferenceSearch {
     declared_pkg: Option<String>,
     decl_files: Vec<String>,
 }
+
+#[cfg(test)]
+#[path = "references_tests.rs"]
+mod tests;

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -811,4 +811,23 @@ class ReducerC {
         "ReducerC.kt (imports ReducerA but declares own create) must NOT appear; got: {:?}",
         files
     );
+
+    // Same assertions must hold when include_decl=true (LSP default).
+    let locs_incl = find_references_with_qualifier("create", None, &ra_uri, 3, true, &*idx).await;
+    let files_incl = hit_files(&locs_incl);
+    assert!(
+        files_incl.iter().any(|f| f == "ReducerA.kt"),
+        "ReducerA.kt (declaration) must appear with include_decl=true; got: {:?}",
+        files_incl
+    );
+    assert!(
+        files_incl.iter().any(|f| f == "Dashboard.kt"),
+        "Dashboard.kt must appear with include_decl=true; got: {:?}",
+        files_incl
+    );
+    assert!(
+        !files_incl.iter().any(|f| f == "ReducerC.kt"),
+        "ReducerC.kt must NOT appear even with include_decl=true; got: {:?}",
+        files_incl
+    );
 }

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -1,0 +1,257 @@
+//! End-to-end tests for [`find_references`].
+//!
+//! These tests write real `.kt` files to a temp directory so that `rg`
+//! can search them, then drive the full `find_references → rg_scope_for_path
+//! → rg_find_references` pipeline against an [`Indexer`] whose
+//! `workspace_root` is (or isn't) configured.
+//!
+//! The scenarios targeted by these tests:
+//!
+//! - **workspace_root set** — rg searches the workspace dir → cross-file hits.
+//! - **workspace_root unset** — `effective_rg_root` falls back to the file's
+//!   parent directory → cross-file hits still found (files are co-located).
+//! - **workspace_root set to a *different* project** — `effective_rg_root`
+//!   walks up from the open file to its git root; `scoped_source_roots` is
+//!   cleared because effective != configured root → rg searches the file's
+//!   git root without leaking the stale workspace's source-path scoping.
+
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::Url;
+
+use crate::features::references::find_references;
+use crate::indexer::Indexer;
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+fn write(dir: &std::path::Path, name: &str, content: &str) -> (std::path::PathBuf, Url) {
+    let path = dir.join(name);
+    std::fs::write(&path, content).unwrap();
+    let uri = Url::from_file_path(&path).unwrap();
+    (path, uri)
+}
+
+fn hit_files(locs: &[tower_lsp::lsp_types::Location]) -> Vec<String> {
+    locs.iter()
+        .filter_map(|l| l.uri.to_file_path().ok())
+        .filter_map(|p| p.file_name().map(|n| n.to_string_lossy().into_owned()))
+        .collect()
+}
+
+// ─── tests ───────────────────────────────────────────────────────────────────
+
+/// **Core regression**: `find_references` must return cross-file results when
+/// `workspace_root` is properly set.
+///
+/// Layout:
+///   Foo.kt — `class MyClass`  (declaration)
+///   Bar.kt — `fun use(): MyClass = MyClass()` (usage)
+///
+/// Calling `find_references("MyClass", foo_uri, …)` must return a hit in
+/// `Bar.kt`.  If only `Foo.kt` is returned, `rg_scope_for_path` is not
+/// delivering the workspace root to `rg_find_references`.
+#[tokio::test]
+async fn find_references_cross_file_with_workspace_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let foo_src = "package com.example\nclass MyClass";
+    let bar_src = "package com.example\nfun use(): MyClass = MyClass()";
+
+    let (_foo_path, foo_uri) = write(root, "Foo.kt", foo_src);
+    let (_bar_path, _bar_uri) = write(root, "Bar.kt", bar_src);
+
+    let idx = Arc::new(Indexer::new());
+    idx.workspace_root.set(root.to_path_buf());
+    idx.index_content(&foo_uri, foo_src);
+
+    let locs = find_references("MyClass", &foo_uri, 1, true, &*idx).await;
+    let files = hit_files(&locs);
+
+    assert!(
+        files.iter().any(|f| f == "Bar.kt"),
+        "find_references must include Bar.kt; got files: {:?}",
+        files
+    );
+}
+
+/// `find_references` must still return cross-file results when `workspace_root`
+/// is **not** set on the indexer.
+///
+/// In this case `effective_rg_root` falls back through:
+///   1. `walk_to_git_root(open_file)` — tempdir has no `.git`, returns `None`
+///   2. `open_file.parent()`           — the tempdir itself ← this must work
+///
+/// If the fallback resolves to the correct directory, `Bar.kt` is found.
+/// If it resolves to the wrong directory (e.g. CWD = the lsp repo), the test
+/// catches the broken fallback.
+#[tokio::test]
+async fn find_references_cross_file_without_workspace_root() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let foo_src = "package com.example\nclass MyClass";
+    let bar_src = "package com.example\nfun use(): MyClass = MyClass()";
+
+    let (_foo_path, foo_uri) = write(root, "Foo.kt", foo_src);
+    let (_bar_path, _bar_uri) = write(root, "Bar.kt", bar_src);
+
+    // ← workspace_root intentionally NOT set
+    let idx = Arc::new(Indexer::new());
+    idx.index_content(&foo_uri, foo_src);
+
+    let locs = find_references("MyClass", &foo_uri, 1, true, &*idx).await;
+    let files = hit_files(&locs);
+
+    assert!(
+        files.iter().any(|f| f == "Bar.kt"),
+        "find_references must include Bar.kt even without workspace_root; \
+         effective_rg_root should fall back to the file's parent directory. \
+         Got files: {:?}",
+        files
+    );
+}
+
+/// **Package-scoped regression**: `find_references` for an *uppercase* symbol
+/// must use the package-scoped rg path and return cross-file results.
+///
+/// `resolve_scope` for an uppercase symbol that IS the declaration returns
+/// `(parent=None, pkg=Some("com.example"))`.  This triggers
+/// `package_scoped_reference_locations` which first scans for
+/// candidate files via import/package patterns, then searches those files.
+///
+/// If `rg_scope_for_path` returns the wrong `search_root`, the import-pattern
+/// scan finds no candidates and the function returns empty — showing only the
+/// current-file hit injected by `add_current_file_locations`.
+#[tokio::test]
+async fn find_references_package_scoped_cross_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Foo.kt: declaration of MyClass at line 1 (0-indexed)
+    let foo_src = "package com.example\nclass MyClass";
+    // Bar.kt: same package → no import needed, but has explicit import for clarity
+    let bar_src = "package com.example\nimport com.example.MyClass\nfun use(): MyClass = MyClass()";
+    // Baz.kt: different package, imports MyClass explicitly
+    let baz_src = "package com.other\nimport com.example.MyClass\nval x: MyClass = MyClass()";
+
+    let (_, foo_uri) = write(root, "Foo.kt", foo_src);
+    write(root, "Bar.kt", bar_src);
+    write(root, "Baz.kt", baz_src);
+
+    let idx = Arc::new(Indexer::new());
+    idx.workspace_root.set(root.to_path_buf());
+    idx.index_content(&foo_uri, foo_src);
+
+    // line=1: declaration of MyClass → resolve_scope returns (None, Some("com.example"))
+    // → package_scoped_reference_locations is used
+    let locs = find_references("MyClass", &foo_uri, 1, true, &*idx).await;
+    let files = hit_files(&locs);
+
+    assert!(
+        files.iter().any(|f| f == "Bar.kt"),
+        "package-scoped search must find Bar.kt (same package); got files: {:?}",
+        files
+    );
+    assert!(
+        files.iter().any(|f| f == "Baz.kt"),
+        "package-scoped search must find Baz.kt (imports MyClass); got files: {:?}",
+        files
+    );
+}
+
+/// End-to-end actor test: after a full workspace scan, `find_references` on a
+/// symbol declared in one file must find usages in another file.
+///
+/// This is the canonical regression test for "find refs only returns current
+/// file" — it drives the complete path:
+///   Helix opens file → actor receives Initialize → scan completes →
+///   user calls find_references → cross-file hits returned.
+#[tokio::test]
+async fn actor_scan_then_find_references_cross_file() {
+    use tokio::sync::oneshot;
+
+    use crate::indexer::NoopReporter;
+    use crate::workspace::{Actor, Config, Event};
+
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    // workspace.json opts out of external sourcePaths (test isolation)
+    std::fs::write(root.join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();
+
+    let foo_src = "package com.example\nclass MyClass";
+    let bar_src = "package com.example\nfun use(): MyClass = MyClass()";
+    let (_, foo_uri) = write(root, "Foo.kt", foo_src);
+    write(root, "Bar.kt", bar_src);
+
+    let indexer = Arc::new(Indexer::new());
+    let (tx, rx) = tokio::sync::mpsc::channel(16);
+    let actor = Actor::new(Arc::clone(&indexer), Arc::new(NoopReporter), rx, None);
+    tokio::spawn(actor.run());
+
+    let (done_tx, done_rx) = oneshot::channel();
+    tx.send(Event::Initialize {
+        config: Config {
+            root: root.to_path_buf(),
+            explicit_source_paths: Vec::new(),
+            ignore_patterns: Vec::new(),
+            pin_workspace: false,
+        },
+        completion_tx: Some(done_tx),
+    })
+    .await
+    .unwrap();
+
+    // Wait for the workspace scan to complete before querying.
+    tokio::time::timeout(std::time::Duration::from_secs(10), done_rx)
+        .await
+        .expect("workspace scan must complete within 10s")
+        .unwrap();
+
+    let locs = find_references("MyClass", &foo_uri, 1, true, &*indexer).await;
+    let files = hit_files(&locs);
+
+    assert!(
+        files.iter().any(|f| f == "Bar.kt"),
+        "after full scan, find_references must return Bar.kt; got files: {:?}\n\
+         workspace_root = {:?}",
+        files,
+        indexer.workspace_root.get()
+    );
+}
+///
+/// Concretely: workspace_root = `/tmp/other_project`, open file = in a
+/// different tempdir.  `effective_rg_root` walks up from the file, finds no
+/// `.git`, falls back to `file.parent()` (the correct tempdir) → Bar.kt found.
+///
+/// This catches the case where stale `workspace_source_roots` from the old
+/// project "leak" into the search and scope rg to paths that don't contain
+/// the current file's siblings.
+#[tokio::test]
+async fn find_references_stale_workspace_root_does_not_suppress_results() {
+    let other_project = tempfile::tempdir().unwrap();
+    let current_project = tempfile::tempdir().unwrap();
+
+    let foo_src = "package com.example\nclass MyClass";
+    let bar_src = "package com.example\nfun use(): MyClass = MyClass()";
+
+    // Files live in `current_project`, but workspace_root points elsewhere.
+    let (_foo_path, foo_uri) = write(current_project.path(), "Foo.kt", foo_src);
+    let (_bar_path, _bar_uri) = write(current_project.path(), "Bar.kt", bar_src);
+
+    let idx = Arc::new(Indexer::new());
+    // workspace_root → wrong project; scoped_source_roots will be cleared
+    // by rg_scope_for_path because effective_root != workspace_root.
+    idx.workspace_root.set(other_project.path().to_path_buf());
+    idx.index_content(&foo_uri, foo_src);
+
+    let locs = find_references("MyClass", &foo_uri, 1, true, &*idx).await;
+    let files = hit_files(&locs);
+
+    assert!(
+        files.iter().any(|f| f == "Bar.kt"),
+        "find_references must search the file's actual project when workspace_root \
+         points to a different directory; got files: {:?}",
+        files
+    );
+}

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -757,14 +757,28 @@ class Dashboard(private val reducerAFactory: ReducerA.Factory) {
     fun build() = reducerAFactory.create()
 }
 ";
+    // A file that imports ReducerA (so it appears in owner-class candidate files)
+    // AND declares its own unrelated `fun create()` — must NOT appear as an FP.
+    let reducer_c = "\
+package com.example.a
+import com.example.a.ReducerA
+class ReducerC {
+    interface Factory {
+        fun create(): ReducerC
+    }
+    fun useA(f: ReducerA.Factory) = Unit
+}
+";
 
     let ra_uri = Url::from_file_path(root.join("ReducerA.kt")).unwrap();
     let rb_uri = Url::from_file_path(root.join("ReducerB.kt")).unwrap();
     let dash_uri = Url::from_file_path(root.join("Dashboard.kt")).unwrap();
+    let rc_uri = Url::from_file_path(root.join("ReducerC.kt")).unwrap();
 
     write(root, "ReducerA.kt", reducer_a);
     write(root, "ReducerB.kt", reducer_b);
     write(root, "Dashboard.kt", dashboard);
+    write(root, "ReducerC.kt", reducer_c);
     std::fs::write(root.join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();
 
     let idx = Arc::new(Indexer::new());
@@ -772,6 +786,7 @@ class Dashboard(private val reducerAFactory: ReducerA.Factory) {
     idx.index_content(&ra_uri, reducer_a);
     idx.index_content(&rb_uri, reducer_b);
     idx.index_content(&dash_uri, dashboard);
+    idx.index_content(&rc_uri, reducer_c);
 
     // Cursor on `create` in `fun create(): ReducerA` — line 3 (0-based).
     let locs = find_references_with_qualifier("create", None, &ra_uri, 3, false, &*idx).await;
@@ -784,10 +799,16 @@ class Dashboard(private val reducerAFactory: ReducerA.Factory) {
         "Dashboard.kt (parent-package caller) must appear; got: {:?}",
         files
     );
-    // Sibling factory's `fun create` declaration must NOT appear.
+    // Sibling factory in same package — must NOT appear.
     assert!(
         !files.iter().any(|f| f == "ReducerB.kt"),
-        "ReducerB.kt (sibling factory) must NOT appear; got: {:?}",
+        "ReducerB.kt (sibling factory, same pkg) must NOT appear; got: {:?}",
+        files
+    );
+    // File that imports ReducerA but declares its own create() — must NOT appear.
+    assert!(
+        !files.iter().any(|f| f == "ReducerC.kt"),
+        "ReducerC.kt (imports ReducerA but declares own create) must NOT appear; got: {:?}",
         files
     );
 }

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -256,6 +256,96 @@ async fn find_references_stale_workspace_root_does_not_suppress_results() {
     );
 }
 
+/// **Regression: nested Factory — declaration-site cursor should scope correctly**
+///
+/// When the cursor is ON the `class Factory` declaration line (no qualifier in
+/// the source text), `on_decl=true` and `enclosing_class_at` must return the
+/// parent class (`ReducerA`).  Without this the scope falls back to bare-word
+/// search and bleeds across all reducers.
+#[tokio::test]
+async fn find_references_nested_factory_from_declaration_site() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let reducer_a = "\
+package com.example.a
+class ReducerA {
+    interface Factory {
+        fun create(): ReducerA
+    }
+}
+";
+    let reducer_b = "\
+package com.example.b
+class ReducerB {
+    interface Factory {
+        fun create(): ReducerB
+    }
+}
+";
+    let viewmodel = "\
+package com.example
+import com.example.a.ReducerA
+import com.example.b.ReducerB
+class ViewModel(
+    private val reducerAFactory: ReducerA.Factory,
+    private val reducerBFactory: ReducerB.Factory,
+)
+";
+    let other_caller = "\
+package com.example
+import com.example.b.ReducerB
+class OtherCaller(val f: ReducerB.Factory)
+";
+
+    write(root, "ReducerA.kt", reducer_a);
+    write(root, "ReducerB.kt", reducer_b);
+    write(root, "ViewModel.kt", viewmodel);
+    write(root, "OtherCaller.kt", other_caller);
+    std::fs::write(root.join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();
+
+    let (_, ra_uri) = (
+        root.join("ReducerA.kt"),
+        Url::from_file_path(root.join("ReducerA.kt")).unwrap(),
+    );
+    let (_, rb_uri) = (
+        root.join("ReducerB.kt"),
+        Url::from_file_path(root.join("ReducerB.kt")).unwrap(),
+    );
+    let (_, vm_uri) = (
+        root.join("ViewModel.kt"),
+        Url::from_file_path(root.join("ViewModel.kt")).unwrap(),
+    );
+    let (_, oc_uri) = (
+        root.join("OtherCaller.kt"),
+        Url::from_file_path(root.join("OtherCaller.kt")).unwrap(),
+    );
+
+    let idx = Arc::new(Indexer::new());
+    idx.workspace_root.set(root.to_path_buf());
+    idx.index_content(&ra_uri, reducer_a);
+    idx.index_content(&rb_uri, reducer_b);
+    idx.index_content(&vm_uri, viewmodel);
+    idx.index_content(&oc_uri, other_caller);
+
+    // Cursor on `Factory` in `    interface Factory {` — line 2 (0-based) in ReducerA.kt.
+    // No dot-qualifier in the source → qualifier=None, on_decl=true.
+    let locs = find_references_with_qualifier("Factory", None, &ra_uri, 2, false, &*idx).await;
+
+    let files = hit_files(&locs);
+
+    assert!(
+        files.iter().any(|f| f == "ViewModel.kt"),
+        "ReducerA.Factory usage in ViewModel.kt must be found; got: {:?}",
+        files
+    );
+    assert!(
+        !files.iter().any(|f| f == "OtherCaller.kt"),
+        "OtherCaller.kt uses ReducerB.Factory and must NOT appear; got: {:?}",
+        files
+    );
+}
+
 /// **Regression: nested Factory scoped by qualifier**
 ///
 /// Two classes `ReducerA` and `ReducerB` both have a nested `Factory` interface.

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -1,9 +1,9 @@
-//! End-to-end tests for [`find_references`].
+//! End-to-end tests for [`find_references_with_qualifier`].
 //!
 //! These tests write real `.kt` files to a temp directory so that `rg`
-//! can search them, then drive the full `find_references → rg_scope_for_path
-//! → rg_find_references` pipeline against an [`Indexer`] whose
-//! `workspace_root` is (or isn't) configured.
+//! can search them, then drive the full `find_references_with_qualifier →
+//! rg_scope_for_path → rg_find_references` pipeline against an [`Indexer`]
+//! whose `workspace_root` is (or isn't) configured.
 //!
 //! The scenarios targeted by these tests:
 //!

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -262,14 +262,23 @@ async fn find_references_stale_workspace_root_does_not_suppress_results() {
 /// the source text), `on_decl=true` and `enclosing_class_at` must return the
 /// parent class (`ReducerA`).  Without this the scope falls back to bare-word
 /// search and bleeds across all reducers.
+///
+/// Also covers the annotation case: `@AssistedFactory\n interface Factory {` —
+/// the annotation pushes the tree-sitter `interface_declaration` start row above
+/// the `interface` keyword line, tricking `enclosing_class_at` into returning
+/// `"Factory"` itself (start_row < cursor_row satisfied by Factory's own node).
+/// The fix checks that the cursor is inside the class *body*, not the header.
 #[tokio::test]
 async fn find_references_nested_factory_from_declaration_site() {
     let dir = tempfile::tempdir().unwrap();
     let root = dir.path();
 
+    // @AssistedFactory is on line 2 (0-based), `interface Factory` on line 3.
+    // This triggers the annotation-offset bug in enclosing_class_at.
     let reducer_a = "\
 package com.example.a
 class ReducerA {
+    @SomeAnnotation
     interface Factory {
         fun create(): ReducerA
     }
@@ -328,9 +337,10 @@ class OtherCaller(val f: ReducerB.Factory)
     idx.index_content(&vm_uri, viewmodel);
     idx.index_content(&oc_uri, other_caller);
 
-    // Cursor on `Factory` in `    interface Factory {` — line 2 (0-based) in ReducerA.kt.
-    // No dot-qualifier in the source → qualifier=None, on_decl=true.
-    let locs = find_references_with_qualifier("Factory", None, &ra_uri, 2, false, &*idx).await;
+    // Cursor on `Factory` in `    interface Factory {` — line 3 (0-based) in ReducerA.kt
+    // (line 2 is `@SomeAnnotation`).  No dot-qualifier → qualifier=None, on_decl=true.
+    // enclosing_class_at must return "ReducerA", not "Factory".
+    let locs = find_references_with_qualifier("Factory", None, &ra_uri, 3, false, &*idx).await;
 
     let files = hit_files(&locs);
 

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -621,3 +621,90 @@ fun buildReducer(f: ReducerA.Factory): ReducerA = f.create()
         files
     );
 }
+
+/// **Regression: multi-segment qualifier is normalised to immediate parent**
+///
+/// `word_and_qualifier_at` returns the full dot-chain, so for cursor on
+/// `Factory` in `Outer.Inner.Factory` the qualifier is `"Outer.Inner"`, not
+/// just `"Inner"`.  The old code stored the full chain as `parent_class` and
+/// passed it to `has_wrong_qualifier`; that function extracts the *single*
+/// token immediately before the dot in each line, so `"Inner" != "Outer.Inner"`
+/// caused every valid reference to be dropped (false negatives).
+///
+/// The fix: `resolve_scope_with_qualifier` takes `.split('.').next_back()` to
+/// normalise `"Outer.Inner"` → `"Inner"` before storing `parent_class`.
+#[tokio::test]
+async fn find_references_multi_segment_qualifier_normalised() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Three-level nesting: Outer → Inner → Factory.
+    let outer = "\
+package com.example
+class Outer {
+    class Inner {
+        interface Factory {
+            fun create(): Inner
+        }
+    }
+}
+";
+    // Another class has its own nested Factory that must NOT appear.
+    let other = "\
+package com.example
+class Other {
+    class Inner {
+        interface Factory {
+            fun create(): Other.Inner
+        }
+    }
+}
+";
+    // Caller uses Outer.Inner.Factory — multi-segment qualifier.
+    let caller = "\
+package com.example
+class Caller(val f: Outer.Inner.Factory)
+";
+
+    let outer_uri = Url::from_file_path(root.join("Outer.kt")).unwrap();
+    let other_uri = Url::from_file_path(root.join("Other.kt")).unwrap();
+    let caller_uri = Url::from_file_path(root.join("Caller.kt")).unwrap();
+
+    write(root, "Outer.kt", outer);
+    write(root, "Other.kt", other);
+    write(root, "Caller.kt", caller);
+    std::fs::write(root.join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();
+
+    let idx = Arc::new(Indexer::new());
+    idx.workspace_root.set(root.to_path_buf());
+    idx.index_content(&outer_uri, outer);
+    idx.index_content(&other_uri, other);
+    idx.index_content(&caller_uri, caller);
+
+    // Simulate what word_and_qualifier_at returns for cursor on `Factory`
+    // in `class Caller(val f: Outer.Inner.Factory)`: qualifier = "Outer.Inner".
+    let locs = find_references_with_qualifier(
+        "Factory",
+        Some("Outer.Inner"),
+        &caller_uri,
+        1, // line 1 (0-based): `class Caller(val f: Outer.Inner.Factory)`
+        false,
+        &*idx,
+    )
+    .await;
+
+    let files = hit_files(&locs);
+
+    // Caller.kt uses Outer.Inner.Factory — must be found.
+    assert!(
+        files.iter().any(|f| f == "Caller.kt"),
+        "Caller.kt (uses Outer.Inner.Factory) must be found; got: {:?}",
+        files
+    );
+    // Other.kt uses Other.Inner.Factory — must NOT appear (different qualifier).
+    assert!(
+        !files.iter().any(|f| f == "Other.kt"),
+        "Other.kt (Other.Inner.Factory) must NOT appear; got: {:?}",
+        files
+    );
+}

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -460,3 +460,164 @@ class OtherCaller(val f: ReducerB.Factory)
         files
     );
 }
+
+/// **Regression: sibling qualifier bleed**
+///
+/// When a single file (`ViewModel.kt`) has BOTH `ReducerA.Factory` AND `ReducerC.Factory`
+/// as constructor parameters, searching for references of `ReducerA.Factory` must not
+/// include the line that has `ReducerC.Factory`.
+///
+/// Root cause: the bare-word step in `parent_scoped_reference_locations` searches for
+/// `Factory` word-boundary in candidate files without checking whether a specific hit
+/// has a *different* qualifier on the same line.
+#[tokio::test]
+async fn find_references_sibling_qualifier_does_not_bleed() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let reducer_a = "\
+package com.example.a
+class ReducerA {
+    interface Factory {
+        fun create(): ReducerA
+    }
+}
+";
+    let reducer_b = "\
+package com.example.b
+class ReducerB {
+    interface Factory {
+        fun create(): ReducerB
+    }
+}
+";
+    let reducer_c = "\
+package com.example.c
+class ReducerC {
+    interface Factory {
+        fun create(): ReducerC
+    }
+}
+";
+    // ViewModel has BOTH ReducerA.Factory AND ReducerC.Factory as params.
+    let viewmodel = "\
+package com.example
+import com.example.a.ReducerA
+import com.example.b.ReducerB
+import com.example.c.ReducerC
+class ViewModel(
+    private val reducerAFactory: ReducerA.Factory,
+    private val reducerBFactory: ReducerB.Factory,
+    private val reducerCFactory: ReducerC.Factory,
+)
+";
+
+    write(root, "ReducerA.kt", reducer_a);
+    write(root, "ReducerB.kt", reducer_b);
+    write(root, "ReducerC.kt", reducer_c);
+    let (_, vm_uri) = write(root, "ViewModel.kt", viewmodel);
+    std::fs::write(root.join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();
+
+    let idx = Arc::new(Indexer::new());
+    idx.workspace_root.set(root.to_path_buf());
+    let ra_uri = Url::from_file_path(root.join("ReducerA.kt")).unwrap();
+    let rb_uri = Url::from_file_path(root.join("ReducerB.kt")).unwrap();
+    let rc_uri = Url::from_file_path(root.join("ReducerC.kt")).unwrap();
+    idx.index_content(&ra_uri, reducer_a);
+    idx.index_content(&rb_uri, reducer_b);
+    idx.index_content(&rc_uri, reducer_c);
+    idx.index_content(&vm_uri, viewmodel);
+
+    // Search refs of ReducerA.Factory (qualifier = "ReducerA").
+    // Line 5 = `    private val reducerAFactory: ReducerA.Factory,` (0-based)
+    let locs =
+        find_references_with_qualifier("Factory", Some("ReducerA"), &vm_uri, 5, false, &*idx).await;
+
+    let lines: Vec<u32> = locs
+        .iter()
+        .filter(|l| l.uri == vm_uri)
+        .map(|l| l.range.start.line)
+        .collect();
+
+    // Line 5 (ReducerA.Factory) must appear; lines 6 and 7 (ReducerB/C.Factory) must not.
+    assert!(
+        lines.contains(&5),
+        "ReducerA.Factory line (5) must be found; got lines: {:?}",
+        lines
+    );
+    assert!(
+        !lines.contains(&7),
+        "ReducerC.Factory line (7) must NOT appear in ReducerA.Factory search; got lines: {:?}",
+        lines
+    );
+}
+
+/// **Regression: lowercase method names at declaration site are scoped to package**
+///
+/// `fun create()` declared inside a nested `Factory` interface was previously
+/// treated as "no scope" (lowercase early-return) and fell through to a
+/// codebase-wide rg search, returning every file with `create` in the entire
+/// workspace.
+///
+/// The fix: when cursor is at the declaration site (`on_decl=true`) of a lowercase
+/// name, use the declaring file's package as the search scope instead of None.
+#[tokio::test]
+async fn find_references_lowercase_method_scoped_to_package_on_decl() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    let reducer_a = "\
+package com.example.a
+class ReducerA {
+    interface Factory {
+        fun create(): ReducerA
+    }
+}
+";
+    // A totally unrelated file in a *different* package that also has `fun create`.
+    let unrelated = "\
+package com.unrelated
+class Unrelated {
+    fun create(): Unrelated = Unrelated()
+}
+";
+    // Same-package caller that calls reducer factory.
+    let caller = "\
+package com.example.a
+import com.example.a.ReducerA
+fun buildReducer(f: ReducerA.Factory): ReducerA = f.create()
+";
+
+    let ra_uri = Url::from_file_path(root.join("ReducerA.kt")).unwrap();
+    let unrelated_uri = Url::from_file_path(root.join("Unrelated.kt")).unwrap();
+    let caller_uri = Url::from_file_path(root.join("Caller.kt")).unwrap();
+
+    write(root, "ReducerA.kt", reducer_a);
+    write(root, "Unrelated.kt", unrelated);
+    write(root, "Caller.kt", caller);
+    std::fs::write(root.join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();
+
+    let idx = Arc::new(Indexer::new());
+    idx.workspace_root.set(root.to_path_buf());
+    idx.index_content(&ra_uri, reducer_a);
+    idx.index_content(&unrelated_uri, unrelated);
+    idx.index_content(&caller_uri, caller);
+
+    // Cursor on `create` in `fun create(): ReducerA` — line 3 (0-based).
+    let locs = find_references_with_qualifier("create", None, &ra_uri, 3, false, &*idx).await;
+
+    let files = hit_files(&locs);
+
+    // Same-package caller must be found (calls f.create()).
+    assert!(
+        files.iter().any(|f| f == "Caller.kt"),
+        "Caller.kt (same package) must appear; got: {:?}",
+        files
+    );
+    // Unrelated.kt in a different package must NOT be returned.
+    assert!(
+        !files.iter().any(|f| f == "Unrelated.kt"),
+        "Unrelated.kt (different package) must NOT appear; got: {:?}",
+        files
+    );
+}

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -622,17 +622,19 @@ fun buildReducer(f: ReducerA.Factory): ReducerA = f.create()
     );
 }
 
-/// **Regression: multi-segment qualifier is normalised to immediate parent**
+/// **Regression: multi-segment qualifier is matched against the full extracted chain**
 ///
 /// `word_and_qualifier_at` returns the full dot-chain, so for cursor on
 /// `Factory` in `Outer.Inner.Factory` the qualifier is `"Outer.Inner"`, not
-/// just `"Inner"`.  The old code stored the full chain as `parent_class` and
-/// passed it to `has_wrong_qualifier`; that function extracts the *single*
-/// token immediately before the dot in each line, so `"Inner" != "Outer.Inner"`
-/// caused every valid reference to be dropped (false negatives).
+/// just `"Inner"`.  The old (whole-line) qualifier check extracted only the
+/// *single* token immediately before the dot in each line, so
+/// `"Inner" != "Outer.Inner"` caused every valid reference to be dropped (false
+/// negatives).
 ///
-/// The fix: `resolve_scope_with_qualifier` takes `.split('.').next_back()` to
-/// normalise `"Outer.Inner"` → `"Inner"` before storing `parent_class`.
+/// The fix: `has_wrong_qualifier_at_col` walks backward over `[A-Za-z0-9_.]`
+/// to extract the full dot-chain from the specific column of each hit, so
+/// `"Outer.Inner" == "Outer.Inner"` matches correctly and valid references are
+/// preserved.
 #[tokio::test]
 async fn find_references_multi_segment_qualifier_normalised() {
     let dir = tempfile::tempdir().unwrap();

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use tower_lsp::lsp_types::Url;
 
-use crate::features::references::find_references;
+use crate::features::references::find_references_with_qualifier;
 use crate::indexer::Indexer;
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
@@ -65,7 +65,7 @@ async fn find_references_cross_file_with_workspace_root() {
     idx.workspace_root.set(root.to_path_buf());
     idx.index_content(&foo_uri, foo_src);
 
-    let locs = find_references("MyClass", &foo_uri, 1, true, &*idx).await;
+    let locs = find_references_with_qualifier("MyClass", None, &foo_uri, 1, true, &*idx).await;
     let files = hit_files(&locs);
 
     assert!(
@@ -100,7 +100,7 @@ async fn find_references_cross_file_without_workspace_root() {
     let idx = Arc::new(Indexer::new());
     idx.index_content(&foo_uri, foo_src);
 
-    let locs = find_references("MyClass", &foo_uri, 1, true, &*idx).await;
+    let locs = find_references_with_qualifier("MyClass", None, &foo_uri, 1, true, &*idx).await;
     let files = hit_files(&locs);
 
     assert!(
@@ -145,7 +145,7 @@ async fn find_references_package_scoped_cross_file() {
 
     // line=1: declaration of MyClass → resolve_scope returns (None, Some("com.example"))
     // → package_scoped_reference_locations is used
-    let locs = find_references("MyClass", &foo_uri, 1, true, &*idx).await;
+    let locs = find_references_with_qualifier("MyClass", None, &foo_uri, 1, true, &*idx).await;
     let files = hit_files(&locs);
 
     assert!(
@@ -208,7 +208,7 @@ async fn actor_scan_then_find_references_cross_file() {
         .expect("workspace scan must complete within 10s")
         .unwrap();
 
-    let locs = find_references("MyClass", &foo_uri, 1, true, &*indexer).await;
+    let locs = find_references_with_qualifier("MyClass", None, &foo_uri, 1, true, &*indexer).await;
     let files = hit_files(&locs);
 
     assert!(
@@ -245,13 +245,118 @@ async fn find_references_stale_workspace_root_does_not_suppress_results() {
     idx.workspace_root.set(other_project.path().to_path_buf());
     idx.index_content(&foo_uri, foo_src);
 
-    let locs = find_references("MyClass", &foo_uri, 1, true, &*idx).await;
+    let locs = find_references_with_qualifier("MyClass", None, &foo_uri, 1, true, &*idx).await;
     let files = hit_files(&locs);
 
     assert!(
         files.iter().any(|f| f == "Bar.kt"),
         "find_references must search the file's actual project when workspace_root \
          points to a different directory; got files: {:?}",
+        files
+    );
+}
+
+/// **Regression: nested Factory scoped by qualifier**
+///
+/// Two classes `ReducerA` and `ReducerB` both have a nested `Factory` interface.
+/// Class `ViewModel` injects `ReducerA.Factory` in its constructor.
+/// The file does NOT import `ReducerA.Factory` directly — only `ReducerA`.
+///
+/// `find_references("Factory", …, qualifier=Some("ReducerA"))` must return
+/// only usages of `ReducerA.Factory`, NOT every use of `ReducerB.Factory`
+/// or bare `Factory` in other files.
+///
+/// Without the fix the qualifier is discarded, `declared_parent_class_of`
+/// picks an arbitrary `Factory` definition from the index (non-deterministic
+/// when multiple classes define `Factory`), and results bleed across the
+/// whole project.
+#[tokio::test]
+async fn find_references_nested_factory_scoped_by_qualifier() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // Two different reducers each with a nested Factory.
+    let reducer_a = "\
+package com.example.a
+class ReducerA {
+    interface Factory {
+        fun create(): ReducerA
+    }
+}
+";
+    let reducer_b = "\
+package com.example.b
+class ReducerB {
+    interface Factory {
+        fun create(): ReducerB
+    }
+}
+";
+    // ViewModel uses ReducerA.Factory in its constructor.
+    // No direct `import com.example.a.ReducerA.Factory` — only `import com.example.a.ReducerA`.
+    let viewmodel = "\
+package com.example
+import com.example.a.ReducerA
+import com.example.b.ReducerB
+class ViewModel(
+    private val reducerAFactory: ReducerA.Factory,
+    private val reducerBFactory: ReducerB.Factory,
+)
+";
+    // A second caller that uses ReducerB.Factory only.
+    let other_caller = "\
+package com.example
+import com.example.b.ReducerB
+class OtherCaller(val f: ReducerB.Factory)
+";
+
+    write(root, "ReducerA.kt", reducer_a);
+    write(root, "ReducerB.kt", reducer_b);
+    let (_, vm_uri) = write(root, "ViewModel.kt", viewmodel);
+    write(root, "OtherCaller.kt", other_caller);
+
+    // Write workspace.json to prevent scanning ~/.kotlin-lsp/sources.
+    std::fs::write(root.join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();
+
+    let idx = Arc::new(Indexer::new());
+    idx.workspace_root.set(root.to_path_buf());
+    idx.index_content(&vm_uri, viewmodel);
+
+    // Index the companion files so `declared_parent_class_of` has both entries.
+    let (_, ra_uri) = (
+        root.join("ReducerA.kt"),
+        Url::from_file_path(root.join("ReducerA.kt")).unwrap(),
+    );
+    let (_, rb_uri) = (
+        root.join("ReducerB.kt"),
+        Url::from_file_path(root.join("ReducerB.kt")).unwrap(),
+    );
+    let (_, oc_uri) = (
+        root.join("OtherCaller.kt"),
+        Url::from_file_path(root.join("OtherCaller.kt")).unwrap(),
+    );
+    idx.index_content(&ra_uri, reducer_a);
+    idx.index_content(&rb_uri, reducer_b);
+    idx.index_content(&oc_uri, other_caller);
+
+    // Cursor is on `Factory` in `private val reducerAFactory: ReducerA.Factory`
+    // (line 4, after the dot — qualifier = "ReducerA").
+    // Line 4 (0-based) = `    private val reducerAFactory: ReducerA.Factory,`
+    let locs =
+        find_references_with_qualifier("Factory", Some("ReducerA"), &vm_uri, 4, false, &*idx).await;
+
+    let files = hit_files(&locs);
+
+    // Must find the ViewModel itself (it uses ReducerA.Factory).
+    assert!(
+        files.iter().any(|f| f == "ViewModel.kt"),
+        "ReducerA.Factory usage in ViewModel.kt must be found; got: {:?}",
+        files
+    );
+    // Must NOT bleed into OtherCaller (uses ReducerB.Factory, different class).
+    assert!(
+        !files.iter().any(|f| f == "OtherCaller.kt"),
+        "OtherCaller.kt uses ReducerB.Factory and must NOT appear; got: {:?}",
         files
     );
 }

--- a/src/features/references_tests.rs
+++ b/src/features/references_tests.rs
@@ -708,3 +708,84 @@ class Caller(val f: Outer.Inner.Factory)
         files
     );
 }
+
+/// **Regression: `create()` inside nested Factory finds callers in parent package**
+///
+/// `fun create()` declared inside `ReducerA.Factory` must:
+///   1. Return callers in a *parent* package that use variable-name syntax
+///      (`reducerAFactory.create()`), and
+///   2. NOT return `fun create` declarations in sibling factories that live in
+///      the same package as `ReducerA`.
+///
+/// Root cause: package-scoped search (patterns matching `package com.example.a`)
+/// finds all sibling factories in the same package → FPs, while callers in
+/// `com.example` (parent) are outside the package scope → FNs.
+///
+/// Fix: `outer_class_for_decl_site` walks the CST chain to find that `create`
+/// is inside `Factory` inside `ReducerA`; the outer class `ReducerA` is used for
+/// file discovery so only files that reference `ReducerA` are searched.
+#[tokio::test]
+async fn find_references_nested_factory_create_finds_callers_not_siblings() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+
+    // ReducerA in package a with a nested Factory.
+    let reducer_a = "\
+package com.example.a
+class ReducerA {
+    interface Factory {
+        fun create(): ReducerA
+    }
+}
+";
+    // Sibling in same package — also has Factory.create (must NOT appear).
+    let reducer_b = "\
+package com.example.a
+class ReducerB {
+    interface Factory {
+        fun create(): ReducerB
+    }
+}
+";
+    // Caller in PARENT package that references ReducerA.Factory via a variable.
+    let dashboard = "\
+package com.example
+import com.example.a.ReducerA
+class Dashboard(private val reducerAFactory: ReducerA.Factory) {
+    fun build() = reducerAFactory.create()
+}
+";
+
+    let ra_uri = Url::from_file_path(root.join("ReducerA.kt")).unwrap();
+    let rb_uri = Url::from_file_path(root.join("ReducerB.kt")).unwrap();
+    let dash_uri = Url::from_file_path(root.join("Dashboard.kt")).unwrap();
+
+    write(root, "ReducerA.kt", reducer_a);
+    write(root, "ReducerB.kt", reducer_b);
+    write(root, "Dashboard.kt", dashboard);
+    std::fs::write(root.join("workspace.json"), r#"{"sourcePaths":[]}"#).unwrap();
+
+    let idx = Arc::new(Indexer::new());
+    idx.workspace_root.set(root.to_path_buf());
+    idx.index_content(&ra_uri, reducer_a);
+    idx.index_content(&rb_uri, reducer_b);
+    idx.index_content(&dash_uri, dashboard);
+
+    // Cursor on `create` in `fun create(): ReducerA` — line 3 (0-based).
+    let locs = find_references_with_qualifier("create", None, &ra_uri, 3, false, &*idx).await;
+
+    let files = hit_files(&locs);
+
+    // Caller in parent package must be found.
+    assert!(
+        files.iter().any(|f| f == "Dashboard.kt"),
+        "Dashboard.kt (parent-package caller) must appear; got: {:?}",
+        files
+    );
+    // Sibling factory's `fun create` declaration must NOT appear.
+    assert!(
+        !files.iter().any(|f| f == "ReducerB.kt"),
+        "ReducerB.kt (sibling factory) must NOT appear; got: {:?}",
+        files
+    );
+}

--- a/src/indexer/live_tree_impl.rs
+++ b/src/indexer/live_tree_impl.rs
@@ -26,6 +26,34 @@ impl Indexer {
         self.live_trees.get(uri.as_str()).map(|r| Arc::clone(&*r))
     }
 
+    /// Return the `LiveDoc` for `uri`, parsing on-demand if not already cached.
+    ///
+    /// Used by CST-based queries (e.g. `enclosing_class_at`) that are called
+    /// before `textDocument/didOpen` has been fully processed — the actor
+    /// receives `did_open` asynchronously so the live tree may not exist yet
+    /// when a navigation request arrives.  Content is taken from `live_lines`
+    /// (if present) or reconstructed from the indexed file lines; the result is
+    /// stored into `live_trees` so later calls in the same request are free.
+    pub(crate) fn live_doc_or_parse(&self, uri: &Url) -> Option<Arc<LiveDoc>> {
+        if let Some(doc) = self.live_doc(uri) {
+            return Some(doc);
+        }
+
+        let content: String = if let Some(ll) = self.live_lines.get(uri.as_str()) {
+            ll.join("\n")
+        } else if let Some(fd) = self.files.get(uri.as_str()) {
+            fd.lines.join("\n")
+        } else {
+            return None;
+        };
+
+        let lang = lang_for_path(uri.path())?;
+        let doc = parse_live(&content, lang)?;
+        let doc = Arc::new(doc);
+        self.live_trees.insert(uri.to_string(), Arc::clone(&doc));
+        Some(doc)
+    }
+
     /// Remove the live parse tree for `uri` (called on `textDocument/didClose`).
     pub(crate) fn remove_live_tree(&self, uri: &Url) {
         self.live_trees.remove(uri.as_str());

--- a/src/indexer/live_tree_impl.rs
+++ b/src/indexer/live_tree_impl.rs
@@ -32,8 +32,9 @@ impl Indexer {
     /// before `textDocument/didOpen` has been fully processed — the actor
     /// receives `did_open` asynchronously so the live tree may not exist yet
     /// when a navigation request arrives.  Content is taken from `live_lines`
-    /// (if present) or reconstructed from the indexed file lines; the result is
-    /// stored into `live_trees` so later calls in the same request are free.
+    /// (if present), the indexed file, or disk (cold-start fallback); the
+    /// result is stored into `live_trees` so later calls in the same request
+    /// are free.
     pub(crate) fn live_doc_or_parse(&self, uri: &Url) -> Option<Arc<LiveDoc>> {
         if let Some(doc) = self.live_doc(uri) {
             return Some(doc);
@@ -43,6 +44,8 @@ impl Indexer {
             ll.join("\n")
         } else if let Some(fd) = self.files.get(uri.as_str()) {
             fd.lines.join("\n")
+        } else if let Ok(path) = uri.to_file_path() {
+            std::fs::read_to_string(path).ok()?
         } else {
             return None;
         };

--- a/src/indexer/live_tree_impl.rs
+++ b/src/indexer/live_tree_impl.rs
@@ -33,12 +33,15 @@ impl Indexer {
     /// receives `did_open` asynchronously so the live tree may not exist yet
     /// when a navigation request arrives.  Content is taken from `live_lines`
     /// (if present), the indexed file, or disk (cold-start fallback); the
-    /// result is stored into `live_trees` so later calls in the same request
-    /// are free.
+    /// result is stored into `live_trees` **only when the file is currently open**
+    /// (i.e. `live_lines` is present) so that `live_trees` does not accumulate
+    /// parse trees for files that were never opened by the editor.
     pub(crate) fn live_doc_or_parse(&self, uri: &Url) -> Option<Arc<LiveDoc>> {
         if let Some(doc) = self.live_doc(uri) {
             return Some(doc);
         }
+
+        let is_open = self.live_lines.contains_key(uri.as_str());
 
         let content: String = if let Some(ll) = self.live_lines.get(uri.as_str()) {
             ll.join("\n")
@@ -53,7 +56,9 @@ impl Indexer {
         let lang = lang_for_path(uri.path())?;
         let doc = parse_live(&content, lang)?;
         let doc = Arc::new(doc);
-        self.live_trees.insert(uri.to_string(), Arc::clone(&doc));
+        if is_open {
+            self.live_trees.insert(uri.to_string(), Arc::clone(&doc));
+        }
         Some(doc)
     }
 

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -398,8 +398,10 @@ impl Indexer {
     pub(crate) fn enclosing_class_at(&self, uri: &Url, row: u32) -> Option<String> {
         let row = row as usize;
 
-        // ── CST fast path ────────────────────────────────────────────────────
-        if let Some(doc) = self.live_doc(uri) {
+        // ── CST path ─────────────────────────────────────────────────────────
+        // `live_doc_or_parse` parses on-demand if the live tree isn't cached
+        // yet (e.g. when findReferences arrives before did_open is processed).
+        if let Some(doc) = self.live_doc_or_parse(uri) {
             // Use the first non-whitespace byte on the row as the probe column.
             let probe_col = self
                 .live_lines

--- a/src/indexer/scope.rs
+++ b/src/indexer/scope.rs
@@ -13,7 +13,8 @@ use super::{
 use crate::indexer::live_tree::utf16_col_to_byte;
 use crate::indexer::NodeExt;
 use crate::queries::{
-    KIND_CLASS_DECL, KIND_COMPANION_OBJ, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT, KIND_OBJECT_DECL,
+    KIND_CLASS_BODY, KIND_CLASS_DECL, KIND_COMPANION_OBJ, KIND_INTERFACE_DECL, KIND_LAMBDA_LIT,
+    KIND_OBJECT_DECL,
 };
 use crate::types::CursorPos;
 use crate::StrExt;
@@ -422,8 +423,17 @@ impl Indexer {
                         | KIND_COMPANION_OBJ
                             if cur.start_position().row < row =>
                         {
-                            if let Some(name) = cur.extract_type_name(&doc.bytes) {
-                                return Some(name);
+                            // Guard: cursor must be inside the class body, not on the
+                            // declaration header (annotations can push the start row
+                            // of the declaration *above* the `class/interface` keyword
+                            // line, so `start_position().row < row` is insufficient).
+                            let body_inside = cur.children(&mut cur.walk()).any(|c| {
+                                c.kind() == KIND_CLASS_BODY && c.start_position().row < row
+                            });
+                            if body_inside {
+                                if let Some(name) = cur.extract_type_name(&doc.bytes) {
+                                    return Some(name);
+                                }
                             }
                         }
                         _ => {}

--- a/src/indexer/scope_tests.rs
+++ b/src/indexer/scope_tests.rs
@@ -601,6 +601,32 @@ fn enclosing_class_cst_nested() {
 }
 
 #[test]
+fn enclosing_class_cst_annotated_nested_interface() {
+    // Regression: `@AssistedFactory` on line 2 pushes the interface_declaration
+    // start row to 2 while the cursor is on line 3 (`interface Factory`).
+    // Before the fix, enclosing_class_at returned Some("Factory") because
+    // start_row(2) < cursor_row(3) was satisfied by Factory's own node.
+    // After the fix, it correctly skips Factory (cursor not inside its body)
+    // and returns the outer class.
+    let src = "\
+class Outer {
+    class Inner {
+        @SomeAnnotation
+        interface Factory {
+            fun create(): Inner
+        }
+    }
+}
+";
+    let (u, idx) = indexed_with_live("/Outer.kt", src);
+    // Line 3 = `        interface Factory {` — on the declaration header.
+    // enclosing_class_at must return "Inner", not "Factory".
+    assert_eq!(idx.enclosing_class_at(&u, 3), Some("Inner".into()));
+    // Line 4 = `            fun create(): Inner` — inside Factory's body.
+    assert_eq!(idx.enclosing_class_at(&u, 4), Some("Factory".into()));
+}
+
+#[test]
 fn lambda_params_at_col_cst_collects_named() {
     let src = "val x = items.map { item ->\n    item.id\n}";
     let (u, idx) = indexed_with_live("/t.kt", src);

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -803,16 +803,18 @@ fn owner_scoped_reference_locations(
     // Bare search for the method name in candidate files; qualifier filter is
     // intentionally skipped since callers use variable names, not class names.
     //
-    // Declaration lines (e.g. `fun create()` in a sibling factory that happens to
-    // import the outer class) are dropped across ALL files, not just `from_uri`,
-    // because we are looking for call sites only.
+    // Declaration lines of the same method name in OTHER files (e.g. `fun create()`
+    // in a sibling factory, or in a same-named class in a different feature) are
+    // always dropped, regardless of `include_decl`.  In `from_uri` itself the
+    // `should_skip_reference` logic already handles the `include_decl` flag correctly.
     rg_word_in_files(&safe_name, &candidate_files)
         .into_iter()
         .filter_map(|(loc, content)| {
             if should_skip_reference(&loc, &content, request) {
                 return None;
             }
-            if !request.include_decl && is_declaration_of(&content, request.name) {
+            let is_other_file = loc.uri.as_str() != request.from_uri.as_str();
+            if is_other_file && is_declaration_of(&content, request.name) {
                 return None;
             }
             Some(loc)

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -879,15 +879,29 @@ fn qualifier_hints_owner(content: &str, name_byte_col: usize, owner_class: &str)
 
 /// Returns `true` if `content` declares `name` specifically (e.g. `fun create()`),
 /// as opposed to a line that merely calls `name` inside a different declaration
-/// (e.g. `fun build() = factory.create()`).
+/// (e.g. `fun build() = factory.create()` or `fun createWidget() = factory.create()`).
+///
+/// Requires a word boundary *after* `name` to avoid matching declarations of
+/// longer identifiers that share a prefix — e.g. `fun createWidget` must not be
+/// treated as a declaration of `create`.
 ///
 /// Used by [`owner_scoped_reference_locations`] to filter out sibling
 /// declarations of the same method name that appear in files which also reference
 /// the outer class.
 pub(crate) fn is_declaration_of(content: &str, name: &str) -> bool {
-    REFERENCE_DECLARATION_KEYWORDS
-        .iter()
-        .any(|kw| content.contains(&format!("{kw}{name}")))
+    REFERENCE_DECLARATION_KEYWORDS.iter().any(|kw| {
+        let prefix = format!("{kw}{name}");
+        if let Some(idx) = content.find(&prefix) {
+            let end = idx + prefix.len();
+            // Word-boundary check: name must not be followed by more identifier chars.
+            content
+                .as_bytes()
+                .get(end)
+                .is_none_or(|&b| !b.is_ascii_alphanumeric() && b != b'_')
+        } else {
+            false
+        }
+    })
 }
 
 /// Run `rg` to find all *usages* of `name` in the project.

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -802,12 +802,35 @@ fn owner_scoped_reference_locations(
 
     // Bare search for the method name in candidate files; qualifier filter is
     // intentionally skipped since callers use variable names, not class names.
+    //
+    // Declaration lines (e.g. `fun create()` in a sibling factory that happens to
+    // import the outer class) are dropped across ALL files, not just `from_uri`,
+    // because we are looking for call sites only.
     rg_word_in_files(&safe_name, &candidate_files)
         .into_iter()
         .filter_map(|(loc, content)| {
-            (!should_skip_reference(&loc, &content, request)).then_some(loc)
+            if should_skip_reference(&loc, &content, request) {
+                return None;
+            }
+            if !request.include_decl && is_declaration_of(&content, request.name) {
+                return None;
+            }
+            Some(loc)
         })
         .collect()
+}
+
+/// Returns `true` if `content` declares `name` specifically (e.g. `fun create()`),
+/// as opposed to a line that merely calls `name` inside a different declaration
+/// (e.g. `fun build() = factory.create()`).
+///
+/// Used by [`owner_scoped_reference_locations`] to filter out sibling
+/// declarations of the same method name that appear in files which also reference
+/// the outer class.
+fn is_declaration_of(content: &str, name: &str) -> bool {
+    REFERENCE_DECLARATION_KEYWORDS
+        .iter()
+        .any(|kw| content.contains(&format!("{kw}{name}")))
 }
 
 /// Run `rg` to find all *usages* of `name` in the project.

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -253,6 +253,15 @@ pub(crate) struct RgSearchRequest<'a> {
     name: &'a str,
     parent_class: Option<&'a str>,
     declared_pkg: Option<&'a str>,
+    /// Outer-outer class for a lowercase method declared inside a doubly-nested
+    /// class (e.g. `create` inside `Factory` inside `RegularReducer`).
+    ///
+    /// When set, file discovery searches for files that mention this class (via
+    /// `\bOwnerClass\b`) rather than using import or package patterns.  This
+    /// ensures callers that reference the outer class via a variable name
+    /// (`factory.create()`) are found, while sibling factories in the same
+    /// package are excluded because they do not reference the outer class.
+    owner_class: Option<&'a str>,
     search_root: std::borrow::Cow<'a, Path>,
     /// Source-root directories from workspace config; when non-empty, rg is
     /// scoped to these directories instead of the full workspace root.
@@ -474,6 +483,7 @@ impl<'a> RgSearchRequest<'a> {
             name,
             parent_class,
             declared_pkg,
+            owner_class: None,
             search_root,
             source_paths: &[],
             include_decl,
@@ -484,6 +494,11 @@ impl<'a> RgSearchRequest<'a> {
 
     pub(crate) fn with_source_paths(mut self, source_paths: &'a [String]) -> Self {
         self.source_paths = source_paths;
+        self
+    }
+
+    pub(crate) fn with_owner_class(mut self, owner_class: &'a str) -> Self {
+        self.owner_class = Some(owner_class);
         self
     }
 }
@@ -737,6 +752,48 @@ fn package_scoped_reference_locations(
         .collect()
 }
 
+/// Find references to a lowercase method declared inside a doubly-nested class
+/// (e.g. `create` inside `Factory` inside `RegularReducer`).
+///
+/// Callers use variable-name syntax (`factory.create()`) rather than qualified
+/// syntax (`RegularReducer.create()`), so standard parent-class scoping misses
+/// them.  Instead we find candidate files by searching for any mention of the
+/// outer class, then do a bare-word search for the method name within those
+/// files.  Sibling factories in the same package are naturally excluded because
+/// they do not reference the outer class.
+fn owner_scoped_reference_locations(
+    request: &RgSearchRequest<'_>,
+    matcher: Option<&IgnoreMatcher>,
+) -> Vec<Location> {
+    let owner_class = request.owner_class.expect("owner_class must be set");
+    let safe_owner = regex_escape(owner_class);
+    let safe_name = regex_escape(request.name);
+
+    // Find files that mention the outer class (as a type, import, or constructor param).
+    let owner_pattern = format!(r"\b{safe_owner}\b");
+    let candidate_files = filter_candidate_files(
+        rg_files_with_matches_scoped(
+            &owner_pattern,
+            request.source_paths,
+            request.search_root.as_ref(),
+        ),
+        matcher,
+    );
+
+    if candidate_files.is_empty() {
+        return vec![];
+    }
+
+    // Bare search for the method name in candidate files; qualifier filter is
+    // intentionally skipped since callers use variable names, not class names.
+    rg_word_in_files(&safe_name, &candidate_files)
+        .into_iter()
+        .filter_map(|(loc, content)| {
+            (!should_skip_reference(&loc, &content, request)).then_some(loc)
+        })
+        .collect()
+}
+
 /// Run `rg` to find all *usages* of `name` in the project.
 ///
 /// Uses `--word-regexp` so only whole-word matches are returned.
@@ -750,13 +807,17 @@ pub(crate) fn rg_find_references(
     request: &RgSearchRequest<'_>,
     matcher: Option<&IgnoreMatcher>,
 ) -> Vec<Location> {
-    let patterns = build_rg_patterns(request);
-    let result = if request.parent_class.is_some() {
-        parent_scoped_reference_locations(request, &patterns, matcher)
-    } else if request.declared_pkg.is_some() {
-        package_scoped_reference_locations(request, &patterns, matcher)
+    let result = if request.owner_class.is_some() {
+        owner_scoped_reference_locations(request, matcher)
     } else {
-        run_rg_search(request, &patterns)
+        let patterns = build_rg_patterns(request);
+        if request.parent_class.is_some() {
+            parent_scoped_reference_locations(request, &patterns, matcher)
+        } else if request.declared_pkg.is_some() {
+            package_scoped_reference_locations(request, &patterns, matcher)
+        } else {
+            run_rg_search(request, &patterns)
+        }
     };
 
     if let Some(matcher) = matcher {

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -625,11 +625,18 @@ pub(crate) fn has_wrong_qualifier(content: &str, name: &str, expected_parent: &s
             offset = name_end;
             continue;
         }
-        // Extract the qualifier word immediately before the dot.
-        let qualifier = content[..match_start]
-            .rsplit(|c: char| !c.is_alphanumeric() && c != '_')
-            .next()
-            .unwrap_or("");
+        // Extract the full qualifier chain immediately before the dot
+        // (e.g. "Outer.Inner" for "Outer.Inner.Factory", "ReducerA" for "ReducerA.Factory").
+        // We walk back over [A-Za-z0-9_.] so multi-segment chains are captured whole.
+        let qualifier: String = content[..match_start]
+            .chars()
+            .rev()
+            .take_while(|&c| c.is_alphanumeric() || c == '_' || c == '.')
+            .collect::<String>()
+            .chars()
+            .rev()
+            .collect::<String>();
+        let qualifier = qualifier.trim_start_matches('.');
         if !qualifier.is_empty() && qualifier != expected_parent {
             return true;
         }

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -803,18 +803,28 @@ fn owner_scoped_reference_locations(
     // Bare search for the method name in candidate files; qualifier filter is
     // intentionally skipped since callers use variable names, not class names.
     //
-    // Declaration lines of the same method name in OTHER files (e.g. `fun create()`
-    // in a sibling factory, or in a same-named class in a different feature) are
-    // always dropped, regardless of `include_decl`.  In `from_uri` itself the
-    // `should_skip_reference` logic already handles the `include_decl` flag correctly.
+    // Filtering rules:
+    // - `from_uri`: the declaring file. Only the declaration line is relevant;
+    //   all other `create()` calls in it are to OTHER injected factory instances
+    //   (the declaring file doesn't call its own Factory.create()).
+    // - Other files: skip declaration lines of the same method name (e.g. sibling
+    //   Factory.create() in a file that also imports the outer class).
     rg_word_in_files(&safe_name, &candidate_files)
         .into_iter()
         .filter_map(|(loc, content)| {
             if should_skip_reference(&loc, &content, request) {
                 return None;
             }
-            let is_other_file = loc.uri.as_str() != request.from_uri.as_str();
-            if is_other_file && is_declaration_of(&content, request.name) {
+            let is_from_uri = loc.uri.as_str() == request.from_uri.as_str();
+            if is_from_uri {
+                // In the declaring file, only the declaration itself is relevant.
+                return if request.include_decl && is_declaration_of(&content, request.name) {
+                    Some(loc)
+                } else {
+                    None
+                };
+            }
+            if is_declaration_of(&content, request.name) {
                 return None;
             }
             Some(loc)

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -607,6 +607,37 @@ fn scope_decl_files<'a>(
     std::borrow::Cow::Owned(filtered)
 }
 
+/// Returns `true` when `content` contains `.<name>` preceded by a qualifier word
+/// that is NOT `expected_parent`.  A bare `name` (no qualifier) is always allowed.
+///
+/// This prevents sibling qualified names from bleeding into results: when searching
+/// for `ReducerA.Factory`, a line containing `ReducerC.Factory` must be excluded even
+/// though it also contains the bare word `Factory`.
+pub(crate) fn has_wrong_qualifier(content: &str, name: &str, expected_parent: &str) -> bool {
+    let dotname = format!(".{name}");
+    let mut offset = 0;
+    while let Some(rel) = content[offset..].find(&dotname) {
+        let match_start = offset + rel;
+        let name_end = match_start + dotname.len();
+        // Confirm word boundary after the name (not a prefix of a longer identifier).
+        let after_ch = content[name_end..].chars().next();
+        if after_ch.is_some_and(|c| c.is_alphanumeric() || c == '_') {
+            offset = name_end;
+            continue;
+        }
+        // Extract the qualifier word immediately before the dot.
+        let qualifier = content[..match_start]
+            .rsplit(|c: char| !c.is_alphanumeric() && c != '_')
+            .next()
+            .unwrap_or("");
+        if !qualifier.is_empty() && qualifier != expected_parent {
+            return true;
+        }
+        offset = name_end;
+    }
+    false
+}
+
 fn append_unique_reference_hits(
     locations: &mut Vec<Location>,
     hits: Vec<(Location, String)>,
@@ -626,6 +657,11 @@ fn append_unique_reference_hits(
     for (location, content) in hits {
         if should_skip_reference(&location, &content, request) {
             continue;
+        }
+        if let Some(parent) = request.parent_class {
+            if has_wrong_qualifier(&content, request.name, parent) {
+                continue;
+            }
         }
 
         let key = (

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -809,6 +809,10 @@ fn owner_scoped_reference_locations(
     //   (the declaring file doesn't call its own Factory.create()).
     // - Other files: skip declaration lines of the same method name (e.g. sibling
     //   Factory.create() in a file that also imports the outer class).
+    //   Additionally apply a naming-convention heuristic: if there is an explicit
+    //   dot-qualifier before the name (e.g. `overviewMapperFactory.create`) and
+    //   that qualifier does not contain the outer class name, the call is almost
+    //   certainly to a different factory.
     rg_word_in_files(&safe_name, &candidate_files)
         .into_iter()
         .filter_map(|(loc, content)| {
@@ -827,9 +831,50 @@ fn owner_scoped_reference_locations(
             if is_declaration_of(&content, request.name) {
                 return None;
             }
+            if !qualifier_hints_owner(&content, loc.range.start.character as usize, owner_class) {
+                return None;
+            }
             Some(loc)
         })
         .collect()
+}
+
+/// Naming-convention heuristic: returns `false` when the dot-qualifier before
+/// `name_byte_col` in `content` is a non-empty identifier that does NOT contain
+/// `owner_class` as a substring (case-insensitive).
+///
+/// Example: for `overviewMapperFactory.create(...)` with owner `DashboardProductsReducer`,
+/// the qualifier is `overviewMapperFactory` which does NOT contain `dashboardproductsreducer`
+/// → returns `false` (skip — different factory).
+///
+/// Returns `true` (keep) for: bare names (no qualifier), or when the qualifier
+/// contains the owner name (e.g. `dashboardProductsReducerFactory`).
+fn qualifier_hints_owner(content: &str, name_byte_col: usize, owner_class: &str) -> bool {
+    let col = name_byte_col;
+    if col == 0 || content.as_bytes().get(col - 1) != Some(&b'.') {
+        return true; // bare name — no qualifier to check
+    }
+    // Walk back over alphanumeric/underscore to extract the immediate qualifier token.
+    let qualifier: String = content[..col - 1]
+        .chars()
+        .rev()
+        .take_while(|&c| c.is_alphanumeric() || c == '_')
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect();
+    if qualifier.is_empty() {
+        return true; // can't determine — allow
+    }
+    // Only apply the heuristic for long qualifiers (≥10 chars) that look like they
+    // are derived from a class name.  Short names (e.g. `f`, `it`, `factory`) could
+    // be generic variables for ANY factory — keep them to avoid false negatives.
+    if qualifier.len() < 10 {
+        return true;
+    }
+    qualifier
+        .to_lowercase()
+        .contains(&owner_class.to_lowercase())
 }
 
 /// Returns `true` if `content` declares `name` specifically (e.g. `fun create()`),

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -622,41 +622,52 @@ fn scope_decl_files<'a>(
     std::borrow::Cow::Owned(filtered)
 }
 
-/// Returns `true` when `content` contains `.<name>` preceded by a qualifier word
-/// that is NOT `expected_parent`.  A bare `name` (no qualifier) is always allowed.
+/// Returns `true` if `c` is a valid identifier or qualifier-chain character.
 ///
-/// This prevents sibling qualified names from bleeding into results: when searching
-/// for `ReducerA.Factory`, a line containing `ReducerC.Factory` must be excluded even
-/// though it also contains the bare word `Factory`.
-pub(crate) fn has_wrong_qualifier(content: &str, name: &str, expected_parent: &str) -> bool {
-    let dotname = format!(".{name}");
-    let mut offset = 0;
-    while let Some(rel) = content[offset..].find(&dotname) {
-        let match_start = offset + rel;
-        let name_end = match_start + dotname.len();
-        // Confirm word boundary after the name (not a prefix of a longer identifier).
-        let after_ch = content[name_end..].chars().next();
-        if after_ch.is_some_and(|c| c.is_alphanumeric() || c == '_') {
-            offset = name_end;
-            continue;
-        }
-        // Extract the full qualifier chain immediately before the dot
-        // (e.g. "Outer.Inner" for "Outer.Inner.Factory", "ReducerA" for "ReducerA.Factory").
-        // We walk back over [A-Za-z0-9_.] so multi-segment chains are captured whole.
-        let qualifier: String = content[..match_start]
+/// Used when walking backward over text to extract the dot-qualified chain
+/// preceding a name (e.g. `"ReducerA"` in `ReducerA.Factory` or
+/// `"Outer.Inner"` in `Outer.Inner.Factory`).
+fn is_qualifier_char(c: char) -> bool {
+    c.is_alphanumeric() || c == '_' || c == '.'
+}
+
+/// Returns `true` if the `.<name>` occurrence whose name starts at **byte** offset
+/// `name_byte_col` has a qualifier that doesn't match `expected_parent`.
+///
+/// This inspects only the single occurrence at `name_byte_col`, preventing false
+/// positives on lines that contain multiple qualified names
+/// (e.g. `ReducerA.Factory, ReducerC.Factory` — the hit for `ReducerA.Factory`
+/// at its specific column should not be dropped because `ReducerC.Factory` appears
+/// later on the same line).
+///
+/// `name_byte_col` is the 0-based byte offset of the start of `name` within
+/// `content` (matching the `character` field in [`Location`] as returned by rg).
+pub(crate) fn has_wrong_qualifier_at_col(
+    content: &str,
+    name: &str,
+    expected_parent: &str,
+    name_byte_col: u32,
+) -> bool {
+    let col = name_byte_col as usize;
+    // Verify the occurrence is actually `name` at this position (guards against
+    // byte-offset mismatches with multi-byte content).
+    if content.get(col..col + name.len()).is_none_or(|s| s != name) {
+        return false;
+    }
+    // A dot immediately before the name signals a qualified reference.
+    if col > 0 && content.as_bytes().get(col - 1) == Some(&b'.') {
+        let qualifier: String = content[..col - 1]
             .chars()
             .rev()
-            .take_while(|&c| c.is_alphanumeric() || c == '_' || c == '.')
+            .take_while(|&c| is_qualifier_char(c))
             .collect::<String>()
             .chars()
             .rev()
-            .collect::<String>();
+            .collect();
         let qualifier = qualifier.trim_start_matches('.');
-        if !qualifier.is_empty() && qualifier != expected_parent {
-            return true;
-        }
-        offset = name_end;
+        return !qualifier.is_empty() && qualifier != expected_parent;
     }
+    // No dot immediately before: bare name usage at this position — always allowed.
     false
 }
 
@@ -681,7 +692,12 @@ fn append_unique_reference_hits(
             continue;
         }
         if let Some(parent) = request.parent_class {
-            if has_wrong_qualifier(&content, request.name, parent) {
+            if has_wrong_qualifier_at_col(
+                &content,
+                request.name,
+                parent,
+                location.range.start.character,
+            ) {
                 continue;
             }
         }

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -839,7 +839,7 @@ fn owner_scoped_reference_locations(
 /// Used by [`owner_scoped_reference_locations`] to filter out sibling
 /// declarations of the same method name that appear in files which also reference
 /// the outer class.
-fn is_declaration_of(content: &str, name: &str) -> bool {
+pub(crate) fn is_declaration_of(content: &str, name: &str) -> bool {
     REFERENCE_DECLARATION_KEYWORDS
         .iter()
         .any(|kw| content.contains(&format!("{kw}{name}")))

--- a/src/rg_tests.rs
+++ b/src/rg_tests.rs
@@ -10,7 +10,8 @@
 use tower_lsp::lsp_types::Url;
 
 use crate::rg::{
-    parse_rg_line, rg_find_definition, rg_find_references, IgnoreMatcher, RgSearchRequest,
+    is_declaration_of, parse_rg_line, rg_find_definition, rg_find_references, IgnoreMatcher,
+    RgSearchRequest,
 };
 
 // ─── parse_rg_line ────────────────────────────────────────────────────────────
@@ -621,4 +622,39 @@ fn rg_find_references_scoped_to_source_paths() {
         !files.iter().any(|f| f.contains("generated")),
         "must not include files outside source_paths (generated/); got: {files:?}"
     );
+}
+
+// ─── is_declaration_of ────────────────────────────────────────────────────────
+
+#[test]
+fn is_declaration_of_matches_exact_name() {
+    assert!(is_declaration_of("    fun create(): Foo", "create"));
+    assert!(is_declaration_of("    fun create(x: Int): Foo", "create"));
+    assert!(is_declaration_of("val create: Factory", "create"));
+}
+
+#[test]
+fn is_declaration_of_rejects_longer_name_with_same_prefix() {
+    // "fun createWidget" must NOT be treated as a declaration of "create"
+    assert!(!is_declaration_of(
+        "    fun createWidget(): Widget",
+        "create"
+    ));
+    assert!(!is_declaration_of(
+        "    fun createReducer() = factory.create()",
+        "create"
+    ));
+    assert!(!is_declaration_of(
+        "    fun createAccount(name: String): Account",
+        "create"
+    ));
+}
+
+#[test]
+fn is_declaration_of_rejects_call_site_in_non_declaration() {
+    assert!(!is_declaration_of("    val x = factory.create()", "create"));
+    assert!(!is_declaration_of(
+        "    fun build() = factory.create()",
+        "create"
+    ));
 }

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -89,8 +89,9 @@ impl<R: ProgressReporter + 'static> Actor<R> {
     pub(crate) async fn run(mut self) {
         let mut was_ready = false;
         loop {
+            // No `biased;` — both arms compete fairly so that a flood of
+            // FileChanged events cannot starve scan completions indefinitely.
             tokio::select! {
-                biased;
                 maybe_event = self.rx.recv() => {
                     let Some(event) = maybe_event else { break };
                     self.handle_event(event).await;
@@ -201,7 +202,10 @@ impl<R: ProgressReporter + 'static> Actor<R> {
             .await;
     }
 
-    async fn handle_file_deleted(&self, uri: Url) {
+    async fn handle_file_deleted(&mut self, uri: Url) {
+        // Cancel any pending debounce task — same as close, so the spawn_blocking
+        // inside it has the best chance of being aborted before it re-indexes the file.
+        self.file_change_handler.cancel_pending_reindex(&uri);
         self.document_handler.handle_file_deleted(uri).await;
     }
 }

--- a/src/workspace/file_change_handler.rs
+++ b/src/workspace/file_change_handler.rs
@@ -80,7 +80,12 @@ impl FileChangeHandler {
     fn spawn_live_tree_update(&self, uri: Url, text: String) {
         let indexer = Arc::clone(&self.indexer);
         drop(tokio::task::spawn_blocking(move || {
-            indexer.store_live_tree(&uri, &text);
+            // Guard: if the file was closed or deleted while we were blocked,
+            // live_lines will have been removed. Re-inserting the live tree
+            // after that would leave stale data in the index.
+            if indexer.live_lines.contains_key(uri.as_str()) {
+                indexer.store_live_tree(&uri, &text);
+            }
         }));
     }
 
@@ -110,6 +115,12 @@ impl FileChangeHandler {
             let diagnostics_uri = uri.clone();
             let diagnostics_text = text.clone();
             let result = tokio::task::spawn_blocking(move || {
+                // Guard: if the file was closed or deleted before the debounce
+                // fired, skip re-indexing to avoid reinserting stale content.
+                if !indexer.live_lines.contains_key(uri.as_str()) {
+                    drop(permit);
+                    return None;
+                }
                 let data = indexer.index_content(&uri, &text);
                 drop(permit);
                 data


### PR DESCRIPTION
## Summary

Two find_references precision bugs fixed.

### Issue A: Sibling qualifier bleed (ReducerC.Factory in ReducerA.Factory results)

When a ViewModel has both `ReducerA.Factory` and `ReducerC.Factory` as constructor parameters, searching references for `ReducerA.Factory` was returning lines for all siblings too.

**Root cause:** The bare-word step in `parent_scoped_reference_locations` found all `Factory` occurrences in candidate files without checking whether a specific hit had a *different* qualifier on the same line. The fix also applies to `add_current_file_locations` (the in-memory injection path) which bypassed rg filtering entirely.

**Fix:** `has_wrong_qualifier(content, name, parent_class)` — scans content for `.<name>` patterns and returns `true` if the word before the dot is non-empty and not `parent_class`.

### Issue B: Lowercase method names (e.g. `create`) find all occurrences codebase-wide


**Fix:** When `on_decl = true` for a lowercase name, return `(None, package_of(uri))` — scopes rg to same-package files rather than the whole codebase.

## Tests

- `find_references_sibling_qualifier_does_not_bleed` — ReducerA/B/C.Factory in same ViewModel; searching ReducerA.Factory must not include ReducerC.Factory line
- `find_references_lowercase_method_scoped_to_package_on_decl` — `fun create()` at decl site finds same-package caller but not different-package unrelated class