### PR TITLE
fix: address PR #109 review comments

### DIFF
--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -32,6 +32,6 @@ impl Backend {
             return Ok(None);
         };
 
-        Ok(imp::find_implementation(&word, &*self.indexer, uri).await)
+        Ok(imp::find_implementation(&word, &*self.indexer, uri, position.line).await)
     }
 }

--- a/src/features/implementation.rs
+++ b/src/features/implementation.rs
@@ -27,8 +27,9 @@ pub(crate) async fn find_implementation(
     word: &str,
     index: &(impl SymbolIndex + DocumentAccess + SearchAccess),
     uri: &Url,
+    line: u32,
 ) -> Option<GotoDefinitionResponse> {
-    if let Some(declaring_class) = declaring_class_of_method(index, uri, word) {
+    if let Some(declaring_class) = declaring_class_of_method(index, uri, word, line) {
         find_method_implementations(word, &declaring_class, index, uri).await
     } else {
         find_type_implementations(word, index, uri).await
@@ -105,7 +106,12 @@ async fn find_type_implementations(
 /// If `word` is a function/method declared inside a class or interface at `uri`,
 /// returns the name of the declaring class.  Returns `None` for top-level
 /// functions, constructors, and non-function symbols.
-fn declaring_class_of_method(index: &impl SymbolIndex, uri: &Url, word: &str) -> Option<String> {
+fn declaring_class_of_method(
+    index: &impl SymbolIndex,
+    uri: &Url,
+    word: &str,
+    line: u32,
+) -> Option<String> {
     index
         .file_symbols(uri)
         .into_iter()
@@ -113,16 +119,26 @@ fn declaring_class_of_method(index: &impl SymbolIndex, uri: &Url, word: &str) ->
             s.name == word
                 && matches!(s.kind, SymbolKind::FUNCTION | SymbolKind::METHOD)
                 && s.container.is_some()
+                && s.selection_range.start.line == line
         })
         .and_then(|s| s.container)
 }
 
-/// Collect all `override fun method_name` locations within `data`.
+/// Collect `override fun method_name` (Kotlin) or same-named method (Java)
+/// locations within `data` for a confirmed subtype.
+///
+/// For Kotlin, `detail` must contain `"override"` to exclude same-named
+/// non-overriding overloads. For Java, `@Override` lives on the preceding line
+/// and is not in the indexed detail, so all same-named methods in a confirmed
+/// subtype are included.
 fn method_overrides_in(method_name: &str, data: &Arc<FileData>, uri: &Url) -> Vec<Location> {
+    let lang = crate::Language::from_path(uri.path());
     data.symbols
         .iter()
         .filter(|s| {
-            s.name == method_name && matches!(s.kind, SymbolKind::FUNCTION | SymbolKind::METHOD)
+            s.name == method_name
+                && matches!(s.kind, SymbolKind::FUNCTION | SymbolKind::METHOD)
+                && lang.detail_is_override(&s.detail)
         })
         .map(|s| Location {
             uri: uri.clone(),

--- a/src/features/implementation_tests.rs
+++ b/src/features/implementation_tests.rs
@@ -78,7 +78,7 @@ async fn goto_implementation_interface_method_returns_overrides() {
     idx.index_content(&irepo_uri, irepo_src);
 
     // "load" is the method name at cursor; declared inside IRepo
-    let resp = find_implementation("load", &*idx, &irepo_uri).await;
+    let resp = find_implementation("load", &*idx, &irepo_uri, 2).await;
     let files = response_files(resp);
 
     assert!(
@@ -119,7 +119,7 @@ async fn goto_implementation_abstract_method_returns_overrides() {
     idx.workspace_root.set(root.to_path_buf());
     idx.index_content(&base_uri, base_src);
 
-    let resp = find_implementation("compute", &*idx, &base_uri).await;
+    let resp = find_implementation("compute", &*idx, &base_uri, 2).await;
     let files = response_files(resp);
 
     assert!(
@@ -154,7 +154,8 @@ async fn goto_implementation_interface_type_unbroken() {
     let impl_uri = Url::from_file_path(root.join("Impl.kt")).unwrap();
     idx.index_content(&impl_uri, impl_src);
 
-    let resp = find_implementation("IService", &*idx, &iservice_uri).await;
+    // "IService" is a type (not a method); line is the interface declaration line.
+    let resp = find_implementation("IService", &*idx, &iservice_uri, 1).await;
     let files = response_files(resp);
 
     assert!(

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -49,9 +49,10 @@ pub(crate) async fn find_references_with_qualifier(
             None
         };
 
-    // For fields (val/var/Java field) at their declaration site: scope file discovery
-    // to files that mention the declaring class, instead of the whole package.
-    // Only fires when there is no doubly-nested owner_class already covering the site.
+    // For class members (fields, properties, methods) at their declaration site:
+    // scope file discovery to files that mention the declaring class, instead of
+    // the whole package. Only fires when there is no doubly-nested owner_class
+    // already covering the site.
     let field_owner = if !name.starts_with_uppercase()
         && owner_class.is_none()
         && qualifier.is_none()
@@ -384,7 +385,7 @@ fn field_owner_for_decl(
     index
         .file_symbols(uri)
         .iter()
-        .find(|s| s.name == name && s.range.start.line == line)
+        .find(|s| s.name == name && s.selection_range.start.line == line)
         .and_then(|s| s.container.clone())
 }
 

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -262,14 +262,15 @@ pub(crate) struct RgSearchRequest<'a> {
     /// (`factory.create()`) are found, while sibling factories in the same
     /// package are excluded because they do not reference the outer class.
     owner_class: Option<&'a str>,
-    /// Declaring class for a field/property reference (e.g. `"FamilyAccount"` for
-    /// a `val value` declared inside `FamilyAccount`).
+    /// Declaring class for a class member (field, property, or method) reference
+    /// (e.g. `"FamilyAccount"` for a `val value` or `fun load()` declared inside
+    /// `FamilyAccount`).
     ///
     /// When set, file discovery finds files mentioning the declaring class, then
-    /// searches for the field name within those files.  Unlike `owner_class`, the
-    /// declaring file is NOT restricted to only the declaration — bare field access
+    /// searches for the member name within those files.  Unlike `owner_class`, the
+    /// declaring file is NOT restricted to only the declaration — bare member access
     /// inside the class body is valid.  Declaration lines in other files are
-    /// filtered out to avoid picking up same-named fields in other classes.
+    /// filtered out to avoid picking up same-named members in other classes.
     field_owner: Option<&'a str>,
     search_root: std::borrow::Cow<'a, Path>,
     /// Source-root directories from workspace config; when non-empty, rg is
@@ -1095,8 +1096,8 @@ pub(crate) fn rg_find_method_overrides(
     rg_word_in_files(&safe_method, &candidate_files)
         .into_iter()
         .filter_map(|(loc, content)| {
-            let line = content.trim();
-            if line.contains("override") && line.contains("fun ") {
+            let lang = crate::Language::from_path(loc.uri.path());
+            if lang.is_override_declaration(content.trim(), method_name) {
                 Some(loc)
             } else {
                 None

--- a/src/types.rs
+++ b/src/types.rs
@@ -52,6 +52,39 @@ impl Language {
         matches!(self, Language::Java)
     }
 
+    /// Returns true if `line` looks like an override declaration of `method_name`
+    /// in this language.
+    ///
+    /// - **Kotlin**: requires `override` and `fun` on the same line as the declaration.
+    /// - **Java**: accepts any declaration of `method_name` — `@Override` is placed
+    ///   on the *preceding* line and is not visible in a single-line rg result.
+    /// - **Swift**: always false (not supported).
+    pub(crate) fn is_override_declaration(self, line: &str, method_name: &str) -> bool {
+        use crate::rg::is_declaration_of;
+        match self {
+            Language::Kotlin => {
+                line.contains("override")
+                    && line.contains("fun ")
+                    && is_declaration_of(line, method_name)
+            }
+            Language::Java => is_declaration_of(line, method_name),
+            Language::Swift => false,
+        }
+    }
+
+    /// Returns true if `detail` (the indexed declaration signature) indicates
+    /// this symbol overrides a supertype member.
+    pub(crate) fn detail_is_override(self, detail: &str) -> bool {
+        match self {
+            Language::Kotlin => detail.contains("override"),
+            // Java @Override is an annotation on the preceding line; the indexed
+            // detail is just the method signature — accept any same-named method
+            // found via BFS subtypes (already scoped to confirmed implementors).
+            Language::Java => true,
+            Language::Swift => false,
+        }
+    }
+
     pub(crate) fn val_keyword(self) -> &'static str {
         match self {
             Language::Swift => "let",


### PR DESCRIPTION
Fixes all 6 inline comments from the Copilot reviewer on #109.

## Changes

### `references.rs`
- Use `selection_range.start.line` in `field_owner_for_decl` (was `range.start.line`) — annotated members now match at their identifier line, not the annotation line
- Update stale "fields only" comment to "class members (fields, properties, methods)"

### `implementation.rs`
- Thread cursor `line: u32` into `declaring_class_of_method` — unambiguously picks the right declaring class when the file has multiple methods with the same name in different containers

### `types.rs` + `implementation.rs` — language-aware override detection
- `Language::detail_is_override` — Kotlin checks `"override"` in indexed detail; Java accepts all same-named methods in confirmed subtypes (`@Override` is an annotation on the *preceding* line, not captured in the signature detail)
- `Language::is_override_declaration` — for the rg cold-start fallback: Kotlin requires `override + fun + is_declaration_of`; Java uses only `is_declaration_of` (same reason)

### `rg.rs`
- `rg_find_method_overrides`: replace bare string literal filter with `lang.is_override_declaration()`, detecting language per file from `loc.uri`
- Remove `OVERRIDE_KEYWORD` constant (logic now lives in `Language`)
- Update `field_owner` doc comment to mention methods