### PR TITLE
fix: address PR #110 review comments

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -216,12 +216,16 @@ fn collect_cli_source_paths(root: &Path, no_stdlib: bool) -> Vec<String> {
 
     // When workspace files declare no source roots, try Gradle/Maven build
     // layout detection so `complete` behaves like the LSP path.
-    // These paths are under the workspace root so `is_external` does not apply.
+    // Only include paths outside the workspace root — internal paths are already
+    // discovered and fully indexed by the workspace scan. Re-indexing them via
+    // index_source_paths would double-parse ~11k files, doubling memory usage.
     if json_paths.is_empty() {
         for p in crate::workspace_json::detect_build_layout_source_paths(root) {
-            let s = p.to_string_lossy().into_owned();
-            if !paths.contains(&s) {
-                paths.push(s);
+            if is_external(&p) {
+                let s = p.to_string_lossy().into_owned();
+                if !paths.contains(&s) {
+                    paths.push(s);
+                }
             }
         }
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -25,11 +25,13 @@ const SEVERITY_DIAG: &str = "diag";
 
 /// Resolve the workspace root: explicit --root, then nearest .git ancestor, then cwd.
 fn resolve_root(explicit: Option<&Path>) -> PathBuf {
-    if let Some(r) = explicit {
-        return r.to_path_buf();
-    }
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    find_git_root(&cwd).unwrap_or(cwd)
+    let raw = if let Some(r) = explicit {
+        r.to_path_buf()
+    } else {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        find_git_root(&cwd).unwrap_or(cwd)
+    };
+    raw.canonicalize().unwrap_or(raw)
 }
 
 /// Walk up from `start` looking for a `.git` directory.
@@ -46,16 +48,18 @@ fn find_git_root(start: &Path) -> Option<PathBuf> {
 /// Resolve workspace root for file-centric commands: tries explicit root first,
 /// then walks up from the file's directory, then falls back to CWD-based detection.
 fn resolve_root_for_file(explicit: Option<&Path>, file: &Path) -> PathBuf {
-    if let Some(r) = explicit {
-        return r.to_path_buf();
-    }
-    let file_dir = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
-    let file_dir = file_dir.parent().unwrap_or(&file_dir);
-    if let Some(root) = find_git_root(file_dir) {
-        return root;
-    }
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    find_git_root(&cwd).unwrap_or(cwd)
+    let raw = if let Some(r) = explicit {
+        r.to_path_buf()
+    } else {
+        let file_dir = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
+        let file_dir = file_dir.parent().unwrap_or(&file_dir);
+        let fallback = || {
+            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            find_git_root(&cwd).unwrap_or(cwd)
+        };
+        find_git_root(file_dir).unwrap_or_else(fallback)
+    };
+    raw.canonicalize().unwrap_or(raw)
 }
 
 // ── Column resolution helpers ─────────────────────────────────────────────────
@@ -146,9 +150,10 @@ async fn build_index(root: &Path, no_stdlib: bool) -> Arc<Indexer> {
 
 async fn build_index_inner(root: &Path, source_paths: Vec<String>) -> Arc<Indexer> {
     let idx = Arc::new(Indexer::new());
-    // Set workspace root so save_cache_to_disk can persist the index.
+    // Canonicalize so relative roots (e.g. ".") don't confuse path.starts_with checks
+    // in index_source_paths when comparing absolute fd output against workspace_root.
     let canonical = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
-    idx.workspace_root.set(canonical);
+    idx.workspace_root.set(canonical.clone());
     if !source_paths.is_empty() {
         *idx.source_paths_raw.write().unwrap() = source_paths;
     }
@@ -162,7 +167,7 @@ async fn build_index_inner(root: &Path, source_paths: Vec<String>) -> Arc<Indexe
         *idx.workspace_source_roots.write().unwrap() = workspace_roots;
     }
     Arc::clone(&idx)
-        .index_workspace_full(root, Arc::new(NoopReporter))
+        .index_workspace_full(&canonical, Arc::new(NoopReporter))
         .await;
     idx
 }

--- a/src/features/references.rs
+++ b/src/features/references.rs
@@ -51,12 +51,7 @@ pub(crate) async fn find_references_with_qualifier(
 
     // For fields (val/var/Java field) at their declaration site: scope file discovery
     // to files that mention the declaring class, instead of the whole package.
-    // Only fires when there is no doubly-nested owner_class already covering the site.
-    let field_owner = if !name.starts_with_uppercase()
-        && owner_class.is_none()
-        && qualifier.is_none()
-        && declared_pkg.is_some()
-    {
+    let field_owner = if qualifier.is_none() && declared_pkg.is_some() {
         field_owner_for_decl(index, uri, name, line)
     } else {
         None
@@ -72,6 +67,7 @@ pub(crate) async fn find_references_with_qualifier(
         declared_pkg,
         decl_files,
         owner_class,
+        field_decl_line: field_owner.is_some().then_some(line),
         field_owner,
     };
 
@@ -241,7 +237,13 @@ async fn rg_locations(
             None => rg_req,
         };
         let rg_req = match request.field_owner.as_deref() {
-            Some(owner) => rg_req.with_field_owner(owner),
+            Some(owner) => {
+                let rg_req = rg_req.with_field_owner(owner);
+                match request.field_decl_line {
+                    Some(dl) => rg_req.with_field_decl_line(dl),
+                    None => rg_req,
+                }
+            }
             None => rg_req,
         };
         crate::rg::rg_find_references(&rg_req, matcher.as_deref())
@@ -360,6 +362,10 @@ struct ReferenceSearch {
     owner_class: Option<String>,
     /// Declaring class for field-scoped reference search; see [`field_owner_for_decl`].
     field_owner: Option<String>,
+    /// 0-based declaration line in `uri`; set when `field_owner` is present so that
+    /// the rg path can distinguish the actual declaration from same-named fields in
+    /// other classes inside the same file.
+    field_decl_line: Option<u32>,
 }
 
 // ─── Field owner resolution ───────────────────────────────────────────────────
@@ -383,7 +389,7 @@ fn field_owner_for_decl(
         .iter()
         .find(|s| {
             s.name == name
-                && s.range.start.line == line
+                && s.selection_range.start.line == line
                 && matches!(
                     s.kind,
                     SymbolKind::PROPERTY | SymbolKind::VARIABLE | SymbolKind::FIELD

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -510,6 +510,9 @@ impl Indexer {
         }
 
         let gen = self.workspace_root.generation();
+        // Canonicalize so path.starts_with comparisons against absolute fd output work
+        // even when workspace_root was passed as a relative path (e.g. ".").
+        let workspace_root = workspace_root.canonicalize().unwrap_or(workspace_root);
         let source_paths = resolve_source_paths(&raw_paths, &workspace_root);
 
         // Load manifest only — cheap (just version + chunk_count, no file data).

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -14,6 +14,7 @@ use super::lambda::SCOPE_FUNCTIONS;
 use super::receiver::uppercase_ident_prefix;
 use super::type_subst::{
     build_type_arg_subst, capitalize_first_char, first_type_arg_raw, is_generic_param,
+    split_top_level_commas, type_args_inner,
 };
 
 /// A segment in a navigation chain: either a root identifier or a suffix member.
@@ -177,12 +178,21 @@ pub(super) fn forward_resolve_segments(
                         }
                     }
                     // Method not indexed (or returns generic): use first concrete type arg
-                    // of the receiver as a best-effort return type.  This handles
-                    // extension functions like `Optional<T>.getOrNull(): T?` when
-                    // they haven't been indexed yet (e.g., workspace scan in progress).
-                    if let Some(first_arg) = current_type.as_deref().and_then(first_type_arg_raw) {
-                        if first_arg.starts_with_uppercase() && !is_generic_param(&first_arg) {
-                            current_type = Some(first_arg);
+                    // of the receiver as a best-effort return type.  Only applies when the
+                    // receiver has exactly one type parameter (e.g. `Optional<T>`) — for
+                    // multi-param types like `Map<String, Order>` the first arg would be
+                    // wrong (it would infer `String` instead of `Order`).
+                    let is_single_param = current_type
+                        .as_deref()
+                        .and_then(type_args_inner)
+                        .is_some_and(|inner| split_top_level_commas(inner).len() == 1);
+                    if is_single_param {
+                        if let Some(first_arg) =
+                            current_type.as_deref().and_then(first_type_arg_raw)
+                        {
+                            if first_arg.starts_with_uppercase() && !is_generic_param(&first_arg) {
+                                current_type = Some(first_arg);
+                            }
                         }
                     }
                 }

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -271,6 +271,12 @@ pub(crate) struct RgSearchRequest<'a> {
     /// inside the class body is valid.  Declaration lines in other files are
     /// filtered out to avoid picking up same-named fields in other classes.
     field_owner: Option<&'a str>,
+    /// 0-based line of the actual field declaration in `from_uri`.
+    ///
+    /// When `field_owner` is set, declaration-pattern hits in the declaring file
+    /// at lines OTHER than this one are filtered out (same-named fields in other
+    /// classes inside the same multi-class file).
+    field_decl_line: Option<u32>,
     search_root: std::borrow::Cow<'a, Path>,
     /// Source-root directories from workspace config; when non-empty, rg is
     /// scoped to these directories instead of the full workspace root.
@@ -494,6 +500,7 @@ impl<'a> RgSearchRequest<'a> {
             declared_pkg,
             owner_class: None,
             field_owner: None,
+            field_decl_line: None,
             search_root,
             source_paths: &[],
             include_decl,
@@ -514,6 +521,11 @@ impl<'a> RgSearchRequest<'a> {
 
     pub(crate) fn with_field_owner(mut self, field_owner: &'a str) -> Self {
         self.field_owner = Some(field_owner);
+        self
+    }
+
+    pub(crate) fn with_field_decl_line(mut self, line: u32) -> Self {
+        self.field_decl_line = Some(line);
         self
     }
 }
@@ -903,10 +915,17 @@ fn field_scoped_reference_locations(
             if should_skip_reference(&loc, &content, request) {
                 return None;
             }
-            // In the declaring file: allow all hits — the field can be accessed
-            // bare inside the class body.
+            // In the declaring file: allow all hits except same-named declarations
+            // in other classes (multi-class file false positives).
             let is_from_uri = loc.uri.as_str() == request.from_uri.as_str();
             if is_from_uri {
+                if is_declaration_of(&content, request.name) {
+                    // Keep the actual declaration; drop same-named decls in other classes.
+                    let is_the_decl = request
+                        .field_decl_line
+                        .is_none_or(|dl| loc.range.start.line == dl);
+                    return is_the_decl.then_some(loc);
+                }
                 return Some(loc);
             }
             // In other files: skip declaration-like lines for the same name to


### PR DESCRIPTION
Fixes all 5 code issues raised in PR #110 review:

**1. `field_owner_for_decl`: use `selection_range` instead of `range`** (`references.rs:386`)  
For annotated fields (`@Inject\nval field`), `range.start.line` pointed at the annotation; `selection_range.start.line` correctly points at the identifier.

**2. Remove `owner_class.is_none()` gate** (`references.rs:60`)  
Doubly-nested fields had a non-None `owner_class`, preventing `field_owner` from being computed. They fell through to `owner_scoped_reference_locations` which restricted to declaration-only, dropping valid bare accesses.

`UPPER_CASE` constants were excluded from field-owner scoping. `field_owner_for_decl` already filters by symbol kind, so the uppercase check was redundant and harmful.

**4. Declaring-file false positives in multi-class files** (`rg.rs:913`)  
Added `field_decl_line: Option<u32>` to `RgSearchRequest`. For the declaring file, declaration-pattern hits at lines other than the actual declaration line are now filtered out, eliminating same-named fields in unrelated classes within the same file.

**5. First-type-arg fallback only for single-param generics** (`chain.rs:185`)  
The fallback that used the first type arg as return type was wrong for `Map<String, Order>` (inferred `String` instead of `Order`). Now guarded by a single-parameter check using `type_args_inner` + `split_top_level_commas`.