### PR TITLE
fix: canonicalize workspace root in CLI (library misclassification)

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -216,12 +216,16 @@ fn collect_cli_source_paths(root: &Path, no_stdlib: bool) -> Vec<String> {
 
     // When workspace files declare no source roots, try Gradle/Maven build
     // layout detection so `complete` behaves like the LSP path.
-    // These paths are under the workspace root so `is_external` does not apply.
+    // Only include paths outside the workspace root — internal paths are already
+    // discovered and fully indexed by the workspace scan. Re-indexing them via
+    // index_source_paths would double-parse ~11k files, doubling memory usage.
     if json_paths.is_empty() {
         for p in crate::workspace_json::detect_build_layout_source_paths(root) {
-            let s = p.to_string_lossy().into_owned();
-            if !paths.contains(&s) {
-                paths.push(s);
+            if is_external(&p) {
+                let s = p.to_string_lossy().into_owned();
+                if !paths.contains(&s) {
+                    paths.push(s);
+                }
             }
         }
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -25,11 +25,13 @@ const SEVERITY_DIAG: &str = "diag";
 
 /// Resolve the workspace root: explicit --root, then nearest .git ancestor, then cwd.
 fn resolve_root(explicit: Option<&Path>) -> PathBuf {
-    if let Some(r) = explicit {
-        return r.to_path_buf();
-    }
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    find_git_root(&cwd).unwrap_or(cwd)
+    let raw = if let Some(r) = explicit {
+        r.to_path_buf()
+    } else {
+        let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+        find_git_root(&cwd).unwrap_or(cwd)
+    };
+    raw.canonicalize().unwrap_or(raw)
 }
 
 /// Walk up from `start` looking for a `.git` directory.
@@ -46,16 +48,18 @@ fn find_git_root(start: &Path) -> Option<PathBuf> {
 /// Resolve workspace root for file-centric commands: tries explicit root first,
 /// then walks up from the file's directory, then falls back to CWD-based detection.
 fn resolve_root_for_file(explicit: Option<&Path>, file: &Path) -> PathBuf {
-    if let Some(r) = explicit {
-        return r.to_path_buf();
-    }
-    let file_dir = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
-    let file_dir = file_dir.parent().unwrap_or(&file_dir);
-    if let Some(root) = find_git_root(file_dir) {
-        return root;
-    }
-    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
-    find_git_root(&cwd).unwrap_or(cwd)
+    let raw = if let Some(r) = explicit {
+        r.to_path_buf()
+    } else {
+        let file_dir = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
+        let file_dir = file_dir.parent().unwrap_or(&file_dir);
+        let fallback = || {
+            let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+            find_git_root(&cwd).unwrap_or(cwd)
+        };
+        find_git_root(file_dir).unwrap_or_else(fallback)
+    };
+    raw.canonicalize().unwrap_or(raw)
 }
 
 // ── Column resolution helpers ─────────────────────────────────────────────────
@@ -146,9 +150,10 @@ async fn build_index(root: &Path, no_stdlib: bool) -> Arc<Indexer> {
 
 async fn build_index_inner(root: &Path, source_paths: Vec<String>) -> Arc<Indexer> {
     let idx = Arc::new(Indexer::new());
-    // Set workspace root so save_cache_to_disk can persist the index.
+    // Canonicalize so relative roots (e.g. ".") don't confuse path.starts_with checks
+    // in index_source_paths when comparing absolute fd output against workspace_root.
     let canonical = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
-    idx.workspace_root.set(canonical);
+    idx.workspace_root.set(canonical.clone());
     if !source_paths.is_empty() {
         *idx.source_paths_raw.write().unwrap() = source_paths;
     }
@@ -162,7 +167,7 @@ async fn build_index_inner(root: &Path, source_paths: Vec<String>) -> Arc<Indexe
         *idx.workspace_source_roots.write().unwrap() = workspace_roots;
     }
     Arc::clone(&idx)
-        .index_workspace_full(root, Arc::new(NoopReporter))
+        .index_workspace_full(&canonical, Arc::new(NoopReporter))
         .await;
     idx
 }

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -510,6 +510,9 @@ impl Indexer {
         }
 
         let gen = self.workspace_root.generation();
+        // Canonicalize so path.starts_with comparisons against absolute fd output work
+        // even when workspace_root was passed as a relative path (e.g. ".").
+        let workspace_root = workspace_root.canonicalize().unwrap_or(workspace_root);
         let source_paths = resolve_source_paths(&raw_paths, &workspace_root);
 
         // Load manifest only — cheap (just version + chunk_count, no file data).


### PR DESCRIPTION
## Root cause

When running `kotlin-lsp index --root .` or `diagnose --root .`, `resolve_root` returned the path **as-is** (i.e. `"."`) without canonicalizing. This relative path was threaded through to `index_source_paths(workspace_root)`, which uses it in `path.starts_with(workspace_root)` comparisons against **absolute** paths produced by `fd`.

`absolute_path.starts_with(".")` is always `false`, so every source-path file (11,876 workspace files in Moneta) was tagged as a library URI. `save_cache` then skipped all of them, persisting only the 56 files that happened to fall outside all build-layout source roots. Every subsequent warm start discovered only those 56 files.

## Symptoms
- `kotlin-lsp index --root .` reported 11,932 files indexed but `Cache saved (56 files)`
- Warm starts only loaded 56 files → the full workspace was invisible to `diagnose`
- `TransactionHistoryViewModel.kt:106` reported a false positive (private same-file `loadData(3 args)` not found because the file was never in the index)

## Fix

Canonicalize at three points to make it impossible to regress:
1. `resolve_root` / `resolve_root_for_file` — canonicalize before returning
2. `build_index_inner` — pass `canonical` (not raw `root`) to `index_workspace_full`
3. `index_source_paths` — defensively canonicalize the `workspace_root` param

## Verification
```
Warm start: 11932 cached (on-disk) + 0 new files
Cache saved (11932 files, 107129 KB)
TransactionHistoryViewModel.kt → No diagnostics.
```