### PR TITLE
fix: skip internal build-layout paths in source_paths_raw (memory regression)

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -216,12 +216,16 @@ fn collect_cli_source_paths(root: &Path, no_stdlib: bool) -> Vec<String> {
 
     // When workspace files declare no source roots, try Gradle/Maven build
     // layout detection so `complete` behaves like the LSP path.
-    // These paths are under the workspace root so `is_external` does not apply.
+    // Only include paths outside the workspace root — internal paths are already
+    // discovered and fully indexed by the workspace scan. Re-indexing them via
+    // index_source_paths would double-parse ~11k files, doubling memory usage.
     if json_paths.is_empty() {
         for p in crate::workspace_json::detect_build_layout_source_paths(root) {
-            let s = p.to_string_lossy().into_owned();
-            if !paths.contains(&s) {
-                paths.push(s);
+            if is_external(&p) {
+                let s = p.to_string_lossy().into_owned();
+                if !paths.contains(&s) {
+                    paths.push(s);
+                }
             }
         }
     }


### PR DESCRIPTION
After PR #114 fixed root canonicalization, memory jumped 7GB -> 11GB.

Root cause: collect_cli_source_paths added 107 build-layout paths (all inside workspace root) to source_paths_raw. After the canonicalization fix, index_source_paths correctly processed them as workspace-internal, triggering a full re-parse of 11,876 files already indexed by the workspace scan — doubling memory and parse time.

Fix: apply the existing is_external guard to the build-layout detection branch. Internal paths are already covered by the workspace scan.

Verification:
- Before: 107 build-layout source paths re-indexed (11876 re-parses)
- After: only ~/.kotlin-lsp/sources indexed as library (65683 files)
- Cache saved: 11932 files
- TransactionHistoryViewModel.kt: No diagnostics.