### PR TITLE
refactor(sig): fix two high-CRAP complexity offenders

### DIFF
--- a/src/features/signature_help.rs
+++ b/src/features/signature_help.rs
@@ -24,10 +24,7 @@ pub(crate) fn compute_signature_help(
     let ci = index.call_info_at(pos, uri)?;
 
     let params_text =
-        index.find_fun_signature_with_receiver(uri, &ci.fn_name, ci.qualifier.as_deref());
-    if params_text.is_empty() {
-        return None;
-    }
+        index.find_fun_signature_with_receiver(uri, &ci.fn_name, ci.qualifier.as_deref())?;
 
     build_signature_help(&ci.fn_name, &params_text, ci.active_param)
 }

--- a/src/features/traits.rs
+++ b/src/features/traits.rs
@@ -146,12 +146,13 @@ pub(crate) trait CompletionIndex {
 /// Function signature lookup with optional receiver type matching.
 pub(crate) trait SignatureIndex {
     /// Signature text for `name`, optionally narrowed to `receiver`'s type.
+    /// Returns `None` when lookup fails; `Some("")` for a zero-parameter function.
     fn find_fun_signature_with_receiver(
         &self,
         uri: &Url,
         name: &str,
         receiver: Option<&str>,
-    ) -> String;
+    ) -> Option<String>;
 }
 
 // ─── LiveTreeAccess ──────────────────────────────────────────────────────────

--- a/src/features/traits_impl.rs
+++ b/src/features/traits_impl.rs
@@ -147,7 +147,7 @@ impl SignatureIndex for Indexer {
         uri: &Url,
         name: &str,
         receiver: Option<&str>,
-    ) -> String {
+    ) -> Option<String> {
         find_fun_signature_with_receiver(self, uri, name, receiver)
     }
 }

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -349,49 +349,69 @@ pub(crate) fn extract_params_from_detail(detail: &str) -> Option<String> {
 /// Skips annotation lines (`@Foo(...)`) before the `fun`/`class` keyword to avoid
 /// parsing annotation arguments as function parameters.
 pub(crate) fn collect_params_from_line(lines: &[String], start_line: usize) -> Option<String> {
-    let mut paren_depth: i32 = 0;
-    let mut found_open = false;
-    let mut params = String::new();
-    let mut found_keyword = false;
+    let end_line = start_line + FUN_PARAMS_SCAN_LINES;
+    let decl_start = skip_annotation_lines(lines, start_line, end_line)?;
+    extract_balanced_parens(lines, decl_start, end_line)
+}
 
-    'outer: for ln in start_line..start_line + FUN_PARAMS_SCAN_LINES {
+/// Returns the first line index in `[start, end)` that is NOT a pure annotation
+/// (starts with `@` but contains none of `fun`/`class`/`constructor`).
+/// Returns `None` when all lines in the window are pure annotations — avoids
+/// `extract_balanced_parens` re-scanning them and misreading `@Anno(arg)` as params.
+fn skip_annotation_lines(lines: &[String], start: usize, end: usize) -> Option<usize> {
+    for ln in start..end {
+        let trimmed = lines.get(ln)?.trim();
+        if !is_pure_annotation_line(trimmed) {
+            return Some(ln);
+        }
+    }
+    None
+}
+
+fn is_pure_annotation_line(trimmed: &str) -> bool {
+    trimmed.starts_with('@')
+        && !trimmed.contains(" fun ")
+        && !trimmed.contains(" fun<")
+        && !trimmed.contains(" class ")
+        && !trimmed.contains(" constructor")
+}
+
+fn has_declaration_keyword(trimmed: &str) -> bool {
+    trimmed.starts_with("fun ")
+        || trimmed.starts_with("fun<")
+        || trimmed.contains(" fun ")
+        || trimmed.contains(" fun<")
+        || trimmed.starts_with("class ")
+        || trimmed.starts_with("constructor")
+        || trimmed.contains(" class ")
+        || trimmed.contains(" constructor")
+}
+
+/// Scan `lines[start..end]`, collecting the content between the outermost `(…)`.
+///
+/// `{` encountered before any `(` on a keyword line signals a zero-arg class or
+/// object declaration → `Some("")`.  The `end` bound preserves the original
+/// `FUN_PARAMS_SCAN_LINES` window even when `start` was advanced by annotation skipping.
+fn extract_balanced_parens(lines: &[String], start: usize, end: usize) -> Option<String> {
+    let mut depth: i32 = 0;
+    let mut found_open = false;
+    let mut found_keyword = false;
+    let mut params = String::new();
+
+    'outer: for ln in start..end {
         let line = match lines.get(ln) {
             Some(l) => l,
             None => break,
         };
-        let trimmed = line.trim();
-        // Skip annotation-only lines before encountering fun/class/constructor keyword
-        if !found_keyword {
-            if trimmed.starts_with('@')
-                && !trimmed.contains(" fun ")
-                && !trimmed.contains(" fun<")
-                && !trimmed.contains(" class ")
-                && !trimmed.contains(" constructor")
-            {
-                continue;
-            }
-            if trimmed.starts_with("fun ")
-                || trimmed.starts_with("fun<")
-                || trimmed.contains(" fun ")
-                || trimmed.contains(" fun<")
-                || trimmed.starts_with("class ")
-                || trimmed.starts_with("constructor")
-                || trimmed.contains(" class ")
-                || trimmed.contains(" constructor")
-            {
-                found_keyword = true;
-            }
+        if !found_keyword && has_declaration_keyword(line.trim()) {
+            found_keyword = true;
         }
-        let chars = line.char_indices().peekable();
-        for (_, ch) in chars {
+        for ch in line.chars() {
             match ch {
-                // If we hit '{' before finding any '(', the class has no constructor params
-                '{' if !found_open && found_keyword => {
-                    return Some(String::new());
-                }
+                '{' if !found_open && found_keyword => return Some(String::new()),
                 '(' => {
-                    paren_depth += 1;
-                    if paren_depth == 1 {
+                    depth += 1;
+                    if depth == 1 {
                         found_open = true;
                         continue;
                     }
@@ -400,8 +420,8 @@ pub(crate) fn collect_params_from_line(lines: &[String], start_line: usize) -> O
                     }
                 }
                 ')' => {
-                    paren_depth -= 1;
-                    if found_open && paren_depth == 0 {
+                    depth -= 1;
+                    if found_open && depth == 0 {
                         break 'outer;
                     }
                     if found_open {
@@ -530,18 +550,18 @@ pub(crate) fn find_fun_signature_with_receiver(
     uri: &Url,
     name: &str,
     receiver: Option<&str>,
-) -> String {
+) -> Option<String> {
     if let Some(recv) = receiver {
         let Some(rt) = infer_receiver_type(idx, ReceiverKind::Variable(recv), uri) else {
             // Receiver present but type could not be resolved — avoid a global
             // name-only scan that may return a completely unrelated function.
-            return String::new();
+            return None;
         };
         let locs = idx.resolve_symbol(&rt.outer, None, uri);
         for loc in &locs {
             if let Some(data) = idx.files.get(loc.uri.as_str()) {
                 if let Some(sig) = collect_fun_params_text(name, loc.uri.as_str(), idx) {
-                    return sig;
+                    return Some(sig);
                 }
                 // Also search by line range within the type's body.
                 let type_end = data
@@ -556,17 +576,17 @@ pub(crate) fn find_fun_signature_with_receiver(
                     .filter(|s| s.name == name && s.range.start.line <= type_end)
                 {
                     if !sym.params.is_empty() {
-                        return sym.params.clone();
+                        return Some(sym.params.clone());
                     }
                     if let Some(params) = extract_params_from_detail(&sym.detail) {
-                        return params;
+                        return Some(params);
                     }
                 }
             }
         }
-        return String::new();
+        return None;
     }
-    find_fun_signature_full(name, idx, uri).unwrap_or_default()
+    find_fun_signature_full(name, idx, uri)
 }
 
 /// Receiver-aware params lookup: find `method_name`'s parameter text inside

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -541,7 +541,8 @@ pub(crate) fn strip_trailing_call_args(s: &str) -> &str {
 ///
 /// When `receiver` is given (e.g. `"oneYearOlderInteractor"`), resolves its
 /// type, finds that type's file, and looks up `name` there specifically.
-/// Falls back to the plain name-based search if receiver resolution fails.
+/// Returns `None` if the receiver type cannot be resolved — no fallback to
+/// plain name-based search, to avoid returning a completely unrelated overload.
 ///
 /// This is the free-function form of the former `Indexer::find_fun_signature_with_receiver`
 /// method.  `backend.rs` calls this directly.

--- a/src/indexer/infer/sig_tests.rs
+++ b/src/indexer/infer/sig_tests.rs
@@ -402,6 +402,61 @@ fn resolve_unqualified_test_definition_visible_only_to_test_callers() {
     );
 }
 
+// ─── extract_params_from_detail ──────────────────────────────────────────────
+
+#[test]
+fn extract_params_zero_param_returns_some_empty() {
+    // `None` used to mean "no signature found"; `Some("")` means
+    // "signature found, zero parameters". They must not be conflated.
+    assert_eq!(
+        extract_params_from_detail("fun onClick()"),
+        Some("".into()),
+        "zero-param function must return Some(\"\") not None"
+    );
+}
+
+#[test]
+fn extract_params_regular_function_returns_params() {
+    assert_eq!(
+        extract_params_from_detail("fun greet(name: String, age: Int)"),
+        Some("name: String, age: Int".into())
+    );
+}
+
+// ─── collect_params_from_line ─────────────────────────────────────────────────
+
+#[test]
+fn collect_params_skips_annotation_lines() {
+    // Annotation lines like `@Suppress("UNCHECKED_CAST")` must be skipped
+    // entirely; their argument text must not be treated as function parameters.
+    let lines: Vec<String> = vec![
+        "@Suppress(\"UNCHECKED_CAST\")".into(),
+        "@SomethingElse(value = 1)".into(),
+        "fun process(input: String, count: Int) {".into(),
+    ];
+    let result = collect_params_from_line(&lines, 0);
+    assert_eq!(
+        result,
+        Some("input: String, count: Int".into()),
+        "annotation arguments must not be treated as function parameters"
+    );
+}
+
+#[test]
+fn collect_params_pure_annotation_window_does_not_return_annotation_args() {
+    // If the only lines visible are annotations (no fun line in the window),
+    // the result should be None rather than the annotation's own args.
+    let lines: Vec<String> = vec![
+        "@Composable".into(),
+        "@Preview(showBackground = true)".into(),
+    ];
+    assert_eq!(
+        collect_params_from_line(&lines, 0),
+        None,
+        "window with only annotations must return None"
+    );
+}
+
 #[cfg(test)]
 mod import_reachable {
     use super::{collect_params_from_file, is_import_reachable, ResolutionScope};


### PR DESCRIPTION
## What

Reduces complexity of two functions flagged by CRAP analysis (Change Risk Anti-Patterns):

### `collect_params_from_line` (CC ~44 → ~12)
- Extract `skip_annotation_lines() -> Option<usize>`: returns `None` when the entire scan window is pure annotations, preventing `extract_balanced_parens` from rescanning them and misreading `@Anno(arg)` as function parameters
- Extract `extract_balanced_parens(lines, start, end)`: takes an absolute `end` bound so annotation skipping never extends the original `FUN_PARAMS_SCAN_LINES` scan window
- Extract `is_pure_annotation_line` / `has_declaration_keyword` as named predicates replacing duplicated inline conditions

### `find_fun_signature_with_receiver` (CC 28, 0% coverage)
- Change return type `String` → `Option<String>`: `None` = lookup failed, `Some("")` = zero-param function found
- Caller was using `.is_empty()` as the failure signal, silently dropping signature help for zero-param functions (e.g. `fun init()`); now uses `?` so `Some("")` proceeds correctly
- Update `SignatureIndex` trait and `Indexer` impl accordingly

## Why

Both functions had objectively high complexity and real bug risk:
- `collect_params_from_line`: annotation-only scan windows caused misparsing
- `find_fun_signature_with_receiver`: `String::new()` served dual purpose (failure + valid result); 0% test coverage meant the semantic bug went undetected

## Testing

All 1068 tests pass. Clippy clean.