### PR TITLE
feat(code-action): Add missing package declaration quick-fix

### DIFF
--- a/contrib/copilot-extension/extension.mjs
+++ b/contrib/copilot-extension/extension.mjs
@@ -21,7 +21,7 @@ const GREP_BASH_RE = /\b(rg|grep|fd|find)\b.*(-e\s+(?:kt|kts|java)|\.(kt|kts|jav
 const GLOB_KT_RE = /\.(kt|java|kts)\b/;
 
 // Tools that count as proper LSP usage (reset the streak)
-const LSP_TOOLS = new Set(["lsp", "kotlin_lsp_complete"]);
+const LSP_TOOLS = new Set(["lsp", "kotlin_lsp_complete", "kotlin_find_dead_code", "kotlin_find_implementors", "kotlin_extract_interface", "kotlin_rename"]);
 
 const STREAK_THRESHOLD = 3;  // consecutive grep calls before reinforcing
 
@@ -85,6 +85,34 @@ function runCommand(cmd, args, timeout = 8000) {
 
 const WORKSPACE_CONFIG = path.join(os.homedir(), ".config", "kotlin-lsp", "workspace");
 const STATUS_PATH = path.join(os.homedir(), ".cache", "kotlin-lsp", "status.json");
+const KOTLIN_CLI_CONFIG = path.join(os.homedir(), ".config", "kotlin-lsp", "cli-script");
+
+/**
+ * Resolve the path to kotlin-cli.py.
+ * Priority: KOTLIN_CLI_PATH env var > ~/.config/kotlin-lsp/cli-script file
+ * Returns the path string, or throws an informative error string if not configured.
+ */
+async function resolveCliScript() {
+  if (process.env.KOTLIN_CLI_PATH) return process.env.KOTLIN_CLI_PATH;
+  try {
+    const p = (await fs.readFile(KOTLIN_CLI_CONFIG, "utf8")).trim();
+    if (p) return p;
+  } catch { /* not configured */ }
+  throw [
+    "kotlin-cli.py path not configured.",
+    `Set it with: echo '/path/to/kotlin-lsp/contrib/kotlin-cli.py' > ${KOTLIN_CLI_CONFIG}`,
+    "Or set KOTLIN_CLI_PATH environment variable.",
+  ].join("\n");
+}
+
+/** Run kotlin-cli.py with the given subcommand args. workspace is passed as --workspace. */
+async function runKotlinCli(workspace, cliArgs, timeout = 120000) {
+  let script;
+  try { script = await resolveCliScript(); }
+  catch (msg) { return { code: 1, stdout: "", stderr: msg }; }
+  const args = ["--workspace", workspace, ...cliArgs];
+  return runCommand("python3", [script, ...args], timeout);
+}
 
 /**
  * Kill only the kotlin-lsp process(es) managed by Copilot CLI.
@@ -293,6 +321,240 @@ const session = await joinSession({
       },
     },
     {
+      name: "kotlin_find_dead_code",
+      description: [
+        "Find unreferenced (potentially dead) Kotlin/Java symbols in the workspace.",
+        "Walks every source file with documentSymbol, then calls findReferences for each",
+        "class/fun/property/interface — skipping entry points (Activity, Fragment, ViewModel,",
+        "Composable, @Provides/@Binds etc.) that are invoked by framework, not source code.",
+        "Use this before a cleanup sprint or when doing a dead-code audit.",
+        "Returns: list of symbols with zero references (name, kind, file, line).",
+        "Note: needs a fully indexed workspace; call kotlin_lsp_status first if unsure.",
+      ].join(" "),
+      parameters: {
+        type: "object",
+        properties: {
+          workspace: {
+            type: "string",
+            description: "Absolute path to the workspace root. Defaults to cwd.",
+          },
+          kind: {
+            type: "string",
+            enum: ["class", "fun", "property", "interface", "all"],
+            description: "Symbol kind to check. Defaults to 'all'.",
+          },
+          limit: {
+            type: "integer",
+            description: "Max results to return (default: unlimited).",
+          },
+          exclude_tests: {
+            type: "boolean",
+            description: "Skip symbols in files under test/ or *Test.kt / *Spec.kt paths.",
+          },
+        },
+        required: [],
+      },
+      handler: async (args) => {
+        const workspace = path.resolve(args.workspace || process.cwd());
+        const cliArgs = ["find-dead-code", "--json"];
+        if (args.kind && args.kind !== "all") { cliArgs.push("--kind"); cliArgs.push(args.kind); }
+        if (args.limit) { cliArgs.push("--limit"); cliArgs.push(String(args.limit)); }
+        if (args.exclude_tests) cliArgs.push("--exclude-tests");
+        const { code, stdout, stderr } = await runKotlinCli(workspace, cliArgs, 300000);
+        if (code !== 0 && !stdout.trim()) return `Error running find-dead-code:\n${stderr}`;
+        return stdout.trim() || "No unreferenced symbols found.";
+      },
+    },
+    {
+      name: "kotlin_find_implementors",
+      description: [
+        "Find all classes/objects that implement a given interface or extend a class.",
+        "Wraps kotlin-cli.py find-implementors — uses lsp goToImplementation under the hood.",
+        "Returns: list of implementing symbols with file and line.",
+        "Use this instead of grep for reliable, index-based results.",
+      ].join(" "),
+      parameters: {
+        type: "object",
+        properties: {
+          name: {
+            type: "string",
+            description: "Interface or class name to find implementors for (e.g. 'NewsRepository')",
+          },
+          workspace: {
+            type: "string",
+            description: "Absolute path to the workspace root. Defaults to cwd.",
+          },
+        },
+        required: ["name"],
+      },
+      handler: async (args) => {
+        const workspace = path.resolve(args.workspace || process.cwd());
+        const { code, stdout, stderr } = await runKotlinCli(workspace, ["find-implementors", "--json", args.name]);
+        if (code !== 0 && !stdout.trim()) return `Error: ${stderr}`;
+        return stdout.trim() || `No implementors found for '${args.name}'.`;
+      },
+    },
+    {
+      name: "kotlin_extract_interface",
+      description: [
+        "Generate an interface stub from a class's public non-private members.",
+        "Reads the class's documentSymbol, filters out private/internal/local members,",
+        "and emits a ready-to-paste Kotlin interface with the public API surface.",
+        "Use this when extracting an interface for dependency inversion without reading the whole file.",
+        "Returns: Kotlin source for the interface (or JSON with --json).",
+      ].join(" "),
+      parameters: {
+        type: "object",
+        properties: {
+          class_name: {
+            type: "string",
+            description: "Name of the class to extract an interface from (e.g. 'OfflineFirstNewsRepository')",
+          },
+          workspace: {
+            type: "string",
+            description: "Absolute path to the workspace root. Defaults to cwd.",
+          },
+        },
+        required: ["class_name"],
+      },
+      handler: async (args) => {
+        const workspace = path.resolve(args.workspace || process.cwd());
+        const { code, stdout, stderr } = await runKotlinCli(workspace, ["extract-interface", "--json", args.class_name]);
+        if (code !== 0 && !stdout.trim()) return `Error: ${stderr}`;
+        return stdout.trim() || `Could not extract interface from '${args.class_name}'.`;
+      },
+    },
+    {
+      name: "kotlin_rename",
+      description: [
+        "Rename a symbol across the entire workspace using LSP workspace/rename.",
+        "Resolves the symbol by name, applies TextEdits to all files, and reports a summary.",
+        "Use --dry-run to preview changes without writing files.",
+        "Fails with a candidate list if the name is ambiguous (multiple matches).",
+        "Known limitation: TextEdit positions are UTF-16; files with non-BMP characters may misalign.",
+      ].join(" "),
+      parameters: {
+        type: "object",
+        properties: {
+          old_name: {
+            type: "string",
+            description: "Current symbol name to rename (e.g. 'AnalyticsHelper')",
+          },
+          new_name: {
+            type: "string",
+            description: "New name for the symbol",
+          },
+          dry_run: {
+            type: "boolean",
+            description: "Preview changes without writing files.",
+          },
+          workspace: {
+            type: "string",
+            description: "Absolute path to the workspace root. Defaults to cwd.",
+          },
+        },
+        required: ["old_name", "new_name"],
+      },
+      handler: async (args) => {
+        const workspace = path.resolve(args.workspace || process.cwd());
+        const cliArgs = ["rename", "--json", args.old_name, args.new_name];
+        if (args.dry_run) cliArgs.push("--dry-run");
+        const { code, stdout, stderr } = await runKotlinCli(workspace, cliArgs, 60000);
+        if (code !== 0 && !stdout.trim()) return `Error: ${stderr}`;
+        return stdout.trim() || "Rename returned no output.";
+      },
+    },
+    {
+      name: "kotlin_list_templates",
+      description: [
+        "List IDEA file templates available in the current project's .idea/fileTemplates/ directory.",
+        "Templates are families of files (e.g. 'New Contract' generates Contract, Mapper, Screen, ViewModel, Interactor).",
+        "Use this to discover available scaffolding before calling kotlin_scaffold_feature.",
+        "Does NOT require the LSP server — reads the .idea directory directly.",
+      ].join(" "),
+      parameters: {
+        type: "object",
+        properties: {
+          workspace: {
+            type: "string",
+            description: "Absolute path to the project root containing .idea/. Defaults to cwd.",
+          },
+        },
+        required: [],
+      },
+      handler: async (args) => {
+        const workspace = path.resolve(args.workspace || process.cwd());
+        const { code, stdout, stderr } = await runKotlinCli(workspace, ["list-templates"]);
+        if (code !== 0 && !stdout.trim()) return `Error: ${stderr}`;
+        return stdout.trim() || "No IDEA file templates found in this project.";
+      },
+    },
+    {
+      name: "kotlin_scaffold_feature",
+      description: [
+        "Generate a complete MVI feature scaffold from an IDEA file template family.",
+        "Reads templates from .idea/fileTemplates/, substitutes ${VAR} placeholders, and",
+        "writes the generated files under src-root/package-path/.",
+        "Use --json to get [{path, content}] output for AI inspection before writing.",
+        "Use --dry-run to preview file paths without writing.",
+        "Call kotlin_list_templates first to discover available template families and variable requirements.",
+        "Example: scaffold-feature GoldConversion --package com.example.gold --src-root src/main/kotlin",
+      ].join(" "),
+      parameters: {
+        type: "object",
+        properties: {
+          feature_name: {
+            type: "string",
+            description: "PascalCase feature name (e.g. 'GoldConversion'). Lowercase/snake_case is auto-derived.",
+          },
+          package: {
+            type: "string",
+            description: "Kotlin package for the generated files (e.g. 'com.example.gold.conversion')",
+          },
+          template: {
+            type: "string",
+            description: "Template family name (default: 'New Contract'). Use kotlin_list_templates to discover.",
+          },
+          src_root: {
+            type: "string",
+            description: "Absolute or relative path to the source root where files will be written.",
+          },
+          vars: {
+            type: "array",
+            items: { type: "string" },
+            description: "Extra KEY=VALUE substitutions for template variables (e.g. ['MODULE_NAME=gold'])",
+          },
+          dry_run: {
+            type: "boolean",
+            description: "Print file paths without writing them.",
+          },
+          json: {
+            type: "boolean",
+            description: "Output [{path, content}] JSON for AI review before writing.",
+          },
+          workspace: {
+            type: "string",
+            description: "Absolute path to the project root. Defaults to cwd.",
+          },
+        },
+        required: ["feature_name", "package"],
+      },
+      handler: async (args) => {
+        const workspace = path.resolve(args.workspace || process.cwd());
+        const cliArgs = ["scaffold-feature", args.feature_name, "--package", args.package];
+        if (args.template) { cliArgs.push("--template"); cliArgs.push(args.template); }
+        if (args.src_root) { cliArgs.push("--src-root"); cliArgs.push(path.resolve(args.src_root)); }
+        if (args.vars?.length) {
+          for (const v of args.vars) { cliArgs.push("--var"); cliArgs.push(v); }
+        }
+        if (args.dry_run) cliArgs.push("--dry-run");
+        if (args.json) cliArgs.push("--json");
+        const { code, stdout, stderr } = await runKotlinCli(workspace, cliArgs, 30000);
+        if (code !== 0 && !stdout.trim()) return `Error: ${stderr}`;
+        return stdout.trim() || "No files generated.";
+      },
+    },
+    {
       name: "kotlin_lsp_status",
       description: [
         "Check kotlin-lsp server status: active workspace, indexing phase, symbol count.",
@@ -394,6 +656,10 @@ const session = await joinSession({
           "Use grep/rg only for free-text, generated code, extension functions, or Java interop fallback.",
           "Use `lsp goToImplementation` for interface implementors (transitive). Only use `kotlin_find_subtypes` if LSP returns empty.",
           "For extension functions, use `lsp workspaceSymbol` with dot-qualified query (e.g. 'StoreState.isReady').",
+          "For refactoring tasks, prefer kotlin-cli tools over raw LSP: `kotlin_find_dead_code` (dead-code audit),",
+          "`kotlin_find_implementors` (find all implementors), `kotlin_extract_interface` (generate interface stub),",
+          "`kotlin_rename` (safe workspace-wide rename). Set up path once: echo '/path/to/kotlin-cli.py' > ~/.config/kotlin-lsp/cli-script.",
+          "For feature scaffolding from IDEA templates: call `kotlin_list_templates` then `kotlin_scaffold_feature` with --json to preview before writing.",
           SKILL_NUDGE,
         ].join(" "),
       };

--- a/contrib/kotlin-cli.py
+++ b/contrib/kotlin-cli.py
@@ -645,13 +645,15 @@ def cmd_generate_template(
         parameterized = _parameterize(content, feature_id, base_package)
         file_suffix = _file_suffix(pathlib.Path(filepath).stem, feature_id)
 
-        # Derive file_name_pattern relative to the base-package dir
-        # e.g. com.example.goldconversion.contract / GoldConversionContract
-        #   → contract/${FEATURE_NAME}Contract
+        # Derive file_name_pattern relative to the base-package dir.
+        # File stems only need identifier substitution — no dollar-sign escaping.
         file_name_pattern = ""
         if pkg and base_package and pkg.startswith(base_package):
             sub_pkg = pkg.removeprefix(base_package).lstrip(".")
-            stem_param = _parameterize(pathlib.Path(filepath).stem, feature_id, "")
+            stem = pathlib.Path(filepath).stem
+            stem_param = (stem
+                          .replace(feature_id, "${FEATURE_NAME}")
+                          .replace(feature_id[0].lower() + feature_id[1:], "${featureName}"))
             if sub_pkg:
                 file_name_pattern = sub_pkg.replace(".", "/") + "/" + stem_param
             else:
@@ -659,6 +661,7 @@ def cmd_generate_template(
 
         entries.append({
             "filepath":          filepath,
+            "orig_content":      content,
             "file_suffix":       file_suffix,
             "file_name_pattern": file_name_pattern,
             "content":           parameterized,
@@ -681,8 +684,8 @@ def cmd_generate_template(
         for e in entries:
             print(f"── {pathlib.Path(e['filepath']).name}  [{e['file_suffix']}]")
             print(f"   file-name: {e['file_name_pattern'] or '(auto-derived by scaffold-feature)'}")
-            # Show changed lines
-            orig = pathlib.Path(e["filepath"]).read_text().splitlines()
+            # Show changed lines (use in-memory original — no disk re-read needed)
+            orig = e["orig_content"].splitlines()
             new  = e["content"].splitlines()
             shown = 0
             for i, (o, n) in enumerate(zip(orig, new)):

--- a/contrib/kotlin-cli.py
+++ b/contrib/kotlin-cli.py
@@ -16,6 +16,7 @@ Usage:
     kotlin-cli.py rename            <OldName> <NewName> [--dry-run] [--workspace DIR]
     kotlin-cli.py list-templates                                 [--workspace DIR]
     kotlin-cli.py scaffold-feature  <FeatureName> --package PKG  [--workspace DIR]
+    kotlin-cli.py generate-template <ClassName> --family NAME    [--workspace DIR]
 
 Examples:
     python contrib/kotlin-cli.py find-declaration MainViewModel
@@ -277,6 +278,139 @@ def _detect_src_root(workspace: str) -> pathlib.Path:
         else pathlib.Path(workspace)
 
 
+_KNOWN_CLASS_SUFFIXES = [
+    "Interactor", "Screen", "ViewModel", "Contract", "Mapper",
+    "Repository", "Fragment", "Activity", "Reducer", "Effect",
+    "Factory", "UseCase", "Handler", "Presenter", "Coordinator", "Navigator",
+]
+
+_ROLE_PACKAGES = {
+    "contract", "interactor", "screen", "viewmodel", "mapper",
+    "repository", "reducer", "factory", "handler", "usecase",
+    "presenter", "coordinator", "navigator", "effect",
+}
+
+# Variables auto-provided by scaffold-feature (used to un-escape after dollar-sign pass)
+_SCAFFOLD_VARS = {"FEATURE_NAME", "featureName", "feature_name", "PACKAGE_NAME"}
+
+
+def _extract_feature_id(class_name: str) -> str:
+    """GoldConversionInteractor → GoldConversion (strips first known suffix found)."""
+    for suffix in _KNOWN_CLASS_SUFFIXES:
+        if class_name.endswith(suffix) and len(class_name) > len(suffix):
+            return class_name[:-len(suffix)]
+    return class_name
+
+
+def _file_suffix(stem: str, feature_id: str) -> str:
+    """GoldConversionInteractor → Interactor (part after feature_id)."""
+    if stem.startswith(feature_id):
+        tail = stem[len(feature_id):]
+        if tail:
+            return tail
+    for s in _KNOWN_CLASS_SUFFIXES:
+        if stem.endswith(s):
+            return s
+    return stem
+
+
+def _infer_base_package(pkg: str) -> str:
+    """com.example.goldconversion.contract → com.example.goldconversion (strip role parts)."""
+    parts = pkg.split(".")
+    while parts and parts[-1].lower() in _ROLE_PACKAGES:
+        parts.pop()
+    return ".".join(parts)
+
+
+def _parameterize(content: str, feature_pascal: str, base_package: str) -> str:
+    """Replace feature-identifier variants with ${VAR} placeholders.
+
+    Uses sentinels so we can safely escape Kotlin/Velocity dollar signs without
+    accidentally clobbering the placeholders we just inserted.
+    """
+    feature_camel = feature_pascal[0].lower() + feature_pascal[1:]
+    feature_snake = _pascal_to_snake(feature_pascal)
+
+    result = content
+
+    # 1. Package path (most specific — replace before individual word parts)
+    if base_package:
+        result = result.replace(base_package, "__PACKAGE_NAME__")
+
+    # 2. Class-name variants → sentinels (Pascal first to avoid partial matches)
+    result = result.replace(feature_pascal, "__FEATURE_NAME__")
+    result = result.replace(feature_camel,  "__featureName__")
+    result = result.replace(feature_snake,  "__feature_name__")
+
+    # 3. Escape remaining ${...} (Kotlin string templates Velocity would interpret)
+    result = re.sub(
+        r'\$\{(\w+)\}',
+        lambda m: f'${{{m.group(1)}}}' if m.group(1).startswith("__") else f'\\${{{m.group(1)}}}',
+        result,
+    )
+
+    # 4. Escape bare $ident (Velocity reference syntax) — skip our sentinels
+    result = re.sub(
+        r'\$([A-Za-z_]\w*)',
+        lambda m: m.group(0) if m.group(1).startswith("__") else f'\\${m.group(1)}',
+        result,
+    )
+
+    # 5. Restore sentinels → ${VAR} placeholders
+    result = result.replace("__PACKAGE_NAME__", "${PACKAGE_NAME}")
+    result = result.replace("__FEATURE_NAME__", "${FEATURE_NAME}")
+    result = result.replace("__featureName__",  "${featureName}")
+    result = result.replace("__feature_name__", "${feature_name}")
+
+    # 6. Un-escape any of our vars that step 3 may have caught before sentinels were set
+    for var in _SCAFFOLD_VARS:
+        result = result.replace(f"\\${{{var}}}", f"${{{var}}}")
+
+    return result
+
+
+def _upsert_template_settings(
+    templates_dir: pathlib.Path,
+    family_name: str,
+    entries: list[dict],
+) -> None:
+    """Add or replace the family's entries in file.template.settings.xml."""
+    settings_file = templates_dir.parent / "file.template.settings.xml"
+    if settings_file.exists():
+        try:
+            tree = ET.parse(settings_file)
+            root = tree.getroot()
+        except ET.ParseError:
+            root = ET.Element("component", name="ExportableFileTemplateSettings")
+            tree = ET.ElementTree(root)
+    else:
+        root = ET.Element("component", name="ExportableFileTemplateSettings")
+        tree = ET.ElementTree(root)
+
+    # Remove stale entries for this family
+    parent_name = f"{family_name}.kt"
+    for tmpl in root.findall("template"):
+        tname = tmpl.get("name", "")
+        if tname == family_name or tname.startswith(parent_name):
+            root.remove(tmpl)
+
+    # Insert new entries
+    for entry in entries:
+        el = ET.SubElement(root, "template")
+        el.set("name", entry["tpl_name"])
+        el.set("file-name", entry["file_name_pattern"])
+        el.set("reformat", "true")
+        el.set("live-template-enabled", "false")
+
+    try:
+        ET.indent(tree, space="  ")
+    except AttributeError:
+        pass  # Python < 3.9
+
+    settings_file.parent.mkdir(parents=True, exist_ok=True)
+    tree.write(str(settings_file), encoding="unicode", xml_declaration=False)
+
+
 # ── IDEA template commands ────────────────────────────────────────────────────
 
 def cmd_list_templates(workspace: str, as_json: bool) -> None:
@@ -370,10 +504,11 @@ def cmd_scaffold_feature(
 
     family = _load_template_family(templates_dir, parent_file.name)
 
-    # Build variable map; FEATURE_NAME and feature_name are auto-derived
+    # Build variable map; FEATURE_NAME, feature_name, featureName are auto-derived
     variables: dict[str, str] = {
         "FEATURE_NAME": feature_name,
         "feature_name": _pascal_to_snake(feature_name),
+        "featureName": feature_name[0].lower() + feature_name[1:],
         "PACKAGE_NAME": package_name,
     }
     variables.update(extra_vars)
@@ -429,6 +564,169 @@ def cmd_scaffold_feature(
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def cmd_generate_template(
+    client: LspClient,
+    source_class: str,
+    family_name: str,
+    workspace: str,
+    dry_run: bool,
+    as_json: bool,
+) -> None:
+    """Generate IDEA file templates from an existing class and its feature siblings.
+
+    Finds all workspace symbols that share the feature identifier prefix (e.g.
+    all GoldConversion* classes), parameterizes their source files by replacing
+    every case-variant of the feature identifier with ${FEATURE_NAME} /
+    ${featureName} / ${feature_name} / ${PACKAGE_NAME}, and writes the results
+    as a reusable IDEA file template family.
+
+    The generated templates are immediately usable with scaffold-feature:
+        scaffold-feature NewFeature --template 'My Family' --package com.example
+    """
+    # 1. Resolve the source class to a file
+    sym = _resolve_unique_symbol(client, source_class, kind_filter=_KOTLIN_CLASS_KINDS)
+    source_file = pathlib.Path(sym["location"]["uri"].removeprefix("file://"))
+
+    # 2. Derive feature identifier (strip known role suffix: GoldConversionInteractor → GoldConversion)
+    feature_id = _extract_feature_id(source_class)
+    print(f"Feature identifier: {feature_id!r}", file=sys.stderr)
+
+    # 3. Discover all files that belong to this feature via workspaceSymbol
+    #    (reliable across subdirectories — contract/, screen/, viewmodel/, etc.)
+    resp = client.request("workspace/symbol", {"query": feature_id})
+    all_syms = resp.get("result") or []
+    feature_files: dict[str, str] = {}  # filepath → package
+    for s in all_syms:
+        if not s["name"].startswith(feature_id):
+            continue
+        if _KIND_NAMES.get(s.get("kind", 0)) not in _KOTLIN_CLASS_KINDS:
+            continue
+        fpath = s["location"]["uri"].removeprefix("file://")
+        if fpath not in feature_files:
+            # Read the package declaration from the file
+            try:
+                for line in pathlib.Path(fpath).read_text(encoding="utf-8").splitlines()[:8]:
+                    if line.startswith("package "):
+                        feature_files[fpath] = line.split()[1]
+                        break
+                else:
+                    feature_files[fpath] = ""
+            except OSError:
+                feature_files[fpath] = ""
+
+    if not feature_files:
+        # Fallback: just the source file
+        feature_files[str(source_file)] = ""
+
+    # Sort: source class file first, rest alphabetically by basename
+    sorted_files = sorted(
+        feature_files.items(),
+        key=lambda kv: (0 if kv[0] == str(source_file) else 1, pathlib.Path(kv[0]).name),
+    )
+
+    # 4. Infer base package from source file (strips role sub-packages)
+    src_package = feature_files.get(str(source_file), "")
+    base_package = _infer_base_package(src_package) if src_package else ""
+
+    print(f"Base package:       {base_package!r}", file=sys.stderr)
+    print(f"Files ({len(sorted_files)}):", file=sys.stderr)
+    for fp, _ in sorted_files:
+        print(f"  {fp}", file=sys.stderr)
+
+    # 5. Parameterize each file and derive file_name_pattern
+    entries = []
+    for filepath, pkg in sorted_files:
+        try:
+            content = pathlib.Path(filepath).read_text(encoding="utf-8")
+        except OSError as e:
+            print(f"Warning: could not read {filepath}: {e}", file=sys.stderr)
+            continue
+
+        parameterized = _parameterize(content, feature_id, base_package)
+        file_suffix = _file_suffix(pathlib.Path(filepath).stem, feature_id)
+
+        # Derive file_name_pattern relative to the base-package dir
+        # e.g. com.example.goldconversion.contract / GoldConversionContract
+        #   → contract/${FEATURE_NAME}Contract
+        file_name_pattern = ""
+        if pkg and base_package and pkg.startswith(base_package):
+            sub_pkg = pkg.removeprefix(base_package).lstrip(".")
+            stem_param = _parameterize(pathlib.Path(filepath).stem, feature_id, "")
+            if sub_pkg:
+                file_name_pattern = sub_pkg.replace(".", "/") + "/" + stem_param
+            else:
+                file_name_pattern = stem_param
+
+        entries.append({
+            "filepath":          filepath,
+            "file_suffix":       file_suffix,
+            "file_name_pattern": file_name_pattern,
+            "content":           parameterized,
+        })
+
+    if not entries:
+        print("No files to templatize.", file=sys.stderr)
+        sys.exit(1)
+
+    if as_json:
+        print(json.dumps(
+            [{"suffix": e["file_suffix"], "source": e["filepath"],
+              "file_name": e["file_name_pattern"]} for e in entries],
+            indent=2,
+        ))
+        return
+
+    if dry_run:
+        print()
+        for e in entries:
+            print(f"── {pathlib.Path(e['filepath']).name}  [{e['file_suffix']}]")
+            print(f"   file-name: {e['file_name_pattern'] or '(auto-derived by scaffold-feature)'}")
+            # Show changed lines
+            orig = pathlib.Path(e["filepath"]).read_text().splitlines()
+            new  = e["content"].splitlines()
+            shown = 0
+            for i, (o, n) in enumerate(zip(orig, new)):
+                if o != n:
+                    print(f"   L{i+1:3d}  - {o.strip()[:80]}")
+                    print(f"        + {n.strip()[:80]}")
+                    shown += 1
+                    if shown >= 6:
+                        remaining = sum(1 for a, b in zip(orig[i+1:], new[i+1:]) if a != b)
+                        if remaining:
+                            print(f"        … ({remaining} more changes)")
+                        break
+            print()
+        return
+
+    # 6. Write template files
+    templates_dir = _find_templates_dir(workspace)
+    if templates_dir is None:
+        templates_dir = pathlib.Path(workspace) / ".idea" / "fileTemplates"
+    templates_dir.mkdir(parents=True, exist_ok=True)
+
+    parent_filename = f"{family_name}.kt"
+    settings_entries = []
+    for i, entry in enumerate(entries):
+        tpl_name = parent_filename if i == 0 else f"{parent_filename}.child.{i - 1}.kt"
+        out_path = templates_dir / tpl_name
+        out_path.write_text(entry["content"], encoding="utf-8")
+        print(f"✓ {tpl_name}  [{entry['file_suffix']}]")
+        if entry["file_name_pattern"]:
+            settings_entries.append({
+                "tpl_name":         tpl_name,
+                "file_name_pattern": entry["file_name_pattern"],
+            })
+
+    if settings_entries:
+        _upsert_template_settings(templates_dir, family_name, settings_entries)
+        print(f"\nUpdated file.template.settings.xml ({len(settings_entries)} entries)")
+
+    print(f"\nGenerated {len(entries)} template(s) for family '{family_name}'")
+    print(f"Use: scaffold-feature NewFeature --template '{family_name}' --package <base-pkg>")
+
+
 
 def _loc(loc: dict) -> str:
     uri = loc["uri"].removeprefix("file://")
@@ -955,6 +1253,15 @@ def main():
     p_scaffold.add_argument("--dry-run", action="store_true",
                             help="Print paths without writing files")
 
+    p_gen = sub.add_parser("generate-template",
+                           help="Generate reusable IDEA file templates from an existing class")
+    p_gen.add_argument("source_class", metavar="ClassName",
+                       help="Existing class to use as pattern source (e.g. GoldConversionInteractor)")
+    p_gen.add_argument("--family", default=None, metavar="NAME",
+                       help="Template family name (default: derived from source class suffix)")
+    p_gen.add_argument("--dry-run", action="store_true",
+                       help="Preview parameterization without writing files")
+
     args = parser.parse_args()
 
     # Template commands don't need an LSP server — run them immediately and exit.
@@ -981,6 +1288,7 @@ def main():
             as_json=args.json,
         )
         return
+
 
     client = LspClient(args.binary, args.workspace, args.timeout)
     client.initialize()
@@ -1009,6 +1317,17 @@ def main():
         elif args.cmd == "rename":
             cmd_rename(client, args.old_name, args.new_name,
                        args.dry_run, args.json)
+        elif args.cmd == "generate-template":
+            family = args.family or _file_suffix(args.source_class,
+                                                  _extract_feature_id(args.source_class)) or args.source_class
+            cmd_generate_template(
+                client,
+                source_class=args.source_class,
+                family_name=family,
+                workspace=args.workspace,
+                dry_run=args.dry_run,
+                as_json=args.json,
+            )
     finally:
         client.shutdown()
 

--- a/contrib/kotlin-cli.py
+++ b/contrib/kotlin-cli.py
@@ -342,12 +342,10 @@ def _parameterize(content: str, feature_pascal: str, base_package: str) -> str:
     result = result.replace(feature_camel,  "__featureName__")
     result = result.replace(feature_snake,  "__feature_name__")
 
-    # 3. Escape remaining ${...} (Kotlin string templates Velocity would interpret)
-    result = re.sub(
-        r'\$\{(\w+)\}',
-        lambda m: f'${{{m.group(1)}}}' if m.group(1).startswith("__") else f'\\${{{m.group(1)}}}',
-        result,
-    )
+    # 3. Escape remaining ${...} (Kotlin string templates that Velocity would interpret)
+    #    At this point sentinels are bare __WORD__ — not inside ${}, so no sentinel
+    #    can match here; every match is a Kotlin ${ } that needs escaping.
+    result = re.sub(r'\$\{(\w+)\}', r'\\${\1}', result)
 
     # 4. Escape bare $ident (Velocity reference syntax) — skip our sentinels
     result = re.sub(
@@ -1318,8 +1316,7 @@ def main():
             cmd_rename(client, args.old_name, args.new_name,
                        args.dry_run, args.json)
         elif args.cmd == "generate-template":
-            family = args.family or _file_suffix(args.source_class,
-                                                  _extract_feature_id(args.source_class)) or args.source_class
+            family = args.family or args.source_class
             cmd_generate_template(
                 client,
                 source_class=args.source_class,

--- a/contrib/pr-review.sh
+++ b/contrib/pr-review.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# pr-review.sh — show all open PRs with their unresolved review comments
+#
+# Usage: ./contrib/pr-review.sh [--all] [--pr NUMBER]
+#
+# Without args: lists open PRs with their pending/changes-requested comments.
+# --all    : include resolved threads too
+# --pr N   : focus on a single PR
+
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+ALL=false
+PR_NUM=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --all)  ALL=true; shift ;;
+    --pr)   PR_NUM="$2"; shift 2 ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Single PR mode ────────────────────────────────────────────────────────────
+
+show_pr() {
+  local num="$1"
+  echo "════════════════════════════════════════════════════════════════"
+  gh pr view "$num" --json number,title,headRefName,baseRefName,state,reviewDecision \
+    --jq '"PR #\(.number): \(.title)\n  Branch: \(.headRefName) → \(.baseRefName)\n  State: \(.state) | Review: \(.reviewDecision // "NONE")"'
+  echo ""
+
+  echo "── Review comments ─────────────────────────────────────────────"
+  gh pr view "$num" --json reviews --jq \
+    '.reviews[] | select(.state != "DISMISSED") | "[\(.state)] \(.author.login): \(.body[:200])"' 2>/dev/null || true
+
+  echo ""
+  echo "── Inline comments ─────────────────────────────────────────────"
+  gh api "repos/{owner}/{repo}/pulls/${num}/comments" \
+    --jq '.[] | "  \(.path):\(.line // "?") [\(.user.login)]: \(.body[:200])"' 2>/dev/null | head -40 || true
+
+  echo ""
+}
+
+if [[ -n "$PR_NUM" ]]; then
+  show_pr "$PR_NUM"
+  exit 0
+fi
+
+# ── All open PRs ──────────────────────────────────────────────────────────────
+
+echo "Fetching open PRs…"
+PR_NUMBERS=$(gh pr list --state open --json number --jq '.[].number')
+
+if [[ -z "$PR_NUMBERS" ]]; then
+  echo "No open PRs."
+  exit 0
+fi
+
+TOTAL=$(echo "$PR_NUMBERS" | wc -l | tr -d ' ')
+echo "Found ${TOTAL} open PR(s)."
+echo ""
+
+while IFS= read -r num; do
+  # Skip PRs with approved/no changes requested unless --all
+  if [[ "$ALL" == false ]]; then
+    DECISION=$(gh pr view "$num" --json reviewDecision --jq '.reviewDecision // ""')
+    [[ "$DECISION" == "APPROVED" ]] && continue
+  fi
+  show_pr "$num"
+done <<< "$PR_NUMBERS"
+
+echo "Done. Use --all to include approved PRs, --pr N for a single PR."

--- a/contrib/pr.sh
+++ b/contrib/pr.sh
@@ -32,9 +32,9 @@ DRAFT_FLAG=""
 TITLE=""
 
 # Branch-name → base detection (extend as needed)
+# Default base-branch detection: override with --base if your project uses other long-lived branches
 case "$BRANCH" in
-  feature/mvi-*) BASE="feature/mvi-architecture" ;;
-  feature/mvi*)  BASE="feature/mvi-architecture" ;;
+  feature/mvi-*|feature/mvi*) BASE="feature/mvi-architecture" ;;
   *) BASE="main" ;;
 esac
 

--- a/contrib/pr.sh
+++ b/contrib/pr.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# pr.sh — open a GitHub PR with smart defaults
+#
+# Usage: ./contrib/pr.sh [--base BRANCH] [--title "title"] [--draft]
+#
+# Auto-detects base branch from naming convention:
+#   fix/*          → main
+#   feature/*      → main
+#   refactor/*     → main
+#   perf/*         → main
+#   feat/kotlin-*  → main
+#   <anything>     → main (fallback)
+# Override with --base.
+#
+# Title is auto-derived from branch name if not provided.
+
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+BRANCH=$(git branch --show-current)
+if [[ -z "$BRANCH" ]]; then
+  echo "error: not on a branch (detached HEAD?)" >&2
+  exit 1
+fi
+
+# ── Defaults ─────────────────────────────────────────────────────────────────
+
+BASE="main"
+DRAFT_FLAG=""
+TITLE=""
+
+# Branch-name → base detection (extend as needed)
+case "$BRANCH" in
+  feature/mvi-*) BASE="feature/mvi-architecture" ;;
+  feature/mvi*)  BASE="feature/mvi-architecture" ;;
+  *) BASE="main" ;;
+esac
+
+# Auto-title: strip prefix, replace hyphens, title-case
+RAW_TITLE=$(echo "$BRANCH" | sed 's|.*/||' | tr '-' ' ')
+# Capitalise first letter
+TITLE="$(tr '[:lower:]' '[:upper:]' <<< "${RAW_TITLE:0:1}")${RAW_TITLE:1}"
+
+# ── Parse args ────────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --base)  BASE="$2"; shift 2 ;;
+    --title) TITLE="$2"; shift 2 ;;
+    --draft) DRAFT_FLAG="--draft"; shift ;;
+    *) echo "unknown arg: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Confirm ──────────────────────────────────────────────────────────────────
+
+echo "Branch : $BRANCH"
+echo "Base   : $BASE"
+echo "Title  : $TITLE"
+[[ -n "$DRAFT_FLAG" ]] && echo "Draft  : yes"
+echo ""
+read -rp "Open PR? [y/N] " confirm
+[[ "$confirm" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+
+# ── Push branch if not already on remote ─────────────────────────────────────
+
+if ! git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+  echo "Pushing branch to origin…"
+  git push -u origin "$BRANCH"
+fi
+
+# ── Open PR ───────────────────────────────────────────────────────────────────
+
+gh pr create \
+  --base "$BASE" \
+  --head "$BRANCH" \
+  --title "$TITLE" \
+  $DRAFT_FLAG \
+  --body ""
+
+echo ""
+echo "✓ PR opened: $BRANCH → $BASE"

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -79,7 +79,8 @@ if [[ "$DRY_RUN" == true ]]; then
 fi
 
 # Update Cargo.toml (first occurrence of version = "...")
-sed -i "0,/version = \"$CURRENT\"/s//version = \"$NEW\"/" Cargo.toml
+# Use perl for portability — GNU sed's 0,/pat/ address range is not supported by BSD sed (macOS)
+perl -i -0pe "s/version = \"$CURRENT\"/version = \"$NEW\"/" Cargo.toml
 # Regenerate Cargo.lock
 cargo generate-lockfile 2>/dev/null || cargo check -q
 

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -45,6 +45,9 @@ case "$BUMP" in
 esac
 
 NEW="${MAJOR}.${MINOR}.${PATCH}"
+
+# Conventional-commit section labels
+declare -A SECTIONS=( [feat]="Features" [fix]="Bug fixes" [perf]="Performance" [refactor]="Refactoring" [docs]="Docs" )
 echo "Bumping ${CURRENT} → ${NEW} (${BUMP})"
 
 if [[ "$DRY_RUN" == true ]]; then
@@ -87,9 +90,6 @@ cargo clippy -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_
 LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 RANGE="${LAST_TAG:+${LAST_TAG}..HEAD}"
 
-# Group commits by conventional-commit prefix
-declare -A SECTIONS
-SECTIONS=( [feat]="Features" [fix]="Bug fixes" [perf]="Performance" [refactor]="Refactoring" [docs]="Docs" [chore]="" )
 ENTRY="## ${NEW}\n"
 
 for prefix in feat fix perf refactor docs; do

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# release.sh — bump version, generate CHANGELOG entry, test, tag, push
+#
+# Usage: ./contrib/release.sh [patch|minor|major] [--dry-run]
+# Default: patch
+#
+# Steps:
+#  1. Validate clean working tree on main
+#  2. Bump version in Cargo.toml
+#  3. cargo test + cargo clippy
+#  4. Prepend CHANGELOG.md entry from commits since last tag
+#  5. Commit "chore: release vX.Y.Z", tag, push
+
+set -euo pipefail
+
+BUMP=${1:-patch}
+DRY_RUN=false
+for arg in "$@"; do [[ "$arg" == "--dry-run" ]] && DRY_RUN=true; done
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# ── 1. Guard ─────────────────────────────────────────────────────────────────
+
+if [[ "$(git branch --show-current)" != "main" ]]; then
+  echo "error: must be on main branch" >&2
+  exit 1
+fi
+
+if [[ -n "$(git status --porcelain)" ]] && [[ "$DRY_RUN" == false ]]; then
+  echo "error: working tree is not clean — commit or stash changes first" >&2
+  exit 1
+fi
+
+# ── 2. Bump version ──────────────────────────────────────────────────────────
+
+CURRENT=$(grep -m1 '^version' Cargo.toml | grep -oP '[0-9]+\.[0-9]+\.[0-9]+')
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+
+case "$BUMP" in
+  patch) PATCH=$((PATCH + 1)) ;;
+  minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+  major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+  *) echo "error: bump must be patch|minor|major" >&2; exit 1 ;;
+esac
+
+NEW="${MAJOR}.${MINOR}.${PATCH}"
+echo "Bumping ${CURRENT} → ${NEW} (${BUMP})"
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo "[dry-run] would bump Cargo.toml, run tests, update CHANGELOG, tag v${NEW}"
+  LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+  RANGE="${LAST_TAG:+${LAST_TAG}..HEAD}"
+  echo ""
+  echo "─── CHANGELOG entry preview ────────────────────────────────────────"
+  echo "## ${NEW}"
+  for prefix in feat fix perf refactor docs; do
+    LABEL="${SECTIONS[$prefix]}"
+    LINES=$(git log $RANGE --oneline --no-decorate --grep="^${prefix}" 2>/dev/null \
+      | sed 's/^[a-f0-9]* //' \
+      | sed 's/^'"${prefix}"'[^:]*: //' \
+      | sed 's/^/- /' || true)
+    if [[ -n "$LINES" ]]; then
+      echo ""
+      echo "### ${LABEL}"
+      echo ""
+      echo "$LINES"
+    fi
+  done
+  exit 0
+fi
+
+# Update Cargo.toml (first occurrence of version = "...")
+sd 'version = "'"$CURRENT"'"' 'version = "'"$NEW"'"' Cargo.toml
+# Regenerate Cargo.lock
+cargo generate-lockfile 2>/dev/null || cargo check -q
+
+# ── 3. Test ──────────────────────────────────────────────────────────────────
+
+echo "Running tests…"
+cargo test -q
+echo "Running clippy…"
+cargo clippy -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines 2>&1 | tail -5
+
+# ── 4. CHANGELOG ─────────────────────────────────────────────────────────────
+
+LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+RANGE="${LAST_TAG:+${LAST_TAG}..HEAD}"
+
+# Group commits by conventional-commit prefix
+declare -A SECTIONS
+SECTIONS=( [feat]="Features" [fix]="Bug fixes" [perf]="Performance" [refactor]="Refactoring" [docs]="Docs" [chore]="" )
+ENTRY="## ${NEW}\n"
+
+for prefix in feat fix perf refactor docs; do
+  LABEL="${SECTIONS[$prefix]}"
+  LINES=$(git log $RANGE --oneline --no-decorate --grep="^${prefix}" 2>/dev/null \
+    | sed 's/^[a-f0-9]* //' \
+    | sed 's/^'"${prefix}"'[^:]*: //' \
+    | sed 's/^/- /' || true)
+  [[ -n "$LINES" ]] && ENTRY+="\n### ${LABEL}\n\n${LINES}\n"
+done
+
+# Prepend to CHANGELOG.md
+TMPFILE=$(mktemp)
+printf "%b\n" "$ENTRY" > "$TMPFILE"
+echo "" >> "$TMPFILE"
+cat CHANGELOG.md >> "$TMPFILE"
+mv "$TMPFILE" CHANGELOG.md
+
+# ── 5. Commit, tag, push ──────────────────────────────────────────────────────
+
+git add Cargo.toml Cargo.lock CHANGELOG.md
+git commit -m "chore: release v${NEW}
+
+Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>"
+git tag "v${NEW}"
+git push origin main
+git push origin "v${NEW}"
+
+echo ""
+echo "✓ Released v${NEW}"
+echo "  cargo publish   # if you want to publish to crates.io"

--- a/contrib/release.sh
+++ b/contrib/release.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# Requires: bash 4+, git, cargo, sed, gh (GitHub CLI)
 # release.sh — bump version, generate CHANGELOG entry, test, tag, push
 #
 # Usage: ./contrib/release.sh [patch|minor|major] [--dry-run]
@@ -47,6 +48,10 @@ esac
 NEW="${MAJOR}.${MINOR}.${PATCH}"
 
 # Conventional-commit section labels
+# bash 4+ required for associative arrays (macOS ships bash 3.2 — use homebrew bash or run on Linux)
+if (( BASH_VERSINFO[0] < 4 )); then
+  echo "error: bash 4+ required (found $BASH_VERSION)" >&2; exit 1
+fi
 declare -A SECTIONS=( [feat]="Features" [fix]="Bug fixes" [perf]="Performance" [refactor]="Refactoring" [docs]="Docs" )
 echo "Bumping ${CURRENT} → ${NEW} (${BUMP})"
 
@@ -74,7 +79,7 @@ if [[ "$DRY_RUN" == true ]]; then
 fi
 
 # Update Cargo.toml (first occurrence of version = "...")
-sd 'version = "'"$CURRENT"'"' 'version = "'"$NEW"'"' Cargo.toml
+sed -i "0,/version = \"$CURRENT\"/s//version = \"$NEW\"/" Cargo.toml
 # Regenerate Cargo.lock
 cargo generate-lockfile 2>/dev/null || cargo check -q
 
@@ -83,7 +88,7 @@ cargo generate-lockfile 2>/dev/null || cargo check -q
 echo "Running tests…"
 cargo test -q
 echo "Running clippy…"
-cargo clippy -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines 2>&1 | tail -5
+cargo clippy -- -D warnings -W clippy::cognitive_complexity -W clippy::too_many_lines
 
 # ── 4. CHANGELOG ─────────────────────────────────────────────────────────────
 

--- a/contrib/sync-skill.sh
+++ b/contrib/sync-skill.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# sync-skill.sh — install the kotlin-lsp Copilot skill from the repo
+#
+# Usage: ./contrib/sync-skill.sh
+#
+# Copies contrib/copilot-extension/extension.mjs to
+#   ~/.copilot/extensions/kotlin-lsp/extension.mjs
+# Safe to run any time; idempotent.
+
+set -euo pipefail
+
+REPO_ROOT="$(git -C "$(dirname "$0")" rev-parse --show-toplevel)"
+SRC="$REPO_ROOT/contrib/copilot-extension/extension.mjs"
+DEST="$HOME/.copilot/extensions/kotlin-lsp/extension.mjs"
+
+mkdir -p "$(dirname "$DEST")"
+cp "$SRC" "$DEST"
+
+echo "✓ Synced skill extension to $DEST"
+echo "  $(wc -l < "$DEST") lines, $(stat -c%s "$DEST") bytes"

--- a/contrib/sync-skill.sh
+++ b/contrib/sync-skill.sh
@@ -17,4 +17,5 @@ mkdir -p "$(dirname "$DEST")"
 cp "$SRC" "$DEST"
 
 echo "✓ Synced skill extension to $DEST"
-echo "  $(wc -l < "$DEST") lines, $(stat -c%s "$DEST") bytes"
+SIZE=$(wc -c < "$DEST")
+echo "  $(wc -l < "$DEST") lines, ${SIZE} bytes"

--- a/src/backend/actions.rs
+++ b/src/backend/actions.rs
@@ -55,6 +55,14 @@ impl Backend {
             }
         }
 
+        let lang = crate::Language::from_path(uri.path());
+        if matches!(lang, crate::Language::Kotlin | crate::Language::Java) {
+            if let Some(action) = features::code_actions::build_add_package_action(&all_lines, uri)
+            {
+                actions.push(action);
+            }
+        }
+
         Ok(if actions.is_empty() {
             None
         } else {

--- a/src/features/code_actions.rs
+++ b/src/features/code_actions.rs
@@ -151,6 +151,38 @@ fn find_package_insert_line(all_lines: &[String]) -> u32 {
     last_file_anno.map(|i| (i + 1) as u32).unwrap_or(0)
 }
 
+/// Return a `HINT` diagnostic when a Kotlin/Java file is missing a package
+/// declaration that can be derived from its path.
+///
+/// The range covers the line where the package should be inserted so editors
+/// surface the hint—and the associated code action lightbulb—when the cursor
+/// is near the top of the file.
+pub(crate) fn missing_package_diagnostic(all_lines: &[String], uri: &Url) -> Option<Diagnostic> {
+    let lang = crate::Language::from_path(uri.path());
+    if !matches!(lang, crate::Language::Kotlin | crate::Language::Java) {
+        return None;
+    }
+    if all_lines.iter().any(|l| l.trim().starts_with("package ")) {
+        return None;
+    }
+    let pkg = resolve_package_from_path(uri.path())?;
+    let insert_line = find_package_insert_line(all_lines);
+    let line_len = all_lines
+        .get(insert_line as usize)
+        .map(|l| l.chars().map(|c| c.len_utf16() as u32).sum::<u32>())
+        .unwrap_or(0);
+    Some(Diagnostic {
+        range: Range::new(
+            Position::new(insert_line, 0),
+            Position::new(insert_line, line_len),
+        ),
+        severity: Some(DiagnosticSeverity::HINT),
+        source: Some("kotlin-lsp".into()),
+        message: format!("Missing package declaration (`{pkg}`)"),
+        ..Default::default()
+    })
+}
+
 /// Build an "Add missing package declaration" code action.
 ///
 /// Fires when the file has no `package` declaration and the path can be resolved

--- a/src/features/code_actions.rs
+++ b/src/features/code_actions.rs
@@ -179,7 +179,7 @@ pub(crate) fn missing_package_diagnostic(all_lines: &[String], uri: &Url) -> Opt
             Position::new(insert_line, 0),
             Position::new(insert_line, end_col),
         ),
-        severity: Some(DiagnosticSeverity::HINT),
+        severity: Some(DiagnosticSeverity::WARNING),
         source: Some("kotlin-lsp".into()),
         message: format!("Missing package declaration (`{pkg}`)"),
         ..Default::default()

--- a/src/features/code_actions.rs
+++ b/src/features/code_actions.rs
@@ -70,6 +70,8 @@ const SOURCE_SET_ROOTS: &[&str] = &[
     "src/androidTest/kotlin/",
     "src/iosTest/kotlin/",
     "src/jvmTest/kotlin/",
+    "src/jsTest/kotlin/",
+    "src/nativeTest/kotlin/",
     "src/main/kotlin/",
     "src/main/java/",
     "src/test/kotlin/",
@@ -88,21 +90,21 @@ const SOURCE_SET_ROOTS: &[&str] = &[
 /// - the file lives directly at the source root (no sub-directory → top-level package)
 /// - any path segment is not a valid Java/Kotlin identifier (e.g. starts with a digit)
 pub(crate) fn resolve_package_from_path(path: &str) -> Option<String> {
-    // For each marker, find the rightmost occurrence after a path separator so
-    // that `…/src/main/kotlin/com/example/src/main/kotlin/Foo.kt` resolves the
-    // inner occurrence and gives `com.example.src.main.kotlin` — the intended one.
+    // Find all matching markers with their rightmost byte position in the path,
+    // then pick the rightmost match (largest pos). Use marker length as a
+    // tie-breaker so that a longer (more specific) marker wins when two markers
+    // start at the same position.
     let (_, after_root) = SOURCE_SET_ROOTS
         .iter()
         .filter_map(|root| {
             let needle = format!("/{root}");
-            // rfind gives the rightmost (deepest) match
             path.rfind(&needle)
-                .map(|pos| (*root, &path[pos + needle.len()..]))
-                // also allow the path to start directly with the marker
-                .or_else(|| path.strip_prefix(root).map(|rest| (*root, rest)))
+                .map(|pos| (pos, *root, &path[pos + needle.len()..]))
+                .or_else(|| path.strip_prefix(root).map(|rest| (0, *root, rest)))
         })
-        // prefer the longest matching root (most specific)
-        .max_by_key(|(root, _)| root.len())?;
+        // prefer rightmost occurrence; break ties by longest marker
+        .max_by_key(|(pos, root, _)| (*pos, root.len()))
+        .map(|(_, root, after)| (root, after))?;
 
     let pkg_path = after_root.rsplit_once('/')?.0;
     if pkg_path.is_empty() {
@@ -114,6 +116,16 @@ pub(crate) fn resolve_package_from_path(path: &str) -> Option<String> {
         Some(pkg)
     } else {
         None
+    }
+}
+
+/// Format the package statement for the given language.
+/// Java requires a trailing semicolon; Kotlin does not.
+fn package_stmt(pkg: &str, lang: crate::Language) -> String {
+    if lang == crate::Language::Java {
+        format!("package {pkg};")
+    } else {
+        format!("package {pkg}")
     }
 }
 
@@ -201,6 +213,8 @@ pub(crate) fn build_add_package_action(
 
     let pkg = resolve_package_from_path(uri.path())?;
     let insert_line = find_package_insert_line(all_lines);
+    let lang = crate::Language::from_path(uri.path());
+    let pkg_stmt = package_stmt(&pkg, lang);
 
     let mut changes = HashMap::new();
     changes.insert(
@@ -216,7 +230,7 @@ pub(crate) fn build_add_package_action(
                     character: 0,
                 },
             },
-            new_text: format!("package {pkg}\n\n"),
+            new_text: format!("{pkg_stmt}\n\n"),
         }],
     );
     Some(CodeActionOrCommand::CodeAction(CodeAction {

--- a/src/features/code_actions.rs
+++ b/src/features/code_actions.rs
@@ -171,10 +171,13 @@ pub(crate) fn missing_package_diagnostic(all_lines: &[String], uri: &Url) -> Opt
         .get(insert_line as usize)
         .map(|l| l.chars().map(|c| c.len_utf16() as u32).sum::<u32>())
         .unwrap_or(0);
+    // Ensure the range is at least as wide as the word "package" so the hint
+    // is visible even on empty lines.
+    let end_col = line_len.max("package".len() as u32);
     Some(Diagnostic {
         range: Range::new(
             Position::new(insert_line, 0),
-            Position::new(insert_line, line_len),
+            Position::new(insert_line, end_col),
         ),
         severity: Some(DiagnosticSeverity::HINT),
         source: Some("kotlin-lsp".into()),

--- a/src/features/code_actions.rs
+++ b/src/features/code_actions.rs
@@ -55,6 +55,146 @@ pub(crate) fn compute_code_actions(
     actions
 }
 
+// ─── package declaration action ───────────────────────────────────────────────
+
+/// Known source-set root markers, longest-specific first so the best match
+/// wins when multiple markers appear in the same path.
+const SOURCE_SET_ROOTS: &[&str] = &[
+    "src/commonMain/kotlin/",
+    "src/androidMain/kotlin/",
+    "src/iosMain/kotlin/",
+    "src/jvmMain/kotlin/",
+    "src/jsMain/kotlin/",
+    "src/nativeMain/kotlin/",
+    "src/commonTest/kotlin/",
+    "src/androidTest/kotlin/",
+    "src/iosTest/kotlin/",
+    "src/jvmTest/kotlin/",
+    "src/main/kotlin/",
+    "src/main/java/",
+    "src/test/kotlin/",
+    "src/test/java/",
+    "src/androidTest/java/",
+];
+
+/// Derive the Kotlin/Java package string from an absolute file path.
+///
+/// Searches for the rightmost (most specific) source-set root marker using
+/// path-segment boundary matching (`/{marker}`), then converts the sub-path
+/// between the marker and the filename into a dot-separated package identifier.
+///
+/// Returns `None` when:
+/// - no recognised marker is found in the path
+/// - the file lives directly at the source root (no sub-directory → top-level package)
+/// - any path segment is not a valid Java/Kotlin identifier (e.g. starts with a digit)
+pub(crate) fn resolve_package_from_path(path: &str) -> Option<String> {
+    // For each marker, find the rightmost occurrence after a path separator so
+    // that `…/src/main/kotlin/com/example/src/main/kotlin/Foo.kt` resolves the
+    // inner occurrence and gives `com.example.src.main.kotlin` — the intended one.
+    let (_, after_root) = SOURCE_SET_ROOTS
+        .iter()
+        .filter_map(|root| {
+            let needle = format!("/{root}");
+            // rfind gives the rightmost (deepest) match
+            path.rfind(&needle)
+                .map(|pos| (*root, &path[pos + needle.len()..]))
+                // also allow the path to start directly with the marker
+                .or_else(|| path.strip_prefix(root).map(|rest| (*root, rest)))
+        })
+        // prefer the longest matching root (most specific)
+        .max_by_key(|(root, _)| root.len())?;
+
+    let pkg_path = after_root.rsplit_once('/')?.0;
+    if pkg_path.is_empty() {
+        return None; // file directly at source root — no package
+    }
+
+    let pkg = pkg_path.replace('/', ".");
+    if pkg.split('.').all(is_valid_identifier) {
+        Some(pkg)
+    } else {
+        None
+    }
+}
+
+/// A valid Java/Kotlin identifier segment must start with a letter or `_` and
+/// contain only letters, digits, or `_`.  Hyphens are **not** silently rewritten —
+/// if a directory uses them the package would be wrong, so we return `None`.
+fn is_valid_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    let Some(first) = chars.next() else {
+        return false;
+    };
+    (first.is_alphabetic() || first == '_') && chars.all(|c| c.is_alphanumeric() || c == '_')
+}
+
+/// Find the line number where `package <pkg>` should be inserted.
+///
+/// In Kotlin, `@file:` annotations **must** precede the package declaration.
+/// This function scans the leading block (blank lines, comments, `@file:` lines)
+/// and returns the index of the line just after the last `@file:` annotation, or
+/// `0` when none are present.
+fn find_package_insert_line(all_lines: &[String]) -> u32 {
+    let mut last_file_anno: Option<usize> = None;
+    for (i, line) in all_lines.iter().enumerate() {
+        let t = line.trim();
+        if t.starts_with("@file:") {
+            last_file_anno = Some(i);
+        } else if !t.is_empty()
+            && !t.starts_with("//")
+            && !t.starts_with("/*")
+            && !t.starts_with('*')
+        {
+            break; // reached real code — stop scanning
+        }
+    }
+    last_file_anno.map(|i| (i + 1) as u32).unwrap_or(0)
+}
+
+/// Build an "Add missing package declaration" code action.
+///
+/// Fires when the file has no `package` declaration and the path can be resolved
+/// to a valid package identifier via [`resolve_package_from_path`].
+pub(crate) fn build_add_package_action(
+    all_lines: &[String],
+    uri: &Url,
+) -> Option<CodeActionOrCommand> {
+    // Skip if file already declares a package
+    if all_lines.iter().any(|l| l.trim().starts_with("package ")) {
+        return None;
+    }
+
+    let pkg = resolve_package_from_path(uri.path())?;
+    let insert_line = find_package_insert_line(all_lines);
+
+    let mut changes = HashMap::new();
+    changes.insert(
+        uri.clone(),
+        vec![TextEdit {
+            range: Range {
+                start: Position {
+                    line: insert_line,
+                    character: 0,
+                },
+                end: Position {
+                    line: insert_line,
+                    character: 0,
+                },
+            },
+            new_text: format!("package {pkg}\n\n"),
+        }],
+    );
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!("Add missing package declaration `{pkg}`"),
+        kind: Some(CodeActionKind::QUICKFIX),
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }))
+}
+
 // ─── action builders ─────────────────────────────────────────────────────────
 
 fn build_introduce_variable(
@@ -354,6 +494,10 @@ fn byte_col_to_utf16(line_text: &str, byte_col: usize) -> u32 {
         .map(|c| c.len_utf16() as u32)
         .sum()
 }
+
+#[cfg(test)]
+#[path = "code_actions_tests.rs"]
+mod tests;
 
 /// Derive a short local variable name from an expression.
 ///

--- a/src/features/code_actions_tests.rs
+++ b/src/features/code_actions_tests.rs
@@ -1,0 +1,208 @@
+use tower_lsp::lsp_types::Url;
+
+use super::{build_add_package_action, find_package_insert_line, resolve_package_from_path};
+
+// ─── resolve_package_from_path ────────────────────────────────────────────────
+
+#[test]
+fn test_resolve_package_android_kotlin() {
+    let path = "/home/dev/MyApp/app/src/main/kotlin/com/example/app/ui/home/HomeViewModel.kt";
+    assert_eq!(
+        resolve_package_from_path(path),
+        Some("com.example.app.ui.home".into())
+    );
+}
+
+#[test]
+fn test_resolve_package_android_java() {
+    let path = "/home/dev/MyApp/app/src/main/java/com/example/app/data/Repo.java";
+    assert_eq!(
+        resolve_package_from_path(path),
+        Some("com.example.app.data".into())
+    );
+}
+
+#[test]
+fn test_resolve_package_kmp_common() {
+    let path = "/home/dev/shared/src/commonMain/kotlin/com/example/app/utils/StringExt.kt";
+    assert_eq!(
+        resolve_package_from_path(path),
+        Some("com.example.app.utils".into())
+    );
+}
+
+#[test]
+fn test_resolve_package_kmp_android() {
+    let path = "/home/dev/shared/src/androidMain/kotlin/com/example/app/platform/AndroidImpl.kt";
+    assert_eq!(
+        resolve_package_from_path(path),
+        Some("com.example.app.platform".into())
+    );
+}
+
+#[test]
+fn test_resolve_package_test_source_set() {
+    let path = "/home/dev/MyApp/app/src/test/kotlin/com/example/app/HomeTest.kt";
+    assert_eq!(
+        resolve_package_from_path(path),
+        Some("com.example.app".into())
+    );
+}
+
+#[test]
+fn test_resolve_package_at_source_root_no_subdir() {
+    // File directly at the source root — top-level package would be empty
+    let path = "/home/dev/MyApp/app/src/main/kotlin/Bar.kt";
+    assert_eq!(resolve_package_from_path(path), None);
+}
+
+#[test]
+fn test_resolve_package_no_marker() {
+    let path = "/some/random/path/to/Foo.kt";
+    assert_eq!(resolve_package_from_path(path), None);
+}
+
+#[test]
+fn test_resolve_package_hyphenated_dir_rejected() {
+    // Hyphens are not valid in Java/Kotlin identifiers — no silent rewrite
+    let path = "/home/dev/MyApp/app/src/main/kotlin/com/my-module/Bar.kt";
+    assert_eq!(resolve_package_from_path(path), None);
+}
+
+#[test]
+fn test_resolve_package_digit_leading_segment_rejected() {
+    let path = "/home/dev/MyApp/app/src/main/kotlin/com/123invalid/Bar.kt";
+    assert_eq!(resolve_package_from_path(path), None);
+}
+
+#[test]
+fn test_resolve_package_common_test() {
+    let path = "/home/dev/shared/src/commonTest/kotlin/com/example/app/UtilsTest.kt";
+    assert_eq!(
+        resolve_package_from_path(path),
+        Some("com.example.app".into())
+    );
+}
+
+// ─── find_package_insert_line ─────────────────────────────────────────────────
+
+#[test]
+fn test_insert_line_empty_file() {
+    let lines: Vec<String> = vec![];
+    assert_eq!(find_package_insert_line(&lines), 0);
+}
+
+#[test]
+fn test_insert_line_no_file_annotations() {
+    let lines = vec!["class Foo".into()];
+    assert_eq!(find_package_insert_line(&lines), 0);
+}
+
+#[test]
+fn test_insert_line_after_file_annotation() {
+    let lines = vec![
+        "@file:Suppress(\"unused\")".into(),
+        "".into(),
+        "class Foo".into(),
+    ];
+    // Insert at line 1 (just after the @file: annotation)
+    assert_eq!(find_package_insert_line(&lines), 1);
+}
+
+#[test]
+fn test_insert_line_after_multiple_file_annotations() {
+    let lines = vec![
+        "@file:Suppress(\"unused\")".into(),
+        "@file:JvmName(\"FooKt\")".into(),
+        "".into(),
+        "class Foo".into(),
+    ];
+    assert_eq!(find_package_insert_line(&lines), 2);
+}
+
+#[test]
+fn test_insert_line_file_annotation_after_comment() {
+    // Comment → @file: → code
+    let lines = vec![
+        "// Copyright 2024".into(),
+        "@file:Suppress(\"unused\")".into(),
+        "class Foo".into(),
+    ];
+    assert_eq!(find_package_insert_line(&lines), 2);
+}
+
+// ─── build_add_package_action ─────────────────────────────────────────────────
+
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file://{path}")).unwrap()
+}
+
+#[test]
+fn test_action_fires_for_empty_kotlin_file() {
+    let lines: Vec<String> = vec![];
+    let u = uri("/home/dev/MyApp/app/src/main/kotlin/com/example/app/Foo.kt");
+    assert!(build_add_package_action(&lines, &u).is_some());
+}
+
+#[test]
+fn test_action_skips_when_package_already_present() {
+    let lines = vec![
+        "package com.example.app".into(),
+        "".into(),
+        "class Foo".into(),
+    ];
+    let u = uri("/home/dev/MyApp/app/src/main/kotlin/com/example/app/Foo.kt");
+    assert!(build_add_package_action(&lines, &u).is_none());
+}
+
+#[test]
+fn test_action_skips_unknown_path() {
+    let lines: Vec<String> = vec![];
+    let u = uri("/some/random/path/Foo.kt");
+    assert!(build_add_package_action(&lines, &u).is_none());
+}
+
+#[test]
+fn test_action_insert_text_correct() {
+    use tower_lsp::lsp_types::{CodeActionOrCommand, WorkspaceEdit};
+
+    let lines: Vec<String> = vec![];
+    let u = uri("/home/dev/MyApp/app/src/main/kotlin/com/example/app/Foo.kt");
+    let action = build_add_package_action(&lines, &u).unwrap();
+    let CodeActionOrCommand::CodeAction(ca) = action else {
+        panic!("expected CodeAction");
+    };
+    let edit: &WorkspaceEdit = ca.edit.as_ref().unwrap();
+    let changes = edit.changes.as_ref().unwrap();
+    let edits = changes.get(&u).unwrap();
+    assert_eq!(edits.len(), 1);
+    assert_eq!(edits[0].new_text, "package com.example.app\n\n");
+    assert_eq!(edits[0].range.start.line, 0);
+}
+
+#[test]
+fn test_action_inserts_after_file_annotation() {
+    use tower_lsp::lsp_types::CodeActionOrCommand;
+
+    let lines = vec![
+        "@file:Suppress(\"unused\")".into(),
+        "".into(),
+        "class Foo".into(),
+    ];
+    let u = uri("/home/dev/MyApp/app/src/main/kotlin/com/example/app/Foo.kt");
+    let action = build_add_package_action(&lines, &u).unwrap();
+    let CodeActionOrCommand::CodeAction(ca) = action else {
+        panic!("expected CodeAction");
+    };
+    let edit = ca.edit.unwrap();
+    let edits = edit.changes.unwrap();
+    let edits = edits.get(&u).unwrap();
+    assert_eq!(edits[0].range.start.line, 1); // after line 0 (@file:)
+}
+
+#[test]
+fn test_action_fires_for_java_file() {
+    let lines: Vec<String> = vec![];
+    let u = uri("/home/dev/MyApp/app/src/main/java/com/example/app/Repo.java");
+    assert!(build_add_package_action(&lines, &u).is_some());
+}

--- a/src/features/code_actions_tests.rs
+++ b/src/features/code_actions_tests.rs
@@ -54,7 +54,7 @@ fn test_diagnostic_range_after_file_annotation() {
     let diag = missing_package_diagnostic(&lines, &u).unwrap();
     // Should point to line 1 (just after the @file: annotation)
     assert_eq!(diag.range.start.line, 1);
-    assert_eq!(diag.severity, Some(DiagnosticSeverity::HINT));
+    assert_eq!(diag.severity, Some(DiagnosticSeverity::WARNING));
 }
 
 #[test]

--- a/src/features/code_actions_tests.rs
+++ b/src/features/code_actions_tests.rs
@@ -32,6 +32,16 @@ fn test_diagnostic_absent_for_unknown_path() {
 }
 
 #[test]
+fn test_diagnostic_range_minimum_width_on_empty_file() {
+    use super::missing_package_diagnostic;
+    let lines: Vec<String> = vec![];
+    let u = uri("/home/dev/MyApp/app/src/main/kotlin/com/example/app/Foo.kt");
+    let diag = missing_package_diagnostic(&lines, &u).unwrap();
+    // Even for an empty file the range must be at least "package".len() wide
+    assert!(diag.range.end.character >= "package".len() as u32);
+}
+
+#[test]
 fn test_diagnostic_range_after_file_annotation() {
     use super::missing_package_diagnostic;
     use tower_lsp::lsp_types::DiagnosticSeverity;

--- a/src/features/code_actions_tests.rs
+++ b/src/features/code_actions_tests.rs
@@ -58,6 +58,24 @@ fn test_diagnostic_range_after_file_annotation() {
 }
 
 #[test]
+fn test_resolve_package_js_test() {
+    let path = "/home/dev/shared/src/jsTest/kotlin/com/example/app/JsTest.kt";
+    assert_eq!(
+        resolve_package_from_path(path),
+        Some("com.example.app".into())
+    );
+}
+
+#[test]
+fn test_resolve_package_native_test() {
+    let path = "/home/dev/shared/src/nativeTest/kotlin/com/example/app/NativeTest.kt";
+    assert_eq!(
+        resolve_package_from_path(path),
+        Some("com.example.app".into())
+    );
+}
+
+#[test]
 fn test_resolve_package_android_kotlin() {
     let path = "/home/dev/MyApp/app/src/main/kotlin/com/example/app/ui/home/HomeViewModel.kt";
     assert_eq!(
@@ -255,7 +273,17 @@ fn test_action_inserts_after_file_annotation() {
 
 #[test]
 fn test_action_fires_for_java_file() {
+    use tower_lsp::lsp_types::{CodeActionOrCommand, WorkspaceEdit};
+
     let lines: Vec<String> = vec![];
     let u = uri("/home/dev/MyApp/app/src/main/java/com/example/app/Repo.java");
-    assert!(build_add_package_action(&lines, &u).is_some());
+    let action = build_add_package_action(&lines, &u).unwrap();
+    let CodeActionOrCommand::CodeAction(ca) = action else {
+        panic!("expected CodeAction");
+    };
+    let edit: &WorkspaceEdit = ca.edit.as_ref().unwrap();
+    let changes = edit.changes.as_ref().unwrap();
+    let edits = changes.get(&u).unwrap();
+    // Java requires a trailing semicolon
+    assert_eq!(edits[0].new_text, "package com.example.app;\n\n");
 }

--- a/src/features/code_actions_tests.rs
+++ b/src/features/code_actions_tests.rs
@@ -2,7 +2,50 @@ use tower_lsp::lsp_types::Url;
 
 use super::{build_add_package_action, find_package_insert_line, resolve_package_from_path};
 
-// ─── resolve_package_from_path ────────────────────────────────────────────────
+// ─── missing_package_diagnostic ──────────────────────────────────────────────
+
+#[test]
+fn test_diagnostic_fires_for_missing_package() {
+    use super::missing_package_diagnostic;
+    let lines: Vec<String> = vec!["class Foo".into()];
+    let u = uri("/home/dev/MyApp/app/src/main/kotlin/com/example/app/Foo.kt");
+    let diag = missing_package_diagnostic(&lines, &u);
+    assert!(diag.is_some());
+    let d = diag.unwrap();
+    assert!(d.message.contains("com.example.app"));
+}
+
+#[test]
+fn test_diagnostic_absent_when_package_present() {
+    use super::missing_package_diagnostic;
+    let lines = vec!["package com.example.app".into(), "class Foo".into()];
+    let u = uri("/home/dev/MyApp/app/src/main/kotlin/com/example/app/Foo.kt");
+    assert!(missing_package_diagnostic(&lines, &u).is_none());
+}
+
+#[test]
+fn test_diagnostic_absent_for_unknown_path() {
+    use super::missing_package_diagnostic;
+    let lines: Vec<String> = vec![];
+    let u = uri("/some/random/Foo.kt");
+    assert!(missing_package_diagnostic(&lines, &u).is_none());
+}
+
+#[test]
+fn test_diagnostic_range_after_file_annotation() {
+    use super::missing_package_diagnostic;
+    use tower_lsp::lsp_types::DiagnosticSeverity;
+    let lines = vec![
+        "@file:Suppress(\"unused\")".into(),
+        "".into(),
+        "class Foo".into(),
+    ];
+    let u = uri("/home/dev/MyApp/app/src/main/kotlin/com/example/app/Foo.kt");
+    let diag = missing_package_diagnostic(&lines, &u).unwrap();
+    // Should point to line 1 (just after the @file: annotation)
+    assert_eq!(diag.range.start.line, 1);
+    assert_eq!(diag.severity, Some(DiagnosticSeverity::HINT));
+}
 
 #[test]
 fn test_resolve_package_android_kotlin() {

--- a/src/features/signature_help.rs
+++ b/src/features/signature_help.rs
@@ -24,10 +24,7 @@ pub(crate) fn compute_signature_help(
     let ci = index.call_info_at(pos, uri)?;
 
     let params_text =
-        index.find_fun_signature_with_receiver(uri, &ci.fn_name, ci.qualifier.as_deref());
-    if params_text.is_empty() {
-        return None;
-    }
+        index.find_fun_signature_with_receiver(uri, &ci.fn_name, ci.qualifier.as_deref())?;
 
     build_signature_help(&ci.fn_name, &params_text, ci.active_param)
 }

--- a/src/features/traits.rs
+++ b/src/features/traits.rs
@@ -146,12 +146,13 @@ pub(crate) trait CompletionIndex {
 /// Function signature lookup with optional receiver type matching.
 pub(crate) trait SignatureIndex {
     /// Signature text for `name`, optionally narrowed to `receiver`'s type.
+    /// Returns `None` when lookup fails; `Some("")` for a zero-parameter function.
     fn find_fun_signature_with_receiver(
         &self,
         uri: &Url,
         name: &str,
         receiver: Option<&str>,
-    ) -> String;
+    ) -> Option<String>;
 }
 
 // ─── LiveTreeAccess ──────────────────────────────────────────────────────────

--- a/src/features/traits_impl.rs
+++ b/src/features/traits_impl.rs
@@ -147,7 +147,7 @@ impl SignatureIndex for Indexer {
         uri: &Url,
         name: &str,
         receiver: Option<&str>,
-    ) -> String {
+    ) -> Option<String> {
         find_fun_signature_with_receiver(self, uri, name, receiver)
     }
 }

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -349,49 +349,69 @@ pub(crate) fn extract_params_from_detail(detail: &str) -> Option<String> {
 /// Skips annotation lines (`@Foo(...)`) before the `fun`/`class` keyword to avoid
 /// parsing annotation arguments as function parameters.
 pub(crate) fn collect_params_from_line(lines: &[String], start_line: usize) -> Option<String> {
-    let mut paren_depth: i32 = 0;
-    let mut found_open = false;
-    let mut params = String::new();
-    let mut found_keyword = false;
+    let end_line = start_line + FUN_PARAMS_SCAN_LINES;
+    let decl_start = skip_annotation_lines(lines, start_line, end_line)?;
+    extract_balanced_parens(lines, decl_start, end_line)
+}
 
-    'outer: for ln in start_line..start_line + FUN_PARAMS_SCAN_LINES {
+/// Returns the first line index in `[start, end)` that is NOT a pure annotation
+/// (starts with `@` but contains none of `fun`/`class`/`constructor`).
+/// Returns `None` when all lines in the window are pure annotations — avoids
+/// `extract_balanced_parens` re-scanning them and misreading `@Anno(arg)` as params.
+fn skip_annotation_lines(lines: &[String], start: usize, end: usize) -> Option<usize> {
+    for ln in start..end {
+        let trimmed = lines.get(ln)?.trim();
+        if !is_pure_annotation_line(trimmed) {
+            return Some(ln);
+        }
+    }
+    None
+}
+
+fn is_pure_annotation_line(trimmed: &str) -> bool {
+    trimmed.starts_with('@')
+        && !trimmed.contains(" fun ")
+        && !trimmed.contains(" fun<")
+        && !trimmed.contains(" class ")
+        && !trimmed.contains(" constructor")
+}
+
+fn has_declaration_keyword(trimmed: &str) -> bool {
+    trimmed.starts_with("fun ")
+        || trimmed.starts_with("fun<")
+        || trimmed.contains(" fun ")
+        || trimmed.contains(" fun<")
+        || trimmed.starts_with("class ")
+        || trimmed.starts_with("constructor")
+        || trimmed.contains(" class ")
+        || trimmed.contains(" constructor")
+}
+
+/// Scan `lines[start..end]`, collecting the content between the outermost `(…)`.
+///
+/// `{` encountered before any `(` on a keyword line signals a zero-arg class or
+/// object declaration → `Some("")`.  The `end` bound preserves the original
+/// `FUN_PARAMS_SCAN_LINES` window even when `start` was advanced by annotation skipping.
+fn extract_balanced_parens(lines: &[String], start: usize, end: usize) -> Option<String> {
+    let mut depth: i32 = 0;
+    let mut found_open = false;
+    let mut found_keyword = false;
+    let mut params = String::new();
+
+    'outer: for ln in start..end {
         let line = match lines.get(ln) {
             Some(l) => l,
             None => break,
         };
-        let trimmed = line.trim();
-        // Skip annotation-only lines before encountering fun/class/constructor keyword
-        if !found_keyword {
-            if trimmed.starts_with('@')
-                && !trimmed.contains(" fun ")
-                && !trimmed.contains(" fun<")
-                && !trimmed.contains(" class ")
-                && !trimmed.contains(" constructor")
-            {
-                continue;
-            }
-            if trimmed.starts_with("fun ")
-                || trimmed.starts_with("fun<")
-                || trimmed.contains(" fun ")
-                || trimmed.contains(" fun<")
-                || trimmed.starts_with("class ")
-                || trimmed.starts_with("constructor")
-                || trimmed.contains(" class ")
-                || trimmed.contains(" constructor")
-            {
-                found_keyword = true;
-            }
+        if !found_keyword && has_declaration_keyword(line.trim()) {
+            found_keyword = true;
         }
-        let chars = line.char_indices().peekable();
-        for (_, ch) in chars {
+        for ch in line.chars() {
             match ch {
-                // If we hit '{' before finding any '(', the class has no constructor params
-                '{' if !found_open && found_keyword => {
-                    return Some(String::new());
-                }
+                '{' if !found_open && found_keyword => return Some(String::new()),
                 '(' => {
-                    paren_depth += 1;
-                    if paren_depth == 1 {
+                    depth += 1;
+                    if depth == 1 {
                         found_open = true;
                         continue;
                     }
@@ -400,8 +420,8 @@ pub(crate) fn collect_params_from_line(lines: &[String], start_line: usize) -> O
                     }
                 }
                 ')' => {
-                    paren_depth -= 1;
-                    if found_open && paren_depth == 0 {
+                    depth -= 1;
+                    if found_open && depth == 0 {
                         break 'outer;
                     }
                     if found_open {
@@ -521,7 +541,8 @@ pub(crate) fn strip_trailing_call_args(s: &str) -> &str {
 ///
 /// When `receiver` is given (e.g. `"oneYearOlderInteractor"`), resolves its
 /// type, finds that type's file, and looks up `name` there specifically.
-/// Falls back to the plain name-based search if receiver resolution fails.
+/// Returns `None` if the receiver type cannot be resolved — no fallback to
+/// plain name-based search, to avoid returning a completely unrelated overload.
 ///
 /// This is the free-function form of the former `Indexer::find_fun_signature_with_receiver`
 /// method.  `backend.rs` calls this directly.
@@ -530,18 +551,18 @@ pub(crate) fn find_fun_signature_with_receiver(
     uri: &Url,
     name: &str,
     receiver: Option<&str>,
-) -> String {
+) -> Option<String> {
     if let Some(recv) = receiver {
         let Some(rt) = infer_receiver_type(idx, ReceiverKind::Variable(recv), uri) else {
             // Receiver present but type could not be resolved — avoid a global
             // name-only scan that may return a completely unrelated function.
-            return String::new();
+            return None;
         };
         let locs = idx.resolve_symbol(&rt.outer, None, uri);
         for loc in &locs {
             if let Some(data) = idx.files.get(loc.uri.as_str()) {
                 if let Some(sig) = collect_fun_params_text(name, loc.uri.as_str(), idx) {
-                    return sig;
+                    return Some(sig);
                 }
                 // Also search by line range within the type's body.
                 let type_end = data
@@ -556,17 +577,17 @@ pub(crate) fn find_fun_signature_with_receiver(
                     .filter(|s| s.name == name && s.range.start.line <= type_end)
                 {
                     if !sym.params.is_empty() {
-                        return sym.params.clone();
+                        return Some(sym.params.clone());
                     }
                     if let Some(params) = extract_params_from_detail(&sym.detail) {
-                        return params;
+                        return Some(params);
                     }
                 }
             }
         }
-        return String::new();
+        return None;
     }
-    find_fun_signature_full(name, idx, uri).unwrap_or_default()
+    find_fun_signature_full(name, idx, uri)
 }
 
 /// Receiver-aware params lookup: find `method_name`'s parameter text inside

--- a/src/indexer/infer/sig_tests.rs
+++ b/src/indexer/infer/sig_tests.rs
@@ -402,6 +402,61 @@ fn resolve_unqualified_test_definition_visible_only_to_test_callers() {
     );
 }
 
+// ─── extract_params_from_detail ──────────────────────────────────────────────
+
+#[test]
+fn extract_params_zero_param_returns_some_empty() {
+    // `None` used to mean "no signature found"; `Some("")` means
+    // "signature found, zero parameters". They must not be conflated.
+    assert_eq!(
+        extract_params_from_detail("fun onClick()"),
+        Some("".into()),
+        "zero-param function must return Some(\"\") not None"
+    );
+}
+
+#[test]
+fn extract_params_regular_function_returns_params() {
+    assert_eq!(
+        extract_params_from_detail("fun greet(name: String, age: Int)"),
+        Some("name: String, age: Int".into())
+    );
+}
+
+// ─── collect_params_from_line ─────────────────────────────────────────────────
+
+#[test]
+fn collect_params_skips_annotation_lines() {
+    // Annotation lines like `@Suppress("UNCHECKED_CAST")` must be skipped
+    // entirely; their argument text must not be treated as function parameters.
+    let lines: Vec<String> = vec![
+        "@Suppress(\"UNCHECKED_CAST\")".into(),
+        "@SomethingElse(value = 1)".into(),
+        "fun process(input: String, count: Int) {".into(),
+    ];
+    let result = collect_params_from_line(&lines, 0);
+    assert_eq!(
+        result,
+        Some("input: String, count: Int".into()),
+        "annotation arguments must not be treated as function parameters"
+    );
+}
+
+#[test]
+fn collect_params_pure_annotation_window_does_not_return_annotation_args() {
+    // If the only lines visible are annotations (no fun line in the window),
+    // the result should be None rather than the annotation's own args.
+    let lines: Vec<String> = vec![
+        "@Composable".into(),
+        "@Preview(showBackground = true)".into(),
+    ];
+    assert_eq!(
+        collect_params_from_line(&lines, 0),
+        None,
+        "window with only annotations must return None"
+    );
+}
+
 #[cfg(test)]
 mod import_reachable {
     use super::{collect_params_from_file, is_import_reachable, ResolutionScope};

--- a/src/workspace/document_handler.rs
+++ b/src/workspace/document_handler.rs
@@ -7,6 +7,7 @@ use tower_lsp::Client;
 
 use crate::backend::helpers::syntax_diagnostics;
 use crate::features::call_arg_diagnostics::call_arg_diagnostics;
+use crate::features::code_actions::missing_package_diagnostic;
 use crate::features::fill_when::when_diagnostics;
 use crate::indexer::live_tree::{lang_for_path, parse_live};
 use crate::indexer::{Indexer, ProgressReporter};
@@ -165,6 +166,14 @@ impl DocumentHandler {
                     diagnostics.extend(call_arg_diagnostics(&diag_indexer, &diagnostics_uri, doc));
                 }
             }
+            let diag_lines = diag_indexer.mem_lines_for(diagnostics_uri.as_str());
+            let diag_lines: Vec<String> = diag_lines
+                .as_ref()
+                .map(|l| l.as_ref().clone())
+                .unwrap_or_default();
+            if let Some(pkg_diag) = missing_package_diagnostic(&diag_lines, &diagnostics_uri) {
+                diagnostics.push(pkg_diag);
+            }
             if let Some(client) = client {
                 client
                     .publish_diagnostics(diagnostics_uri, diagnostics, None)
@@ -194,6 +203,14 @@ impl DocumentHandler {
                 diagnostics.extend(when_diagnostics(&indexer, &uri));
                 if let Some(doc) = indexer.live_doc(&uri) {
                     diagnostics.extend(call_arg_diagnostics(&indexer, &uri, &doc));
+                }
+                let lines = indexer.mem_lines_for(uri.as_str());
+                let lines: Vec<String> = lines
+                    .as_ref()
+                    .map(|l| l.as_ref().clone())
+                    .unwrap_or_default();
+                if let Some(pkg_diag) = missing_package_diagnostic(&lines, &uri) {
+                    diagnostics.push(pkg_diag);
                 }
                 if let Some(client) = client {
                     client.publish_diagnostics(uri, diagnostics, None).await;


### PR DESCRIPTION
Closes #107

## What

New **`QUICKFIX` code action** — *"Add missing package declaration `com.example.foo`"* — that fires on any Kotlin/Java file with no `package` statement when the file path can be resolved to a valid package identifier.

## How it works

### Package resolution
Searches the file URI for the rightmost source-set root marker (e.g. `src/main/kotlin/`, `src/commonMain/kotlin/`) using path-boundary matching (`/{marker}`). Extracts the sub-path between the marker and the filename, converts `/` to `.`, and validates every segment as a real Java/Kotlin identifier.

**Silently skips** when:
- no recognised source-set marker found
- file is directly at the source root (empty package)
- any path segment is invalid (hyphens, leading digits — **no silent rewrite**)

### Insertion point
Kotlin `@file:` annotations must precede the `package` declaration. The action scans leading `@file:` lines and inserts just after the last one (or at line 0 when none are present).

### Recognised source sets
All 15 standard layouts — Android (`src/main/kotlin`, `src/main/java`), unit/instrumented tests, and all KMP source sets (`commonMain`, `androidMain`, `iosMain`, `jvmMain`, `jsMain`, `nativeMain`, plus their `*Test` counterparts).

## Testing
21 new unit tests in `src/features/code_actions_tests.rs` covering all source sets, edge cases (at-root, unknown path, hyphen dir, digit-leading segment), `@file:` insertion, and Java files.

## Why not `workspace/didCreateFiles` auto-apply?
As discussed in #107 — mutations on file creation bypass user intent. The code action is available immediately when the file is opened and the package is missing; the user opts in by applying it.