### PR TITLE
fix(completion): include cross-package symbols for single-char uppercase prefix

### DIFF
--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -118,8 +118,10 @@ pub(crate) const COMPLETION_CAP: usize = 150;
 /// Prefix length at which local-symbol relevance score is reduced (longer prefix → more confident match).
 const MIN_PREFIX_SCORE_REDUCTION: usize = 4;
 
-/// Minimum prefix length to enable case-insensitive completion matching.
-const MIN_CASE_INSENSITIVE_PREFIX: usize = 2;
+/// Minimum prefix length for camel-acronym cross-package matching.
+/// Single-char prefixes still run collect_cross_package, but are restricted
+/// to score-0 (exact starts_with) matches to avoid too much noise.
+const MIN_CAMEL_ACRONYM_PREFIX: usize = 2;
 
 /// Provide completion candidates for `prefix` at the current position.
 ///
@@ -973,7 +975,7 @@ impl<'a> BareCompletionWalk<'a> {
     }
 
     fn collect_cross_package(&mut self) {
-        if self.completer.lowercase_mode || self.prefix.len() < MIN_CASE_INSENSITIVE_PREFIX {
+        if self.completer.lowercase_mode || self.prefix.is_empty() {
             return;
         }
 
@@ -1018,8 +1020,15 @@ impl<'a> BareCompletionWalk<'a> {
     }
 
     fn cross_package_score(&self, bare_name: &str) -> Option<u8> {
+        // For single-char prefixes, only allow exact starts-with (score 0);
+        // camel-acronym matching (score 1) is too noisy for one character.
+        let max_score: u8 = if self.prefix.len() < MIN_CAMEL_ACRONYM_PREFIX {
+            0
+        } else {
+            1
+        };
         match match_score(bare_name, self.prefix) {
-            Some(score) if score <= 1 => Some(score),
+            Some(score) if score <= max_score => Some(score),
             _ => None,
         }
     }

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -118,9 +118,9 @@ pub(crate) const COMPLETION_CAP: usize = 150;
 /// Prefix length at which local-symbol relevance score is reduced (longer prefix → more confident match).
 const MIN_PREFIX_SCORE_REDUCTION: usize = 4;
 
-/// Minimum prefix length for camel-acronym cross-package matching.
+/// Minimum prefix char count for camel-acronym cross-package matching.
 /// Single-char prefixes still run collect_cross_package, but are restricted
-/// to score-0 (exact starts_with) matches to avoid too much noise.
+/// to score-0 (case-insensitive prefix match) to avoid camel-acronym noise.
 const MIN_CAMEL_ACRONYM_PREFIX: usize = 2;
 
 /// Provide completion candidates for `prefix` at the current position.
@@ -975,7 +975,10 @@ impl<'a> BareCompletionWalk<'a> {
     }
 
     fn collect_cross_package(&mut self) {
-        if self.completer.lowercase_mode || self.prefix.is_empty() {
+        // Only run for uppercase-starting prefixes — the bare_name_cache holds
+        // class names (PascalCase/SCREAMING_SNAKE), so digits, underscores, or
+        // lowercase prefixes produce zero matches at the cost of a full scan.
+        if !self.completer.uppercase_mode {
             return;
         }
 
@@ -1020,9 +1023,11 @@ impl<'a> BareCompletionWalk<'a> {
     }
 
     fn cross_package_score(&self, bare_name: &str) -> Option<u8> {
-        // For single-char prefixes, only allow exact starts-with (score 0);
-        // camel-acronym matching (score 1) is too noisy for one character.
-        let max_score: u8 = if self.prefix.len() < MIN_CAMEL_ACRONYM_PREFIX {
+        // For single-char prefixes, only allow score-0 (case-insensitive prefix
+        // match); camel-acronym matching (score 1) is too noisy for one character.
+        // Use char count so a single non-ASCII char (len >= 2 bytes) is treated
+        // correctly as a single character.
+        let max_score: u8 = if self.prefix.chars().count() < MIN_CAMEL_ACRONYM_PREFIX {
             0
         } else {
             1

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -1543,26 +1543,48 @@ fn match_score_prefix_beats_acronym_in_sort() {
 }
 
 #[test]
-fn tier2_requires_prefix_length_2() {
+fn tier2_fires_for_single_char_prefix() {
     let idx = Indexer::new();
     idx.index_content(&uri("/lib/Foo.kt"), "package com.lib\nclass Column");
     let cur_uri = uri("/app/Bar.kt");
     idx.index_content(&cur_uri, "package com.example\n");
 
-    // Single char 'C' — tier-2 should NOT fire, so Column (cross-pkg) not returned.
+    // Single char 'C' — tier-2 now fires for single-char starts-with matches,
+    // so Column (cross-pkg) IS returned (score 0: starts_with).
     let (items, _) = complete_symbol(&idx, "C", None, &cur_uri, false, None);
     assert!(
-        !items
-            .iter()
-            .any(|i| i.label == "Column" && i.additional_text_edits.is_some()),
-        "tier-2 must not fire for single-char prefix"
+        items.iter().any(|i| i.label == "Column"),
+        "tier-2 must fire for single-char prefix (starts-with, score 0)"
     );
 
-    // Two chars 'Co' — tier-2 SHOULD fire.
+    // Two chars 'Co' — tier-2 also fires.
     let (items, _) = complete_symbol(&idx, "Co", None, &cur_uri, false, None);
     assert!(
         items.iter().any(|i| i.label == "Column"),
         "tier-2 must fire for prefix length >= 2"
+    );
+}
+
+#[test]
+fn tier2_single_char_excludes_camel_acronym_noise() {
+    let idx = Indexer::new();
+    // "SomeButton" would camel-acronym-match "B" (score 1) but must NOT appear
+    // for single-char prefix — only starts-with (score 0) is allowed.
+    idx.index_content(
+        &uri("/lib/Foo.kt"),
+        "package com.lib\nclass SomeButton\nclass Button",
+    );
+    let cur_uri = uri("/app/Bar.kt");
+    idx.index_content(&cur_uri, "package com.example\n");
+
+    let (items, _) = complete_symbol(&idx, "B", None, &cur_uri, false, None);
+    assert!(
+        items.iter().any(|i| i.label == "Button"),
+        "Button (starts with B) must appear"
+    );
+    assert!(
+        !items.iter().any(|i| i.label == "SomeButton"),
+        "SomeButton (camel-acronym score 1) must not appear for single-char prefix"
     );
 }
 

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -1550,11 +1550,14 @@ fn tier2_fires_for_single_char_prefix() {
     idx.index_content(&cur_uri, "package com.example\n");
 
     // Single char 'C' — tier-2 now fires for single-char starts-with matches,
-    // so Column (cross-pkg) IS returned (score 0: starts_with).
+    // so Column (cross-pkg) IS returned (score 0: case-insensitive prefix match).
+    // Being a cross-package symbol it must carry an auto-import edit.
     let (items, _) = complete_symbol(&idx, "C", None, &cur_uri, false, None);
     assert!(
-        items.iter().any(|i| i.label == "Column"),
-        "tier-2 must fire for single-char prefix (starts-with, score 0)"
+        items
+            .iter()
+            .any(|i| i.label == "Column" && i.additional_text_edits.is_some()),
+        "tier-2 must fire for single-char prefix and include auto-import edit"
     );
 
     // Two chars 'Co' — tier-2 also fires.


### PR DESCRIPTION
## Problem

Closes #117

When typing a fresh word (e.g. `Edit` for `EditText`), completions never appeared. The root cause was a chain reaction:

1. User types `E` (first char)
2. `collect_cross_package` was skipped because `prefix.len() < MIN_CASE_INSENSITIVE_PREFIX (2)` → empty items → server returned `null`
3. Editor receives `null` → **completion session closed**
4. User types `d`, `i`, `t` — editor sends no further requests (no active session, no trigger char)
5. Result: no completions for the whole word

The workaround of typing `Editxy` then deleting `xy` worked because deletion triggers a *fresh* completion request for `Edit` directly (4 chars), which is above the old min-prefix guard.

## Fix

- Allow single-char uppercase prefixes to query `bare_name_cache` (remove the length guard)
- Restrict single-char queries to **score 0 only** (exact `starts_with` match) to avoid camel-acronym noise — e.g. `SomeButton` matching prefix `B` via acronym would be very noisy
- Camel-acronym matching (score 1) still requires ≥2 chars (`MIN_CAMEL_ACRONYM_PREFIX`)

## Behaviour after fix

| Keystroke | Before | After |
|-----------|--------|-------|
| `B` | empty → null → session closed | returns `Button`, `Box`, etc. → session stays alive |
| `Bu` | items (session already dead) | items via TriggerForIncompleteCompletions |
| `But`, `Butt`, `Butto`, `Button` | no completions | completions all the way through |

`SomeButton` does **not** appear for prefix `B` (camel-acronym score 1 excluded for single-char).