### PR TITLE
fix(rename): guard against keyword renames in Kotlin and Java

### DIFF
--- a/src/features/rename.rs
+++ b/src/features/rename.rs
@@ -12,7 +12,7 @@ use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 
 use crate::features::references::resolve_scope;
-use crate::features::text_utils::is_kotlin_keyword;
+use crate::features::text_utils::is_keyword_for_file;
 #[cfg(test)]
 use crate::indexer::live_tree::utf16_col_to_byte;
 use crate::indexer::{cst_cursor_is_local_var, Indexer};
@@ -253,7 +253,8 @@ fn resolve_cursor_symbol(
     pos: Position,
 ) -> Option<RenameCursorSymbol> {
     let name = indexer.word_at(uri, pos)?;
-    if is_kotlin_keyword(&name) {
+    let file_path = uri.path();
+    if is_keyword_for_file(&name, file_path) {
         return None;
     }
     let (parent_class, declared_package, scope_limited_to_current_file) =
@@ -422,7 +423,7 @@ pub(crate) async fn prepare_rename_impl(
         None => return Ok(None),
     };
 
-    if word.len() <= 1 || is_kotlin_keyword(&word) {
+    if word.len() <= 1 || is_keyword_for_file(&word, uri.path()) {
         return Ok(None);
     }
 

--- a/src/features/text_utils.rs
+++ b/src/features/text_utils.rs
@@ -29,22 +29,17 @@ pub(crate) fn utf16_column(text: &str) -> u32 {
     text.chars().map(|c| c.len_utf16() as u32).sum()
 }
 
-/// All Kotlin and Java keywords that are never valid rename targets.
+/// Kotlin hard keywords and soft keywords — never valid rename targets in `.kt` files.
 ///
-/// **Must remain sorted** — `is_renameable_identifier` uses binary search.
-pub(crate) const KOTLIN_JAVA_KEYWORDS: &[&str] = &[
+/// **Must remain sorted** — `is_keyword_for_file` uses binary search.
+pub(crate) const KOTLIN_KEYWORDS: &[&str] = &[
     "abstract",
     "actual",
     "annotation",
     "as",
-    "assert",
-    "boolean",
     "break",
     "by",
-    "byte",
-    "case",
     "catch",
-    "char",
     "class",
     "companion",
     "const",
@@ -52,44 +47,33 @@ pub(crate) const KOTLIN_JAVA_KEYWORDS: &[&str] = &[
     "continue",
     "crossinline",
     "data",
-    "default",
     "delegate",
     "do",
-    "double",
     "dynamic",
     "else",
     "enum",
     "expect",
-    "extends",
     "external",
     "false",
     "field",
     "file",
     "final",
     "finally",
-    "float",
     "for",
     "fun",
     "get",
-    "goto",
     "if",
-    "implements",
     "import",
     "in",
     "infix",
     "init",
     "inline",
     "inner",
-    "instanceof",
-    "int",
     "interface",
     "internal",
     "is",
     "it",
     "lateinit",
-    "long",
-    "native",
-    "new",
     "noinline",
     "null",
     "object",
@@ -109,18 +93,11 @@ pub(crate) const KOTLIN_JAVA_KEYWORDS: &[&str] = &[
     "sealed",
     "set",
     "setparam",
-    "short",
-    "static",
-    "strictfp",
     "super",
     "suspend",
-    "switch",
-    "synchronized",
     "tailrec",
     "this",
     "throw",
-    "throws",
-    "transient",
     "true",
     "try",
     "typealias",
@@ -129,16 +106,52 @@ pub(crate) const KOTLIN_JAVA_KEYWORDS: &[&str] = &[
     "value",
     "var",
     "vararg",
-    "void",
-    "volatile",
     "when",
     "where",
     "while",
 ];
 
-/// Returns `true` when `name` is a Kotlin or Java keyword — not a valid rename target.
-pub(crate) fn is_kotlin_keyword(name: &str) -> bool {
-    KOTLIN_JAVA_KEYWORDS.binary_search(&name).is_ok()
+/// Java-only reserved words that are NOT Kotlin keywords (valid Kotlin identifiers).
+/// Applied in addition to `KOTLIN_KEYWORDS` for `.java` files.
+///
+/// **Must remain sorted** — `is_keyword_for_file` uses binary search.
+pub(crate) const JAVA_EXTRA_KEYWORDS: &[&str] = &[
+    "assert",
+    "boolean",
+    "byte",
+    "case",
+    "char",
+    "default",
+    "double",
+    "extends",
+    "float",
+    "goto",
+    "implements",
+    "instanceof",
+    "int",
+    "long",
+    "native",
+    "new",
+    "short",
+    "static",
+    "strictfp",
+    "switch",
+    "synchronized",
+    "throws",
+    "transient",
+    "void",
+    "volatile",
+];
+
+/// Returns `true` when `name` is a reserved keyword for the given file path —
+/// i.e. not a valid rename target. Java files check both `KOTLIN_KEYWORDS` and
+/// `JAVA_EXTRA_KEYWORDS`; all other files check `KOTLIN_KEYWORDS` only.
+pub(crate) fn is_keyword_for_file(name: &str, file_path: &str) -> bool {
+    let in_kotlin = KOTLIN_KEYWORDS.binary_search(&name).is_ok();
+    if in_kotlin {
+        return true;
+    }
+    file_path.ends_with(".java") && JAVA_EXTRA_KEYWORDS.binary_search(&name).is_ok()
 }
 
 /// Replace all whole-word occurrences of `word` with `replacement` across

--- a/src/features/text_utils.rs
+++ b/src/features/text_utils.rs
@@ -29,17 +29,22 @@ pub(crate) fn utf16_column(text: &str) -> u32 {
     text.chars().map(|c| c.len_utf16() as u32).sum()
 }
 
-/// All Kotlin hard keywords and common soft keywords that are never valid rename targets.
+/// All Kotlin and Java keywords that are never valid rename targets.
 ///
-/// **Must remain sorted** — `is_kotlin_keyword` uses binary search.
-pub(crate) const KOTLIN_KEYWORDS: &[&str] = &[
+/// **Must remain sorted** — `is_renameable_identifier` uses binary search.
+pub(crate) const KOTLIN_JAVA_KEYWORDS: &[&str] = &[
     "abstract",
     "actual",
     "annotation",
     "as",
+    "assert",
+    "boolean",
     "break",
     "by",
+    "byte",
+    "case",
     "catch",
+    "char",
     "class",
     "companion",
     "const",
@@ -47,33 +52,44 @@ pub(crate) const KOTLIN_KEYWORDS: &[&str] = &[
     "continue",
     "crossinline",
     "data",
+    "default",
     "delegate",
     "do",
+    "double",
     "dynamic",
     "else",
     "enum",
     "expect",
+    "extends",
     "external",
     "false",
     "field",
     "file",
     "final",
     "finally",
+    "float",
     "for",
     "fun",
     "get",
+    "goto",
     "if",
+    "implements",
     "import",
     "in",
     "infix",
     "init",
     "inline",
     "inner",
+    "instanceof",
+    "int",
     "interface",
     "internal",
     "is",
     "it",
     "lateinit",
+    "long",
+    "native",
+    "new",
     "noinline",
     "null",
     "object",
@@ -93,11 +109,18 @@ pub(crate) const KOTLIN_KEYWORDS: &[&str] = &[
     "sealed",
     "set",
     "setparam",
+    "short",
+    "static",
+    "strictfp",
     "super",
     "suspend",
+    "switch",
+    "synchronized",
     "tailrec",
     "this",
     "throw",
+    "throws",
+    "transient",
     "true",
     "try",
     "typealias",
@@ -106,14 +129,16 @@ pub(crate) const KOTLIN_KEYWORDS: &[&str] = &[
     "value",
     "var",
     "vararg",
+    "void",
+    "volatile",
     "when",
     "where",
     "while",
 ];
 
-/// Returns `true` when `name` is a Kotlin keyword — not a valid rename target.
+/// Returns `true` when `name` is a Kotlin or Java keyword — not a valid rename target.
 pub(crate) fn is_kotlin_keyword(name: &str) -> bool {
-    KOTLIN_KEYWORDS.binary_search(&name).is_ok()
+    KOTLIN_JAVA_KEYWORDS.binary_search(&name).is_ok()
 }
 
 /// Replace all whole-word occurrences of `word` with `replacement` across


### PR DESCRIPTION
## Problem

Three rename bugs reported by an agent testing the LSP:

1. **Catastrophic**: cursor on `val savingsItem` at char 10 — if it lands on the `val` keyword, `whole_word_replace_file` replaces *every* `val` in the file (110+ destructive edits)
2. **Partial**: renaming a lowercase property only updated the declaration file, missing cross-file references (e.g. `texts.scenes.finalSteps` in another ViewModel)
3. **Java gap**: `static`, `void`, `new`, `extends`, `implements`, `instanceof`, all primitive types, `switch`, `case`, `synchronized` etc. were absent from the keyword guard

## Fix

- Replace `is_non_call_keyword` (incomplete `matches!()` blacklist, Kotlin-only) with `KOTLIN_JAVA_KEYWORDS: &[&str]` — a sorted const array covering all Kotlin hard/soft keywords + 25 Java-only keywords. `is_kotlin_keyword` uses binary search (O(log n)).
- Add keyword guard to `rename_impl` directly — previously only `prepare_rename_impl` was guarded; editors that skip `prepareRename` would bypass it.
- Use `cst_cursor_is_local_var` in `resolve_cursor_symbol` to distinguish local variables (file-scoped rename) from class-level properties (cross-file rename via rg).