### PR TITLE
fix: cherry-pick improvements from community forks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,8 @@ lexopt = "0.3"
 parking_lot = "0.12.5"
 # jemalloc: dramatically reduces RSS on long-running processes by avoiding
 # glibc malloc arena fragmentation (same pattern as rust-analyzer)
+# Not supported on Windows.
+[target.'cfg(not(target_os = "windows"))'.dependencies]
 tikv-jemallocator = "0.6"
 
 [profile.release]

--- a/src/indexer/discover.rs
+++ b/src/indexer/discover.rs
@@ -54,20 +54,30 @@ pub(super) fn find_source_files(root: &Path, matcher: Option<&IgnoreMatcher>) ->
     fd_args.push(".".into());
     fd_args.push(root_str.to_string());
 
-    let fd_result = Command::new("fd").args(&fd_args).output();
-    if let Ok(out) = fd_result {
-        if out.status.success() {
-            let paths: Vec<_> = String::from_utf8_lossy(&out.stdout)
-                .lines()
-                .filter(|l| !l.is_empty())
-                .map(PathBuf::from)
-                .collect();
-            return paths;
-        }
+    if let Some(stdout) = run_fd(&fd_args) {
+        let paths: Vec<_> = String::from_utf8_lossy(&stdout)
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(PathBuf::from)
+            .collect();
+        return paths;
     }
 
-    log::info!("fd unavailable or failed; falling back to walkdir");
+    log::info!("fd/fdfind unavailable or failed; falling back to walkdir");
     walkdir_find(root, matcher)
+}
+
+/// Run `fd` (or `fdfind` on Debian/Ubuntu) with `args` and return stdout on success.
+/// Returns `None` when neither binary is available or both fail.
+fn run_fd(args: &[String]) -> Option<Vec<u8>> {
+    for bin in &["fd", "fdfind"] {
+        if let Ok(out) = Command::new(bin).args(args).output() {
+            if out.status.success() {
+                return Some(out.stdout);
+            }
+        }
+    }
+    None
 }
 
 fn walkdir_find(root: &Path, matcher: Option<&IgnoreMatcher>) -> Vec<PathBuf> {
@@ -149,22 +159,19 @@ pub(super) fn find_source_files_unconstrained(root: &Path) -> Vec<PathBuf> {
     fd_args.push(".".into());
     fd_args.push(root_str.to_string());
 
-    let fd_result = Command::new("fd").args(&fd_args).output();
-    if let Ok(out) = fd_result {
-        if out.status.success() {
-            let paths: Vec<_> = String::from_utf8_lossy(&out.stdout)
-                .lines()
-                .filter(|l| !l.is_empty())
-                .map(PathBuf::from)
-                .collect();
-            if !paths.is_empty() {
-                return paths;
-            }
+    if let Some(stdout) = run_fd(&fd_args) {
+        let paths: Vec<_> = String::from_utf8_lossy(&stdout)
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(PathBuf::from)
+            .collect();
+        if !paths.is_empty() {
+            return paths;
         }
     }
 
     log::info!(
-        "fd unavailable or failed; falling back to walkdir for source path {}",
+        "fd/fdfind unavailable or failed; falling back to walkdir for source path {}",
         root.display()
     );
     let mut paths = Vec::new();
@@ -233,14 +240,15 @@ fn find_source_files_newer_than(
     fd_args.push(".".into());
     fd_args.push(root_str.to_string());
 
-    match Command::new("fd").args(&fd_args).output() {
-        Ok(out) if out.status.success() => String::from_utf8_lossy(&out.stdout)
-            .lines()
-            .filter(|l| !l.is_empty())
-            .map(PathBuf::from)
-            .collect(),
-        _ => vec![],
-    }
+    run_fd(&fd_args)
+        .map(|stdout| {
+            String::from_utf8_lossy(&stdout)
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(PathBuf::from)
+                .collect()
+        })
+        .unwrap_or_default()
 }
 
 // ─── warm-start discovery ────────────────────────────────────────────────────

--- a/src/indexer/doc.rs
+++ b/src/indexer/doc.rs
@@ -21,7 +21,7 @@
 /// - Skips `@suppress`, `@hide`, `@internal` — not user-facing
 /// - Strips `[LinkText](url)` Markdown links from KDoc `[Symbol]` references
 pub(super) fn extract_doc_comment(lines: &[String], decl_line: usize) -> Option<String> {
-    if decl_line == 0 {
+    if decl_line == 0 || decl_line >= lines.len() {
         return None;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 #![warn(unreachable_pub)]
 
+#[cfg(not(target_os = "windows"))]
 #[global_allocator]
 static ALLOC: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
 mod backend;

--- a/src/workspace_json.rs
+++ b/src/workspace_json.rs
@@ -154,6 +154,13 @@ pub(crate) fn load_configured_source_paths(workspace_root: &Path) -> Option<Vec<
 ///
 /// Multi-module Gradle: `settings.gradle(.kts)` is parsed for `include(":module")` calls;
 /// each listed module is treated as a subproject and its standard source dirs are probed.
+/// Nested module paths (`":features:play-domain"` → `features/play-domain`) are supported.
+///
+/// Probed layout: every immediate child of `src/` that contains a `kotlin/` or `java/`
+/// subdirectory is treated as a source root. This covers plain Gradle/Maven
+/// (`src/main/kotlin`, `src/test/java`), every standard KMP source set (`commonMain`,
+/// `androidMain`, `iosMain`, `jvmMain`, `wasmJsMain`, …), and any user-defined source
+/// set without requiring an allowlist update.
 ///
 /// These paths are typically already covered by the workspace root scan, but listing them
 /// explicitly ensures consistent indexing when the workspace root is set to a parent dir.
@@ -190,17 +197,9 @@ pub(crate) fn detect_build_layout_source_paths(workspace_root: &Path) -> Vec<Pat
         }
     }
 
-    let source_candidates = [
-        "src/main/kotlin",
-        "src/main/java",
-        "src/test/kotlin",
-        "src/test/java",
-    ];
-
     for dir in &all_dirs {
-        for candidate in &source_candidates {
-            let path = dir.join(candidate);
-            if path.is_dir() && !roots.contains(&path) {
+        for path in probe_source_set_roots(dir) {
+            if !roots.contains(&path) {
                 roots.push(path);
             }
         }
@@ -208,6 +207,37 @@ pub(crate) fn detect_build_layout_source_paths(workspace_root: &Path) -> Vec<Pat
 
     if !roots.is_empty() {
         log::info!("build-layout: auto-discovered {} source roots", roots.len());
+    }
+    roots
+}
+
+/// Returns every `src/<set>/kotlin` and `src/<set>/java` directory under `module_dir`.
+///
+/// Discovery is structural: any child of `src/` that has a `kotlin/` or `java/` subdir
+/// is treated as a source root. Catches plain layouts (`src/main/kotlin`, `src/test/java`),
+/// all standard KMP source sets, and user-defined sets without an allowlist.
+fn probe_source_set_roots(module_dir: &Path) -> Vec<PathBuf> {
+    const SOURCE_LANG_DIRS: &[&str] = &["kotlin", "java"];
+    let src = module_dir.join("src");
+    let Ok(entries) = std::fs::read_dir(&src) else {
+        return Vec::new();
+    };
+
+    let mut sets: Vec<PathBuf> = entries
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| p.is_dir())
+        .collect();
+    sets.sort();
+
+    let mut roots = Vec::new();
+    for set_dir in sets {
+        for lang in SOURCE_LANG_DIRS {
+            let candidate = set_dir.join(lang);
+            if candidate.is_dir() {
+                roots.push(candidate);
+            }
+        }
     }
     roots
 }


### PR DESCRIPTION
Cherry-picked four low-risk, high-value fixes identified from active forks.

## Changes

### 1. `doc.rs` — OOB panic fix (from ulite-Amr)
`extract_doc_comment` would panic when `decl_line >= lines.len()` (e.g. partially loaded library source). Adds a bounds guard. Closes the crash that poisoned shared locks in the current LSP session.

### 2. Jemalloc Windows gate (from hellopw)
`tikv-jemallocator` doesn't support Windows. Gate it behind `cfg(not(target_os = "windows"))` in both `Cargo.toml` and `main.rs` so the crate compiles on Windows without any source change. Prerequisite for the Windows port tracked in #127.

### 3. KMP source-set discovery (from qdsfdhvh)
Replaces the hardcoded 4-entry allowlist (`src/main/kotlin`, `src/test/kotlin`, `src/main/java`, `src/test/java`) with a structural probe: any child of `src/` that contains a `kotlin/` or `java/` subdir is auto-discovered. Covers all standard KMP source sets (`commonMain`, `androidMain`, `iosMain`, `jvmMain`, `wasmJsMain`, …) and user-defined sets, with no allowlist to maintain.

### 4. `fd`/`fdfind` fallback (CI fix)
On Debian/Ubuntu `fd` is packaged as `fdfind`. The indexer was silently falling back to walkdir on every scan for Ubuntu users (no error, just slower and no `--changed-within` support for warm cache). Extracts a `run_fd()` helper that tries `fd` → `fdfind` and uses it at all three call sites.

## Attribution
- ulite-Amr (Amr Ayman) — doc panic fix
- hellopw — jemalloc Windows gate  
- qdsfdhvh — KMP source-set discovery, fdfind CI insight