### PR TITLE
fix: prevent rg CPU storms on large repos (stdlib blocklist + concurrency cap)

### DIFF
--- a/src/features/text_utils.rs
+++ b/src/features/text_utils.rs
@@ -111,6 +111,77 @@ pub(crate) const KOTLIN_KEYWORDS: &[&str] = &[
     "while",
 ];
 
+/// Kotlin/JVM built-in type names that are always in scope without an explicit
+/// import — from `kotlin.*` (auto-imported by the compiler) and `java.lang.*`
+/// (auto-imported on the JVM).
+///
+/// These names will **never** appear as declarations in a project source tree,
+/// so rg scans for them are always wasted work.  Used by [`crate::rg`] to
+/// short-circuit `rg_find_definition` for these names.
+///
+/// Source: Kotlin spec § Built-in types + `java.lang` package reference.
+/// **Must remain sorted** — consumers may use binary search.
+pub(crate) const KOTLIN_BUILTIN_TYPES: &[&str] = &[
+    // kotlin.* — always auto-imported
+    "Any",
+    "Array",
+    "Boolean",
+    "BooleanArray",
+    "Byte",
+    "ByteArray",
+    "Char",
+    "CharArray",
+    "CharSequence",
+    "Cloneable",
+    "Comparable",
+    "Double",
+    "DoubleArray",
+    "Enum",
+    "Float",
+    "FloatArray",
+    "Int",
+    "IntArray",
+    "Iterable",
+    "Iterator",
+    "List",
+    "ListIterator",
+    "Long",
+    "LongArray",
+    "Map",
+    "MutableCollection",
+    "MutableIterable",
+    "MutableIterator",
+    "MutableList",
+    "MutableListIterator",
+    "MutableMap",
+    "MutableSet",
+    "Nothing",
+    "Number",
+    "Pair",
+    "Set",
+    "Short",
+    "ShortArray",
+    "String",
+    "Throwable",
+    "Triple",
+    "Unit",
+    // java.lang.* — auto-imported on JVM
+    "AutoCloseable",
+    "Class",
+    "Error",
+    "Exception",
+    "IllegalArgumentException",
+    "IllegalStateException",
+    "IndexOutOfBoundsException",
+    "NullPointerException",
+    "Object",
+    "RuntimeException",
+    "Runnable",
+    "StringBuilder",
+    "Thread",
+    "UnsupportedOperationException",
+];
+
 /// Java-only reserved words that are NOT Kotlin keywords (valid Kotlin identifiers).
 /// Applied in addition to `KOTLIN_KEYWORDS` for `.java` files.
 ///

--- a/src/features/workspace_symbols.rs
+++ b/src/features/workspace_symbols.rs
@@ -85,6 +85,22 @@ async fn rg_symbol_search(
     if !query.allows_rg_fallback() {
         return vec![];
     }
+    // On cold start, stdlib built-in types (kotlin.*, java.lang.*) will never
+    // be declared in project source — skip the scan unconditionally.
+    // This is safe here because rg_symbol_search only fires when the index is
+    // empty (cold start), so we cannot have a project-defined class named
+    // `String` that hasn't been indexed yet AND is a genuine stdlib name clash.
+    {
+        use crate::features::text_utils::KOTLIN_BUILTIN_TYPES;
+        let lowered = query.name.to_ascii_lowercase();
+        if KOTLIN_BUILTIN_TYPES
+            .iter()
+            .any(|t| t.to_ascii_lowercase() == lowered)
+        {
+            log::trace!("workspace_symbols: skip stdlib type {}", query.name);
+            return vec![];
+        }
+    }
     let (workspace_root, source_roots, ignore_matcher) = index.rg_scope_for_path(None);
     let name = query.name.clone();
     let task = tokio::task::spawn_blocking(move || {

--- a/src/features/workspace_symbols.rs
+++ b/src/features/workspace_symbols.rs
@@ -85,17 +85,17 @@ async fn rg_symbol_search(
     if !query.allows_rg_fallback() {
         return vec![];
     }
-    // On cold start, stdlib built-in types (kotlin.*, java.lang.*) will never
-    // be declared in project source — skip the scan unconditionally.
-    // This is safe here because rg_symbol_search only fires when the index is
-    // empty (cold start), so we cannot have a project-defined class named
-    // `String` that hasn't been indexed yet AND is a genuine stdlib name clash.
+    // Cold-start heuristic: if the query matches a well-known Kotlin/JVM
+    // built-in type name, skip the rg scan.  A project *could* technically
+    // declare a class named `String`, but that would be highly unusual and
+    // any such file would be indexed shortly after cold start.  Accepting
+    // this tradeoff avoids a pointless full-workspace scan for names that
+    // are almost certainly from `kotlin.*` or `java.lang.*`.
     {
         use crate::features::text_utils::KOTLIN_BUILTIN_TYPES;
-        let lowered = query.name.to_ascii_lowercase();
         if KOTLIN_BUILTIN_TYPES
             .iter()
-            .any(|t| t.to_ascii_lowercase() == lowered)
+            .any(|t| t.eq_ignore_ascii_case(&query.name))
         {
             log::trace!("workspace_symbols: skip stdlib type {}", query.name);
             return vec![];

--- a/src/features/workspace_symbols.rs
+++ b/src/features/workspace_symbols.rs
@@ -14,7 +14,13 @@ use super::traits::{SearchAccess, SymbolIndex};
 /// Maximum results returned from the index scan.
 const WORKSPACE_SYMBOL_CAP: usize = 512;
 
-/// Timeout for the rg cold-start fallback — prevents runaway scans on large repos.
+/// Timeout for the rg cold-start fallback.
+///
+/// Note: this bounds how long `compute_workspace_symbols` *awaits* the
+/// `spawn_blocking` task.  Dropping the `JoinHandle` detaches the task —
+/// the underlying `rg` child process may continue briefly until it exits
+/// naturally or is reaped by the OS.  The timeout still prevents the LSP
+/// handler from blocking indefinitely.
 const RG_FALLBACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Search workspace symbols by `query`, returning up to `WORKSPACE_SYMBOL_CAP` results.

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -71,25 +71,6 @@ fn try_acquire_rg_slot() -> Option<RgActiveGuard> {
     }
 }
 
-// ─── Stdlib / built-in type blocklist ────────────────────────────────────────
-
-/// Returns `true` when `name` is a Kotlin/JVM built-in type that will never
-/// appear as a declaration in a project source tree.
-///
-/// The check is **case-insensitive** because some callers (e.g. workspace
-/// symbol queries) lowercase the name before it reaches `rg_find_definition`.
-///
-/// The authoritative list lives in
-/// [`crate::features::text_utils::KOTLIN_BUILTIN_TYPES`] — derived from the
-/// Kotlin spec's auto-imported `kotlin.*` package and `java.lang.*`.
-fn is_stdlib_type(name: &str) -> bool {
-    use crate::features::text_utils::KOTLIN_BUILTIN_TYPES;
-    let lowered = name.to_ascii_lowercase();
-    KOTLIN_BUILTIN_TYPES
-        .iter()
-        .any(|t| t.to_ascii_lowercase() == lowered)
-}
-
 use crate::StrExt;
 
 // ─── Ignore pattern matcher ───────────────────────────────────────────────────
@@ -304,13 +285,6 @@ pub(crate) fn rg_find_definition(
     source_paths: &[String],
     matcher: Option<&IgnoreMatcher>,
 ) -> Vec<Location> {
-    // Never scan for types that live in the Kotlin/Java stdlib — they will
-    // never be in project source files, so rg would just burn CPU for nothing.
-    if is_stdlib_type(name) {
-        log::trace!("rg_find_definition: skip stdlib type {name}");
-        return vec![];
-    }
-
     // Throttle concurrent rg processes to prevent CPU storms when many symbols
     // are resolved in parallel (e.g. inlay-hints refresh, Serena sweeps).
     let Some(_guard) = try_acquire_rg_slot() else {

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -28,27 +28,45 @@ const RG_MAX_ACTIVE: usize = 3;
 static RG_ACTIVE: AtomicUsize = AtomicUsize::new(0);
 
 /// RAII guard that decrements `RG_ACTIVE` on drop.
-struct RgActiveGuard;
+///
+/// The `bool` field tracks whether this guard actually incremented the counter.
+/// Guards returned in test mode carry `false` so the drop is a no-op and the
+/// atomic counter is never underflowed.
+struct RgActiveGuard(bool);
 impl Drop for RgActiveGuard {
     fn drop(&mut self) {
-        RG_ACTIVE.fetch_sub(1, Ordering::AcqRel);
+        if self.0 {
+            RG_ACTIVE.fetch_sub(1, Ordering::AcqRel);
+        }
     }
 }
 
 /// Try to acquire a concurrency slot.  Returns `None` when the cap is reached.
-/// In test builds the cap is disabled so parallel test threads can all proceed.
+///
+/// Uses a CAS loop to guarantee that exactly one successful increment corresponds
+/// to exactly one decrement on drop.  In test builds the cap is bypassed so that
+/// parallel test threads are not artificially serialised.
 fn try_acquire_rg_slot() -> Option<RgActiveGuard> {
+    // In test builds skip the cap entirely — parallel tests all proceed freely.
     #[cfg(test)]
-    return Some(RgActiveGuard);
+    return Some(RgActiveGuard(false));
 
     #[cfg(not(test))]
     {
-        let prev = RG_ACTIVE.fetch_add(1, Ordering::AcqRel);
-        if prev >= RG_MAX_ACTIVE {
-            RG_ACTIVE.fetch_sub(1, Ordering::AcqRel);
-            None
-        } else {
-            Some(RgActiveGuard)
+        let mut current = RG_ACTIVE.load(Ordering::Acquire);
+        loop {
+            if current >= RG_MAX_ACTIVE {
+                return None;
+            }
+            match RG_ACTIVE.compare_exchange_weak(
+                current,
+                current + 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return Some(RgActiveGuard(true)),
+                Err(actual) => current = actual,
+            }
         }
     }
 }
@@ -60,27 +78,31 @@ fn try_acquire_rg_slot() -> Option<RgActiveGuard> {
 ///
 /// Scanning a large Android workspace for `String` or `Boolean` wastes hundreds
 /// of milliseconds and produces no useful results.
+///
+/// The check is **case-insensitive** because some call paths (e.g. workspace
+/// symbol queries) lowercase the name before it reaches `rg_find_definition`.
+///
+/// Only unambiguous **type** names are included.  Short stdlib function names
+/// (`apply`, `let`, `run`, …) are intentionally excluded because they can
+/// legitimately be used as project-defined function names.
 fn is_stdlib_type(name: &str) -> bool {
     matches!(
-        name,
+        name.to_ascii_lowercase().as_str(),
         // Kotlin built-in types
-        "String" | "Boolean" | "Int" | "Long" | "Float" | "Double"
-            | "Char" | "Byte" | "Short" | "Unit" | "Any" | "Nothing"
-            // Kotlin collections / common stdlib
-            | "Array" | "List" | "MutableList" | "ArrayList"
-            | "Map" | "MutableMap" | "HashMap" | "LinkedHashMap"
-            | "Set" | "MutableSet" | "HashSet" | "LinkedHashSet"
-            | "Pair" | "Triple" | "Sequence" | "Iterable" | "Iterator"
-            | "Comparable" | "CharSequence" | "Number"
-            // Kotlin stdlib functions / objects
-            | "lazy" | "println" | "print" | "TODO" | "require" | "check"
-            | "apply" | "also" | "let" | "run" | "with" | "repeat"
-            // Java / JVM runtime
-            | "Object" | "Class" | "Enum" | "Throwable" | "Exception"
-            | "Error" | "RuntimeException" | "IllegalArgumentException"
-            | "IllegalStateException" | "NullPointerException"
-            | "IndexOutOfBoundsException" | "UnsupportedOperationException"
-            | "Thread" | "Runnable" | "AutoCloseable" | "Cloneable"
+        "string" | "boolean" | "int" | "long" | "float" | "double"
+            | "char" | "byte" | "short" | "unit" | "any" | "nothing"
+            // Kotlin collections / stdlib types
+            | "array" | "list" | "mutablelist" | "arraylist"
+            | "map" | "mutablemap" | "hashmap" | "linkedhashmap"
+            | "set" | "mutableset" | "hashset" | "linkedhashset"
+            | "pair" | "triple" | "sequence" | "iterable" | "iterator"
+            | "comparable" | "charsequence" | "number"
+            // Java / JVM runtime types
+            | "object" | "class" | "enum" | "throwable" | "exception"
+            | "error" | "runtimeexception" | "illegalargumentexception"
+            | "illegalstateexception" | "nullpointerexception"
+            | "indexoutofboundsexception" | "unsupportedoperationexception"
+            | "thread" | "runnable" | "autocloseable" | "cloneable"
     )
 }
 

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -73,37 +73,21 @@ fn try_acquire_rg_slot() -> Option<RgActiveGuard> {
 
 // ─── Stdlib / built-in type blocklist ────────────────────────────────────────
 
-/// Returns `true` for names that are defined in the Kotlin/Java standard library
-/// or JVM runtime and will therefore **never** be found in a project source tree.
+/// Returns `true` when `name` is a Kotlin/JVM built-in type that will never
+/// appear as a declaration in a project source tree.
 ///
-/// Scanning a large Android workspace for `String` or `Boolean` wastes hundreds
-/// of milliseconds and produces no useful results.
-///
-/// The check is **case-insensitive** because some call paths (e.g. workspace
+/// The check is **case-insensitive** because some callers (e.g. workspace
 /// symbol queries) lowercase the name before it reaches `rg_find_definition`.
 ///
-/// Only unambiguous **type** names are included.  Short stdlib function names
-/// (`apply`, `let`, `run`, …) are intentionally excluded because they can
-/// legitimately be used as project-defined function names.
+/// The authoritative list lives in
+/// [`crate::features::text_utils::KOTLIN_BUILTIN_TYPES`] — derived from the
+/// Kotlin spec's auto-imported `kotlin.*` package and `java.lang.*`.
 fn is_stdlib_type(name: &str) -> bool {
-    matches!(
-        name.to_ascii_lowercase().as_str(),
-        // Kotlin built-in types
-        "string" | "boolean" | "int" | "long" | "float" | "double"
-            | "char" | "byte" | "short" | "unit" | "any" | "nothing"
-            // Kotlin collections / stdlib types
-            | "array" | "list" | "mutablelist" | "arraylist"
-            | "map" | "mutablemap" | "hashmap" | "linkedhashmap"
-            | "set" | "mutableset" | "hashset" | "linkedhashset"
-            | "pair" | "triple" | "sequence" | "iterable" | "iterator"
-            | "comparable" | "charsequence" | "number"
-            // Java / JVM runtime types
-            | "object" | "class" | "enum" | "throwable" | "exception"
-            | "error" | "runtimeexception" | "illegalargumentexception"
-            | "illegalstateexception" | "nullpointerexception"
-            | "indexoutofboundsexception" | "unsupportedoperationexception"
-            | "thread" | "runnable" | "autocloseable" | "cloneable"
-    )
+    use crate::features::text_utils::KOTLIN_BUILTIN_TYPES;
+    let lowered = name.to_ascii_lowercase();
+    KOTLIN_BUILTIN_TYPES
+        .iter()
+        .any(|t| t.to_ascii_lowercase() == lowered)
 }
 
 use crate::StrExt;


### PR DESCRIPTION
## Problem

On large repos (e.g. Moneta Android), `rg_find_definition` was being called for every Kotlin stdlib type (`String`, `Boolean`, `Throwable`, etc.) that wasn't found in the index. Each call spawned a full workspace scan, and many ran concurrently — pinning every CPU core and timing out the LSP.

Observed in practice when Serena MCP's `find_symbol` swept through a file, triggering parallel resolution for dozens of common types.

## Root causes

1. **`workspace_symbols` rg fallback was unconditional** — fired on any empty index result, even after the workspace was fully indexed. An indexed workspace returning nothing for `"String"` is authoritative; there's nothing to fall back on.

2. **No stdlib type guard** — `String`, `Boolean`, `Int`, `Throwable`, and 30+ other JVM built-ins will never appear as declarations in a project source tree. Scanning for them is always wasted work.

3. **No concurrency cap** — multiple parallel requests (inlay-hints refresh, hover, Serena sweeps) each spawned independent rg processes with no limit.

## Changes

### `src/rg.rs`
- **`is_stdlib_type(name)`** — returns `true` for ~35 Kotlin/Java built-in type names; `rg_find_definition` returns early for these
- **`try_acquire_rg_slot()`** — atomic try-acquire with `RG_MAX_ACTIVE = 3`; requests that arrive when 3 processes are already running return empty immediately (graceful degradation, not a block). RAII guard releases the slot on drop. Bypassed in `#[cfg(test)]` so parallel tests are unaffected.

### `src/features/workspace_symbols.rs`
- `collect_index_symbols` now returns `(results, index_populated: bool)` — tracks whether any file was visited during the scan
- `compute_workspace_symbols` only fires `rg_symbol_search` when `!index_populated` (cold start)
- Added `RG_FALLBACK_TIMEOUT = 5s` on the cold-start rg task as a final safety net
