### PR TITLE
feat:(generate_constructor): add resolver fallback chain for unindexed supertypes

### DIFF
--- a/src/backend/actions.rs
+++ b/src/backend/actions.rs
@@ -40,7 +40,8 @@ impl Backend {
             .as_ref()
             .map(|l| l.as_ref().clone())
             .unwrap_or_default();
-        let is_kotlin = crate::Language::from_path(uri.path()) == crate::Language::Kotlin;
+        let lang = crate::Language::from_path(uri.path());
+        let is_kotlin = lang == crate::Language::Kotlin;
 
         let mut actions = features::code_actions::compute_code_actions(
             &line_text, &all_lines, uri, range, is_kotlin,
@@ -53,9 +54,16 @@ impl Backend {
             {
                 actions.push(action);
             }
+
+            if let Some(action) = features::generate_constructor::build_generate_constructor_action(
+                self.indexer.as_ref(),
+                uri,
+                range,
+            ) {
+                actions.push(action);
+            }
         }
 
-        let lang = crate::Language::from_path(uri.path());
         if matches!(lang, crate::Language::Kotlin | crate::Language::Java) {
             if let Some(action) = features::code_actions::build_add_package_action(&all_lines, uri)
             {

--- a/src/features/generate_constructor.rs
+++ b/src/features/generate_constructor.rs
@@ -34,25 +34,25 @@ pub(crate) fn build_generate_constructor_action(
         return None;
     }
 
-    let lines = indexer.mem_lines_for(uri.as_str())?;
-    let content = lines.join("\n");
-    let ts_lang = lang_for_path(uri.path())?;
-    let doc = parse_live(&content, ts_lang)?;
-    let bytes = &doc.bytes;
+    let document_lines = indexer.mem_lines_for(uri.as_str())?;
+    let document_content = document_lines.join("\n");
+    let tree_sitter_language = lang_for_path(uri.path())?;
+    let parsed_document = parse_live(&document_content, tree_sitter_language)?;
+    let document_bytes = &parsed_document.bytes;
 
     // Find class declaration at cursor
     let cursor_line = range.start.line as usize;
-    let line_text = lines.get(cursor_line)?;
-    let byte_col = utf16_col_to_byte(line_text, range.start.character as usize);
+    let line_text = document_lines.get(cursor_line)?;
+    let byte_column = utf16_col_to_byte(line_text, range.start.character as usize);
     let point = tree_sitter::Point {
         row: cursor_line,
-        column: byte_col,
+        column: byte_column,
     };
-    let leaf = doc
+    let leaf_node = parsed_document
         .tree
         .root_node()
         .descendant_for_point_range(point, point)?;
-    let class_node = ancestor_of_kind(leaf, KIND_CLASS_DECL)?;
+    let class_node = ancestor_of_kind(leaf_node, KIND_CLASS_DECL)?;
 
     // Skip if class already has a primary constructor
     if has_child_of_kind(class_node, KIND_PRIMARY_CTOR) {
@@ -60,87 +60,123 @@ pub(crate) fn build_generate_constructor_action(
     }
 
     // Find delegation specifier (the `: SuperType` part)
-    let spec = class_node
+    let delegation_specifier = class_node
         .children(&mut class_node.walk())
-        .find(|c| c.kind() == KIND_DELEGATION_SPEC)?;
+        .find(|child| child.kind() == KIND_DELEGATION_SPEC)?;
 
-    // Extract supertype name; skip if already has constructor invocation args
-    let (super_name, _) = spec.super_from_delegation(bytes)?;
-    if has_child_of_kind(spec, KIND_CONSTRUCTOR_INVOCATION) {
+    // Extract supertype name and concrete type arguments; skip if already has constructor invocation arguments
+    let (supertype_name, type_arguments) =
+        delegation_specifier.super_from_delegation(document_bytes)?;
+    if has_child_of_kind(delegation_specifier, KIND_CONSTRUCTOR_INVOCATION) {
         return None;
     }
 
     // Get class name
     let class_name = class_node
         .children(&mut class_node.walk())
-        .find(|c| c.kind() == KIND_TYPE_IDENT)?
-        .utf8_text(bytes)
+        .find(|child| child.kind() == KIND_TYPE_IDENT)?
+        .utf8_text(document_bytes)
         .ok()?
         .to_owned();
 
-    // Resolve supertype's constructor params from the indexed file data
-    let super_ctor_params = resolve_supertype_ctor_params(indexer, &super_name, uri)?;
-    if super_ctor_params.is_empty() {
+    // Resolve supertype's constructor parameters and formal type parameters from the indexed file data
+    let (supertype_constructor_parameters, formal_type_parameters) =
+        resolve_supertype_constructor_parameters(indexer, &supertype_name, uri)?;
+    if supertype_constructor_parameters.is_empty() {
         return None;
     }
 
-    // Build param entries: (name, type_text)
-    let params: Vec<(&str, &str)> = super_ctor_params
+    // Map formal type parameters (e.g., "T") to concrete type arguments (e.g., "String")
+    let mut substitutions = HashMap::new();
+    for (formal_parameter, concrete_argument) in
+        formal_type_parameters.iter().zip(type_arguments.iter())
+    {
+        substitutions.insert(formal_parameter.clone(), concrete_argument.clone());
+    }
+
+    // Build parameter entries: (name, substituted_type_text)
+    let parameters: Vec<(&str, String)> = supertype_constructor_parameters
         .iter()
-        .filter_map(|p| parse_param(p))
+        .filter_map(|parameter_string| {
+            let (parameter_name, parameter_type) = parse_parameter(parameter_string)?;
+            let substituted_type = substitute_types(parameter_type, &substitutions);
+            Some((parameter_name, substituted_type))
+        })
         .collect();
-    if params.is_empty() {
+    if parameters.is_empty() {
         return None;
     }
 
-    // ── generate edit ───────────────────────────────────────────────────────
-    let indent = class_indent(&content, class_node.start_position().row);
-    let param_indent = format!("{indent}    ");
+    // Generate edit formatting
+    let class_indentation = class_indent(&document_content, class_node.start_position().row);
+    let parameter_indentation = format!("{class_indentation}    ");
 
-    let mut param_text: String = String::new();
-    for (i, (name, ty)) in params.iter().enumerate() {
-        let comma = if i + 1 < params.len() { "," } else { "" };
-        param_text.push_str(&format!("{param_indent}val {name}: {ty}{comma}\n"));
+    let mut parameters_text: String = String::new();
+    for (index, (parameter_name, parameter_type)) in parameters.iter().enumerate() {
+        let comma = if index + 1 < parameters.len() {
+            ","
+        } else {
+            ""
+        };
+        parameters_text.push_str(&format!(
+            "{parameter_indentation}val {parameter_name}: {parameter_type}{comma}\n"
+        ));
     }
 
-    let args: Vec<&str> = params.iter().map(|(n, _)| *n).collect();
-    let ctor_block = format!("(\n{param_text}{indent})");
+    let arguments: Vec<&str> = parameters.iter().map(|(name, _)| *name).collect();
+    let constructor_block = format!("(\n{parameters_text}{class_indentation})");
 
-    // Position: after class name → insert primary constructor
-    let name_end = class_node
+    // Position: after the class name or its type parameters → insert primary constructor
+    // For generic classes (e.g. `class Foo<T>`), we must insert AFTER `type_parameters`
+    // to avoid producing invalid Kotlin like `class Foo (...) <T>`.
+    let class_name_end_position = class_node
         .children(&mut class_node.walk())
-        .find(|c| c.kind() == KIND_TYPE_IDENT)?
+        .find(|child| child.kind() == "type_parameters")
+        .or_else(|| {
+            class_node
+                .children(&mut class_node.walk())
+                .find(|child| child.kind() == KIND_TYPE_IDENT)
+        })?
         .end_position();
 
-    // Position: after supertype name in delegation spec → add `(args)`
-    let user_type_end = spec
-        .children(&mut spec.walk())
-        .find(|c| c.kind() == KIND_USER_TYPE)?
+    // Position: after supertype name in delegation spec → add `(arguments)`
+    let user_type_end_position = delegation_specifier
+        .children(&mut delegation_specifier.walk())
+        .find(|child| child.kind() == KIND_USER_TYPE)?
         .end_position();
 
-    let name_lsp = Position::new(name_end.row as u32, name_end.column as u32);
-    let type_lsp = Position::new(user_type_end.row as u32, user_type_end.column as u32);
+    let class_name_position = Position::new(
+        class_name_end_position.row as u32,
+        class_name_end_position.column as u32,
+    );
+    let supertype_position = Position::new(
+        user_type_end_position.row as u32,
+        user_type_end_position.column as u32,
+    );
 
-    let mut changes = HashMap::new();
-    changes.insert(
+    let mut document_changes = HashMap::new();
+    document_changes.insert(
         uri.clone(),
         vec![
             TextEdit {
-                range: Range::new(name_lsp, name_lsp),
-                new_text: format!(" {ctor_block} "),
+                range: Range::new(class_name_position, class_name_position),
+                new_text: format!(" {constructor_block} "),
             },
             TextEdit {
-                range: Range::new(type_lsp, type_lsp),
-                new_text: format!("({})", args.join(", ")),
+                range: Range::new(supertype_position, supertype_position),
+                new_text: format!("({})", arguments.join(", ")),
             },
         ],
     );
 
     Some(CodeActionOrCommand::CodeAction(CodeAction {
-        title: format!("Generate constructor `{class_name}({})`", args.join(", ")),
+        title: format!(
+            "Generate constructor `{class_name}({})`",
+            arguments.join(", ")
+        ),
         kind: Some(CodeActionKind::QUICKFIX),
         edit: Some(WorkspaceEdit {
-            changes: Some(changes),
+            changes: Some(document_changes),
             ..Default::default()
         }),
         ..Default::default()
@@ -149,67 +185,102 @@ pub(crate) fn build_generate_constructor_action(
 
 // ─── helpers ──────────────────────────────────────────────────────────────────
 
-/// Resolve constructor parameter text from the supertype's definition.
+/// Substitutes formal generic parameters with actual type arguments in a type signature.
+/// Respects word boundaries to ensure partial matches are not erroneously replaced.
+fn substitute_types(type_text: &str, substitutions: &HashMap<String, String>) -> String {
+    let mut result = String::new();
+    let mut current_word = String::new();
+
+    for character in type_text.chars() {
+        if character.is_alphanumeric() || character == '_' {
+            current_word.push(character);
+        } else {
+            if !current_word.is_empty() {
+                if let Some(substituted_value) = substitutions.get(&current_word) {
+                    result.push_str(substituted_value);
+                } else {
+                    result.push_str(&current_word);
+                }
+                current_word.clear();
+            }
+            result.push(character);
+        }
+    }
+    if !current_word.is_empty() {
+        if let Some(substituted_value) = substitutions.get(&current_word) {
+            result.push_str(substituted_value);
+        } else {
+            result.push_str(&current_word);
+        }
+    }
+    result
+}
+
+/// Resolve constructor parameter text and formal generic parameters from the supertype's definition.
 ///
 /// Tries the definitions index first (fast path), then falls back to the full
 /// resolver chain (handles same-file, not-yet-indexed files, etc.).
 /// Uses `ensure_file_data` to read from disk when the file is not in the index.
-fn resolve_supertype_ctor_params(
+fn resolve_supertype_constructor_parameters(
     indexer: &Indexer,
     name: &str,
     from_uri: &Url,
-) -> Option<Vec<String>> {
+) -> Option<(Vec<String>, Vec<String>)> {
     // Phase 1: definitions index (fast path)
-    let locs = indexer.definition_locations(name);
-    if !locs.is_empty() {
-        if let Some(params) = ctor_params_from_locs(indexer, name, &locs, from_uri) {
-            return Some(params);
+    let locations = indexer.definition_locations(name);
+    if !locations.is_empty() {
+        if let Some(result) =
+            constructor_parameters_from_locations(indexer, name, &locations, from_uri)
+        {
+            return Some(result);
         }
     }
 
     // Phase 2: full resolver chain (handles same-file, unindexed files, rg, etc.)
-    let locs = resolve_symbol_inner(indexer, name, from_uri, false);
-    if !locs.is_empty() {
-        if let Some(params) = ctor_params_from_locs(indexer, name, &locs, from_uri) {
-            return Some(params);
+    let locations = resolve_symbol_inner(indexer, name, from_uri, false);
+    if !locations.is_empty() {
+        if let Some(result) =
+            constructor_parameters_from_locations(indexer, name, &locations, from_uri)
+        {
+            return Some(result);
         }
     }
 
     None
 }
 
-/// Extract constructor params from a set of candidate locations.
+/// Extract constructor parameters and generic type parameters from candidate locations.
 ///
 /// Prefers the location in the same package as `from_uri`. Falls back to
 /// reading from disk if the target file is not in the in-memory index.
-fn ctor_params_from_locs(
+fn constructor_parameters_from_locations(
     indexer: &Indexer,
     name: &str,
-    locs: &[Location],
+    locations: &[Location],
     from_uri: &Url,
-) -> Option<Vec<String>> {
-    let current_pkg = indexer.package_of(from_uri);
+) -> Option<(Vec<String>, Vec<String>)> {
+    let current_package = indexer.package_of(from_uri);
 
-    let target = current_pkg
+    let target_location = current_package
         .as_ref()
-        .and_then(|pkg| {
-            locs.iter().find(|loc| {
+        .and_then(|package| {
+            locations.iter().find(|location| {
                 indexer
-                    .package_of(&loc.uri)
+                    .package_of(&location.uri)
                     .as_ref()
-                    .is_some_and(|p| p == pkg)
+                    .is_some_and(|p| p == package)
             })
         })
-        .unwrap_or(&locs[0]);
+        .unwrap_or(&locations[0]);
 
     let file_data = indexer
-        .file_data_for(target.uri.as_str())
-        .or_else(|| ensure_file_data(indexer, &target.uri))?;
+        .file_data_for(target_location.uri.as_str())
+        .or_else(|| ensure_file_data(indexer, &target_location.uri))?;
 
-    let class_sym = file_data.symbols.iter().find(|s| {
-        s.name == name
+    let class_symbol = file_data.symbols.iter().find(|symbol| {
+        symbol.name == name
             && matches!(
-                s.kind,
+                symbol.kind,
                 SymbolKind::CLASS
                     | SymbolKind::INTERFACE
                     | SymbolKind::STRUCT
@@ -218,94 +289,102 @@ fn ctor_params_from_locs(
             )
     })?;
 
-    let params_text = class_sym.params.as_str();
-    if params_text.is_empty() {
+    let parameters_text = class_symbol.params.as_str();
+    if parameters_text.is_empty() {
         return None;
     }
 
-    Some(split_params(params_text))
+    // Extract formal generic type parameters directly (already indexed as Vec<String>)
+    let type_parameters = class_symbol.type_params.clone();
+
+    Some((split_parameters(parameters_text), type_parameters))
 }
 
-/// Split comma-separated parameter text into individual param strings,
+/// Split comma-separated parameter text into individual parameter strings,
 /// respecting nesting depth to avoid splitting on commas inside generics.
-fn split_params(text: &str) -> Vec<String> {
+fn split_parameters(text: &str) -> Vec<String> {
     let mut depth = 0u8;
     let mut start = 0usize;
     let mut result = Vec::new();
-    for (i, c) in text.char_indices() {
-        match c {
+    for (index, character) in text.char_indices() {
+        match character {
             '<' | '(' | '[' => depth += 1,
             '>' | ')' | ']' => depth = depth.saturating_sub(1),
             ',' if depth == 0 => {
-                let p = text[start..i].trim();
-                if !p.is_empty() {
-                    result.push(p.to_owned());
+                let parameter = text[start..index].trim();
+                if !parameter.is_empty() {
+                    result.push(parameter.to_owned());
                 }
-                start = i + 1;
+                start = index + 1;
             }
             _ => {}
         }
     }
-    let last = text[start..].trim();
-    if !last.is_empty() {
-        result.push(last.to_owned());
+    let last_parameter = text[start..].trim();
+    if !last_parameter.is_empty() {
+        result.push(last_parameter.to_owned());
     }
     result
 }
 
-/// Extract `(name, type)` from a single param string.
+/// Extract `(name, type)` from a single parameter string.
 ///
 /// Handles forms:
 /// - `"val name: Type"` → `("name", "Type")`
 /// - `"name: Type"` → `("name", "Type")`
 /// - `"vararg name: Type"` → `("name", "Type")`
 /// - `"crossinline name: Type"` → `("name", "Type")`
-fn parse_param(param: &str) -> Option<(&str, &str)> {
-    let param = param.trim();
+fn parse_parameter(parameter: &str) -> Option<(&str, &str)> {
+    let parameter = parameter.trim();
     // Strip optional val/var/vararg/crossinline/noinline/open modifiers
-    let after_mod = param
+    let after_modifiers = parameter
         .strip_prefix("val ")
-        .or_else(|| param.strip_prefix("var "))
-        .or_else(|| param.strip_prefix("vararg "))
-        .or_else(|| param.strip_prefix("crossinline "))
-        .or_else(|| param.strip_prefix("noinline "))
-        .or_else(|| param.strip_prefix("open "))
-        .unwrap_or(param);
-    let colon = after_mod.find(':')?;
-    let name = after_mod[..colon].trim();
-    let ty = after_mod[colon + 1..].trim();
+        .or_else(|| parameter.strip_prefix("var "))
+        .or_else(|| parameter.strip_prefix("vararg "))
+        .or_else(|| parameter.strip_prefix("crossinline "))
+        .or_else(|| parameter.strip_prefix("noinline "))
+        .or_else(|| parameter.strip_prefix("open "))
+        .unwrap_or(parameter);
+    let colon_index = after_modifiers.find(':')?;
+    let name = after_modifiers[..colon_index].trim();
+    let parameter_type = after_modifiers[colon_index + 1..].trim();
     // Strip default value after `=`
-    let eq = ty.find("= ").or_else(|| ty.find('='));
-    let ty = eq.map(|i| ty[..i].trim()).unwrap_or(ty);
-    if name.is_empty() || ty.is_empty() {
+    let equals_index = parameter_type
+        .find("= ")
+        .or_else(|| parameter_type.find('='));
+    let parameter_type = equals_index
+        .map(|index| parameter_type[..index].trim())
+        .unwrap_or(parameter_type);
+    if name.is_empty() || parameter_type.is_empty() {
         return None;
     }
-    Some((name, ty))
+    Some((name, parameter_type))
 }
 
 /// Walk up from a node to find the nearest ancestor of the given kind.
 fn ancestor_of_kind<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
-    let mut cur = node;
+    let mut current_node = node;
     loop {
-        if cur.kind() == kind {
-            return Some(cur);
+        if current_node.kind() == kind {
+            return Some(current_node);
         }
-        if cur.kind() == KIND_SOURCE_FILE {
+        if current_node.kind() == KIND_SOURCE_FILE {
             return None;
         }
-        cur = cur.parent()?;
+        current_node = current_node.parent()?;
     }
 }
 
 fn has_child_of_kind(node: tree_sitter::Node, kind: &str) -> bool {
-    node.children(&mut node.walk()).any(|c| c.kind() == kind)
+    node.children(&mut node.walk())
+        .any(|child| child.kind() == kind)
 }
 
 /// Detect the indentation string for a given row (leading whitespace).
 fn class_indent(content: &str, row: usize) -> String {
     let line = content.lines().nth(row).unwrap_or("");
     line.chars()
-        .take_while(|c| *c == ' ' || *c == '\t')
+        .take_while(|character| *character == ' ' || *character == '\t')
         .collect()
 }
 

--- a/src/features/generate_constructor.rs
+++ b/src/features/generate_constructor.rs
@@ -226,21 +226,26 @@ fn resolve_supertype_constructor_parameters(
     name: &str,
     from_uri: &Url,
 ) -> Option<(Vec<String>, Vec<String>)> {
+    // Normalize nested or dotted type names (e.g., "Outer.Inner" -> "Inner")
+    // to ensure compatibility with indexer queries and symbol resolution.
+    // Utilizing next_back() on DoubleEndedIterator to efficiently retrieve the final segment.
+    let simple_name = name.split('.').next_back().unwrap_or(name);
+
     // Phase 1: definitions index (fast path)
-    let locations = indexer.definition_locations(name);
+    let locations = indexer.definition_locations(simple_name);
     if !locations.is_empty() {
         if let Some(result) =
-            constructor_parameters_from_locations(indexer, name, &locations, from_uri)
+            constructor_parameters_from_locations(indexer, simple_name, &locations, from_uri)
         {
             return Some(result);
         }
     }
 
     // Phase 2: full resolver chain (handles same-file, unindexed files, rg, etc.)
-    let locations = resolve_symbol_inner(indexer, name, from_uri, false);
+    let locations = resolve_symbol_inner(indexer, simple_name, from_uri, false);
     if !locations.is_empty() {
         if let Some(result) =
-            constructor_parameters_from_locations(indexer, name, &locations, from_uri)
+            constructor_parameters_from_locations(indexer, simple_name, &locations, from_uri)
         {
             return Some(result);
         }

--- a/src/features/generate_constructor.rs
+++ b/src/features/generate_constructor.rs
@@ -1,0 +1,314 @@
+//! Generate constructor / primary properties for classes extending a supertype.
+//!
+//! When the cursor is on a class declaration that extends a supertype (e.g.,
+//! `class Foo : Bar`), offers a code action to generate the primary constructor
+//! parameters based on the supertype's constructor.
+
+use std::collections::HashMap;
+
+use tower_lsp::lsp_types::{
+    CodeAction, CodeActionKind, CodeActionOrCommand, Location, Position, Range, SymbolKind,
+    TextEdit, Url, WorkspaceEdit,
+};
+
+use crate::indexer::live_tree::{lang_for_path, parse_live, utf16_col_to_byte};
+use crate::indexer::Indexer;
+use crate::indexer::NodeExt;
+use crate::queries::{
+    KIND_CLASS_DECL, KIND_CONSTRUCTOR_INVOCATION, KIND_DELEGATION_SPEC, KIND_PRIMARY_CTOR,
+    KIND_SOURCE_FILE, KIND_TYPE_IDENT, KIND_USER_TYPE,
+};
+use crate::resolver::{ensure_file_data, resolve_symbol_inner};
+use crate::types::Language;
+
+/// Try to build a "Generate constructor" code action for the cursor position.
+///
+/// Returns `None` if the cursor is not on a class declaration with a supertype
+/// whose constructor can be resolved, or the class already has a constructor.
+pub(crate) fn build_generate_constructor_action(
+    indexer: &Indexer,
+    uri: &Url,
+    range: Range,
+) -> Option<CodeActionOrCommand> {
+    if Language::from_path(uri.path()) != Language::Kotlin {
+        return None;
+    }
+
+    let lines = indexer.mem_lines_for(uri.as_str())?;
+    let content = lines.join("\n");
+    let ts_lang = lang_for_path(uri.path())?;
+    let doc = parse_live(&content, ts_lang)?;
+    let bytes = &doc.bytes;
+
+    // Find class declaration at cursor
+    let cursor_line = range.start.line as usize;
+    let line_text = lines.get(cursor_line)?;
+    let byte_col = utf16_col_to_byte(line_text, range.start.character as usize);
+    let point = tree_sitter::Point {
+        row: cursor_line,
+        column: byte_col,
+    };
+    let leaf = doc
+        .tree
+        .root_node()
+        .descendant_for_point_range(point, point)?;
+    let class_node = ancestor_of_kind(leaf, KIND_CLASS_DECL)?;
+
+    // Skip if class already has a primary constructor
+    if has_child_of_kind(class_node, KIND_PRIMARY_CTOR) {
+        return None;
+    }
+
+    // Find delegation specifier (the `: SuperType` part)
+    let spec = class_node
+        .children(&mut class_node.walk())
+        .find(|c| c.kind() == KIND_DELEGATION_SPEC)?;
+
+    // Extract supertype name; skip if already has constructor invocation args
+    let (super_name, _) = spec.super_from_delegation(bytes)?;
+    if has_child_of_kind(spec, KIND_CONSTRUCTOR_INVOCATION) {
+        return None;
+    }
+
+    // Get class name
+    let class_name = class_node
+        .children(&mut class_node.walk())
+        .find(|c| c.kind() == KIND_TYPE_IDENT)?
+        .utf8_text(bytes)
+        .ok()?
+        .to_owned();
+
+    // Resolve supertype's constructor params from the indexed file data
+    let super_ctor_params = resolve_supertype_ctor_params(indexer, &super_name, uri)?;
+    if super_ctor_params.is_empty() {
+        return None;
+    }
+
+    // Build param entries: (name, type_text)
+    let params: Vec<(&str, &str)> = super_ctor_params
+        .iter()
+        .filter_map(|p| parse_param(p))
+        .collect();
+    if params.is_empty() {
+        return None;
+    }
+
+    // ── generate edit ───────────────────────────────────────────────────────
+    let indent = class_indent(&content, class_node.start_position().row);
+    let param_indent = format!("{indent}    ");
+
+    let mut param_text: String = String::new();
+    for (i, (name, ty)) in params.iter().enumerate() {
+        let comma = if i + 1 < params.len() { "," } else { "" };
+        param_text.push_str(&format!("{param_indent}val {name}: {ty}{comma}\n"));
+    }
+
+    let args: Vec<&str> = params.iter().map(|(n, _)| *n).collect();
+    let ctor_block = format!("(\n{param_text}{indent})");
+
+    // Position: after class name → insert primary constructor
+    let name_end = class_node
+        .children(&mut class_node.walk())
+        .find(|c| c.kind() == KIND_TYPE_IDENT)?
+        .end_position();
+
+    // Position: after supertype name in delegation spec → add `(args)`
+    let user_type_end = spec
+        .children(&mut spec.walk())
+        .find(|c| c.kind() == KIND_USER_TYPE)?
+        .end_position();
+
+    let name_lsp = Position::new(name_end.row as u32, name_end.column as u32);
+    let type_lsp = Position::new(user_type_end.row as u32, user_type_end.column as u32);
+
+    let mut changes = HashMap::new();
+    changes.insert(
+        uri.clone(),
+        vec![
+            TextEdit {
+                range: Range::new(name_lsp, name_lsp),
+                new_text: format!(" {ctor_block} "),
+            },
+            TextEdit {
+                range: Range::new(type_lsp, type_lsp),
+                new_text: format!("({})", args.join(", ")),
+            },
+        ],
+    );
+
+    Some(CodeActionOrCommand::CodeAction(CodeAction {
+        title: format!("Generate constructor `{class_name}({})`", args.join(", ")),
+        kind: Some(CodeActionKind::QUICKFIX),
+        edit: Some(WorkspaceEdit {
+            changes: Some(changes),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }))
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+/// Resolve constructor parameter text from the supertype's definition.
+///
+/// Tries the definitions index first (fast path), then falls back to the full
+/// resolver chain (handles same-file, not-yet-indexed files, etc.).
+/// Uses `ensure_file_data` to read from disk when the file is not in the index.
+fn resolve_supertype_ctor_params(
+    indexer: &Indexer,
+    name: &str,
+    from_uri: &Url,
+) -> Option<Vec<String>> {
+    // Phase 1: definitions index (fast path)
+    let locs = indexer.definition_locations(name);
+    if !locs.is_empty() {
+        if let Some(params) = ctor_params_from_locs(indexer, name, &locs, from_uri) {
+            return Some(params);
+        }
+    }
+
+    // Phase 2: full resolver chain (handles same-file, unindexed files, rg, etc.)
+    let locs = resolve_symbol_inner(indexer, name, from_uri, false);
+    if !locs.is_empty() {
+        if let Some(params) = ctor_params_from_locs(indexer, name, &locs, from_uri) {
+            return Some(params);
+        }
+    }
+
+    None
+}
+
+/// Extract constructor params from a set of candidate locations.
+///
+/// Prefers the location in the same package as `from_uri`. Falls back to
+/// reading from disk if the target file is not in the in-memory index.
+fn ctor_params_from_locs(
+    indexer: &Indexer,
+    name: &str,
+    locs: &[Location],
+    from_uri: &Url,
+) -> Option<Vec<String>> {
+    let current_pkg = indexer.package_of(from_uri);
+
+    let target = current_pkg
+        .as_ref()
+        .and_then(|pkg| {
+            locs.iter().find(|loc| {
+                indexer
+                    .package_of(&loc.uri)
+                    .as_ref()
+                    .is_some_and(|p| p == pkg)
+            })
+        })
+        .unwrap_or(&locs[0]);
+
+    let file_data = indexer
+        .file_data_for(target.uri.as_str())
+        .or_else(|| ensure_file_data(indexer, &target.uri))?;
+
+    let class_sym = file_data.symbols.iter().find(|s| {
+        s.name == name
+            && matches!(
+                s.kind,
+                SymbolKind::CLASS
+                    | SymbolKind::INTERFACE
+                    | SymbolKind::STRUCT
+                    | SymbolKind::ENUM
+                    | SymbolKind::OBJECT
+            )
+    })?;
+
+    let params_text = class_sym.params.as_str();
+    if params_text.is_empty() {
+        return None;
+    }
+
+    Some(split_params(params_text))
+}
+
+/// Split comma-separated parameter text into individual param strings,
+/// respecting nesting depth to avoid splitting on commas inside generics.
+fn split_params(text: &str) -> Vec<String> {
+    let mut depth = 0u8;
+    let mut start = 0usize;
+    let mut result = Vec::new();
+    for (i, c) in text.char_indices() {
+        match c {
+            '<' | '(' | '[' => depth += 1,
+            '>' | ')' | ']' => depth = depth.saturating_sub(1),
+            ',' if depth == 0 => {
+                let p = text[start..i].trim();
+                if !p.is_empty() {
+                    result.push(p.to_owned());
+                }
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    let last = text[start..].trim();
+    if !last.is_empty() {
+        result.push(last.to_owned());
+    }
+    result
+}
+
+/// Extract `(name, type)` from a single param string.
+///
+/// Handles forms:
+/// - `"val name: Type"` → `("name", "Type")`
+/// - `"name: Type"` → `("name", "Type")`
+/// - `"vararg name: Type"` → `("name", "Type")`
+/// - `"crossinline name: Type"` → `("name", "Type")`
+fn parse_param(param: &str) -> Option<(&str, &str)> {
+    let param = param.trim();
+    // Strip optional val/var/vararg/crossinline/noinline/open modifiers
+    let after_mod = param
+        .strip_prefix("val ")
+        .or_else(|| param.strip_prefix("var "))
+        .or_else(|| param.strip_prefix("vararg "))
+        .or_else(|| param.strip_prefix("crossinline "))
+        .or_else(|| param.strip_prefix("noinline "))
+        .or_else(|| param.strip_prefix("open "))
+        .unwrap_or(param);
+    let colon = after_mod.find(':')?;
+    let name = after_mod[..colon].trim();
+    let ty = after_mod[colon + 1..].trim();
+    // Strip default value after `=`
+    let eq = ty.find("= ").or_else(|| ty.find('='));
+    let ty = eq.map(|i| ty[..i].trim()).unwrap_or(ty);
+    if name.is_empty() || ty.is_empty() {
+        return None;
+    }
+    Some((name, ty))
+}
+
+/// Walk up from a node to find the nearest ancestor of the given kind.
+fn ancestor_of_kind<'a>(node: tree_sitter::Node<'a>, kind: &str) -> Option<tree_sitter::Node<'a>> {
+    let mut cur = node;
+    loop {
+        if cur.kind() == kind {
+            return Some(cur);
+        }
+        if cur.kind() == KIND_SOURCE_FILE {
+            return None;
+        }
+        cur = cur.parent()?;
+    }
+}
+
+fn has_child_of_kind(node: tree_sitter::Node, kind: &str) -> bool {
+    node.children(&mut node.walk()).any(|c| c.kind() == kind)
+}
+
+/// Detect the indentation string for a given row (leading whitespace).
+fn class_indent(content: &str, row: usize) -> String {
+    let line = content.lines().nth(row).unwrap_or("");
+    line.chars()
+        .take_while(|c| *c == ' ' || *c == '\t')
+        .collect()
+}
+
+#[cfg(test)]
+#[path = "generate_constructor_tests.rs"]
+mod tests;

--- a/src/features/generate_constructor_tests.rs
+++ b/src/features/generate_constructor_tests.rs
@@ -1,0 +1,372 @@
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::*;
+
+use crate::features::generate_constructor::build_generate_constructor_action;
+use crate::indexer::Indexer;
+
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file:///test{path}")).unwrap()
+}
+
+fn setup(files: &[(&str, &str)]) -> Indexer {
+    let idx = Indexer::new();
+    for (path, src) in files {
+        let u = uri(path);
+        idx.index_content(&u, src);
+        idx.set_live_lines(&u, src);
+        idx.store_live_tree(&u, src);
+    }
+    idx
+}
+
+fn cursor_at(line: u32, col: u32) -> Range {
+    Range::new(Position::new(line, col), Position::new(line, col))
+}
+
+// ─── Happy path ───────────────────────────────────────────────────────────────
+
+const BASE_CLASS: &str = "\
+open class Base(val name: String, val age: Int)
+";
+
+const DERIVED_EMPTY: &str = "\
+class Derived : Base
+";
+
+#[test]
+fn generates_constructor_for_empty_derived_class() {
+    let idx = setup(&[("/Base.kt", BASE_CLASS), ("/Derived.kt", DERIVED_EMPTY)]);
+    let u = uri("/Derived.kt");
+    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    assert!(action.is_some(), "expected generate-constructor action");
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            assert!(ca.title.contains("Derived"), "title: {}", ca.title);
+            assert!(ca.title.contains("name"), "title: {}", ca.title);
+            assert!(ca.title.contains("age"), "title: {}", ca.title);
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            assert_eq!(edits.len(), 2, "expected 2 edits (ctor + super args)");
+            assert!(edits[0].new_text.contains("val name: String"));
+            assert!(edits[0].new_text.contains("val age: Int"));
+            assert_eq!(edits[1].new_text, "(name, age)");
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
+// ─── Class with val/var params ────────────────────────────────────────────────
+
+const BASE_VAL_PARAMS: &str = "\
+open class Base(name: String, val age: Int)
+";
+
+#[test]
+fn generates_constructor_for_mixed_param_prefixes() {
+    let idx = setup(&[
+        ("/Base.kt", BASE_VAL_PARAMS),
+        ("/Derived.kt", DERIVED_EMPTY),
+    ]);
+    let u = uri("/Derived.kt");
+    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    assert!(action.is_some(), "expected generate-constructor action");
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            assert!(edits[0].new_text.contains("val name: String"));
+            assert!(edits[0].new_text.contains("val age: Int"));
+            assert_eq!(edits[1].new_text, "(name, age)");
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
+// ─── Already has primary constructor ──────────────────────────────────────────
+
+#[test]
+fn no_action_when_class_has_primary_ctor() {
+    let src = "\
+class Derived(x: Int) : Base
+";
+    let idx = setup(&[("/Base.kt", BASE_CLASS), ("/Derived.kt", src)]);
+    let u = uri("/Derived.kt");
+    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    assert!(
+        action.is_none(),
+        "no action when constructor already present"
+    );
+}
+
+// ─── Supertype already has constructor args ───────────────────────────────────
+
+#[test]
+fn no_action_when_supertype_has_args() {
+    let src = "\
+class Derived : Base(\"hello\", 5)
+";
+    let idx = setup(&[("/Base.kt", BASE_CLASS), ("/Derived.kt", src)]);
+    let u = uri("/Derived.kt");
+    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    assert!(
+        action.is_none(),
+        "no action when supertype already has args"
+    );
+}
+
+// ─── No supertype ─────────────────────────────────────────────────────────────
+
+#[test]
+fn no_action_when_no_supertype() {
+    let src = "\
+class Standalone
+";
+    let idx = Indexer::new();
+    let u = uri("/Standalone.kt");
+    idx.index_content(&u, src);
+    idx.set_live_lines(&u, src);
+    idx.store_live_tree(&u, src);
+    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    assert!(action.is_none(), "no action for class without supertype");
+}
+
+// ─── Cursor not on a class ───────────────────────────────────────────────────
+
+#[test]
+fn no_action_when_cursor_not_on_class() {
+    let idx = setup(&[("/Base.kt", BASE_CLASS), ("/Derived.kt", DERIVED_EMPTY)]);
+    let u = uri("/Derived.kt");
+    // Cursor on invalid position
+    let action = build_generate_constructor_action(&idx, &u, cursor_at(5, 0));
+    assert!(action.is_none(), "no action when cursor not on class");
+}
+
+// ─── Supertype with generic params ────────────────────────────────────────────
+
+const BASE_GENERIC: &str = "\
+open class Base<T>(val item: T, val count: Int)
+";
+
+const DERIVED_GENERIC: &str = "\
+class Derived : Base<String>
+";
+
+#[test]
+fn generates_constructor_for_generic_supertype() {
+    let idx = setup(&[("/Base.kt", BASE_GENERIC), ("/Derived.kt", DERIVED_GENERIC)]);
+    let u = uri("/Derived.kt");
+    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    assert!(action.is_some(), "expected action for generic supertype");
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            assert!(edits[0].new_text.contains("val item: T"));
+            assert!(edits[0].new_text.contains("val count: Int"));
+            assert_eq!(edits[1].new_text, "(item, count)");
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
+// ─── Supertype with no params ─────────────────────────────────────────────────
+
+const BASE_NO_PARAMS: &str = "\
+open class Base
+";
+
+#[test]
+fn no_action_when_supertype_has_no_params() {
+    let src = "\
+class Derived : Base
+";
+    let idx = setup(&[("/Base.kt", BASE_NO_PARAMS), ("/Derived.kt", src)]);
+    let u = uri("/Derived.kt");
+    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    assert!(action.is_none(), "no action when supertype has no params");
+}
+
+// ─── Multi-line class declaration ─────────────────────────────────────────────
+
+#[test]
+fn generates_constructor_for_supertype_with_complex_params() {
+    let src = "\
+open class Complex(
+    val firstName: String,
+    val lastName: String,
+    val age: Int,
+)
+";
+    let derived = "\
+class Simple : Complex
+";
+    let idx = setup(&[("/Complex.kt", src), ("/Simple.kt", derived)]);
+    let u = uri("/Simple.kt");
+    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    assert!(action.is_some(), "expected action for complex params");
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            assert!(edits[0].new_text.contains("val firstName: String"));
+            assert!(edits[0].new_text.contains("val lastName: String"));
+            assert!(edits[0].new_text.contains("val age: Int"));
+            assert_eq!(edits[1].new_text, "(firstName, lastName, age)");
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
+// ─── File is not Kotlin ───────────────────────────────────────────────────────
+
+#[test]
+fn no_action_for_non_kotlin_file() {
+    let src = "\
+class Foo : Bar
+";
+    let idx = Indexer::new();
+    let u = Url::parse("file:///test/Test.java").unwrap();
+    idx.index_content(&u, src);
+    idx.set_live_lines(&u, src);
+    idx.store_live_tree(&u, src);
+    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    assert!(action.is_none(), "no action for Java file");
+}
+
+// ─── Supertype in same file ───────────────────────────────────────────────────
+
+#[test]
+fn generates_constructor_for_same_file_supertype() {
+    let src = "\
+open class Base(val x: String)
+
+class Derived : Base
+";
+    let idx = Indexer::new();
+    let u = uri("/Test.kt");
+    idx.index_content(&u, src);
+    idx.set_live_lines(&u, src);
+    idx.store_live_tree(&u, src);
+    let action = build_generate_constructor_action(&idx, &u, cursor_at(2, 8));
+    assert!(action.is_some(), "expected action for same-file supertype");
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            assert!(edits[0].new_text.contains("val x: String"));
+            assert_eq!(edits[1].new_text, "(x)");
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
+// ─── Resolver fallback (file on disk, not via index_content) ─────────────────
+
+#[test]
+fn generates_constructor_when_only_on_disk_not_in_index() {
+    let tmp = tempfile::tempdir().unwrap();
+    let file_path = tmp.path().join("Test.kt");
+    let src = "\
+open class Base(val x: String)
+
+class Derived : Base
+";
+    std::fs::write(&file_path, src).unwrap();
+    let u = Url::from_file_path(&file_path).unwrap();
+
+    let idx = Indexer::new();
+    // Only set up live tree — NO index_content, so definitions index is empty.
+    idx.set_live_lines(&u, src);
+    idx.store_live_tree(&u, src);
+
+    let action = build_generate_constructor_action(&idx, &u, cursor_at(2, 8));
+    assert!(
+        action.is_some(),
+        "expected action via resolver fallback (disk indexing)"
+    );
+    match action.unwrap() {
+        CodeActionOrCommand::CodeAction(ca) => {
+            let edit = ca.edit.unwrap();
+            let changes = edit.changes.unwrap();
+            let edits = changes.get(&u).unwrap();
+            assert!(
+                edits[0].new_text.contains("val x: String"),
+                "{}",
+                edits[0].new_text
+            );
+            assert_eq!(edits[1].new_text, "(x)");
+        }
+        _ => panic!("expected CodeAction"),
+    }
+}
+
+// ─── split_params unit test ───────────────────────────────────────────────────
+
+#[test]
+fn split_params_simple() {
+    let result = super::split_params("val x: Int, val y: String");
+    assert_eq!(result, vec!["val x: Int", "val y: String"]);
+}
+
+#[test]
+fn split_params_with_generics() {
+    let result = super::split_params("val items: List<String>, val count: Int");
+    assert_eq!(result, vec!["val items: List<String>", "val count: Int"]);
+}
+
+#[test]
+fn split_params_nested_generics() {
+    let result = super::split_params("val map: Map<String, List<Int>>, val name: String");
+    assert_eq!(
+        result,
+        vec!["val map: Map<String, List<Int>>", "val name: String"]
+    );
+}
+
+#[test]
+fn split_params_single() {
+    let result = super::split_params("val x: Int");
+    assert_eq!(result, vec!["val x: Int"]);
+}
+
+#[test]
+fn split_params_empty() {
+    let result = super::split_params("");
+    assert!(result.is_empty());
+}
+
+// ─── parse_param unit test ────────────────────────────────────────────────────
+
+#[test]
+fn parse_param_val() {
+    assert_eq!(
+        super::parse_param("val name: String"),
+        Some(("name", "String"))
+    );
+}
+
+#[test]
+fn parse_param_no_mod() {
+    assert_eq!(super::parse_param("name: String"), Some(("name", "String")));
+}
+
+#[test]
+fn parse_param_var() {
+    assert_eq!(super::parse_param("var x: Int"), Some(("x", "Int")));
+}
+
+#[test]
+fn parse_param_with_default() {
+    assert_eq!(super::parse_param("val x: Int = 42"), Some(("x", "Int")));
+}
+
+#[test]
+fn parse_param_no_colon() {
+    assert_eq!(super::parse_param("just_name"), None);
+}

--- a/src/features/generate_constructor_tests.rs
+++ b/src/features/generate_constructor_tests.rs
@@ -8,18 +8,18 @@ fn uri(path: &str) -> Url {
 }
 
 fn setup(files: &[(&str, &str)]) -> Indexer {
-    let idx = Indexer::new();
-    for (path, src) in files {
-        let u = uri(path);
-        idx.index_content(&u, src);
-        idx.set_live_lines(&u, src);
-        idx.store_live_tree(&u, src);
+    let indexer = Indexer::new();
+    for (path, source_code) in files {
+        let document_uri = uri(path);
+        indexer.index_content(&document_uri, source_code);
+        indexer.set_live_lines(&document_uri, source_code);
+        indexer.store_live_tree(&document_uri, source_code);
     }
-    idx
+    indexer
 }
 
-fn cursor_at(line: u32, col: u32) -> Range {
-    Range::new(Position::new(line, col), Position::new(line, col))
+fn cursor_at(line: u32, column: u32) -> Range {
+    Range::new(Position::new(line, column), Position::new(line, column))
 }
 
 // ─── Happy path ───────────────────────────────────────────────────────────────
@@ -34,19 +34,35 @@ class Derived : Base
 
 #[test]
 fn generates_constructor_for_empty_derived_class() {
-    let idx = setup(&[("/Base.kt", BASE_CLASS), ("/Derived.kt", DERIVED_EMPTY)]);
-    let u = uri("/Derived.kt");
-    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    let indexer = setup(&[("/Base.kt", BASE_CLASS), ("/Derived.kt", DERIVED_EMPTY)]);
+    let document_uri = uri("/Derived.kt");
+    let action = build_generate_constructor_action(&indexer, &document_uri, cursor_at(0, 8));
     assert!(action.is_some(), "expected generate-constructor action");
     match action.unwrap() {
-        CodeActionOrCommand::CodeAction(ca) => {
-            assert!(ca.title.contains("Derived"), "title: {}", ca.title);
-            assert!(ca.title.contains("name"), "title: {}", ca.title);
-            assert!(ca.title.contains("age"), "title: {}", ca.title);
-            let edit = ca.edit.unwrap();
+        CodeActionOrCommand::CodeAction(code_action) => {
+            assert!(
+                code_action.title.contains("Derived"),
+                "title: {}",
+                code_action.title
+            );
+            assert!(
+                code_action.title.contains("name"),
+                "title: {}",
+                code_action.title
+            );
+            assert!(
+                code_action.title.contains("age"),
+                "title: {}",
+                code_action.title
+            );
+            let edit = code_action.edit.unwrap();
             let changes = edit.changes.unwrap();
-            let edits = changes.get(&u).unwrap();
-            assert_eq!(edits.len(), 2, "expected 2 edits (ctor + super args)");
+            let edits = changes.get(&document_uri).unwrap();
+            assert_eq!(
+                edits.len(),
+                2,
+                "expected 2 edits (constructor + super arguments)"
+            );
             assert!(edits[0].new_text.contains("val name: String"));
             assert!(edits[0].new_text.contains("val age: Int"));
             assert_eq!(edits[1].new_text, "(name, age)");
@@ -55,26 +71,26 @@ fn generates_constructor_for_empty_derived_class() {
     }
 }
 
-// ─── Class with val/var params ────────────────────────────────────────────────
+// ─── Class with val/var parameters ────────────────────────────────────────────
 
 const BASE_VAL_PARAMS: &str = "\
 open class Base(name: String, val age: Int)
 ";
 
 #[test]
-fn generates_constructor_for_mixed_param_prefixes() {
-    let idx = setup(&[
+fn generates_constructor_for_mixed_parameter_prefixes() {
+    let indexer = setup(&[
         ("/Base.kt", BASE_VAL_PARAMS),
         ("/Derived.kt", DERIVED_EMPTY),
     ]);
-    let u = uri("/Derived.kt");
-    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    let document_uri = uri("/Derived.kt");
+    let action = build_generate_constructor_action(&indexer, &document_uri, cursor_at(0, 8));
     assert!(action.is_some(), "expected generate-constructor action");
     match action.unwrap() {
-        CodeActionOrCommand::CodeAction(ca) => {
-            let edit = ca.edit.unwrap();
+        CodeActionOrCommand::CodeAction(code_action) => {
+            let edit = code_action.edit.unwrap();
             let changes = edit.changes.unwrap();
-            let edits = changes.get(&u).unwrap();
+            let edits = changes.get(&document_uri).unwrap();
             assert!(edits[0].new_text.contains("val name: String"));
             assert!(edits[0].new_text.contains("val age: Int"));
             assert_eq!(edits[1].new_text, "(name, age)");
@@ -86,32 +102,32 @@ fn generates_constructor_for_mixed_param_prefixes() {
 // ─── Already has primary constructor ──────────────────────────────────────────
 
 #[test]
-fn no_action_when_class_has_primary_ctor() {
-    let src = "\
+fn no_action_when_class_has_primary_constructor() {
+    let source_code = "\
 class Derived(x: Int) : Base
 ";
-    let idx = setup(&[("/Base.kt", BASE_CLASS), ("/Derived.kt", src)]);
-    let u = uri("/Derived.kt");
-    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    let indexer = setup(&[("/Base.kt", BASE_CLASS), ("/Derived.kt", source_code)]);
+    let document_uri = uri("/Derived.kt");
+    let action = build_generate_constructor_action(&indexer, &document_uri, cursor_at(0, 8));
     assert!(
         action.is_none(),
         "no action when constructor already present"
     );
 }
 
-// ─── Supertype already has constructor args ───────────────────────────────────
+// ─── Supertype already has constructor arguments ───────────────────────────────
 
 #[test]
-fn no_action_when_supertype_has_args() {
-    let src = "\
+fn no_action_when_supertype_has_arguments() {
+    let source_code = "\
 class Derived : Base(\"hello\", 5)
 ";
-    let idx = setup(&[("/Base.kt", BASE_CLASS), ("/Derived.kt", src)]);
-    let u = uri("/Derived.kt");
-    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    let indexer = setup(&[("/Base.kt", BASE_CLASS), ("/Derived.kt", source_code)]);
+    let document_uri = uri("/Derived.kt");
+    let action = build_generate_constructor_action(&indexer, &document_uri, cursor_at(0, 8));
     assert!(
         action.is_none(),
-        "no action when supertype already has args"
+        "no action when supertype already has arguments"
     );
 }
 
@@ -119,15 +135,15 @@ class Derived : Base(\"hello\", 5)
 
 #[test]
 fn no_action_when_no_supertype() {
-    let src = "\
+    let source_code = "\
 class Standalone
 ";
-    let idx = Indexer::new();
-    let u = uri("/Standalone.kt");
-    idx.index_content(&u, src);
-    idx.set_live_lines(&u, src);
-    idx.store_live_tree(&u, src);
-    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    let indexer = Indexer::new();
+    let document_uri = uri("/Standalone.kt");
+    indexer.index_content(&document_uri, source_code);
+    indexer.set_live_lines(&document_uri, source_code);
+    indexer.store_live_tree(&document_uri, source_code);
+    let action = build_generate_constructor_action(&indexer, &document_uri, cursor_at(0, 8));
     assert!(action.is_none(), "no action for class without supertype");
 }
 
@@ -135,14 +151,14 @@ class Standalone
 
 #[test]
 fn no_action_when_cursor_not_on_class() {
-    let idx = setup(&[("/Base.kt", BASE_CLASS), ("/Derived.kt", DERIVED_EMPTY)]);
-    let u = uri("/Derived.kt");
+    let indexer = setup(&[("/Base.kt", BASE_CLASS), ("/Derived.kt", DERIVED_EMPTY)]);
+    let document_uri = uri("/Derived.kt");
     // Cursor on invalid position
-    let action = build_generate_constructor_action(&idx, &u, cursor_at(5, 0));
+    let action = build_generate_constructor_action(&indexer, &document_uri, cursor_at(5, 0));
     assert!(action.is_none(), "no action when cursor not on class");
 }
 
-// ─── Supertype with generic params ────────────────────────────────────────────
+// ─── Supertype with generic parameters ────────────────────────────────────────
 
 const BASE_GENERIC: &str = "\
 open class Base<T>(val item: T, val count: Int)
@@ -154,16 +170,22 @@ class Derived : Base<String>
 
 #[test]
 fn generates_constructor_for_generic_supertype() {
-    let idx = setup(&[("/Base.kt", BASE_GENERIC), ("/Derived.kt", DERIVED_GENERIC)]);
-    let u = uri("/Derived.kt");
-    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    let indexer = setup(&[("/Base.kt", BASE_GENERIC), ("/Derived.kt", DERIVED_GENERIC)]);
+    let document_uri = uri("/Derived.kt");
+    let action = build_generate_constructor_action(&indexer, &document_uri, cursor_at(0, 8));
     assert!(action.is_some(), "expected action for generic supertype");
     match action.unwrap() {
-        CodeActionOrCommand::CodeAction(ca) => {
-            let edit = ca.edit.unwrap();
+        CodeActionOrCommand::CodeAction(code_action) => {
+            let edit = code_action.edit.unwrap();
             let changes = edit.changes.unwrap();
-            let edits = changes.get(&u).unwrap();
-            assert!(edits[0].new_text.contains("val item: T"));
+            let edits = changes.get(&document_uri).unwrap();
+            // The assertion has been corrected to expect "String" instead of "T"
+            // because the types are now successfully substituted to produce compilable code.
+            assert!(
+                edits[0].new_text.contains("val item: String"),
+                "Expected item type to be String but got: {}",
+                edits[0].new_text
+            );
             assert!(edits[0].new_text.contains("val count: Int"));
             assert_eq!(edits[1].new_text, "(item, count)");
         }
@@ -171,28 +193,31 @@ fn generates_constructor_for_generic_supertype() {
     }
 }
 
-// ─── Supertype with no params ─────────────────────────────────────────────────
+// ─── Supertype with no parameters ─────────────────────────────────────────────
 
 const BASE_NO_PARAMS: &str = "\
 open class Base
 ";
 
 #[test]
-fn no_action_when_supertype_has_no_params() {
-    let src = "\
+fn no_action_when_supertype_has_no_parameters() {
+    let source_code = "\
 class Derived : Base
 ";
-    let idx = setup(&[("/Base.kt", BASE_NO_PARAMS), ("/Derived.kt", src)]);
-    let u = uri("/Derived.kt");
-    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
-    assert!(action.is_none(), "no action when supertype has no params");
+    let indexer = setup(&[("/Base.kt", BASE_NO_PARAMS), ("/Derived.kt", source_code)]);
+    let document_uri = uri("/Derived.kt");
+    let action = build_generate_constructor_action(&indexer, &document_uri, cursor_at(0, 8));
+    assert!(
+        action.is_none(),
+        "no action when supertype has no parameters"
+    );
 }
 
 // ─── Multi-line class declaration ─────────────────────────────────────────────
 
 #[test]
-fn generates_constructor_for_supertype_with_complex_params() {
-    let src = "\
+fn generates_constructor_for_supertype_with_complex_parameters() {
+    let source_code = "\
 open class Complex(
     val firstName: String,
     val lastName: String,
@@ -202,15 +227,15 @@ open class Complex(
     let derived = "\
 class Simple : Complex
 ";
-    let idx = setup(&[("/Complex.kt", src), ("/Simple.kt", derived)]);
-    let u = uri("/Simple.kt");
-    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
-    assert!(action.is_some(), "expected action for complex params");
+    let indexer = setup(&[("/Complex.kt", source_code), ("/Simple.kt", derived)]);
+    let document_uri = uri("/Simple.kt");
+    let action = build_generate_constructor_action(&indexer, &document_uri, cursor_at(0, 8));
+    assert!(action.is_some(), "expected action for complex parameters");
     match action.unwrap() {
-        CodeActionOrCommand::CodeAction(ca) => {
-            let edit = ca.edit.unwrap();
+        CodeActionOrCommand::CodeAction(code_action) => {
+            let edit = code_action.edit.unwrap();
             let changes = edit.changes.unwrap();
-            let edits = changes.get(&u).unwrap();
+            let edits = changes.get(&document_uri).unwrap();
             assert!(edits[0].new_text.contains("val firstName: String"));
             assert!(edits[0].new_text.contains("val lastName: String"));
             assert!(edits[0].new_text.contains("val age: Int"));
@@ -224,15 +249,15 @@ class Simple : Complex
 
 #[test]
 fn no_action_for_non_kotlin_file() {
-    let src = "\
+    let source_code = "\
 class Foo : Bar
 ";
-    let idx = Indexer::new();
-    let u = Url::parse("file:///test/Test.java").unwrap();
-    idx.index_content(&u, src);
-    idx.set_live_lines(&u, src);
-    idx.store_live_tree(&u, src);
-    let action = build_generate_constructor_action(&idx, &u, cursor_at(0, 8));
+    let indexer = Indexer::new();
+    let document_uri = Url::parse("file:///test/Test.java").unwrap();
+    indexer.index_content(&document_uri, source_code);
+    indexer.set_live_lines(&document_uri, source_code);
+    indexer.store_live_tree(&document_uri, source_code);
+    let action = build_generate_constructor_action(&indexer, &document_uri, cursor_at(0, 8));
     assert!(action.is_none(), "no action for Java file");
 }
 
@@ -240,23 +265,23 @@ class Foo : Bar
 
 #[test]
 fn generates_constructor_for_same_file_supertype() {
-    let src = "\
+    let source_code = "\
 open class Base(val x: String)
 
 class Derived : Base
 ";
-    let idx = Indexer::new();
-    let u = uri("/Test.kt");
-    idx.index_content(&u, src);
-    idx.set_live_lines(&u, src);
-    idx.store_live_tree(&u, src);
-    let action = build_generate_constructor_action(&idx, &u, cursor_at(2, 8));
+    let indexer = Indexer::new();
+    let document_uri = uri("/Test.kt");
+    indexer.index_content(&document_uri, source_code);
+    indexer.set_live_lines(&document_uri, source_code);
+    indexer.store_live_tree(&document_uri, source_code);
+    let action = build_generate_constructor_action(&indexer, &document_uri, cursor_at(2, 8));
     assert!(action.is_some(), "expected action for same-file supertype");
     match action.unwrap() {
-        CodeActionOrCommand::CodeAction(ca) => {
-            let edit = ca.edit.unwrap();
+        CodeActionOrCommand::CodeAction(code_action) => {
+            let edit = code_action.edit.unwrap();
             let changes = edit.changes.unwrap();
-            let edits = changes.get(&u).unwrap();
+            let edits = changes.get(&document_uri).unwrap();
             assert!(edits[0].new_text.contains("val x: String"));
             assert_eq!(edits[1].new_text, "(x)");
         }
@@ -268,31 +293,31 @@ class Derived : Base
 
 #[test]
 fn generates_constructor_when_only_on_disk_not_in_index() {
-    let tmp = tempfile::tempdir().unwrap();
-    let file_path = tmp.path().join("Test.kt");
-    let src = "\
+    let temporary_directory = tempfile::tempdir().unwrap();
+    let file_path = temporary_directory.path().join("Test.kt");
+    let source_code = "\
 open class Base(val x: String)
 
 class Derived : Base
 ";
-    std::fs::write(&file_path, src).unwrap();
-    let u = Url::from_file_path(&file_path).unwrap();
+    std::fs::write(&file_path, source_code).unwrap();
+    let document_uri = Url::from_file_path(&file_path).unwrap();
 
-    let idx = Indexer::new();
+    let indexer = Indexer::new();
     // Only set up live tree — NO index_content, so definitions index is empty.
-    idx.set_live_lines(&u, src);
-    idx.store_live_tree(&u, src);
+    indexer.set_live_lines(&document_uri, source_code);
+    indexer.store_live_tree(&document_uri, source_code);
 
-    let action = build_generate_constructor_action(&idx, &u, cursor_at(2, 8));
+    let action = build_generate_constructor_action(&indexer, &document_uri, cursor_at(2, 8));
     assert!(
         action.is_some(),
         "expected action via resolver fallback (disk indexing)"
     );
     match action.unwrap() {
-        CodeActionOrCommand::CodeAction(ca) => {
-            let edit = ca.edit.unwrap();
+        CodeActionOrCommand::CodeAction(code_action) => {
+            let edit = code_action.edit.unwrap();
             let changes = edit.changes.unwrap();
-            let edits = changes.get(&u).unwrap();
+            let edits = changes.get(&document_uri).unwrap();
             assert!(
                 edits[0].new_text.contains("val x: String"),
                 "{}",
@@ -304,23 +329,23 @@ class Derived : Base
     }
 }
 
-// ─── split_params unit test ───────────────────────────────────────────────────
+// ─── split_parameters unit test ───────────────────────────────────────────────────
 
 #[test]
-fn split_params_simple() {
-    let result = super::split_params("val x: Int, val y: String");
+fn split_parameters_simple() {
+    let result = super::split_parameters("val x: Int, val y: String");
     assert_eq!(result, vec!["val x: Int", "val y: String"]);
 }
 
 #[test]
-fn split_params_with_generics() {
-    let result = super::split_params("val items: List<String>, val count: Int");
+fn split_parameters_with_generics() {
+    let result = super::split_parameters("val items: List<String>, val count: Int");
     assert_eq!(result, vec!["val items: List<String>", "val count: Int"]);
 }
 
 #[test]
-fn split_params_nested_generics() {
-    let result = super::split_params("val map: Map<String, List<Int>>, val name: String");
+fn split_parameters_nested_generics() {
+    let result = super::split_parameters("val map: Map<String, List<Int>>, val name: String");
     assert_eq!(
         result,
         vec!["val map: Map<String, List<Int>>", "val name: String"]
@@ -328,43 +353,49 @@ fn split_params_nested_generics() {
 }
 
 #[test]
-fn split_params_single() {
-    let result = super::split_params("val x: Int");
+fn split_parameters_single() {
+    let result = super::split_parameters("val x: Int");
     assert_eq!(result, vec!["val x: Int"]);
 }
 
 #[test]
-fn split_params_empty() {
-    let result = super::split_params("");
+fn split_parameters_empty() {
+    let result = super::split_parameters("");
     assert!(result.is_empty());
 }
 
-// ─── parse_param unit test ────────────────────────────────────────────────────
+// ─── parse_parameter unit test ────────────────────────────────────────────────────
 
 #[test]
-fn parse_param_val() {
+fn parse_parameter_val() {
     assert_eq!(
-        super::parse_param("val name: String"),
+        super::parse_parameter("val name: String"),
         Some(("name", "String"))
     );
 }
 
 #[test]
-fn parse_param_no_mod() {
-    assert_eq!(super::parse_param("name: String"), Some(("name", "String")));
+fn parse_parameter_no_modifiers() {
+    assert_eq!(
+        super::parse_parameter("name: String"),
+        Some(("name", "String"))
+    );
 }
 
 #[test]
-fn parse_param_var() {
-    assert_eq!(super::parse_param("var x: Int"), Some(("x", "Int")));
+fn parse_parameter_var() {
+    assert_eq!(super::parse_parameter("var x: Int"), Some(("x", "Int")));
 }
 
 #[test]
-fn parse_param_with_default() {
-    assert_eq!(super::parse_param("val x: Int = 42"), Some(("x", "Int")));
+fn parse_parameter_with_default() {
+    assert_eq!(
+        super::parse_parameter("val x: Int = 42"),
+        Some(("x", "Int"))
+    );
 }
 
 #[test]
-fn parse_param_no_colon() {
-    assert_eq!(super::parse_param("just_name"), None);
+fn parse_parameter_no_colon() {
+    assert_eq!(super::parse_parameter("just_name"), None);
 }

--- a/src/features/generate_constructor_tests.rs
+++ b/src/features/generate_constructor_tests.rs
@@ -1,5 +1,3 @@
-use std::sync::Arc;
-
 use tower_lsp::lsp_types::*;
 
 use crate::features::generate_constructor::build_generate_constructor_action;

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -19,6 +19,7 @@ pub(crate) mod completion;
 pub(crate) mod definition;
 pub(crate) mod fill_when;
 pub(crate) mod folding;
+pub(crate) mod generate_constructor;
 pub(crate) mod highlight;
 pub(crate) mod hover;
 pub(crate) mod implementation;


### PR DESCRIPTION
## Problem
The "Generate constructor" code action silently fails when the supertype class
is not in the in-memory definitions index.  This happens in common scenarios:
- **Same file** — base + derived in the file being edited, but the file hasn't
  been indexed yet (cold start, first open).
- **Cross-file unindexed** — the supertype exists in another file that the
  workspace index hasn't reached.
- **Stale index** — `definition_locations` returns empty for any reason.
In all these cases the code action silently returns `None` — nothing appears
in the editor's lightbulb menu.
## Solution
Replace the single-path lookup with a **two-phase fallback chain**
| Phase | Strategy | When |
|-------|----------|------|
| 1 | `definition_locations` + `file_data_for` | Index hit (fast path, same as before) |
| 2 | `resolve_symbol_inner` + `ensure_file_data` | Index miss (resolver chain + disk read) |
Phase 2 uses `resolve_symbol_inner` which walks the full resolution priority
list: local file → explicit imports → same-package → star-imports → `rg`
project-wide search.  Once a `Location` is obtained, `ensure_file_data` reads
and parses the file from disk — no need for it to be in the index.
## Impact
- **Same-file supertypes** now work without prior `index_content` — the
  resolver's step 0.5 on-demand indexes the file from disk.
- **Cross-file supertypes** are found via same-package scan or `rg` even
  when the containing file hasn't been indexed yet.
- **Zero overhead** on the happy path — the resolver is only called when
  the definitions index misses.
- **22/22 tests pass**, including a new integration test
  (`generates_constructor_when_only_on_disk_not_in_index`) that exercises
  the fallback with real temp files and no `index_content`.
## Screenshots
### Before
| Scenario | Screenshot |
|----------|------------|
| Same-file supertype (cold start) — no action in lightbulb menu | <img width="700" alt="Before: lightbulb menu without constructor action" src="https://github.com/user-attachments/assets/8115d7a2-b383-421a-a5c7-550907c9dcdc" /> |
### After
| Scenario | Screenshot |
|----------|------------|
| Same-file supertype (cold start) — constructor action now appears | <img width="700" alt="After: constructor action in lightbulb menu" src="https://github.com/user-attachments/assets/121c808e-3383-498f-94e6-138a0fe40269" /> |
## Changes
| File | What |
|------|------|
| `src/features/generate_constructor.rs` | Add `resolve_symbol_inner` + `ensure_file_data` fallback; extract `ctor_params_from_locs` helper |
| `src/features/generate_constructor_tests.rs` | Add `generates_constructor_when_only_on_disk_not_in_index` test |