### PR TITLE
feat: callable parameter dot-completion + persistent JAR hover docs

### DIFF
--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -15,10 +15,10 @@ use tower_lsp::lsp_types::{
 use crate::indexer::resolution::{enrich_at_line, IndexRead, ResolveOptions, SubstitutionContext};
 use crate::indexer::Indexer;
 use crate::indexer::{
-    find_it_element_type, find_named_lambda_param_type, is_id_char, is_lambda_param, last_ident_in,
+    find_it_element_type, find_named_lambda_param_type, is_lambda_param, last_ident_in,
 };
 use crate::resolver::complete::{
-    complete_symbol, complete_symbol_with_context, is_annotation_context,
+    complete_symbol, complete_symbol_with_context, is_annotation_context, ReceiverExpr,
 };
 use crate::types::CursorPos;
 
@@ -143,28 +143,37 @@ pub(crate) fn run_completions(
         return (vec![], false);
     }
 
-    let dot_recv = dot_receiver(before_prefix);
+    let dot_recv = ReceiverExpr::parse(before_prefix);
+    let no_dot_recv = dot_recv.is_none();
 
     if let Some(ref recv) = dot_recv {
-        if is_lambda_recv(recv, before, index, uri, position.line) {
+        if is_lambda_recv(recv.as_str(), before, index, uri, position.line) {
             return (
-                complete_lambda_dot(index, recv, before, position, uri, snippets, prefix),
+                complete_lambda_dot(
+                    index,
+                    recv.as_str(),
+                    before,
+                    position,
+                    uri,
+                    snippets,
+                    prefix,
+                ),
                 false,
             );
         }
     }
 
-    let annotation_only = dot_recv.is_none() && is_annotation_context(before, prefix);
+    let annotation_only = no_dot_recv && is_annotation_context(before, prefix);
     let (mut items, hit_cap) = complete_symbol_with_context(
         index,
         prefix,
-        dot_recv.as_deref(),
+        dot_recv,
         uri,
         snippets,
         annotation_only,
         Some(position.line),
     );
-    if dot_recv.is_none() {
+    if no_dot_recv {
         add_lambda_param_completions(index, &mut items, uri, position.line as usize, prefix);
         add_named_arg_completions(index, &mut items, uri, position, prefix);
     }
@@ -436,61 +445,6 @@ fn split_prefix(before: &str) -> (&str, &str) {
     let prefix = last_ident_in(before);
     let before_prefix = &before[..before.len() - prefix.len()];
     (prefix, before_prefix)
-}
-
-/// Returns the expression immediately before a trailing dot in `before_prefix`,
-/// or `None` if `before_prefix` does not end with a dot.
-///
-/// Extracts the full dot-separated chain of identifiers, e.g. `MaterialTheme.colorScheme.` → `"MaterialTheme.colorScheme"`.
-/// A trailing call expression is stripped so `productFlow(arg).` → `"productFlow"`.
-fn dot_receiver(before_prefix: &str) -> Option<String> {
-    let before_dot = before_prefix.strip_suffix('.')?;
-
-    // Strip a trailing call expression, e.g. "foo(arg, bar())" → "foo".
-    let before_call = if before_dot.trim_end().ends_with(')') {
-        let s = before_dot.trim_end();
-        let bytes = s.as_bytes();
-        let mut depth = 0usize;
-        let mut i = bytes.len();
-        let stripped = loop {
-            if i == 0 {
-                break s;
-            }
-            i -= 1;
-            match bytes[i] {
-                b')' => depth += 1,
-                b'(' => {
-                    depth -= 1;
-                    if depth == 0 {
-                        break s[..i].trim_end();
-                    }
-                }
-                _ => {}
-            }
-        };
-        stripped
-    } else {
-        before_dot
-    };
-
-    // Scan backwards to find the dotted chain of identifiers.
-    // Includes bytes >= 0x80 to support non-ASCII (Unicode) characters.
-    let bytes = before_call.as_bytes();
-    let mut start = before_call.len();
-    for i in (0..before_call.len()).rev() {
-        let c = bytes[i];
-        if c.is_ascii_alphanumeric() || c == b'_' || c == b'.' || c >= 0x80 {
-            start = i;
-        } else {
-            break;
-        }
-    }
-
-    let chain = before_call[start..].trim();
-    if chain.is_empty() || chain.starts_with('.') || chain.ends_with('.') {
-        return None;
-    }
-    Some(chain.to_owned())
 }
 
 #[cfg(test)]

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -15,7 +15,7 @@ use tower_lsp::lsp_types::{
 use crate::indexer::resolution::{enrich_at_line, IndexRead, ResolveOptions, SubstitutionContext};
 use crate::indexer::Indexer;
 use crate::indexer::{
-    find_it_element_type, find_named_lambda_param_type, is_lambda_param, last_ident_in,
+    find_it_element_type, find_named_lambda_param_type, is_id_char, is_lambda_param, last_ident_in,
 };
 use crate::resolver::complete::{
     complete_symbol, complete_symbol_with_context, is_annotation_context,
@@ -119,6 +119,12 @@ pub(crate) fn run_completions(
     snippets: bool,
 ) -> (Vec<CompletionItem>, bool) {
     let gen = index.workspace_root.generation();
+    // Capture epoch before any computation. If JAR indexing completes while we
+    // are computing, the epoch will advance and store_in_cache will refuse to
+    // persist the (now-potentially-stale) result.
+    let epoch = index
+        .completion_epoch
+        .load(std::sync::atomic::Ordering::Acquire);
 
     index.ensure_indexed(uri);
 
@@ -163,7 +169,7 @@ pub(crate) fn run_completions(
         add_named_arg_completions(index, &mut items, uri, position, prefix);
     }
 
-    store_in_cache(index, cache_key, prefix, &items);
+    store_in_cache(index, cache_key, prefix, &items, epoch);
     (items, hit_cap)
 }
 
@@ -191,9 +197,25 @@ fn cache_hit(index: &Indexer, key: &str) -> Option<Vec<CompletionItem>> {
 }
 
 /// Persist the latest completion result for subsequent identical requests.
-fn store_in_cache(index: &Indexer, key: String, prefix: &str, items: &[CompletionItem]) {
+///
+/// Only stores if `epoch` still matches the current `completion_epoch` — guards
+/// against an in-flight request storing stale results after JAR indexing
+/// incremented the epoch and cleared the cache.
+fn store_in_cache(
+    index: &Indexer,
+    key: String,
+    prefix: &str,
+    items: &[CompletionItem],
+    epoch: u64,
+) {
     if let Ok(mut guard) = index.last_completion.lock() {
-        *guard = Some((key, prefix.to_owned(), items.to_vec()));
+        if index
+            .completion_epoch
+            .load(std::sync::atomic::Ordering::Acquire)
+            == epoch
+        {
+            *guard = Some((key, prefix.to_owned(), items.to_vec()));
+        }
     }
 }
 
@@ -420,14 +442,42 @@ fn split_prefix(before: &str) -> (&str, &str) {
 /// or `None` if `before_prefix` does not end with a dot.
 ///
 /// Extracts the full dot-separated chain of identifiers, e.g. `MaterialTheme.colorScheme.` → `"MaterialTheme.colorScheme"`.
+/// A trailing call expression is stripped so `productFlow(arg).` → `"productFlow"`.
 fn dot_receiver(before_prefix: &str) -> Option<String> {
     let before_dot = before_prefix.strip_suffix('.')?;
 
+    // Strip a trailing call expression, e.g. "foo(arg, bar())" → "foo".
+    let before_call = if before_dot.trim_end().ends_with(')') {
+        let s = before_dot.trim_end();
+        let bytes = s.as_bytes();
+        let mut depth = 0usize;
+        let mut i = bytes.len();
+        let stripped = loop {
+            if i == 0 {
+                break s;
+            }
+            i -= 1;
+            match bytes[i] {
+                b')' => depth += 1,
+                b'(' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        break s[..i].trim_end();
+                    }
+                }
+                _ => {}
+            }
+        };
+        stripped
+    } else {
+        before_dot
+    };
+
     // Scan backwards to find the dotted chain of identifiers.
     // Includes bytes >= 0x80 to support non-ASCII (Unicode) characters.
-    let bytes = before_dot.as_bytes();
-    let mut start = before_dot.len();
-    for i in (0..before_dot.len()).rev() {
+    let bytes = before_call.as_bytes();
+    let mut start = before_call.len();
+    for i in (0..before_call.len()).rev() {
         let c = bytes[i];
         if c.is_ascii_alphanumeric() || c == b'_' || c == b'.' || c >= 0x80 {
             start = i;
@@ -436,7 +486,7 @@ fn dot_receiver(before_prefix: &str) -> Option<String> {
         }
     }
 
-    let chain = before_dot[start..].trim();
+    let chain = before_call[start..].trim();
     if chain.is_empty() || chain.starts_with('.') || chain.ends_with('.') {
         return None;
     }

--- a/src/features/completion_tests.rs
+++ b/src/features/completion_tests.rs
@@ -1,66 +1,57 @@
-use super::{dot_receiver, param_names_from_sig, split_prefix};
+use super::{param_names_from_sig, split_prefix};
+use crate::resolver::complete::ReceiverExpr;
+
+fn recv(chain: &str, is_call: bool) -> Option<ReceiverExpr> {
+    Some(ReceiverExpr {
+        chain: chain.to_string(),
+        is_call,
+    })
+}
 
 #[test]
 fn dot_receiver_nested_chains() {
-    // Test that nested chain dot receiver is captured completely (e.g., MaterialTheme.colorScheme.)
     assert_eq!(
-        dot_receiver("MaterialTheme.colorScheme."),
-        Some("MaterialTheme.colorScheme".to_string()),
+        ReceiverExpr::parse("MaterialTheme.colorScheme."),
+        recv("MaterialTheme.colorScheme", false),
         "Failed to capture a standard nested dot receiver chain"
     );
-
-    // Test capturing inside an assignment expression
     assert_eq!(
-        dot_receiver("val x = MaterialTheme.colorScheme."),
-        Some("MaterialTheme.colorScheme".to_string()),
+        ReceiverExpr::parse("val x = MaterialTheme.colorScheme."),
+        recv("MaterialTheme.colorScheme", false),
         "Failed to capture a nested chain inside an assignment"
     );
-
-    // Test that standard single receiver remains unaffected (e.g., myVar.)
     assert_eq!(
-        dot_receiver("myVar."),
-        Some("myVar".to_string()),
+        ReceiverExpr::parse("myVar."),
+        recv("myVar", false),
         "Failed to capture a simple single variable receiver"
     );
-
-    // Test nested class paths starting with uppercase letters
     assert_eq!(
-        dot_receiver("Outer.Inner."),
-        Some("Outer.Inner".to_string()),
+        ReceiverExpr::parse("Outer.Inner."),
+        recv("Outer.Inner", false),
         "Failed to capture nested class dot receivers"
     );
-
-    // Test that spaces bound the backward scan correctly
     assert_eq!(
-        dot_receiver("val y = myVar."),
-        Some("myVar".to_string()),
+        ReceiverExpr::parse("val y = myVar."),
+        recv("myVar", false),
         "Backward scan did not correctly stop at spaces"
     );
-
-    // Test that curly braces bound the backward scan correctly
     assert_eq!(
-        dot_receiver("{ myVar."),
-        Some("myVar".to_string()),
+        ReceiverExpr::parse("{ myVar."),
+        recv("myVar", false),
         "Backward scan did not correctly stop at curly braces"
     );
-
-    // Test that parentheses bound the backward scan correctly
     assert_eq!(
-        dot_receiver("(myVar."),
-        Some("myVar".to_string()),
+        ReceiverExpr::parse("(myVar."),
+        recv("myVar", false),
         "Backward scan did not correctly stop at parentheses"
     );
-
-    // Test fallback behavior when there is no trailing dot
     assert_eq!(
-        dot_receiver("no_dot_at_end"),
+        ReceiverExpr::parse("no_dot_at_end"),
         None,
         "Expected None when there is no trailing dot"
     );
-
-    // Test fallback behavior with duplicate trailing dots
     assert_eq!(
-        dot_receiver("trailing.dot.."),
+        ReceiverExpr::parse("trailing.dot.."),
         None,
         "Expected None for duplicate trailing dots"
     );
@@ -82,59 +73,57 @@ fn split_prefix_bare() {
 
 #[test]
 fn dot_receiver_simple() {
-    assert_eq!(dot_receiver("foo."), Some("foo".to_string()));
+    assert_eq!(ReceiverExpr::parse("foo."), recv("foo", false));
 }
 
 #[test]
 fn dot_receiver_qualified() {
     assert_eq!(
-        dot_receiver("Outer.Inner."),
-        Some("Outer.Inner".to_string())
+        ReceiverExpr::parse("Outer.Inner."),
+        recv("Outer.Inner", false)
     );
 }
 
 #[test]
 fn dot_receiver_chained_lowercase() {
-    // "foo.bar." → full chain "foo.bar" for cross-file resolution
     assert_eq!(
-        dot_receiver("refreshDashboardInteractor.triggers."),
-        Some("refreshDashboardInteractor.triggers".to_string())
+        ReceiverExpr::parse("refreshDashboardInteractor.triggers."),
+        recv("refreshDashboardInteractor.triggers", false)
     );
 }
 
 #[test]
 fn dot_receiver_three_segment_chain() {
-    assert_eq!(dot_receiver("a.b.c."), Some("a.b.c".to_string()));
+    assert_eq!(ReceiverExpr::parse("a.b.c."), recv("a.b.c", false));
 }
 
 #[test]
 fn dot_receiver_call_expression_no_args() {
-    // call args are stripped; resolver handles return-type lookup
     assert_eq!(
-        dot_receiver("productFlow()."),
-        Some("productFlow".to_string())
+        ReceiverExpr::parse("productFlow()."),
+        recv("productFlow", true)
     );
 }
 
 #[test]
 fn dot_receiver_call_expression_with_args() {
     assert_eq!(
-        dot_receiver("getFlow(arg1, arg2)."),
-        Some("getFlow".to_string())
+        ReceiverExpr::parse("getFlow(arg1, arg2)."),
+        recv("getFlow", true)
     );
 }
 
 #[test]
 fn dot_receiver_call_expression_nested_args() {
     assert_eq!(
-        dot_receiver("productFlow(trigger.isRefresh())."),
-        Some("productFlow".to_string())
+        ReceiverExpr::parse("productFlow(trigger.isRefresh())."),
+        recv("productFlow", true)
     );
 }
 
 #[test]
 fn dot_receiver_none() {
-    assert_eq!(dot_receiver("foo"), None);
+    assert_eq!(ReceiverExpr::parse("foo"), None);
 }
 
 // ── param_names_from_sig ──────────────────────────────────────────────────────

--- a/src/features/completion_tests.rs
+++ b/src/features/completion_tests.rs
@@ -94,6 +94,45 @@ fn dot_receiver_qualified() {
 }
 
 #[test]
+fn dot_receiver_chained_lowercase() {
+    // "foo.bar." → full chain "foo.bar" for cross-file resolution
+    assert_eq!(
+        dot_receiver("refreshDashboardInteractor.triggers."),
+        Some("refreshDashboardInteractor.triggers".to_string())
+    );
+}
+
+#[test]
+fn dot_receiver_three_segment_chain() {
+    assert_eq!(dot_receiver("a.b.c."), Some("a.b.c".to_string()));
+}
+
+#[test]
+fn dot_receiver_call_expression_no_args() {
+    // call args are stripped; resolver handles return-type lookup
+    assert_eq!(
+        dot_receiver("productFlow()."),
+        Some("productFlow".to_string())
+    );
+}
+
+#[test]
+fn dot_receiver_call_expression_with_args() {
+    assert_eq!(
+        dot_receiver("getFlow(arg1, arg2)."),
+        Some("getFlow".to_string())
+    );
+}
+
+#[test]
+fn dot_receiver_call_expression_nested_args() {
+    assert_eq!(
+        dot_receiver("productFlow(trigger.isRefresh())."),
+        Some("productFlow".to_string())
+    );
+}
+
+#[test]
 fn dot_receiver_none() {
     assert_eq!(dot_receiver("foo"), None);
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -531,13 +531,17 @@ impl Indexer {
         self.subtypes.clear();
         self.content_hashes.clear();
         self.completion_cache.clear();
-        // Retain JAR and library source extension entries — these survive workspace reindexes.
-        // Workspace source entries (not in library_uris, not JAR URIs) are dropped here and
-        // will be re-inserted by apply_workspace_result.  library_uris is cleared afterwards.
+        // Retain JAR extension entries only while still indexed (i.e. jar_files has their URI).
+        // This ensures that after clear_jar_index() on a root change, stale JAR extension
+        // completions from the old workspace are dropped here rather than persisting until
+        // the process restarts.
         self.extension_by_receiver.retain(|_receiver, entries| {
             entries.retain(|entry| {
-                entry.file_uri.starts_with("jar:file://")
-                    || self.library_uris.contains(&entry.file_uri)
+                if entry.file_uri.starts_with("jar:file://") {
+                    self.jar_files.contains_key(&entry.file_uri)
+                } else {
+                    self.library_uris.contains(&entry.file_uri)
+                }
             });
             !entries.is_empty()
         });

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -170,6 +170,12 @@ pub(crate) struct Indexer {
     /// When the key matches, the cached items are returned without recomputation —
     /// covers the common "typing more characters in the same word/after same dot" case.
     pub(crate) last_completion: std::sync::Mutex<Option<(String, String, Vec<CompletionItem>)>>,
+    /// Monotonically incremented whenever index state changes in a way that could
+    /// invalidate an in-flight completion result (JAR indexing completes, workspace
+    /// reindex). Completion requests capture this epoch before computing and refuse
+    /// to store if the epoch has advanced, preventing stale results from racing
+    /// past an invalidation.
+    pub(crate) completion_epoch: AtomicU64,
     /// Guard to prevent concurrent background indexing runs on same Indexer.
     pub(crate) indexing_in_progress: std::sync::atomic::AtomicBool,
     /// Set when a reindex request arrives while a scan is already running.
@@ -455,6 +461,7 @@ impl Indexer {
             bare_name_cache: std::sync::RwLock::new(Vec::new()),
             bare_names_dirty: AtomicBool::new(true),
             last_completion: std::sync::Mutex::new(None),
+            completion_epoch: AtomicU64::new(0),
             indexing_in_progress: std::sync::atomic::AtomicBool::new(false),
             pending_reindex: std::sync::atomic::AtomicBool::new(false),
             pending_reindex_root: RwLock::new(None),
@@ -507,9 +514,15 @@ impl Indexer {
     }
 
     /// Clear all index maps. Called before a full workspace re-index and on root switch.
-    /// Clears everything: files, definitions, qualified, packages, subtypes, content_hashes,
-    /// completion_cache, bare_name_cache. Does NOT touch orchestration fields
-    /// (workspace_root, parse_sem, generation counters, live_lines).
+    ///
+    /// Clears workspace-source data (files, definitions, packages, subtypes, …) and caches.
+    /// JAR entries and library source entries in `extension_by_receiver` are **retained** so
+    /// that extension completions (e.g. `viewModelScope.launch`) remain available during the
+    /// ~5 s it takes for `index_source_paths` to restore the library cache.  Workspace source
+    /// entries are removed and will be re-added by `apply_workspace_result`.
+    ///
+    /// Does NOT touch orchestration fields (workspace_root, parse_sem, generation counters,
+    /// live_lines).
     pub(crate) fn reset_index_state(&self) {
         self.files.clear();
         self.definitions.clear();
@@ -518,6 +531,16 @@ impl Indexer {
         self.subtypes.clear();
         self.content_hashes.clear();
         self.completion_cache.clear();
+        // Retain JAR and library source extension entries — these survive workspace reindexes.
+        // Workspace source entries (not in library_uris, not JAR URIs) are dropped here and
+        // will be re-inserted by apply_workspace_result.  library_uris is cleared afterwards.
+        self.extension_by_receiver.retain(|_receiver, entries| {
+            entries.retain(|entry| {
+                entry.file_uri.starts_with("jar:file://")
+                    || self.library_uris.contains(&entry.file_uri)
+            });
+            !entries.is_empty()
+        });
         self.library_uris.clear();
         if let Ok(mut cache) = self.bare_name_cache.write() {
             cache.clear();
@@ -528,28 +551,8 @@ impl Indexer {
         if let Ok(mut last) = self.last_completion.lock() {
             *last = None;
         }
+        self.completion_epoch.fetch_add(1, Ordering::Release);
         self.sig_cache.clear();
-        self.extension_by_receiver.clear();
-        // Rebuild extension entries from preserved JAR files (issue #4).
-        for entry in self.jar_files.iter() {
-            for sym in &entry.value().symbols {
-                if sym.extension_receiver.is_empty() {
-                    continue;
-                }
-                self.extension_by_receiver
-                    .entry(sym.extension_receiver.clone())
-                    .or_default()
-                    .push(crate::types::ExtensionEntry {
-                        file_uri: entry.key().clone(),
-                        name: sym.name.clone(),
-                        kind: sym.kind,
-                        detail: sym.detail.clone(),
-                        visibility: crate::types::Visibility::Public,
-                        package: None,
-                        trailing_lambda: sym.trailing_lambda,
-                    });
-            }
-        }
         // Clear enrichment dedup so symbols are re-attempted after reindex.
         if let Ok(handle) = self.enrichment.read() {
             handle.clear();

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -407,12 +407,12 @@ impl LibraryBatch {
         for (super_name, locs) in self.subtypes {
             indexer.subtypes.entry(super_name).or_default().extend(locs);
         }
-        for (receiver, entries) in self.extensions {
-            indexer
-                .extension_by_receiver
-                .entry(receiver)
-                .or_default()
-                .extend(entries);
+        for (receiver, new_entries) in self.extensions {
+            let new_uris: std::collections::HashSet<String> =
+                new_entries.iter().map(|e| e.file_uri.clone()).collect();
+            let mut slot = indexer.extension_by_receiver.entry(receiver).or_default();
+            slot.retain(|existing| !new_uris.contains(&existing.file_uri));
+            slot.extend(new_entries);
         }
         for uri_str in self.library_uris {
             indexer.library_uris.insert(uri_str);
@@ -858,11 +858,15 @@ impl Indexer {
             }
         }
 
-        for (receiver, entries) in contrib.extensions {
-            self.extension_by_receiver
-                .entry(receiver)
-                .or_default()
-                .extend(entries);
+        for (receiver, new_entries) in contrib.extensions {
+            // Replace-by-uri: remove stale entries for the same file URIs before inserting
+            // the fresh ones.  This prevents duplicate accumulation when library extension
+            // entries are retained across workspace reindexes (see `reset_index_state`).
+            let new_uris: std::collections::HashSet<String> =
+                new_entries.iter().map(|e| e.file_uri.clone()).collect();
+            let mut slot = self.extension_by_receiver.entry(receiver).or_default();
+            slot.retain(|existing| !new_uris.contains(&existing.file_uri));
+            slot.extend(new_entries);
         }
         // Definitions were modified — mark bare_name_cache as stale.
         self.bare_names_dirty.store(true, Ordering::Release);

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -163,6 +163,15 @@ pub(crate) fn index_jars(
         indexer
             .bare_names_dirty
             .store(true, std::sync::atomic::Ordering::Release);
+        // Invalidate cached completion results: JAR extensions are now available.
+        // Clear the entry and bump the epoch so any in-flight completion that
+        // started before JAR indexing cannot overwrite with stale empty results.
+        if let Ok(mut last) = indexer.last_completion.lock() {
+            *last = None;
+        }
+        indexer
+            .completion_epoch
+            .fetch_add(1, std::sync::atomic::Ordering::Release);
     }
 }
 

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -21,7 +21,8 @@ use crate::sidecar::SidecarSymbol;
 
 /// Bump when `JarCacheEntry` schema changes.
 /// v3 → v4: SidecarSymbol gained `trailing_lambda: bool` (bincode 1.x is positional, no serde(default)).
-const JAR_CACHE_VERSION: u32 = 4;
+/// v4 → v5: SidecarSymbol gained `doc: String` inserted before `type_params` — positional mismatch.
+const JAR_CACHE_VERSION: u32 = 5;
 
 #[derive(Serialize, Deserialize)]
 struct JarCache {

--- a/src/indexer/resolution_tests.rs
+++ b/src/indexer/resolution_tests.rs
@@ -687,3 +687,50 @@ fn enrich_at_line_exact_position_match_preferred() {
         "should prefer exact position match"
     );
 }
+
+// Regression: JAR symbols store their KDoc in `SymbolEntry.doc` because there
+// is no real source to run `extract_doc_comment` on.  `enrich_symbol` must fall
+// back to `sym.doc` when `extract_doc_comment` returns empty.
+//
+// The regression was introduced when `doc: String` was added to `SidecarSymbol`
+// but `JAR_CACHE_VERSION` was NOT bumped.  Bincode is positional, so all cached
+// v4 entries deserialized with wrong field offsets, yielding `doc: ""` for every
+// JAR symbol.  Fixed by bumping `JAR_CACHE_VERSION` to 5.
+#[test]
+fn enrich_uses_sym_doc_when_no_source_lines() {
+    let uri = "jar:file:///coroutines.jar!/CoroutineScope.kt";
+    let mut sym = make_sym("launch", SymbolKind::FUNCTION, 0, 0);
+    sym.detail =
+        "fun CoroutineScope.launch(block: suspend CoroutineScope.() -> Unit): Job".to_owned();
+    sym.doc = "Launches a new coroutine without blocking the current thread.".to_owned();
+
+    // JAR FileData has detail strings as lines, not real source — no KDoc above line 0.
+    let lines = vec![sym.detail.clone()];
+    let data = Arc::new(crate::types::FileData {
+        symbols: vec![sym],
+        lines: Arc::new(lines),
+        ..Default::default()
+    });
+    let mut files = HashMap::new();
+    files.insert(uri.to_owned(), data);
+    let idx = RealTestIndex {
+        files,
+        definitions: HashMap::new(),
+    };
+
+    let result = enrich_at_line(
+        &idx,
+        uri,
+        0,
+        0,
+        SubstitutionContext::None,
+        &ResolveOptions::hover(),
+    )
+    .expect("should resolve JAR symbol");
+
+    assert!(
+        result.doc.contains("Launches a new coroutine"),
+        "JAR sym.doc should appear in hover; got: {:?}",
+        result.doc
+    );
+}

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -128,18 +128,94 @@ const MIN_PREFIX_SCORE_REDUCTION: usize = 4;
 /// to score-0 (case-insensitive prefix match) to avoid camel-acronym noise.
 const MIN_CAMEL_ACRONYM_PREFIX: usize = 2;
 
+/// Parsed receiver expression from text immediately before a `.` trigger.
+///
+/// Carries both the identifier chain and whether the receiver was a function
+/// call, so resolution can be explicit rather than heuristic.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct ReceiverExpr {
+    /// Dotted identifier chain with call args stripped, e.g. `"productFlow"` or `"foo.bar"`.
+    pub(crate) chain: String,
+    /// `true` when the receiver was a call expression like `productFlow(...)`.
+    pub(crate) is_call: bool,
+}
+
+impl ReceiverExpr {
+    /// Parse the text before a `.` completion trigger.
+    ///
+    /// `"productFlow(trigger.isRefresh())."` → `Some(ReceiverExpr { chain: "productFlow", is_call: true })`
+    /// `"foo.bar."` → `Some(ReceiverExpr { chain: "foo.bar", is_call: false })`
+    pub(crate) fn parse(before_prefix: &str) -> Option<Self> {
+        let before_dot = before_prefix.strip_suffix('.')?;
+        let (before_call, is_call) = if before_dot.trim_end().ends_with(')') {
+            (Self::strip_call_args(before_dot.trim_end()), true)
+        } else {
+            (before_dot, false)
+        };
+        // Scan backwards for a dotted identifier chain.
+        // Includes bytes >= 0x80 to support non-ASCII identifiers.
+        let bytes = before_call.as_bytes();
+        let mut start = before_call.len();
+        for i in (0..before_call.len()).rev() {
+            let c = bytes[i];
+            if c.is_ascii_alphanumeric() || c == b'_' || c == b'.' || c >= 0x80 {
+                start = i;
+            } else {
+                break;
+            }
+        }
+        let chain = before_call[start..].trim();
+        if chain.is_empty() || chain.starts_with('.') || chain.ends_with('.') {
+            return None;
+        }
+        Some(Self {
+            chain: chain.to_owned(),
+            is_call,
+        })
+    }
+
+    /// Construct a plain variable / type-name receiver (not a call expression).
+    pub(crate) fn variable(name: &str) -> Self {
+        Self {
+            chain: name.to_owned(),
+            is_call: false,
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.chain
+    }
+
+    /// Strip a balanced trailing `(...)`, e.g. `"foo(arg, bar())"` → `"foo"`.
+    fn strip_call_args(s: &str) -> &str {
+        let bytes = s.as_bytes();
+        let mut depth = 0usize;
+        let mut i = bytes.len();
+        loop {
+            if i == 0 {
+                break;
+            }
+            i -= 1;
+            match bytes[i] {
+                b')' => depth += 1,
+                b'(' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return s[..i].trim_end();
+                    }
+                }
+                _ => {}
+            }
+        }
+        s
+    }
+}
+
 /// Provide completion candidates for `prefix` at the current position.
 ///
-/// Returns `(items, hit_cap)` — when `hit_cap` is true the caller should set
-/// `CompletionList.is_incomplete = true` so the client re-requests completions
-/// as the user types more characters.
-///
-/// Two modes:
 /// - **Dot-completion** (`dot_receiver = Some("obj")`): infer the receiver's type
 ///   and return all its members (symbols + line-scanned constructor params).
-/// - **Bare-word** (`dot_receiver = None`): return all symbols from the current
-///   file, same-package files, and the whole project index whose name starts with
-///   `prefix` (case-insensitive).
+/// - **Bare-word** (`dot_receiver = None`): return all symbols in scope.
 pub(crate) fn complete_symbol(
     indexer: &Indexer,
     prefix: &str,
@@ -151,7 +227,7 @@ pub(crate) fn complete_symbol(
     complete_symbol_with_context(
         indexer,
         prefix,
-        dot_receiver,
+        dot_receiver.map(ReceiverExpr::variable),
         from_uri,
         snippets,
         false,
@@ -164,15 +240,15 @@ pub(crate) fn complete_symbol(
 pub(crate) fn complete_symbol_with_context(
     indexer: &Indexer,
     prefix: &str,
-    dot_receiver: Option<&str>,
+    dot_receiver: Option<ReceiverExpr>,
     from_uri: &Url,
     snippets: bool,
     annotation_only: bool,
     cursor_line: Option<u32>,
 ) -> (Vec<CompletionItem>, bool) {
-    if let Some(receiver) = dot_receiver {
+    if let Some(expr) = dot_receiver {
         return (
-            complete_dot(indexer, receiver, from_uri, snippets, cursor_line),
+            complete_dot_expr(indexer, &expr, from_uri, snippets, cursor_line),
             false,
         );
     }
@@ -464,12 +540,27 @@ pub(crate) fn complete_dot(
     snippets: bool,
     cursor_line: Option<u32>,
 ) -> Vec<CompletionItem> {
-    if receiver == "super" {
+    complete_dot_expr(
+        indexer,
+        &ReceiverExpr::variable(receiver),
+        from_uri,
+        snippets,
+        cursor_line,
+    )
+}
+
+fn complete_dot_expr(
+    indexer: &Indexer,
+    expr: &ReceiverExpr,
+    from_uri: &Url,
+    snippets: bool,
+    cursor_line: Option<u32>,
+) -> Vec<CompletionItem> {
+    if expr.as_str() == "super" {
         return complete_super(indexer, from_uri, snippets);
     }
 
-    // Type inference must succeed to do anything useful.
-    let Some(receiver_type) = resolve_dot_receiver_type(indexer, receiver, from_uri, cursor_line)
+    let Some(receiver_type) = resolve_dot_receiver_type(indexer, expr, from_uri, cursor_line)
     else {
         return vec![];
     };
@@ -501,8 +592,6 @@ pub(crate) fn complete_dot(
     dedup_completion_labels(&mut items);
     strip_completion_snippets(&mut items, snippets);
     items.sort_by_key(|item| kind_sort_rank(item.kind));
-    // Stdlib scope/collection fns only apply when we confirmed a concrete receiver type.
-    // Extension functions from the reverse index are always safe (O(1) lookup).
     append_dot_tail_completions(
         indexer,
         &receiver_type,
@@ -521,11 +610,28 @@ struct DotCompletionContext {
 
 fn resolve_dot_receiver_type(
     indexer: &Indexer,
-    receiver: &str,
+    expr: &ReceiverExpr,
     from_uri: &Url,
     cursor_line: Option<u32>,
 ) -> Option<ReceiverType> {
-    // Try smart-cast narrowing when position is available
+    let receiver = expr.as_str();
+
+    if expr.is_call {
+        // Call expression: skip variable lookup, resolve by function return type.
+        if receiver.contains('.') {
+            if let Some(raw) = resolve_dotted_receiver_type(indexer, receiver, from_uri) {
+                return Some(ReceiverType::from_raw(raw));
+            }
+        }
+        if let Some(ret) = find_fun_return_type_by_name(indexer, receiver) {
+            return Some(ReceiverType::from_raw(ret));
+        }
+        let file = ensure_file_data(indexer, from_uri)?;
+        let ret = infer_callable_param_return_type(&file.lines, receiver)?;
+        return Some(ReceiverType::from_raw(ret));
+    }
+
+    // Non-call expression: smart-cast, chain, variable, type name.
     if let Some(line) = cursor_line {
         let pos = Position::new(line, 0);
         if let Some(rt) = infer_receiver_type_at(indexer, receiver, from_uri, pos) {
@@ -533,15 +639,12 @@ fn resolve_dot_receiver_type(
         }
     }
 
-    // Support nested dot receiver chains (like MaterialTheme.colorScheme)
     if receiver.contains('.') {
-        if let Some(raw_type) = resolve_dotted_receiver_type(indexer, receiver, from_uri) {
-            return Some(ReceiverType::from_raw(raw_type));
+        if let Some(raw) = resolve_dotted_receiver_type(indexer, receiver, from_uri) {
+            return Some(ReceiverType::from_raw(raw));
         }
     }
 
-    // Variable/parameter: also extract return type if the variable has a function type
-    // e.g. `productFlow: (Boolean) -> Flow<X>` inferred as `(Boolean) -> Flow<X>`
     if let Some(rt) = infer_receiver_type(indexer, ReceiverKind::Variable(receiver), from_uri) {
         if let Some(ret) = extract_fn_type_return(&rt.raw) {
             return Some(ReceiverType::from_raw(ret));
@@ -553,9 +656,7 @@ fn resolve_dot_receiver_type(
         return Some(ReceiverType::from_raw(receiver.to_string()));
     }
 
-    // Function call fallback: named fun definition, then callable parameter line-scan.
-    // Reached when the receiver was a bare call like `productFlow` (call args already
-    // stripped by dot_receiver before this point).
+    // Fallback: function defined in scope (e.g. bare `productFlow` written without `()`).
     if let Some(ret) = find_fun_return_type_by_name(indexer, receiver) {
         return Some(ReceiverType::from_raw(ret));
     }
@@ -591,7 +692,8 @@ fn resolve_dotted_receiver_type(indexer: &Indexer, path: &str, uri: &Url) -> Opt
 
         let clean_segment = segment.trim_end_matches("()").trim();
 
-        if let Some(next_type) = find_field_type_in_class(indexer, current_base_leaf, clean_segment) {
+        if let Some(next_type) = find_field_type_in_class(indexer, current_base_leaf, clean_segment)
+        {
             current_type = next_type;
         } else if let Some(next_type) =
             find_method_return_type(indexer, current_base_leaf, clean_segment)
@@ -622,6 +724,7 @@ fn extract_fn_type_return(fn_type: &str) -> Option<String> {
 ///
 /// Thin wrapper over `resolve_dotted_receiver_type` that skips contextual
 /// keywords and converts the result to `ReceiverType`.  Exported for tests.
+#[cfg(test)]
 pub(crate) fn resolve_chain_receiver(
     indexer: &Indexer,
     chain: &str,

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -12,9 +12,11 @@ use crate::LinesExt;
 use crate::StrExt;
 
 use super::infer::{
-    find_field_type_in_class, find_method_return_type, infer_receiver_type, infer_receiver_type_at,
-    infer_variable_type_raw, ReceiverKind, ReceiverType,
+    find_field_type_in_class, find_fun_return_type_by_name, find_method_return_type,
+    infer_receiver_type, infer_receiver_type_at, infer_variable_type_raw, ReceiverKind,
+    ReceiverType,
 };
+use super::infer_lines::infer_callable_param_return_type;
 use super::{
     already_imported, ensure_file_data, fqns_for_name, resolve_symbol_no_rg, walk_hierarchy,
 };
@@ -192,9 +194,12 @@ pub(crate) fn is_annotation_context(line: &str, prefix: &str) -> bool {
         .unwrap_or(false)
 }
 
-/// Completion for `super.` — gather all members from the parent hierarchy.
-/// Scan the index for extension functions whose `extension_receiver` matches `receiver_type`
-/// and return them as `CompletionItem`s with auto-import `additionalTextEdits` when needed.
+/// Scan the index for extension functions whose `extension_receiver` matches
+/// `receiver_type` or any of its supertypes, returning `CompletionItem`s with
+/// auto-import `additionalTextEdits` when needed.
+///
+/// Hierarchy traversal works for source-indexed types. JAR-to-JAR hierarchy is
+/// not currently supported because the sidecar does not populate `FileData.supers`.
 ///
 /// Only called for Kotlin files; Java files don't consume Kotlin extension functions.
 fn extension_fn_completions(
@@ -207,13 +212,38 @@ fn extension_fn_completions(
         return vec![];
     }
 
+    // Build ancestor set: receiver_type + all source-indexed supertypes.
+    let mut ancestor_set: std::collections::HashSet<String> =
+        std::collections::HashSet::from([receiver_type.to_owned()]);
+    if let Some(class_location) = resolve_symbol_no_rg(indexer, receiver_type, from_uri)
+        .into_iter()
+        .next()
+    {
+        let class_uri = class_location.uri.to_string();
+        let caller = CallerContext {
+            uri: Some(from_uri.as_str()),
+            cursor_line: None,
+        };
+        let supers = walk_hierarchy(
+            indexer,
+            receiver_type,
+            &class_uri,
+            caller,
+            8,
+            |_idx, super_name, _super_uri, _caller| vec![super_name.to_owned()],
+        );
+        ancestor_set.extend(supers);
+    }
+
     let context = ExtensionCompletionContext::build(indexer, from_uri);
     let mut builder = ExtensionCompletionBuilder::new(&context, receiver_type, snippets);
 
-    if let Some(entries) = indexer.extension_by_receiver.get(receiver_type) {
-        for entry in entries.iter() {
-            if crate::Language::from_path(&entry.file_uri) == crate::Language::Kotlin {
-                builder.add_entry(entry);
+    for ancestor in &ancestor_set {
+        if let Some(entries) = indexer.extension_by_receiver.get(ancestor) {
+            for entry in entries.iter() {
+                if crate::Language::from_path(&entry.file_uri) == crate::Language::Kotlin {
+                    builder.add_entry(entry);
+                }
             }
         }
     }
@@ -510,11 +540,28 @@ fn resolve_dot_receiver_type(
         }
     }
 
-    infer_receiver_type(indexer, ReceiverKind::Variable(receiver), from_uri).or_else(|| {
-        receiver
-            .starts_with_uppercase()
-            .then(|| ReceiverType::from_raw(receiver.to_string()))
-    })
+    // Variable/parameter: also extract return type if the variable has a function type
+    // e.g. `productFlow: (Boolean) -> Flow<X>` inferred as `(Boolean) -> Flow<X>`
+    if let Some(rt) = infer_receiver_type(indexer, ReceiverKind::Variable(receiver), from_uri) {
+        if let Some(ret) = extract_fn_type_return(&rt.raw) {
+            return Some(ReceiverType::from_raw(ret));
+        }
+        return Some(rt);
+    }
+
+    if receiver.starts_with_uppercase() {
+        return Some(ReceiverType::from_raw(receiver.to_string()));
+    }
+
+    // Function call fallback: named fun definition, then callable parameter line-scan.
+    // Reached when the receiver was a bare call like `productFlow` (call args already
+    // stripped by dot_receiver before this point).
+    if let Some(ret) = find_fun_return_type_by_name(indexer, receiver) {
+        return Some(ReceiverType::from_raw(ret));
+    }
+    let file = ensure_file_data(indexer, from_uri)?;
+    let ret = infer_callable_param_return_type(&file.lines, receiver)?;
+    Some(ReceiverType::from_raw(ret))
 }
 
 /// Iteratively resolve the type of a dot-separated receiver chain.
@@ -556,6 +603,36 @@ fn resolve_dotted_receiver_type(indexer: &Indexer, path: &str, uri: &Url) -> Opt
     }
 
     Some(current_type)
+}
+
+/// Extract the return type from a Kotlin function-type string.
+///
+/// `"(isRefresh: Boolean) -> Flow<ResultState<T>>"` → `"Flow<ResultState<T>>"`
+/// `"() -> Unit"` → `"Unit"`
+fn extract_fn_type_return(fn_type: &str) -> Option<String> {
+    let arrow = fn_type.find(" -> ")?;
+    let ret = fn_type[arrow + 4..].trim();
+    if ret.is_empty() {
+        return None;
+    }
+    Some(ret.to_owned())
+}
+
+/// Resolve a dotted receiver chain to a `ReceiverType`.
+///
+/// Thin wrapper over `resolve_dotted_receiver_type` that skips contextual
+/// keywords and converts the result to `ReceiverType`.  Exported for tests.
+pub(crate) fn resolve_chain_receiver(
+    indexer: &Indexer,
+    chain: &str,
+    from_uri: &Url,
+) -> Option<ReceiverType> {
+    const UNCHAINABLE: &[&str] = &["this", "super", "it", "self"];
+    let head = chain.split('.').next()?;
+    if UNCHAINABLE.contains(&head) {
+        return None;
+    }
+    resolve_dotted_receiver_type(indexer, chain, from_uri).map(ReceiverType::from_raw)
 }
 
 fn resolve_dot_receiver_file(
@@ -1549,3 +1626,7 @@ impl crate::indexer::Indexer {
         symbols_from_uri_as_completions_pub(self, file_uri)
     }
 }
+
+#[cfg(test)]
+#[path = "complete_tests.rs"]
+mod tests;

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -711,8 +711,9 @@ fn resolve_dotted_receiver_type(indexer: &Indexer, path: &str, uri: &Url) -> Opt
 ///
 /// `"(isRefresh: Boolean) -> Flow<ResultState<T>>"` → `"Flow<ResultState<T>>"`
 /// `"() -> Unit"` → `"Unit"`
+/// `"((Foo) -> Bar) -> Baz"` → `"Baz"` (depth-aware; not `"Bar) -> Baz"`)
 fn extract_fn_type_return(fn_type: &str) -> Option<String> {
-    let arrow = fn_type.find(" -> ")?;
+    let arrow = super::infer_lines::find_outer_arrow(fn_type)?;
     let ret = fn_type[arrow + 4..].trim();
     if ret.is_empty() {
         return None;

--- a/src/resolver/complete_tests.rs
+++ b/src/resolver/complete_tests.rs
@@ -1,0 +1,159 @@
+use tower_lsp::lsp_types::Url;
+
+use crate::indexer::Indexer;
+use crate::resolver::infer::find_fun_return_type_by_name;
+
+use super::resolve_chain_receiver;
+
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file:///test{path}")).unwrap()
+}
+
+/// `foo.bar.` where `foo: Foo` and `Foo.bar: Flow<Cause>` (type-annotated member).
+#[test]
+fn chain_one_hop_annotated_member() {
+    let host_uri = uri("/Host.kt");
+    let foo_uri = uri("/Foo.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &foo_uri,
+        "package com.pkg\nclass Foo {\n    val bar: Flow<Cause> = TODO()\n}\n",
+    );
+    idx.index_content(
+        &host_uri,
+        "package com.pkg\nfun go(foo: Foo) { foo.bar. }\n",
+    );
+
+    let rt = resolve_chain_receiver(&idx, "foo.bar", &host_uri);
+    assert!(rt.is_some(), "chain foo.bar should resolve; got None");
+    let rt = rt.unwrap();
+    assert_eq!(
+        rt.outer, "Flow",
+        "outer type should be 'Flow'; got '{}'",
+        rt.outer
+    );
+}
+
+/// `foo.bar.` where `bar` has no type annotation but is inferred via RHS.
+///
+/// `val bar = other.triggersFlow` — unannotated property; `infer_variable_type_raw`
+/// must be used (not `infer_field_type_raw`) to follow the RHS chain.
+#[test]
+fn chain_one_hop_unannotated_member_via_rhs() {
+    let host_uri = uri("/Host.kt");
+    let foo_uri = uri("/Foo.kt");
+    let helper_uri = uri("/Helper.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &helper_uri,
+        "package com.pkg\nclass Helper {\n    val triggersFlow: Flow<Event> = TODO()\n}\n",
+    );
+    idx.index_content(
+        &foo_uri,
+        "package com.pkg\nclass Foo(val helper: Helper) {\n    val bar = helper.triggersFlow\n}\n",
+    );
+    idx.index_content(
+        &host_uri,
+        "package com.pkg\nfun go(foo: Foo) { foo.bar. }\n",
+    );
+
+    let rt = resolve_chain_receiver(&idx, "foo.bar", &host_uri);
+    assert!(
+        rt.is_some(),
+        "chain foo.bar should resolve via RHS; got None"
+    );
+    let rt = rt.unwrap();
+    assert_eq!(
+        rt.outer, "Flow",
+        "outer type should be 'Flow'; got '{}'",
+        rt.outer
+    );
+}
+
+/// Contextual keywords (`this`, `super`, `it`) must not be chain-resolved —
+/// they would attempt variable lookup under that literal name and silently fail
+/// or give wrong results.
+#[test]
+fn chain_this_prefix_returns_none() {
+    let host_uri = uri("/Host.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &host_uri,
+        "package com.pkg\nclass Foo {\n    val bar: Int = 0\n}\n",
+    );
+    // "this.bar" should not go through chain resolver
+    let rt = resolve_chain_receiver(&idx, "this.bar", &host_uri);
+    assert!(
+        rt.is_none(),
+        "this.bar should NOT be resolved by chain resolver"
+    );
+}
+
+/// `productFlow(): Flow<Event>` — `find_fun_return_type_by_name` must find
+/// the return type so that `productFlow().col` resolves correctly.
+#[test]
+fn fun_return_type_lookup_for_call_receiver() {
+    let host_uri = uri("/Host.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &host_uri,
+        "package com.pkg\nfun productFlow(): Flow<Event> { TODO() }\n",
+    );
+
+    let rt = find_fun_return_type_by_name(&idx, "productFlow");
+    assert_eq!(
+        rt.as_deref(),
+        Some("Flow<Event>"),
+        "return type must be 'Flow<Event>'"
+    );
+}
+
+/// `productFlow: (isRefresh: Boolean) -> Flow<ResultState<T>>` passed as a lambda parameter.
+/// Calling `productFlow(trigger.isRefresh()).` must resolve to `Flow<ResultState<T>>`.
+#[test]
+fn call_receiver_callable_parameter() {
+    let host_uri = uri("/Host.kt");
+    let idx = Indexer::new();
+    idx.index_content(
+        &host_uri,
+        concat!(
+            "package com.pkg\n",
+            "fun <T : Any> reloadable(\n",
+            "    key: String,\n",
+            "    productFlow: (isRefresh: Boolean) -> Flow<ResultState<T>>,\n",
+            ") {\n",
+            "    productFlow(true)\n",
+            "}\n"
+        ),
+    );
+
+    // find_fun_return_type_by_name must NOT find "productFlow" (it's a param, not a def).
+    use crate::resolver::infer::find_fun_return_type_by_name;
+    assert!(
+        find_fun_return_type_by_name(&idx, "productFlow").is_none(),
+        "productFlow is a parameter, not a function definition"
+    );
+
+    // The line scanner must resolve the callable param return type directly.
+    use crate::resolver::infer_lines::infer_callable_param_return_type;
+    let file = idx
+        .files
+        .get(host_uri.as_str())
+        .expect("file must be indexed");
+    let ret = infer_callable_param_return_type(&file.lines, "productFlow");
+    assert_eq!(
+        ret.as_deref(),
+        Some("Flow<ResultState<T>>"),
+        "infer_callable_param_return_type must return the full return type for the lambda parameter"
+    );
+
+    // End-to-end: `resolve_dot_receiver_type` with the stripped name `"productFlow"`
+    // (dot_receiver strips call args before passing to the resolver) must resolve to
+    // the lambda's return type via the callable-param line-scan fallback.
+    let rt = super::resolve_dot_receiver_type(&idx, "productFlow", &host_uri, None);
+    assert_eq!(
+        rt.as_ref().map(|r| r.outer.as_str()),
+        Some("Flow"),
+        "resolve_dot_receiver_type('productFlow()') must resolve to 'Flow'"
+    );
+}

--- a/src/resolver/complete_tests.rs
+++ b/src/resolver/complete_tests.rs
@@ -150,7 +150,15 @@ fn call_receiver_callable_parameter() {
     // End-to-end: `resolve_dot_receiver_type` with the stripped name `"productFlow"`
     // (dot_receiver strips call args before passing to the resolver) must resolve to
     // the lambda's return type via the callable-param line-scan fallback.
-    let rt = super::resolve_dot_receiver_type(&idx, "productFlow", &host_uri, None);
+    let rt = super::resolve_dot_receiver_type(
+        &idx,
+        &super::ReceiverExpr {
+            chain: "productFlow".to_string(),
+            is_call: true,
+        },
+        &host_uri,
+        None,
+    );
     assert_eq!(
         rt.as_ref().map(|r| r.outer.as_str()),
         Some("Flow"),

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -441,7 +441,9 @@ fn find_extension_property_type(indexer: &Indexer, prop_name: &str, uri: &Url) -
     use super::walk_hierarchy;
     use crate::types::{CallerContext, Visibility};
 
-    let file = indexer.files.get(uri.as_str())?;
+    // Use ensure_file_data so the function works even when the file has not been
+    // indexed yet (e.g. first open before the workspace scan completes).
+    let file = ensure_file_data(indexer, uri)?;
 
     // Collect class names declared in this file as starting points.
     let class_names: Vec<(String, String)> = file
@@ -498,7 +500,8 @@ fn find_extension_property_type(indexer: &Indexer, prop_name: &str, uri: &Url) -
             ) {
                 continue;
             }
-            if let Some(type_name) = extract_property_type_from_detail(&entry.detail) {
+            let type_name = extract_property_type_from_detail(&entry.detail);
+            if let Some(type_name) = type_name {
                 return Some(type_name);
             }
         }

--- a/src/resolver/infer_lines.rs
+++ b/src/resolver/infer_lines.rs
@@ -364,10 +364,16 @@ pub(super) fn has_dot_after_first_call(rhs: &str, paren_pos: usize) -> bool {
 /// Finds the first `:` after the property name (skipping any receiver `Receiver.`)
 /// then uses [`extract_type_with_generics`] to grab the type token.
 pub(crate) fn extract_property_type_from_detail(detail: &str) -> Option<String> {
-    // Strip `val `/ `var ` prefix.
-    let after_kw = detail
+    // Strip optional visibility modifier then `val `/ `var ` prefix.
+    let after_vis = detail
+        .strip_prefix("public ")
+        .or_else(|| detail.strip_prefix("internal "))
+        .or_else(|| detail.strip_prefix("protected "))
+        .or_else(|| detail.strip_prefix("private "))
+        .unwrap_or(detail);
+    let after_kw = after_vis
         .strip_prefix("val ")
-        .or_else(|| detail.strip_prefix("var "))?;
+        .or_else(|| after_vis.strip_prefix("var "))?;
     // Find the first `:` not inside angle-brackets — that separates name from type.
     let mut depth: i32 = 0;
     let colon_pos = after_kw.char_indices().find_map(|(i, c)| match c {
@@ -795,4 +801,47 @@ fn extract_if_is_type(trimmed: &str, var_name: &str) -> Option<String> {
         return None;
     }
     Some(type_str.to_string())
+}
+
+// ─── Callable parameter return type ──────────────────────────────────────────
+
+/// Scan lines for `name: (...) -> ReturnType` and return `ReturnType`.
+///
+/// Handles callable parameters like:
+/// `productFlow: (isRefresh: Boolean) -> Flow<ResultState<T>>`
+/// → returns `"Flow<ResultState<T>>"`
+pub(crate) fn infer_callable_param_return_type(lines: &[String], name: &str) -> Option<String> {
+    let pattern = format!("{name}:");
+    for line in lines {
+        if !line.contains(&pattern) {
+            continue;
+        }
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("//") || trimmed.starts_with('*') || trimmed.starts_with("/*") {
+            continue;
+        }
+        let pos = line.find(&pattern)?;
+        let before_char = line[..pos].chars().last();
+        if before_char
+            .map(|c| c.is_alphanumeric() || c == '_')
+            .unwrap_or(false)
+        {
+            continue;
+        }
+        let after_colon = line[pos + name.len() + 1..].trim_start();
+        // Must look like a function type: starts with `(`
+        if !after_colon.starts_with('(') {
+            continue;
+        }
+        // Find ` -> ` in the rest of the type string
+        if let Some(arrow) = after_colon.find(" -> ") {
+            let ret = after_colon[arrow + 4..].trim();
+            let ret = ret.trim_end_matches(',').trim_end_matches(')').trim();
+            let type_name = extract_type_with_generics(ret);
+            if !type_name.is_empty() && type_name.starts_with_uppercase() {
+                return Some(type_name);
+            }
+        }
+    }
+    None
 }

--- a/src/resolver/infer_lines.rs
+++ b/src/resolver/infer_lines.rs
@@ -833,8 +833,9 @@ pub(crate) fn infer_callable_param_return_type(lines: &[String], name: &str) -> 
         if !after_colon.starts_with('(') {
             continue;
         }
-        // Find ` -> ` in the rest of the type string
-        if let Some(arrow) = after_colon.find(" -> ") {
+        // Find ` -> ` at paren depth 0 to handle nested function types like
+        // `((Foo) -> Bar) -> Baz` correctly (outer arrow, not the inner one).
+        if let Some(arrow) = find_outer_arrow(after_colon) {
             let ret = after_colon[arrow + 4..].trim();
             let ret = ret.trim_end_matches(',').trim_end_matches(')').trim();
             let type_name = extract_type_with_generics(ret);
@@ -842,6 +843,26 @@ pub(crate) fn infer_callable_param_return_type(lines: &[String], name: &str) -> 
                 return Some(type_name);
             }
         }
+    }
+    None
+}
+
+/// Find the byte offset of ` -> ` at parenthesis depth zero.
+///
+/// Handles nested function types such as `((Foo) -> Bar) -> Baz`, where a
+/// naive `str::find(" -> ")` would return the inner arrow instead of the outer.
+pub(crate) fn find_outer_arrow(s: &str) -> Option<usize> {
+    let mut depth: i32 = 0;
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'(' => depth += 1,
+            b')' => depth -= 1,
+            b' ' if depth == 0 && s[i..].starts_with(" -> ") => return Some(i),
+            _ => {}
+        }
+        i += 1;
     }
     None
 }

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -240,7 +240,6 @@ fn property_type_extension_with_receiver() {
 // Regression: library source detail strings include a visibility keyword before `val`/`var`.
 // `extract_property_type_from_detail` must strip it, otherwise dot-completion on
 // extension properties like `viewModelScope` returns nothing.
-// See: https://github.com/Hessesian/kotlin-lsp/issues/
 #[test]
 fn property_type_with_public_visibility_prefix() {
     assert_eq!(

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -237,6 +237,34 @@ fn property_type_extension_with_receiver() {
     );
 }
 
+// Regression: library source detail strings include a visibility keyword before `val`/`var`.
+// `extract_property_type_from_detail` must strip it, otherwise dot-completion on
+// extension properties like `viewModelScope` returns nothing.
+// See: https://github.com/Hessesian/kotlin-lsp/issues/
+#[test]
+fn property_type_with_public_visibility_prefix() {
+    assert_eq!(
+        extract_property_type_from_detail("public val ViewModel.viewModelScope: CoroutineScope"),
+        Some("CoroutineScope".into()),
+    );
+}
+
+#[test]
+fn property_type_with_internal_visibility_prefix() {
+    assert_eq!(
+        extract_property_type_from_detail("internal var MyClass.count: Int"),
+        Some("Int".into()),
+    );
+}
+
+#[test]
+fn property_type_with_protected_visibility_prefix() {
+    assert_eq!(
+        extract_property_type_from_detail("protected val Base.tag: String"),
+        Some("String".into()),
+    );
+}
+
 #[test]
 fn property_type_simple() {
     assert_eq!(

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -2551,7 +2551,75 @@ fn complete_dot_viewmodelscope_shows_launch() {
     );
 }
 
-// ── trailing lambda completion integration test ───────────────────────────────
+// ── JAR-path extension completion test ───────────────────────────────────────
+
+#[test]
+fn jar_extension_appears_in_dot_completion() {
+    // Verify that extension functions inserted via the JAR path (build_jar_file_data)
+    // appear in dot-completion.  This mirrors the real flow where the sidecar indexes
+    // kotlinx-coroutines and the `launch` function is stored with a `jar:file://` URI.
+    let idx = Indexer::new();
+
+    // Source-index ViewModel so walk_hierarchy can find it.
+    idx.index_content(
+        &Url::parse("file:///sdk/ViewModel.kt").unwrap(),
+        "package androidx.lifecycle\nopen class ViewModel",
+    );
+
+    // Simulate JAR-indexed extensions (what build_jar_file_data does):
+    // 1. val ViewModel.viewModelScope: CoroutineScope
+    idx.extension_by_receiver
+        .entry("ViewModel".to_owned())
+        .or_default()
+        .push(crate::types::ExtensionEntry {
+            file_uri: "jar:file:///lifecycle-ktx.jar/ViewModel.class".to_owned(),
+            name: "viewModelScope".to_owned(),
+            kind: tower_lsp::lsp_types::SymbolKind::PROPERTY,
+            detail: "val ViewModel.viewModelScope: CoroutineScope".to_owned(),
+            visibility: crate::types::Visibility::Public,
+            package: Some("androidx.lifecycle".to_owned()),
+            trailing_lambda: false,
+        });
+
+    // 2. fun CoroutineScope.launch(block: suspend CoroutineScope.() -> Unit): Job
+    idx.extension_by_receiver
+        .entry("CoroutineScope".to_owned())
+        .or_default()
+        .push(crate::types::ExtensionEntry {
+            file_uri: "jar:file:///coroutines-core.jar/Builders.class".to_owned(),
+            name: "launch".to_owned(),
+            kind: tower_lsp::lsp_types::SymbolKind::FUNCTION,
+            detail: "fun CoroutineScope.launch(block: suspend CoroutineScope.() -> Unit): Job"
+                .to_owned(),
+            visibility: crate::types::Visibility::Public,
+            package: Some("kotlinx.coroutines".to_owned()),
+            trailing_lambda: true,
+        });
+
+    let vm_uri = Url::parse("file:///app/MyViewModel.kt").unwrap();
+    idx.index_content(
+        &vm_uri,
+        concat!(
+            "package app\n",
+            "import androidx.lifecycle.ViewModel\n",
+            "class MyViewModel : ViewModel() {\n",
+            "    fun load() { viewModelScope.launch {} }\n",
+            "}\n",
+        ),
+    );
+
+    let items = complete_dot(&idx, "viewModelScope", &vm_uri, true, None);
+    let labels: Vec<&str> = items.iter().map(|i| i.label.as_str()).collect();
+
+    assert!(
+        labels.contains(&"launch"),
+        "expected regular `launch` item from JAR path, got: {labels:?}"
+    );
+    assert!(
+        labels.contains(&"launch { }"),
+        "expected trailing-lambda `launch {{ }}` item from JAR path, got: {labels:?}"
+    );
+}
 
 #[test]
 fn trailing_lambda_completion_offered() {

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -144,6 +144,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             reset_before_scan: true,
             expected_generation: 0,
         });
+        self.spawn_jar_indexing();
     }
 
     /// Apply a [`Config`] to the indexer and transition the phase state.


### PR DESCRIPTION
## Changes

### Callable parameter dot-completion
Resolves dot-completion when the receiver is a callable parameter like:
```kotlin
private fun reloadableProduct(
    productFlow: (isRefresh: Boolean) -> Flow<ResultState<T>>,
) {
    productFlow(true).collect { ... }  // ← now gets Flow members
}
```

- Add `infer_callable_param_return_type` in `infer_lines.rs`: scans for `name: (...) -> ReturnType` patterns (the generic type scanner silently fails when the value begins with `(`)
- Wire into `resolve_call_receiver_type` as final fallback after named-fun def and variable inference
- New `complete_tests.rs` with end-to-end test: `productFlow()` → `Flow`

### Persistent JAR hover docs
KDoc from Gradle-cached JARs now survives workspace root switches:

- Add `doc: String` field to `SidecarSymbol`; stored in `SymbolEntry` by `build_jar_file_data` so docs survive the index round-trip
- Bump `JAR_CACHE_VERSION` 4→5 for the new field shape
- Call `spawn_jar_indexing()` in `switch_workspace_root_for_opened_document` — without this, docs populated by the background sidecar disappeared when the editor auto-switched workspace root (same process reuse; no process restart occurs for in-editor root switches)
- Fix extension-symbol deduplication in `apply.rs`