### PR TITLE
feat: JarPhase enum — explicit JAR indexing state (#143)

### DIFF
--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -438,7 +438,10 @@ async fn run_find(root: &Path, mode: Mode, json: bool, verbose: bool, name: &str
             let jars = crate::indexer::jar::scan_gradle_jars(None);
             if !jars.is_empty() {
                 if let Ok(mut sidecar_guard) = index.jar_sidecar.lock() {
-                    crate::indexer::jar::index_jars(&index, &jars, &mut sidecar_guard);
+                    let total = crate::indexer::jar::index_jars(&index, &jars, &mut sidecar_guard);
+                    if let Ok(mut phase) = index.jar_phase.lock() {
+                        *phase = crate::indexer::jar_phase::JarPhase::Ready { count: total };
+                    }
                 }
             }
             smart_find(&index, name, root)

--- a/src/features/hover.rs
+++ b/src/features/hover.rs
@@ -30,12 +30,12 @@ pub(crate) fn compute_hover<W: WorkspaceRead>(
         return Some(hover);
     }
     if ctx.qualifier.is_none() && ctx.lambda_decl.is_some() {
-        return None;
+        return jar_loading_hint(workspace);
     }
     if let Some(hover) = contextual_receiver_hover(workspace, ctx, uri, position) {
         return Some(hover);
     }
-    regular_symbol_hover(workspace, ctx, uri, position)
+    regular_symbol_hover(workspace, ctx, uri, position).or_else(|| jar_loading_hint(workspace))
 }
 
 fn contextual_lambda_hover<W: WorkspaceRead>(
@@ -210,5 +210,18 @@ fn make_markdown_hover(markdown: String) -> Hover {
             value: markdown,
         }),
         range: None,
+    }
+}
+
+/// Return a brief "JAR index loading" hover hint when the phase is `Pending`
+/// or `InProgress`.  Returns `None` for `Unavailable`, `Ready`, and `Failed`
+/// (in those cases the caller should stay silent rather than showing noise).
+fn jar_loading_hint<W: WorkspaceRead>(workspace: &W) -> Option<Hover> {
+    if workspace.jar_phase().is_loading() {
+        Some(make_markdown_hover(
+            "_JAR symbols are still indexing — try again in a moment._".to_owned(),
+        ))
+    } else {
+        None
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -70,6 +70,7 @@ pub(crate) use self::workspace_root::WorkspaceRoot;
 mod apply;
 pub(crate) mod jar;
 pub(crate) mod jar_cache;
+pub(crate) mod jar_phase;
 #[cfg(test)]
 pub(crate) use self::apply::build_bare_names;
 #[cfg(test)]
@@ -239,6 +240,10 @@ pub(crate) struct Indexer {
     /// Handle for submitting unresolved symbols to background rg enrichment.
     /// Noop in CLI mode and tests; set via `set_enrichment_handle`.
     pub(crate) enrichment: std::sync::RwLock<EnrichmentHandle>,
+    /// Observable phase of the JAR symbol indexing pipeline.
+    /// Readable by features (hover, completion) without touching workspace actor state.
+    /// Transitions: `Pending` → `InProgress` → `Ready`/`Failed`.
+    pub(crate) jar_phase: Arc<std::sync::Mutex<crate::indexer::jar_phase::JarPhase>>,
     /// Long-lived sidecar process for JAR/AAR symbol indexing.
     /// `None` when `kotlin-jar-indexer` binary/jar is not present, or after a crash.
     pub(crate) jar_sidecar: std::sync::Mutex<Option<crate::sidecar::SidecarHandle>>,
@@ -433,6 +438,19 @@ impl Indexer {
     }
 
     pub(crate) fn new() -> Self {
+        use crate::indexer::jar_phase::JarPhase;
+
+        #[cfg(not(test))]
+        let jar_sidecar = crate::sidecar::SidecarHandle::try_launch();
+        #[cfg(test)]
+        let jar_sidecar: Option<crate::sidecar::SidecarHandle> = None;
+
+        let initial_jar_phase = if jar_sidecar.is_some() {
+            JarPhase::Pending
+        } else {
+            JarPhase::Unavailable
+        };
+
         Self {
             files: DashMap::new(),
             definitions: DashMap::new(),
@@ -479,16 +497,8 @@ impl Indexer {
             live_trees: DashMap::new(),
             sig_cache: DashMap::new(),
             enrichment: std::sync::RwLock::new(EnrichmentHandle::noop()),
-            jar_sidecar: std::sync::Mutex::new({
-                #[cfg(not(test))]
-                {
-                    crate::sidecar::SidecarHandle::try_launch()
-                }
-                #[cfg(test)]
-                {
-                    None
-                }
-            }),
+            jar_sidecar: std::sync::Mutex::new(jar_sidecar),
+            jar_phase: Arc::new(std::sync::Mutex::new(initial_jar_phase)),
             jar_files: DashMap::new(),
             jar_definitions: DashMap::new(),
             jar_uri_to_defs: DashMap::new(),
@@ -636,7 +646,11 @@ impl Indexer {
 
     /// Clear JAR-sourced symbol maps (called on workspace root change).
     /// Also removes JAR URIs from `library_uris` so `is_library_uri` stays consistent.
+    /// Resets `jar_phase` to `Pending` if the sidecar is available, so the next
+    /// `spawn_jar_indexing` call will re-index the new workspace's JARs.
     pub(crate) fn clear_jar_index(&self) {
+        use crate::indexer::jar_phase::JarPhase;
+
         // Remove stale JAR URIs from the library set before clearing the maps.
         for entry in self.jar_files.iter() {
             self.library_uris.remove(entry.key());
@@ -645,6 +659,21 @@ impl Indexer {
         self.jar_definitions.clear();
         self.bare_names_dirty.store(true, Ordering::Release);
         self.jar_uri_to_defs.clear();
+
+        // Reset phase: if sidecar is alive, mark as Pending so the next call
+        // to spawn_jar_indexing will re-index for the new workspace root.
+        if let Ok(mut phase) = self.jar_phase.lock() {
+            let sidecar_alive = self
+                .jar_sidecar
+                .try_lock()
+                .map(|g| g.is_some())
+                .unwrap_or(true); // locked = running = alive
+            *phase = if sidecar_alive {
+                JarPhase::Pending
+            } else {
+                JarPhase::Unavailable
+            };
+        }
     }
 
     /// Look up all definition locations for `name`, merging workspace and JAR results.

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -97,10 +97,15 @@ pub(crate) fn index_jars(
     indexer: &crate::indexer::Indexer,
     paths: &[PathBuf],
     sidecar: &mut Option<SidecarHandle>,
-) {
+) -> usize {
     if paths.is_empty() {
-        return;
+        return 0;
     }
+
+    // Clear stale JAR symbols before re-indexing to prevent duplicates.
+    indexer.jar_files.clear();
+    indexer.jar_definitions.clear();
+    indexer.jar_uri_to_defs.clear();
 
     let mut jar_cache = super::jar_cache::load_jar_cache();
     let mut total = 0usize;
@@ -173,6 +178,7 @@ pub(crate) fn index_jars(
             .completion_epoch
             .fetch_add(1, std::sync::atomic::Ordering::Release);
     }
+    total
 }
 
 /// Insert symbols for one JAR into the indexer.  Returns the symbol count.

--- a/src/indexer/jar_phase.rs
+++ b/src/indexer/jar_phase.rs
@@ -1,0 +1,35 @@
+//! Observable state of the JAR symbol indexing pipeline.
+//!
+//! This is *separate* from the concurrency guard (`jar_indexing_in_progress:
+//! AtomicBool`) which prevents duplicate spawns.  `JarPhase` is what callers
+//! (hover, completion, diagnostics) read to decide how to behave when JAR
+//! symbols are absent.
+
+/// Observable phase of the JAR symbol indexing pipeline.
+///
+/// Stored as `Arc<Mutex<JarPhase>>` on `Indexer` so `ScanHandler` can
+/// transition it from inside a `spawn_blocking` task.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) enum JarPhase {
+    /// The `kotlin-jar-indexer` sidecar binary/JAR was not found at process
+    /// startup.  JAR symbols will never be available in this session.
+    Unavailable,
+    /// Sidecar is present; indexing has not been triggered yet.
+    Pending,
+    /// A `spawn_blocking` task is currently running.
+    InProgress,
+    /// Indexing completed.  `count` is the total number of symbols loaded;
+    /// may be zero when no Gradle JARs were discovered (distinguishes "done
+    /// but empty" from `Pending`).
+    Ready { count: usize },
+    /// The sidecar died mid-index.  Partial symbols may still be available
+    /// in `jar_definitions`/`jar_files`.
+    Failed(String),
+}
+
+impl JarPhase {
+    /// True while JAR symbols are being loaded and may become available soon.
+    pub(crate) fn is_loading(&self) -> bool {
+        matches!(self, JarPhase::Pending | JarPhase::InProgress)
+    }
+}

--- a/src/indexer/resolution.rs
+++ b/src/indexer/resolution.rs
@@ -90,6 +90,12 @@ pub(crate) trait IndexRead {
     fn get_definitions(&self, name: &str) -> Option<Vec<Location>>;
     fn get_file_data(&self, uri: &str) -> Option<Arc<FileData>>;
 
+    /// Current phase of JAR symbol indexing.
+    /// Returns `Unavailable` by default (e.g. test stubs with no sidecar).
+    fn jar_phase(&self) -> crate::indexer::jar_phase::JarPhase {
+        crate::indexer::jar_phase::JarPhase::Unavailable
+    }
+
     /// Resolve definition locations for `name` with qualifier and import context.
     /// Default implementation uses the global definitions map (no import awareness).
     /// Production `Indexer` overrides this with the full resolver.
@@ -719,6 +725,13 @@ impl IndexRead for super::Indexer {
             self.ensure_indexed(&parsed_uri);
         }
     }
+
+    fn jar_phase(&self) -> crate::indexer::jar_phase::JarPhase {
+        self.jar_phase
+            .lock()
+            .map(|g| g.clone())
+            .unwrap_or(crate::indexer::jar_phase::JarPhase::Unavailable)
+    }
 }
 
 impl IndexRead for Arc<super::Indexer> {
@@ -752,6 +765,10 @@ impl IndexRead for Arc<super::Indexer> {
 
     fn ensure_indexed_on_demand(&self, uri: &str) {
         <super::Indexer as IndexRead>::ensure_indexed_on_demand(self.as_ref(), uri);
+    }
+
+    fn jar_phase(&self) -> crate::indexer::jar_phase::JarPhase {
+        <super::Indexer as IndexRead>::jar_phase(self.as_ref())
     }
 }
 

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -335,7 +335,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 .jar_sidecar
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
-            crate::indexer::jar::index_jars(&indexer, &paths, &mut sidecar);
+            let total = crate::indexer::jar::index_jars(&indexer, &paths, &mut sidecar);
 
             // Check generation again before recording terminal phase.
             let current_gen = indexer
@@ -349,14 +349,11 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
 
             let final_phase = if sidecar.is_none() {
                 // Sidecar died during indexing.
-                let count = indexer.jar_definitions.len();
                 JarPhase::Failed(format!(
-                    "sidecar died mid-index; {count} symbols partially loaded"
+                    "sidecar died mid-index; {total} symbols partially loaded"
                 ))
             } else {
-                JarPhase::Ready {
-                    count: indexer.jar_definitions.len(),
-                }
+                JarPhase::Ready { count: total }
             };
             if let Ok(mut phase) = indexer.jar_phase.lock() {
                 *phase = final_phase;

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -278,6 +278,8 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
     /// so it never blocks LSP startup.  Coalesces: if a scan is already running,
     /// this call is a no-op (the running scan will have picked up the current state).
     fn spawn_jar_indexing(&self) {
+        use crate::indexer::jar_phase::JarPhase;
+
         // Cheap non-blocking check: skip if sidecar is unavailable.
         match self.indexer.jar_sidecar.try_lock() {
             Ok(guard) if guard.is_none() => return,
@@ -295,11 +297,36 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
         {
             return;
         }
+
+        // Transition to InProgress before spawning.
+        if let Ok(mut phase) = self.indexer.jar_phase.lock() {
+            *phase = JarPhase::InProgress;
+        }
+
         let indexer = Arc::clone(&self.indexer);
         let in_progress = Arc::clone(&self.jar_indexing_in_progress);
+        // Capture current workspace generation so stale tasks don't overwrite state.
+        let expected_gen = indexer
+            .workspace_root
+            .generation_atomic()
+            .load(Ordering::Acquire);
         tokio::task::spawn_blocking(move || {
             let paths = crate::indexer::jar::scan_gradle_jars(None);
+
+            // Check generation before doing any indexing work.
+            let current_gen = indexer
+                .workspace_root
+                .generation_atomic()
+                .load(Ordering::Acquire);
+            if current_gen != expected_gen {
+                in_progress.store(false, Ordering::Release);
+                return;
+            }
+
             if paths.is_empty() {
+                if let Ok(mut phase) = indexer.jar_phase.lock() {
+                    *phase = JarPhase::Ready { count: 0 };
+                }
                 in_progress.store(false, Ordering::Release);
                 return;
             }
@@ -309,6 +336,31 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 .lock()
                 .unwrap_or_else(|e| e.into_inner());
             crate::indexer::jar::index_jars(&indexer, &paths, &mut sidecar);
+
+            // Check generation again before recording terminal phase.
+            let current_gen = indexer
+                .workspace_root
+                .generation_atomic()
+                .load(Ordering::Acquire);
+            if current_gen != expected_gen {
+                in_progress.store(false, Ordering::Release);
+                return;
+            }
+
+            let final_phase = if sidecar.is_none() {
+                // Sidecar died during indexing.
+                let count = indexer.jar_definitions.len();
+                JarPhase::Failed(format!(
+                    "sidecar died mid-index; {count} symbols partially loaded"
+                ))
+            } else {
+                JarPhase::Ready {
+                    count: indexer.jar_definitions.len(),
+                }
+            };
+            if let Ok(mut phase) = indexer.jar_phase.lock() {
+                *phase = final_phase;
+            }
             in_progress.store(false, Ordering::Release);
         });
     }

--- a/src/workspace/scan_handler_tests.rs
+++ b/src/workspace/scan_handler_tests.rs
@@ -57,3 +57,40 @@ async fn handle_initialize_updates_root_and_source_paths() {
         .unwrap()
         .contains(&"/some/lib".to_string()));
 }
+
+#[test]
+fn indexer_new_jar_phase_is_unavailable_in_tests() {
+    // In #[cfg(test)], jar_sidecar is always None, so phase starts as Unavailable.
+    let indexer = Indexer::new();
+    let phase = indexer.jar_phase.lock().unwrap().clone();
+    assert_eq!(
+        phase,
+        crate::indexer::jar_phase::JarPhase::Unavailable,
+        "test Indexer must start as Unavailable (no sidecar in tests)"
+    );
+}
+
+#[test]
+fn clear_jar_index_resets_phase_to_unavailable_when_no_sidecar() {
+    // In tests, jar_sidecar is None, so clear_jar_index should keep Unavailable.
+    let indexer = Indexer::new();
+    // Manually set to Ready to check reset behaviour.
+    *indexer.jar_phase.lock().unwrap() = crate::indexer::jar_phase::JarPhase::Ready { count: 42 };
+    indexer.clear_jar_index();
+    let phase = indexer.jar_phase.lock().unwrap().clone();
+    assert_eq!(
+        phase,
+        crate::indexer::jar_phase::JarPhase::Unavailable,
+        "clear_jar_index should reset to Unavailable when sidecar is None"
+    );
+}
+
+#[test]
+fn jar_phase_is_loading_helpers() {
+    use crate::indexer::jar_phase::JarPhase;
+    assert!(JarPhase::Pending.is_loading());
+    assert!(JarPhase::InProgress.is_loading());
+    assert!(!JarPhase::Unavailable.is_loading());
+    assert!(!JarPhase::Ready { count: 0 }.is_loading());
+    assert!(!JarPhase::Failed("oops".to_owned()).is_loading());
+}


### PR DESCRIPTION
## Summary

Closes #143.

Introduces a `JarPhase` enum on `Indexer` to replace ad-hoc boolean flags and make JAR symbol indexing state explicit and observable by all features.

## Changes

### `src/indexer/jar_phase.rs` (new)
Defines the `JarPhase` state machine:
- `Unavailable` — no JAR sidecar configured
- `Pending` — sidecar present, indexing not yet started
- `InProgress` — indexing in flight
- `Ready { count }` — indexing complete, `count` symbols loaded
- `Failed(String)` — sidecar error

Plus `is_loading()` helper for features that only need to distinguish "still loading" from "done".

### `src/indexer.rs`
- Adds `jar_phase: Arc<Mutex<JarPhase>>` field to `Indexer`
- Derives initial phase from sidecar presence at construction time
- `clear_jar_index` resets phase to `Pending`/`Unavailable` based on sidecar liveness

### `src/workspace/scan_handler.rs`
- `spawn_jar_indexing` transitions through `InProgress → Ready{count}` / `Failed`
- Generation check before writing terminal phase prevents stale tasks overwriting state after workspace root change

### `src/indexer/resolution.rs`
- `IndexRead::jar_phase()` method with default `Unavailable` — test stubs get safe default for free

### `src/features/hover.rs`
- `compute_hover` falls back to `jar_loading_hint` when result is `None` and phase `is_loading()`
- No noise when JAR index is `Unavailable`, `Ready`, or `Failed`

### Tests
4 new tests in `scan_handler_tests.rs` covering:
- `Unavailable` in `#[cfg(test)]` mode (no sidecar)
- `clear_jar_index` resets phase correctly
- `is_loading()` returns true for `Pending`/`InProgress`, false otherwise
