### PR TITLE
refactor(completion): centralise cursor analysis into CompletionContext (#142)

### DIFF
--- a/src/backend/handlers.rs
+++ b/src/backend/handlers.rs
@@ -31,13 +31,13 @@ impl Backend {
         // is async (actor-queued), so the index may not have it yet.
         self.indexer.ensure_indexed(uri);
 
-        let Some((name, qualifier)) = self.indexer.word_and_qualifier_at(uri, position) else {
+        let Some(ctx) = CursorContext::build(&self.indexer, uri, position) else {
             return Ok(None);
         };
 
         let locations = crate::features::references::find_references_with_qualifier(
-            &name,
-            qualifier.as_deref(),
+            &ctx.word,
+            ctx.qualifier.as_deref(),
             uri,
             position.line,
             params.context.include_declaration,

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -28,10 +28,10 @@ impl Backend {
         let uri = &pp.text_document.uri;
         let position = pp.position;
 
-        let Some((word, _qualifier)) = self.indexer.word_and_qualifier_at(uri, position) else {
+        let Some(ctx) = CursorContext::build(&self.indexer, uri, position) else {
             return Ok(None);
         };
 
-        Ok(imp::find_implementation(&word, &*self.indexer, uri, position.line).await)
+        Ok(imp::find_implementation(&ctx.word, &*self.indexer, uri, position.line).await)
     }
 }

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -18,14 +18,14 @@ use crate::indexer::{
     find_it_element_type, find_named_lambda_param_type, is_lambda_param, last_ident_in,
 };
 use crate::resolver::complete::{
-    complete_symbol, complete_symbol_with_context, is_annotation_context, ReceiverExpr,
+    complete_symbol, complete_symbol_with_context, is_annotation_context,
 };
 use crate::types::CursorPos;
 
 use crate::features::traits::{LiveTreeAccess, SignatureIndex};
 use crate::indexer::split_params_at_depth_zero;
 
-use super::completion_context::ScopeContext;
+use super::completion_context::{CompletionContext, ScopeContext};
 use super::traits::CompletionIndex;
 
 // Re-export so callers only need to import from one place.
@@ -142,31 +142,27 @@ pub(crate) fn run_completions(
         return (vec![], false);
     }
 
-    let scope = index
-        .lines_for(uri)
-        .map(|lines| {
-            ScopeContext::build(
-                lines.as_ref(),
-                position.line,
-                position.character,
-                index,
-                uri,
-            )
-        })
-        .unwrap_or_else(|| ScopeContext::build(&[], position.line, position.character, index, uri));
-    let dot_recv = ReceiverExpr::parse(before_prefix);
-    let no_dot_recv = dot_recv.is_none();
+    let annotation_only = is_annotation_context(before, prefix);
+    let lines = index.lines_for(uri).unwrap_or_default();
+    let ctx = CompletionContext::analyse(
+        before_prefix,
+        position,
+        index,
+        uri,
+        lines.as_ref(),
+        annotation_only,
+    );
 
-    if let Some(ref recv) = dot_recv {
+    if let Some(ref recv) = ctx.receiver {
         let recv_str = recv.as_str();
-        if scope.is_scope_receiver(recv_str)
+        if ctx.scope.is_scope_receiver(recv_str)
             || is_lambda_param(recv_str, before, index, uri, position.line as usize)
         {
             return (
                 complete_lambda_dot(
                     index,
                     recv_str,
-                    &scope,
+                    &ctx.scope,
                     CompletionSite {
                         before,
                         position,
@@ -180,18 +176,17 @@ pub(crate) fn run_completions(
         }
     }
 
-    let annotation_only = no_dot_recv && is_annotation_context(before, prefix);
     let (mut items, hit_cap) = complete_symbol_with_context(
         index,
         prefix,
-        dot_recv,
+        ctx.receiver.clone(),
         uri,
         snippets,
-        annotation_only,
+        ctx.annotation_only,
         Some(position.line),
     );
-    if no_dot_recv {
-        add_lambda_param_completions(&mut items, &scope, prefix);
+    if ctx.receiver.is_none() {
+        add_lambda_param_completions(&mut items, &ctx.scope, prefix);
         add_named_arg_completions(index, &mut items, uri, position, prefix);
     }
 

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -25,14 +25,13 @@ use crate::types::CursorPos;
 use crate::features::traits::{LiveTreeAccess, SignatureIndex};
 use crate::indexer::split_params_at_depth_zero;
 
-use super::text_utils::utf16_column;
+use super::completion_context::ScopeContext;
 use super::traits::CompletionIndex;
 
 // Re-export so callers only need to import from one place.
 pub(crate) use crate::resolver::complete::{DATA_CALLING_URI, DATA_COL, DATA_LINE, DATA_URI};
 
 const IT: &str = "it";
-const THIS: &str = "this";
 
 /// Compute completions at `position` in `uri`.
 ///
@@ -143,18 +142,36 @@ pub(crate) fn run_completions(
         return (vec![], false);
     }
 
+    let scope = index
+        .lines_for(uri)
+        .map(|lines| {
+            ScopeContext::build(
+                lines.as_ref(),
+                position.line,
+                position.character,
+                index,
+                uri,
+            )
+        })
+        .unwrap_or_else(|| ScopeContext::build(&[], position.line, position.character, index, uri));
     let dot_recv = ReceiverExpr::parse(before_prefix);
     let no_dot_recv = dot_recv.is_none();
 
     if let Some(ref recv) = dot_recv {
-        if is_lambda_recv(recv.as_str(), before, index, uri, position.line) {
+        let recv_str = recv.as_str();
+        if scope.is_scope_receiver(recv_str)
+            || is_lambda_param(recv_str, before, index, uri, position.line as usize)
+        {
             return (
                 complete_lambda_dot(
                     index,
-                    recv.as_str(),
-                    before,
-                    position,
-                    uri,
+                    recv_str,
+                    &scope,
+                    CompletionSite {
+                        before,
+                        position,
+                        uri,
+                    },
                     snippets,
                     prefix,
                 ),
@@ -174,7 +191,7 @@ pub(crate) fn run_completions(
         Some(position.line),
     );
     if no_dot_recv {
-        add_lambda_param_completions(index, &mut items, uri, position.line as usize, prefix);
+        add_lambda_param_completions(&mut items, &scope, prefix);
         add_named_arg_completions(index, &mut items, uri, position, prefix);
     }
 
@@ -228,29 +245,36 @@ fn store_in_cache(
     }
 }
 
-/// True when `recv` is an `it`/`this` default name or an explicitly declared
-/// lambda parameter at the cursor position.
-fn is_lambda_recv(recv: &str, before: &str, index: &Indexer, uri: &Url, line: u32) -> bool {
-    recv == IT || recv == THIS || is_lambda_param(recv, before, index, uri, line as usize)
+struct CompletionSite<'a> {
+    before: &'a str,
+    position: Position,
+    uri: &'a Url,
 }
 
-/// Run dot-completion for a lambda receiver (`it.`, `this.`, or named param).
+/// Run dot-completion for a lambda receiver (`it.`, `this.`, `this@label.`, or named param).
 ///
 /// Returns a type-hint placeholder item when the type is known but no members
 /// matched yet (gives the user a visible signal of what type was inferred).
 fn complete_lambda_dot(
     index: &Indexer,
     recv: &str,
-    before: &str,
-    position: Position,
-    uri: &Url,
+    scope: &ScopeContext,
+    site: CompletionSite<'_>,
     snippets: bool,
     prefix: &str,
 ) -> Vec<CompletionItem> {
-    let cursor_line = position.line as usize;
-    let cursor_col = utf16_column(before) as usize;
-    let Some(elem_type) =
-        resolve_lambda_recv_type(index, recv, before, cursor_line, cursor_col, uri)
+    let Some(elem_type) = scope
+        .resolve_receiver(recv)
+        .or_else(|| scope.named_param_type(recv))
+        .map(str::to_owned)
+        .or_else(|| {
+            resolve_named_lambda_param_type(index, recv, site.before, site.position, site.uri)
+        })
+        .or_else(|| {
+            (recv == IT)
+                .then(|| find_it_element_type(site.before, index, site.uri))
+                .flatten()
+        })
     else {
         return vec![];
     };
@@ -258,9 +282,9 @@ fn complete_lambda_dot(
         index,
         prefix,
         Some(&elem_type),
-        uri,
+        site.uri,
         snippets,
-        Some(position.line),
+        Some(site.position.line),
     );
     if items.is_empty() {
         vec![type_hint_item(recv, &elem_type)]
@@ -296,59 +320,47 @@ fn line_for_position(index: &Indexer, uri: &Url, line_idx: u32) -> Option<String
         .cloned()
 }
 
-/// Resolves the element type for an `it`/`this`/named-param dot-receiver.
-fn resolve_lambda_recv_type(
+fn resolve_named_lambda_param_type(
     index: &Indexer,
     recv: &str,
     before: &str,
-    cursor_line: usize,
-    cursor_col: usize,
+    position: Position,
     uri: &Url,
 ) -> Option<String> {
-    if recv != IT && recv != THIS {
-        return find_named_lambda_param_type(
-            before,
-            recv,
-            index,
-            uri,
-            CursorPos {
-                line: cursor_line,
-                utf16_col: cursor_col,
-            },
-        );
-    }
-    // Unified inference path (same as hover/inlay-hints) — handles multi-line
-    // scan, enclosing_class_at for this, and call-arg type fallback.
-    let position = Position::new(cursor_line as u32, cursor_col as u32);
-    if let Some(type_name) = index.infer_lambda_param_type_at(recv, uri, position) {
-        return Some(type_name);
-    }
-    // Single-line fallback: when mem_lines is unavailable (e.g. file not yet
-    // opened), use the raw before-cursor text to find the lambda receiver.
-    if recv == IT {
-        return find_it_element_type(before, index, uri);
-    }
-    None
+    find_named_lambda_param_type(
+        before,
+        recv,
+        index,
+        uri,
+        CursorPos {
+            line: position.line as usize,
+            utf16_col: position.character as usize,
+        },
+    )
 }
 
 /// Appends lambda-parameter completions for bare-word (non-dot) completion.
 fn add_lambda_param_completions(
-    index: &Indexer,
     items: &mut Vec<CompletionItem>,
-    uri: &Url,
-    line_idx: usize,
+    scope: &ScopeContext,
     prefix: &str,
 ) {
     use crate::features::text_utils::starts_with_ignore_ascii_case;
+
     let prefix_lower = prefix.to_lowercase();
-    for param in index.lambda_params_at(uri, line_idx) {
-        if starts_with_ignore_ascii_case(&param, &prefix_lower)
-            && !items.iter().any(|i| i.label == param)
+    for (param_name, _) in scope
+        .lambda_scopes
+        .iter()
+        .rev()
+        .flat_map(|lambda_scope| lambda_scope.named_params.iter())
+    {
+        if starts_with_ignore_ascii_case(param_name, &prefix_lower)
+            && !items.iter().any(|item| item.label == *param_name)
         {
             items.push(CompletionItem {
-                label: param.clone(),
+                label: param_name.clone(),
                 kind: Some(CompletionItemKind::VARIABLE),
-                sort_text: Some(format!("005:{param}")),
+                sort_text: Some(format!("005:{param_name}")),
                 ..Default::default()
             });
         }

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -187,7 +187,14 @@ pub(crate) fn run_completions(
     );
     if ctx.receiver.is_none() {
         add_lambda_param_completions(&mut items, &ctx.scope, prefix);
-        add_named_arg_completions(index, &mut items, uri, position, prefix);
+        add_named_arg_completions(
+            index,
+            &mut items,
+            uri,
+            position,
+            prefix,
+            ctx.call_info.as_ref(),
+        );
     }
 
     store_in_cache(index, cache_key, prefix, &items, epoch);
@@ -364,27 +371,29 @@ fn add_lambda_param_completions(
 
 // ─── named argument completions ───────────────────────────────────────────────
 
-/// Append `name =` completion items for each parameter of the function at the
-/// Uses `call_info_at` (which parses on-demand from live lines when no CST
-/// is available) so multiline calls and qualified calls (e.g. `Foo.bar(`) are
-/// handled correctly.  Returns early when call-site info or signature lookup
-/// fails (e.g. cursor is not inside a call expression, or the callee cannot
-/// be resolved to a known signature).
+/// Append `name =` completion items for the active call expression.
+///
+/// Prefers `CompletionContext::call_info` when available, and falls back to
+/// `call_info_at` so callers without a precomputed context keep the old
+/// behavior for multiline and qualified calls.
 fn add_named_arg_completions(
     index: &Indexer,
     items: &mut Vec<CompletionItem>,
     uri: &Url,
     position: Position,
     prefix: &str,
+    call_info: Option<&crate::features::completion_context::CallInfo>,
 ) {
-    let Some(ci) = index.call_info_at(position, uri) else {
+    let params_text = call_info
+        .and_then(|info| index.find_fun_signature_with_receiver(uri, &info.callee, None))
+        .or_else(|| {
+            let ci = index.call_info_at(position, uri)?;
+            index.find_fun_signature_with_receiver(uri, &ci.fn_name, ci.qualifier.as_deref())
+        });
+    let Some(params_text) = params_text else {
         return;
     };
-    let Some(params_text) =
-        index.find_fun_signature_with_receiver(uri, &ci.fn_name, ci.qualifier.as_deref())
-    else {
-        return;
-    };
+    let expected_name = call_info.and_then(|info| info.expected_name.as_deref());
     let raw = params_text.trim_matches(|c| c == '(' || c == ')');
     let prefix_lower = prefix.to_lowercase();
     for name in param_names_from_sig(raw) {
@@ -395,12 +404,17 @@ fn add_named_arg_completions(
         if items.iter().any(|i| i.label == format!("{name} =")) {
             continue;
         }
+        let sort_prefix = if expected_name == Some(name.as_str()) {
+            "000"
+        } else {
+            "001"
+        };
         items.push(CompletionItem {
             label: format!("{name} ="),
             filter_text: Some(name.clone()),
             insert_text: Some(format!("{name} = ")),
             kind: Some(CompletionItemKind::FIELD),
-            sort_text: Some(format!("001:{name}")),
+            sort_text: Some(format!("{sort_prefix}:{name}")),
             ..Default::default()
         });
     }

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -22,7 +22,7 @@ use crate::resolver::complete::{
 };
 use crate::types::CursorPos;
 
-use crate::features::traits::{LiveTreeAccess, SignatureIndex};
+use crate::features::traits::SignatureIndex;
 use crate::indexer::split_params_at_depth_zero;
 
 use super::completion_context::{CompletionContext, ScopeContext};
@@ -187,14 +187,7 @@ pub(crate) fn run_completions(
     );
     if ctx.receiver.is_none() {
         add_lambda_param_completions(&mut items, &ctx.scope, prefix);
-        add_named_arg_completions(
-            index,
-            &mut items,
-            uri,
-            position,
-            prefix,
-            ctx.call_info.as_ref(),
-        );
+        add_named_arg_completions(index, &mut items, uri, prefix, ctx.call_info.as_ref());
     }
 
     store_in_cache(index, cache_key, prefix, &items, epoch);
@@ -380,20 +373,20 @@ fn add_named_arg_completions(
     index: &Indexer,
     items: &mut Vec<CompletionItem>,
     uri: &Url,
-    position: Position,
     prefix: &str,
     call_info: Option<&crate::features::completion_context::CallInfo>,
 ) {
-    let params_text = call_info
-        .and_then(|info| index.find_fun_signature_with_receiver(uri, &info.callee, None))
-        .or_else(|| {
-            let ci = index.call_info_at(position, uri)?;
-            index.find_fun_signature_with_receiver(uri, &ci.fn_name, ci.qualifier.as_deref())
-        });
-    let Some(params_text) = params_text else {
+    let Some(call_info) = call_info else {
         return;
     };
-    let expected_name = call_info.and_then(|info| info.expected_name.as_deref());
+    let Some(params_text) = index.find_fun_signature_with_receiver(
+        uri,
+        &call_info.callee,
+        call_info.qualifier.as_deref(),
+    ) else {
+        return;
+    };
+    let expected_name = call_info.expected_name.as_deref();
     let raw = params_text.trim_matches(|c| c == '(' || c == ')');
     let prefix_lower = prefix.to_lowercase();
     for name in param_names_from_sig(raw) {

--- a/src/features/completion_context.rs
+++ b/src/features/completion_context.rs
@@ -3,6 +3,7 @@ use tower_lsp::lsp_types::{Position, Url};
 use crate::indexer::{
     lambda_receiver_type_from_context, last_ident_in, strip_trailing_call_args, Indexer,
 };
+use crate::resolver::complete::ReceiverExpr;
 use crate::StrExt;
 
 const IT: &str = "it";
@@ -25,6 +26,50 @@ pub(crate) struct ScopeContext {
     /// Lambda scopes, outermost first, innermost last.
     pub lambda_scopes: Vec<LambdaScope>,
     bare_this_type: Option<String>,
+}
+
+/// Semantic facts about the cursor position, computed once per cache miss.
+pub(crate) struct CompletionContext {
+    /// Dot-completion receiver (None = bare word context).
+    pub receiver: Option<ReceiverExpr>,
+    /// True when cursor is immediately after `@` — restrict to annotation types.
+    pub annotation_only: bool,
+    /// Lambda and class scope stack.
+    pub scope: ScopeContext,
+    /// Call argument context — populated in Wave 3; always None for now.
+    #[expect(
+        dead_code,
+        reason = "Wave 3 reads call_info after this placeholder lands"
+    )]
+    pub call_info: Option<CallInfo>,
+}
+
+/// Placeholder for Wave 3 — kept here so Wave 3 can fill it in without touching the struct definition.
+#[expect(dead_code, reason = "Wave 3 constructs and reads this placeholder")]
+pub(crate) struct CallInfo {
+    pub callee: String,
+    pub arg_index: usize,
+    pub expected_name: Option<String>,
+    pub expected_type: Option<String>,
+}
+
+impl CompletionContext {
+    /// Single analysis pass for a cache miss.
+    pub(crate) fn analyse(
+        before_prefix: &str,
+        position: Position,
+        index: &Indexer,
+        uri: &Url,
+        lines: &[String],
+        annotation_only: bool,
+    ) -> Self {
+        Self {
+            receiver: ReceiverExpr::parse(before_prefix),
+            annotation_only,
+            scope: ScopeContext::build(lines, position.line, position.character, index, uri),
+            call_info: None,
+        }
+    }
 }
 
 impl ScopeContext {

--- a/src/features/completion_context.rs
+++ b/src/features/completion_context.rs
@@ -1,7 +1,10 @@
 use tower_lsp::lsp_types::{Position, Url};
 
+use crate::features::completion::param_names_from_sig;
+use crate::features::traits::{LiveTreeAccess, SignatureIndex};
 use crate::indexer::{
-    lambda_receiver_type_from_context, last_ident_in, strip_trailing_call_args, Indexer,
+    lambda_receiver_type_from_context, last_ident_in, split_params_at_depth_zero,
+    strip_trailing_call_args, Indexer,
 };
 use crate::resolver::complete::ReceiverExpr;
 use crate::StrExt;
@@ -36,20 +39,25 @@ pub(crate) struct CompletionContext {
     pub annotation_only: bool,
     /// Lambda and class scope stack.
     pub scope: ScopeContext,
-    /// Call argument context — populated in Wave 3; always None for now.
-    #[expect(
-        dead_code,
-        reason = "Wave 3 reads call_info after this placeholder lands"
-    )]
+    /// Call argument context at the cursor, if inside a call expression.
     pub call_info: Option<CallInfo>,
 }
 
-/// Placeholder for Wave 3 — kept here so Wave 3 can fill it in without touching the struct definition.
-#[expect(dead_code, reason = "Wave 3 constructs and reads this placeholder")]
 pub(crate) struct CallInfo {
     pub callee: String,
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "Wave 4 uses arg_index after centralising call_info"
+        )
+    )]
     pub arg_index: usize,
     pub expected_name: Option<String>,
+    #[cfg_attr(
+        not(test),
+        expect(dead_code, reason = "Wave 4 uses expected_type for ranking hints")
+    )]
     pub expected_type: Option<String>,
 }
 
@@ -63,13 +71,39 @@ impl CompletionContext {
         lines: &[String],
         annotation_only: bool,
     ) -> Self {
+        let scope = ScopeContext::build(lines, position.line, position.character, index, uri);
+        let call_info = build_call_info(position, index, uri);
         Self {
             receiver: ReceiverExpr::parse(before_prefix),
             annotation_only,
-            scope: ScopeContext::build(lines, position.line, position.character, index, uri),
-            call_info: None,
+            scope,
+            call_info,
         }
     }
+}
+
+fn build_call_info(position: Position, index: &Indexer, uri: &Url) -> Option<CallInfo> {
+    let ci = index.call_info_at(position, uri)?;
+    let params_text =
+        index.find_fun_signature_with_receiver(uri, &ci.fn_name, ci.qualifier.as_deref())?;
+    let raw = params_text.trim_matches(|c| c == '(' || c == ')');
+    let arg_index = ci.active_param as usize;
+    let param_names = param_names_from_sig(raw);
+    let expected_name = param_names.get(arg_index).cloned();
+    let expected_type = param_type_at(raw, arg_index);
+    Some(CallInfo {
+        callee: ci.fn_name,
+        arg_index,
+        expected_name,
+        expected_type,
+    })
+}
+
+fn param_type_at(raw: &str, idx: usize) -> Option<String> {
+    let part = split_params_at_depth_zero(raw).into_iter().nth(idx)?.trim();
+    let colon = part.find(':')?;
+    let ty = part[colon + 1..].split('=').next()?.trim();
+    (!ty.is_empty()).then(|| ty.to_owned())
 }
 
 impl ScopeContext {

--- a/src/features/completion_context.rs
+++ b/src/features/completion_context.rs
@@ -1,0 +1,287 @@
+use tower_lsp::lsp_types::{Position, Url};
+
+use crate::indexer::{
+    lambda_receiver_type_from_context, last_ident_in, strip_trailing_call_args, Indexer,
+};
+use crate::StrExt;
+
+const IT: &str = "it";
+const THIS: &str = "this";
+const SCOPE_SCAN_BACK_LINES: usize = 50;
+
+pub(crate) struct LambdaScope {
+    /// Type of the implicit `it` parameter (if single-param lambda).
+    pub it_type: Option<String>,
+    /// Named lambda parameters: (name, type).
+    pub named_params: Vec<(String, String)>,
+    /// Lambda label — the call name just before `{`, e.g. `forEach { }` → `"forEach"`.
+    /// Used to resolve `this@forEach` / `this@label` references.
+    pub label: Option<String>,
+}
+
+pub(crate) struct ScopeContext {
+    /// Innermost enclosing class/object name, if any.
+    pub enclosing_class: Option<String>,
+    /// Lambda scopes, outermost first, innermost last.
+    pub lambda_scopes: Vec<LambdaScope>,
+    bare_this_type: Option<String>,
+}
+
+impl ScopeContext {
+    /// Build scope context from the current cursor position.
+    pub(crate) fn build(
+        lines: &[String],
+        cursor_line: u32,
+        cursor_col: u32,
+        index: &Indexer,
+        uri: &Url,
+    ) -> Self {
+        let position = Position::new(cursor_line, cursor_col);
+        let enclosing_class = index.enclosing_class_at(uri, cursor_line);
+        let bare_this_type = index
+            .infer_lambda_param_type_at(THIS, uri, position)
+            .or_else(|| enclosing_class.clone());
+        let mut lambda_scopes = collect_lambda_scopes(
+            lines,
+            cursor_line as usize,
+            cursor_col as usize,
+            index,
+            uri,
+            position,
+        );
+        let mut param_names =
+            index.lambda_params_at_col(uri, cursor_line as usize, cursor_col as usize);
+        if param_names.is_empty() {
+            param_names = index.lambda_params_at(uri, cursor_line as usize);
+        }
+        merge_named_params(&mut lambda_scopes, param_names, index, uri, position);
+        if let Some(innermost_scope) = lambda_scopes.last_mut() {
+            innermost_scope.it_type = index.infer_lambda_param_type_at(IT, uri, position);
+        }
+        Self {
+            enclosing_class,
+            lambda_scopes,
+            bare_this_type,
+        }
+    }
+
+    /// Resolve a receiver expression to a type string for dot-completion.
+    ///
+    /// Handles:
+    /// - `"it"` → innermost lambda scope where `it_type.is_some()`
+    /// - `"this"` → current `this` binding
+    /// - `"this@Foo"` → walk lambda scopes and enclosing class looking for `Foo`
+    /// - anything else → None (caller handles non-scope receivers)
+    pub(crate) fn resolve_receiver(&self, expr: &str) -> Option<&str> {
+        match expr {
+            IT => self
+                .lambda_scopes
+                .iter()
+                .rev()
+                .find_map(|scope| scope.it_type.as_deref()),
+            THIS => self.bare_this_type.as_deref(),
+            _ => resolve_labeled_receiver(self, expr),
+        }
+    }
+
+    pub(crate) fn named_param_type(&self, name: &str) -> Option<&str> {
+        self.lambda_scopes.iter().rev().find_map(|lambda_scope| {
+            lambda_scope
+                .named_params
+                .iter()
+                .find_map(|(param_name, param_type)| {
+                    (param_name == name && !param_type.is_empty()).then_some(param_type.as_str())
+                })
+        })
+    }
+
+    /// True if the given receiver expression is a lambda scope reference
+    /// (`it`, `this`, or `this@label`).
+    pub(crate) fn is_scope_receiver(&self, expr: &str) -> bool {
+        matches!(expr, IT | THIS)
+            || expr
+                .strip_prefix("this@")
+                .is_some_and(|label| !label.is_empty())
+    }
+}
+
+fn resolve_labeled_receiver<'a>(scope: &'a ScopeContext, expr: &str) -> Option<&'a str> {
+    let label = expr.strip_prefix("this@")?;
+    scope
+        .lambda_scopes
+        .iter()
+        .rev()
+        .find(|lambda_scope| lambda_scope.label.as_deref() == Some(label))
+        .and_then(|lambda_scope| lambda_scope.it_type.as_deref())
+        .or_else(|| {
+            scope
+                .enclosing_class
+                .as_deref()
+                .filter(|class_name| *class_name == label)
+        })
+}
+
+fn collect_lambda_scopes(
+    lines: &[String],
+    cursor_line: usize,
+    cursor_col: usize,
+    index: &Indexer,
+    uri: &Url,
+    position: Position,
+) -> Vec<LambdaScope> {
+    if lines.is_empty() {
+        return Vec::new();
+    }
+
+    let scan_start = cursor_line.saturating_sub(SCOPE_SCAN_BACK_LINES);
+    let mut depth = 0i32;
+    let mut scopes = Vec::new();
+
+    for line_index in (scan_start..=cursor_line).rev() {
+        let Some(line) = lines.get(line_index) else {
+            continue;
+        };
+        let scan_slice = line_before_cursor(line, line_index, cursor_line, cursor_col);
+        for (byte_index, ch) in scan_slice.char_indices().rev() {
+            match ch {
+                '}' => depth += 1,
+                '{' => {
+                    depth -= 1;
+                    if depth >= 0 || scan_slice[..byte_index].ends_with('$') {
+                        if scan_slice[..byte_index].ends_with('$') {
+                            depth = 0;
+                        }
+                        continue;
+                    }
+                    if let Some(scope) =
+                        build_lambda_scope(scan_slice, byte_index, index, uri, position)
+                    {
+                        scopes.push(scope);
+                    }
+                    depth = 0;
+                }
+                _ => {}
+            }
+        }
+    }
+
+    scopes.reverse();
+    scopes
+}
+
+fn merge_named_params(
+    lambda_scopes: &mut Vec<LambdaScope>,
+    param_names: Vec<String>,
+    index: &Indexer,
+    uri: &Url,
+    position: Position,
+) {
+    if param_names.is_empty() {
+        return;
+    }
+
+    if lambda_scopes.is_empty() {
+        lambda_scopes.push(LambdaScope {
+            it_type: None,
+            named_params: Vec::new(),
+            label: None,
+        });
+    }
+
+    let Some(innermost_scope) = lambda_scopes.last_mut() else {
+        return;
+    };
+    for param_name in param_names {
+        if innermost_scope
+            .named_params
+            .iter()
+            .any(|(existing_name, _)| existing_name == &param_name)
+        {
+            continue;
+        }
+        let param_type = index
+            .infer_lambda_param_type_at(&param_name, uri, position)
+            .unwrap_or_default();
+        innermost_scope.named_params.push((param_name, param_type));
+    }
+}
+
+fn build_lambda_scope(
+    scan_slice: &str,
+    brace_byte: usize,
+    index: &Indexer,
+    uri: &Url,
+    position: Position,
+) -> Option<LambdaScope> {
+    let before_brace = &scan_slice[..brace_byte];
+    let named_params = parse_named_params(&scan_slice[brace_byte + 1..], index, uri, position);
+    let it_type = lambda_receiver_type_from_context(before_brace, index, uri);
+    if named_params.is_empty() && it_type.is_none() {
+        return None;
+    }
+    Some(LambdaScope {
+        it_type,
+        named_params,
+        label: lambda_label(before_brace),
+    })
+}
+
+fn parse_named_params(
+    after_brace: &str,
+    index: &Indexer,
+    uri: &Url,
+    position: Position,
+) -> Vec<(String, String)> {
+    let trimmed = after_brace.trim_start();
+    let Some((names, _)) = trimmed.split_once("->") else {
+        return Vec::new();
+    };
+
+    let mut named_params = Vec::new();
+    for token in names.split(',') {
+        let name = token.trim().ident_prefix();
+        if should_collect_named_param(&name, &named_params) {
+            let param_type = index
+                .infer_lambda_param_type_at(&name, uri, position)
+                .unwrap_or_default();
+            named_params.push((name, param_type));
+        }
+    }
+    named_params
+}
+
+fn should_collect_named_param(name: &str, named_params: &[(String, String)]) -> bool {
+    !name.is_empty()
+        && name != IT
+        && name != "_"
+        && name.starts_with_lowercase()
+        && !named_params
+            .iter()
+            .any(|(existing_name, _)| existing_name == name)
+}
+
+fn lambda_label(before_brace: &str) -> Option<String> {
+    let callee = strip_trailing_call_args(before_brace)
+        .replace("?.", ".")
+        .trim()
+        .to_owned();
+    let label = last_ident_in(&callee);
+    (!label.is_empty()).then(|| label.to_owned())
+}
+
+fn line_before_cursor(
+    line: &str,
+    line_index: usize,
+    cursor_line: usize,
+    cursor_col: usize,
+) -> &str {
+    if line_index != cursor_line {
+        return line;
+    }
+    let byte_end = crate::indexer::live_tree::utf16_col_to_byte(line, cursor_col);
+    &line[..byte_end]
+}
+
+#[cfg(test)]
+#[path = "completion_context_tests.rs"]
+mod tests;

--- a/src/features/completion_context.rs
+++ b/src/features/completion_context.rs
@@ -95,7 +95,11 @@ fn build_call_info(position: Position, index: &Indexer, uri: &Url) -> Option<Cal
 }
 
 fn param_type_at(raw: &str, idx: usize) -> Option<String> {
-    let part = split_params_at_depth_zero(raw).into_iter().nth(idx)?.trim();
+    let part = split_params_at_depth_zero(raw)
+        .into_iter()
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .nth(idx)?;
     let colon = part.find(':')?;
     let ty = part[colon + 1..].split('=').next()?.trim();
     (!ty.is_empty()).then(|| ty.to_owned())

--- a/src/features/completion_context.rs
+++ b/src/features/completion_context.rs
@@ -45,19 +45,13 @@ pub(crate) struct CompletionContext {
 
 pub(crate) struct CallInfo {
     pub callee: String,
-    #[cfg_attr(
-        not(test),
-        expect(
-            dead_code,
-            reason = "Wave 4 uses arg_index after centralising call_info"
-        )
-    )]
+    pub qualifier: Option<String>,
+    /// Active argument index — reserved for future ranking use.
+    #[allow(dead_code)]
     pub arg_index: usize,
     pub expected_name: Option<String>,
-    #[cfg_attr(
-        not(test),
-        expect(dead_code, reason = "Wave 4 uses expected_type for ranking hints")
-    )]
+    /// Type hint at `arg_index` — reserved for future ranking use.
+    #[allow(dead_code)]
     pub expected_type: Option<String>,
 }
 
@@ -93,6 +87,7 @@ fn build_call_info(position: Position, index: &Indexer, uri: &Url) -> Option<Cal
     let expected_type = param_type_at(raw, arg_index);
     Some(CallInfo {
         callee: ci.fn_name,
+        qualifier: ci.qualifier,
         arg_index,
         expected_name,
         expected_type,

--- a/src/features/completion_context_tests.rs
+++ b/src/features/completion_context_tests.rs
@@ -1,4 +1,6 @@
-use super::{LambdaScope, ScopeContext};
+use super::{CompletionContext, LambdaScope, ScopeContext};
+use crate::indexer::Indexer;
+use tower_lsp::lsp_types::{Position, Url};
 
 #[test]
 fn scope_resolve_it_returns_innermost_it_type() {
@@ -51,4 +53,59 @@ fn scope_is_scope_receiver() {
     assert!(scope.is_scope_receiver("this@Foo"));
     assert!(!scope.is_scope_receiver("someVar"));
     assert!(!scope.is_scope_receiver("Companion"));
+}
+
+fn uri(path: &str) -> Url {
+    Url::parse(&format!("file:///test{path}")).unwrap()
+}
+
+fn indexed_with_live(path: &str, src: &str) -> (Url, Indexer) {
+    let uri = uri(path);
+    let index = Indexer::new();
+    index.index_content(&uri, src);
+    index.store_live_tree(&uri, src);
+    (uri, index)
+}
+
+fn call_paren_col(src: &str, line_no: usize, fn_name: &str) -> u32 {
+    let line = src.lines().nth(line_no).expect("line out of range");
+    let needle = format!("{fn_name}(");
+    let pos = line
+        .find(&needle)
+        .unwrap_or_else(|| panic!("no `{needle}` on line"));
+    (pos + needle.len()) as u32
+}
+
+#[test]
+fn call_info_expected_name_at_first_arg() {
+    let src =
+        "package com.example\nfun greet(name: String, age: Int) {}\nfun main() {\n    greet()\n}\n";
+    let (uri, index) = indexed_with_live("/CallInfo.kt", src);
+    let position = Position::new(3, call_paren_col(src, 3, "greet"));
+    let lines: Vec<String> = src.lines().map(str::to_owned).collect();
+    let before_prefix = src.lines().nth(3).unwrap()[..position.character as usize].to_owned();
+
+    let ctx = CompletionContext::analyse(&before_prefix, position, &index, &uri, &lines, false);
+
+    let call_info = ctx.call_info.expect("call_info should be populated");
+    assert_eq!(call_info.callee, "greet");
+    assert_eq!(call_info.arg_index, 0);
+    assert_eq!(call_info.expected_name.as_deref(), Some("name"));
+    assert_eq!(call_info.expected_type.as_deref(), Some("String"));
+}
+
+#[test]
+fn call_info_expected_name_none_when_not_in_call() {
+    let src = "package com.example\nfun main() {\n    val value = 1\n    value\n}\n";
+    let (uri, index) = indexed_with_live("/NoCallInfo.kt", src);
+    let position = Position::new(3, 9);
+    let lines: Vec<String> = src.lines().map(str::to_owned).collect();
+    let before_prefix = src.lines().nth(3).unwrap()[..position.character as usize].to_owned();
+
+    let ctx = CompletionContext::analyse(&before_prefix, position, &index, &uri, &lines, false);
+
+    assert!(
+        ctx.call_info.is_none(),
+        "call_info should be None outside calls"
+    );
 }

--- a/src/features/completion_context_tests.rs
+++ b/src/features/completion_context_tests.rs
@@ -1,0 +1,54 @@
+use super::{LambdaScope, ScopeContext};
+
+#[test]
+fn scope_resolve_it_returns_innermost_it_type() {
+    let scope = ScopeContext {
+        enclosing_class: None,
+        lambda_scopes: vec![
+            LambdaScope {
+                it_type: Some("OuterType".into()),
+                named_params: vec![],
+                label: Some("map".into()),
+            },
+            LambdaScope {
+                it_type: Some("InnerType".into()),
+                named_params: vec![],
+                label: Some("forEach".into()),
+            },
+        ],
+        bare_this_type: None,
+    };
+
+    assert_eq!(scope.resolve_receiver("it"), Some("InnerType"));
+}
+
+#[test]
+fn scope_resolve_this_at_label() {
+    let scope = ScopeContext {
+        enclosing_class: Some("MyClass".into()),
+        lambda_scopes: vec![LambdaScope {
+            it_type: Some("Element".into()),
+            named_params: vec![],
+            label: Some("forEach".into()),
+        }],
+        bare_this_type: Some("MyClass".into()),
+    };
+
+    assert_eq!(scope.resolve_receiver("this@forEach"), Some("Element"));
+    assert_eq!(scope.resolve_receiver("this@MyClass"), Some("MyClass"));
+}
+
+#[test]
+fn scope_is_scope_receiver() {
+    let scope = ScopeContext {
+        enclosing_class: None,
+        lambda_scopes: vec![],
+        bare_this_type: None,
+    };
+
+    assert!(scope.is_scope_receiver("it"));
+    assert!(scope.is_scope_receiver("this"));
+    assert!(scope.is_scope_receiver("this@Foo"));
+    assert!(!scope.is_scope_receiver("someVar"));
+    assert!(!scope.is_scope_receiver("Companion"));
+}

--- a/src/features/mod.rs
+++ b/src/features/mod.rs
@@ -16,6 +16,7 @@
 pub(crate) mod call_arg_diagnostics;
 pub(crate) mod code_actions;
 pub(crate) mod completion;
+pub(crate) mod completion_context;
 pub(crate) mod definition;
 pub(crate) mod fill_when;
 pub(crate) mod folding;

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -128,11 +128,9 @@ pub(crate) fn index_jars(
 
     // Batch-process cache misses.
     if !missed.is_empty() {
-        if sidecar.is_none() {
-            // Sidecar already dead — all misses skipped.
-        } else {
+        if let Some(ref mut sidecar_guard) = sidecar {
             let sidecar_paths: Vec<&Path> = missed.iter().map(|(p, _)| p.as_path()).collect();
-            match sidecar.as_mut().unwrap().index_jars(&sidecar_paths) {
+            match sidecar_guard.index_jars(&sidecar_paths) {
                 Ok(results) => {
                     for ((path, path_key), symbols) in missed.into_iter().zip(results) {
                         let count = populate_from_symbols(indexer, &path, &symbols);


### PR DESCRIPTION
## Summary

Closes #142.

Replaces 5–6 independent text/CST walks per completion request with a single `CompletionContext` analysis pass. Modelled after rust-analyzer's `CompletionContext` + `CompletionAnalysis` split, adapted for our tree-sitter/line-scan approach (no HIR).

## Changes

### Wave 1 — `ScopeContext` + label-aware resolution
- `LambdaScope { it_type, named_params, label }` — `label` comes from the call name before `{` (e.g. `forEach { }` → `"forEach"`)
- `ScopeContext { enclosing_class, lambda_scopes }` built once per cache miss
- `ScopeContext::resolve_receiver(expr)` dispatches:
  - `"it"` → innermost lambda `it_type`
  - `"this"` → enclosing class / lambda receiver
  - `"this@Foo"` → walks scope stack to find matching label or class name (**new capability**)
- Replaces scattered `is_lambda_recv` + `resolve_lambda_recv_type` calls

### Wave 2 — `CompletionContext` skeleton
- `CompletionContext { receiver, annotation_only, scope, call_info }`
- `CompletionContext::analyse()` — single pass wrapping `ReceiverExpr::parse` + `ScopeContext::build`
- `run_completions` dispatches from `ctx` fields; pure refactor, no behaviour change

### Wave 3 — `CallInfo` population + ranking boost
- `build_call_info()` uses `cst_call_info` + `find_fun_signature_with_receiver` to populate `callee`, `arg_index`, `expected_name`, `expected_type`
- `add_named_arg_completions` reads from `ctx.call_info` (falls back to `index.call_info_at` if unavailable)
- `expected_name` matching param gets sort rank `000` vs `001` — ranking hint only, never a filter

## Tests
5 new tests across 3 waves:
- `ScopeContext::resolve_receiver` for `it`, `this`, `this@Label`
- `ScopeContext::is_scope_receiver` boundary cases
- `CallInfo` population at first arg position
- `call_info` is `None` when cursor is not inside a call

All 1220 tests pass (1218 existing + 2 new).
