### PR TITLE
refactor(backend): decompose mod.rs into focused sub-modules

### DIFF
--- a/src/backend/capabilities.rs
+++ b/src/backend/capabilities.rs
@@ -1,0 +1,60 @@
+use tower_lsp::lsp_types::*;
+
+use crate::semantic_tokens;
+
+pub(super) fn server_capabilities() -> ServerCapabilities {
+    ServerCapabilities {
+        text_document_sync: Some(TextDocumentSyncCapability::Options(
+            TextDocumentSyncOptions {
+                open_close: Some(true),
+                change: Some(TextDocumentSyncKind::FULL),
+                save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
+                    include_text: Some(false),
+                })),
+                ..Default::default()
+            },
+        )),
+        completion_provider: Some(CompletionOptions {
+            trigger_characters: Some(vec![".".into(), ":".into(), "@".into()]),
+            resolve_provider: Some(true),
+            ..Default::default()
+        }),
+        hover_provider: Some(HoverProviderCapability::Simple(true)),
+        definition_provider: Some(OneOf::Left(true)),
+        declaration_provider: Some(DeclarationCapability::Simple(true)),
+        implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
+        references_provider: Some(OneOf::Left(true)),
+        document_highlight_provider: Some(OneOf::Left(true)),
+        document_symbol_provider: Some(OneOf::Left(true)),
+        inlay_hint_provider: Some(OneOf::Left(true)),
+        workspace: Some(WorkspaceServerCapabilities {
+            workspace_folders: None,
+            file_operations: None,
+        }),
+        workspace_symbol_provider: Some(OneOf::Left(true)),
+        execute_command_provider: Some(ExecuteCommandOptions {
+            commands: vec!["kotlin-lsp/reindex".into(), "kotlin-lsp/clearCache".into()],
+            ..Default::default()
+        }),
+        rename_provider: Some(OneOf::Right(RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: Default::default(),
+        })),
+        folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
+        code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
+        signature_help_provider: Some(SignatureHelpOptions {
+            trigger_characters: Some(vec!["(".into(), ",".into()]),
+            retrigger_characters: None,
+            work_done_progress_options: Default::default(),
+        }),
+        semantic_tokens_provider: Some(SemanticTokensServerCapabilities::SemanticTokensOptions(
+            SemanticTokensOptions {
+                legend: semantic_tokens::legend(),
+                full: Some(SemanticTokensFullOptions::Bool(true)),
+                range: Some(true),
+                work_done_progress_options: Default::default(),
+            },
+        )),
+        ..Default::default()
+    }
+}

--- a/src/backend/commands.rs
+++ b/src/backend/commands.rs
@@ -1,0 +1,99 @@
+use std::sync::Arc;
+
+use tower_lsp::jsonrpc::Result;
+use tower_lsp::lsp_types::*;
+
+use super::progress::LspProgressReporter;
+use super::Backend;
+use crate::indexer::workspace_cache_path;
+
+impl Backend {
+    pub(super) async fn execute_command_impl(
+        &self,
+        params: ExecuteCommandParams,
+    ) -> Result<Option<serde_json::Value>> {
+        if params.command == "kotlin-lsp/reindex" {
+            let root = self.indexer.workspace_root.get();
+            let Some(root) = root else {
+                self.client
+                    .show_message(MessageType::WARNING, "kotlin-lsp: no workspace root set")
+                    .await;
+                return Ok(None);
+            };
+            let idx = Arc::clone(&self.indexer);
+            let client = self.client.clone();
+            idx.reset_index_state();
+            tokio::spawn(async move {
+                idx.index_workspace(&root, Arc::new(LspProgressReporter(client)))
+                    .await;
+            });
+            self.client
+                .show_message(MessageType::INFO, "kotlin-lsp: reindexing workspace…")
+                .await;
+        } else if params.command == "kotlin-lsp/clearCache" {
+            let arg = params
+                .arguments
+                .first()
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            let target_root = if let Some(p) = arg {
+                let pb = std::path::PathBuf::from(p);
+                if !pb.is_dir() {
+                    self.client
+                        .show_message(
+                            MessageType::WARNING,
+                            format!("kotlin-lsp/clearCache: not a directory: {}", pb.display()),
+                        )
+                        .await;
+                    return Ok(None);
+                }
+                pb
+            } else {
+                let current_root_opt = self.indexer.workspace_root.get();
+                match current_root_opt {
+                    Some(r) => r,
+                    None => {
+                        self.client
+                            .show_message(
+                                MessageType::WARNING,
+                                "kotlin-lsp/clearCache: no workspace root set and no path provided",
+                            )
+                            .await;
+                        return Ok(None);
+                    }
+                }
+            };
+            let cache_path = workspace_cache_path(&target_root);
+            if let Some(cache_dir) = cache_path.parent() {
+                match std::fs::remove_dir_all(cache_dir) {
+                    Ok(_) => {
+                        log::info!("Cleared workspace cache directory: {}", cache_dir.display());
+                        self.client
+                            .show_message(
+                                MessageType::INFO,
+                                format!("kotlin-lsp: cleared cache for {}", target_root.display()),
+                            )
+                            .await;
+                    }
+                    Err(e) => {
+                        log::warn!("Failed to remove cache dir {}: {}", cache_dir.display(), e);
+                        self.client
+                            .show_message(
+                                MessageType::WARNING,
+                                format!("kotlin-lsp: failed to clear cache: {}", e),
+                            )
+                            .await;
+                    }
+                }
+            } else {
+                self.client
+                    .show_message(
+                        MessageType::WARNING,
+                        "kotlin-lsp/clearCache: cache path parent missing",
+                    )
+                    .await;
+            }
+        }
+        Ok(None)
+    }
+}

--- a/src/backend/git_watcher.rs
+++ b/src/backend/git_watcher.rs
@@ -35,21 +35,45 @@ fn resolve_git_dir(root: &Path) -> Option<PathBuf> {
     None
 }
 
+/// Resolves the "refs root" directory for a given git dir.
 ///
-/// For a symbolic ref (`ref: refs/heads/main`), reads the pointed-to ref file.
+/// In worktrees, the per-worktree git dir (`.git/worktrees/<name>/`) has a
+/// `commondir` file pointing to the main git dir where all refs live.
+/// In regular repos and submodules, refs are directly under `git_dir`.
+fn refs_dir(git_dir: &Path) -> PathBuf {
+    let commondir_file = git_dir.join("commondir");
+    if let Ok(content) = std::fs::read_to_string(&commondir_file) {
+        let rel = content.trim();
+        let candidate = if rel.starts_with('/') {
+            PathBuf::from(rel)
+        } else {
+            git_dir.join(rel)
+        };
+        if candidate.is_dir() {
+            return candidate;
+        }
+    }
+    git_dir.to_path_buf()
+}
+
+/// Resolves the current git commit SHA from `git_dir/HEAD`.
+///
+/// For a symbolic ref (`ref: refs/heads/main`), reads the pointed-to ref file
+/// from the refs root (which may differ from `git_dir` in worktrees).
 /// For a detached HEAD, returns the raw SHA from HEAD itself.
-/// Returns `None` if the git directory doesn't exist or files can't be read.
+/// Returns `None` if HEAD cannot be read.
 fn read_git_commit(git_dir: &Path) -> Option<String> {
     let head = std::fs::read_to_string(git_dir.join("HEAD")).ok()?;
     let head = head.trim();
     if let Some(ref_path) = head.strip_prefix("ref: ") {
         // Symbolic ref — resolve to actual commit SHA.
-        std::fs::read_to_string(git_dir.join(ref_path))
+        // Use refs_dir() so worktree git dirs look in the common git dir for refs.
+        let sha = std::fs::read_to_string(refs_dir(git_dir).join(ref_path))
             .ok()
-            .map(|s| s.trim().to_string())
-            // If the ref file doesn't exist yet (empty branch), fall back to
-            // the symbolic ref itself so we still detect the branch name change.
-            .or_else(|| Some(head.to_string()))
+            .map(|s| s.trim().to_string());
+        // If the ref file doesn't exist yet (empty branch), fall back to
+        // the symbolic ref itself so we still detect the branch name change.
+        sha.or_else(|| Some(head.to_string()))
     } else {
         // Detached HEAD.
         Some(head.to_string())

--- a/src/backend/git_watcher.rs
+++ b/src/backend/git_watcher.rs
@@ -8,7 +8,33 @@ use crate::indexer::Indexer;
 
 use super::progress::LspProgressReporter;
 
-/// Resolves the current git commit SHA from `.git/HEAD`.
+/// Resolves the actual git directory from a workspace root.
+///
+/// Handles both regular repos (`.git/` is a directory) and worktrees/submodules
+/// where `.git` is a file containing `gitdir: /path/to/actual/git/dir`.
+/// Returns `None` when no git directory can be found.
+fn resolve_git_dir(root: &Path) -> Option<PathBuf> {
+    let git_path = root.join(".git");
+    if git_path.is_dir() {
+        return Some(git_path);
+    }
+    // Worktree or submodule: `.git` is a file with `gitdir: <path>`.
+    if git_path.is_file() {
+        let content = std::fs::read_to_string(&git_path).ok()?;
+        let git_dir_str = content.trim().strip_prefix("gitdir:")?;
+        let git_dir = PathBuf::from(git_dir_str.trim());
+        let resolved = if git_dir.is_absolute() {
+            git_dir
+        } else {
+            root.join(git_dir)
+        };
+        if resolved.is_dir() {
+            return Some(resolved);
+        }
+    }
+    None
+}
+
 ///
 /// For a symbolic ref (`ref: refs/heads/main`), reads the pointed-to ref file.
 /// For a detached HEAD, returns the raw SHA from HEAD itself.
@@ -34,10 +60,9 @@ fn read_git_commit(git_dir: &Path) -> Option<String> {
 /// When the resolved commit SHA changes (branch switch or new commit), clears
 /// the in-memory index and triggers a full workspace reindex.
 pub(super) fn spawn_git_head_watcher(root: PathBuf, indexer: Arc<Indexer>, client: Client) {
-    let git_dir = root.join(".git");
-    if !git_dir.is_dir() {
+    let Some(git_dir) = resolve_git_dir(&root) else {
         return;
-    }
+    };
     let mut last_commit = read_git_commit(&git_dir).unwrap_or_default();
     tokio::spawn(async move {
         let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(2));

--- a/src/backend/git_watcher.rs
+++ b/src/backend/git_watcher.rs
@@ -1,0 +1,69 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use tower_lsp::lsp_types::MessageType;
+use tower_lsp::Client;
+
+use crate::indexer::Indexer;
+
+use super::progress::LspProgressReporter;
+
+/// Resolves the current git commit SHA from `.git/HEAD`.
+///
+/// For a symbolic ref (`ref: refs/heads/main`), reads the pointed-to ref file.
+/// For a detached HEAD, returns the raw SHA from HEAD itself.
+/// Returns `None` if the git directory doesn't exist or files can't be read.
+fn read_git_commit(git_dir: &Path) -> Option<String> {
+    let head = std::fs::read_to_string(git_dir.join("HEAD")).ok()?;
+    let head = head.trim();
+    if let Some(ref_path) = head.strip_prefix("ref: ") {
+        // Symbolic ref — resolve to actual commit SHA.
+        std::fs::read_to_string(git_dir.join(ref_path))
+            .ok()
+            .map(|s| s.trim().to_string())
+            // If the ref file doesn't exist yet (empty branch), fall back to
+            // the symbolic ref itself so we still detect the branch name change.
+            .or_else(|| Some(head.to_string()))
+    } else {
+        // Detached HEAD.
+        Some(head.to_string())
+    }
+}
+
+/// Spawns a background task that polls `.git/HEAD` every 2 seconds.
+/// When the resolved commit SHA changes (branch switch or new commit), clears
+/// the in-memory index and triggers a full workspace reindex.
+pub(super) fn spawn_git_head_watcher(root: PathBuf, indexer: Arc<Indexer>, client: Client) {
+    let git_dir = root.join(".git");
+    if !git_dir.is_dir() {
+        return;
+    }
+    let mut last_commit = read_git_commit(&git_dir).unwrap_or_default();
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(2));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            interval.tick().await;
+            let current = read_git_commit(&git_dir).unwrap_or_default();
+            if current.is_empty() || current == last_commit {
+                continue;
+            }
+            last_commit = current;
+            log::info!("git HEAD changed — triggering workspace reindex");
+            client
+                .show_message(
+                    MessageType::INFO,
+                    "kotlin-lsp: branch changed, reindexing workspace…",
+                )
+                .await;
+            let idx = Arc::clone(&indexer);
+            let root_clone = root.clone();
+            let client_clone = client.clone();
+            idx.reset_index_state();
+            tokio::spawn(async move {
+                idx.index_workspace(&root_clone, Arc::new(LspProgressReporter(client_clone)))
+                    .await;
+            });
+        }
+    });
+}

--- a/src/backend/init.rs
+++ b/src/backend/init.rs
@@ -1,0 +1,146 @@
+use std::path::{Path, PathBuf};
+
+use tower_lsp::lsp_types::*;
+
+use super::Backend;
+use crate::workspace::{Config, Event};
+
+impl Backend {
+    pub(super) fn detect_snippet_support(params: &InitializeParams) -> bool {
+        params
+            .capabilities
+            .text_document
+            .as_ref()
+            .and_then(|text_document| text_document.completion.as_ref())
+            .and_then(|completion| completion.completion_item.as_ref())
+            .and_then(|completion_item| completion_item.snippet_support)
+            .unwrap_or(false)
+    }
+
+    pub(super) fn resolve_workspace_root(params: &InitializeParams) -> Option<PathBuf> {
+        if std::env::var("KOTLIN_LSP_PREFER_CONFIG_ROOT").is_ok() {
+            // Copilot CLI mode: config file overrides client rootUri so
+            // kotlin_lsp_set_workspace works correctly.
+            Self::workspace_root_from_environment()
+                .or_else(Self::workspace_root_from_config)
+                .or_else(|| Self::workspace_root_from_client(params))
+        } else {
+            // Editor mode: always honour the client's rootUri.
+            Self::workspace_root_from_environment()
+                .or_else(|| Self::workspace_root_from_client(params))
+                .or_else(Self::workspace_root_from_config)
+        }
+    }
+
+    fn workspace_root_from_environment() -> Option<PathBuf> {
+        std::env::var("KOTLIN_LSP_WORKSPACE_ROOT")
+            .ok()
+            .map(PathBuf::from)
+            .filter(|workspace_root| workspace_root.is_dir())
+    }
+
+    fn workspace_root_from_client(params: &InitializeParams) -> Option<PathBuf> {
+        Self::initialize_root_uri(params)
+            .and_then(|root_uri| root_uri.to_file_path().ok())
+            .filter(|workspace_root| workspace_root.is_dir())
+            .map(|workspace_root| Self::walk_up_to_git_root(&workspace_root))
+    }
+
+    fn initialize_root_uri(params: &InitializeParams) -> Option<Url> {
+        params.root_uri.clone().or_else(|| {
+            params
+                .workspace_folders
+                .as_deref()
+                .and_then(|workspace_folders| workspace_folders.first())
+                .map(|workspace_folder| workspace_folder.uri.clone())
+        })
+    }
+
+    fn walk_up_to_git_root(workspace_root: &Path) -> PathBuf {
+        let mut current_directory = workspace_root;
+        loop {
+            if current_directory.join(".git").exists() {
+                return current_directory.to_path_buf();
+            }
+            match current_directory.parent() {
+                Some(parent_directory) => current_directory = parent_directory,
+                None => return workspace_root.to_path_buf(),
+            }
+        }
+    }
+
+    fn workspace_root_from_config() -> Option<PathBuf> {
+        let config_file = crate::util::home_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
+            .join(".config/kotlin-lsp/workspace");
+        std::fs::read_to_string(config_file)
+            .ok()
+            .map(|workspace_root| PathBuf::from(workspace_root.trim()))
+            .filter(|workspace_root| workspace_root.is_dir())
+    }
+
+    pub(super) async fn configure_initialized_workspace(
+        &self,
+        params: &InitializeParams,
+        workspace_root: &Path,
+        workspace_pinned: bool,
+    ) {
+        let (explicit_source_paths, ignore_patterns) =
+            self.apply_initialization_options(params.initialization_options.as_ref());
+        if self
+            .event_tx
+            .send(Event::Initialize {
+                config: Config {
+                    root: workspace_root.to_path_buf(),
+                    explicit_source_paths,
+                    ignore_patterns,
+                    pin_workspace: workspace_pinned,
+                },
+                completion_tx: None,
+            })
+            .await
+            .is_err()
+        {
+            log::error!(
+                "configure_initialized_workspace: workspace actor channel closed; \
+                 indexing will not start"
+            );
+        }
+    }
+
+    fn apply_initialization_options(
+        &self,
+        initialization_options: Option<&serde_json::Value>,
+    ) -> (Vec<String>, Vec<String>) {
+        let ignore_patterns =
+            Self::collect_indexing_option_strings(initialization_options, "ignorePatterns")
+                .unwrap_or_default();
+        if !ignore_patterns.is_empty() {
+            log::info!("ignorePatterns: {:?}", ignore_patterns);
+        }
+
+        let explicit_source_paths =
+            Self::collect_indexing_option_strings(initialization_options, "sourcePaths")
+                .unwrap_or_default();
+        if !explicit_source_paths.is_empty() {
+            log::info!("sourcePaths: {:?}", explicit_source_paths);
+        }
+
+        (explicit_source_paths, ignore_patterns)
+    }
+
+    fn collect_indexing_option_strings(
+        initialization_options: Option<&serde_json::Value>,
+        option_name: &str,
+    ) -> Option<Vec<String>> {
+        let option_values = initialization_options?
+            .get("indexingOptions")?
+            .get(option_name)?
+            .as_array()?;
+        let collected_values: Vec<String> = option_values
+            .iter()
+            .filter_map(|value| value.as_str().map(str::to_owned))
+            .collect();
+        (!collected_values.is_empty()).then_some(collected_values)
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -1,151 +1,33 @@
-use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
-use futures::FutureExt;
 use tokio::sync::mpsc;
-use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{async_trait, Client, LanguageServer};
 
-use crate::indexer::{workspace_cache_path, Indexer, ProgressReporter};
+use tower_lsp::jsonrpc::Result;
+
+use crate::indexer::Indexer;
 use crate::semantic_tokens;
-use crate::workspace::{Config, Event};
-
-/// Wraps an async handler in `catch_unwind` so a panic in one request doesn't
-/// kill the server process. Returns an internal error to the client on panic.
-pub(crate) async fn panic_safe<F, T>(method: &str, future: F) -> Result<T>
-where
-    F: std::future::Future<Output = Result<T>> + Send,
-    T: Send + 'static,
-{
-    use std::future::Future;
-    use std::pin::Pin;
-    use std::task::{Context, Poll};
-
-    // Wrapper that sets PANIC_CAUGHT on each poll so the panic hook
-    // always sees the flag regardless of which thread resumes the future.
-    struct PanicGuarded<Fut>(Pin<Box<Fut>>);
-
-    impl<Fut: Future> Future for PanicGuarded<Fut> {
-        type Output = Fut::Output;
-        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-            crate::PANIC_CAUGHT.with(|c| c.set(true));
-            let result = self.0.as_mut().poll(cx);
-            if result.is_ready() {
-                crate::PANIC_CAUGHT.with(|c| c.set(false));
-            }
-            result
-        }
-    }
-
-    impl<Fut> Drop for PanicGuarded<Fut> {
-        fn drop(&mut self) {
-            crate::PANIC_CAUGHT.with(|c| c.set(false));
-        }
-    }
-
-    let guarded = PanicGuarded(Box::pin(future));
-    let result = std::panic::AssertUnwindSafe(guarded).catch_unwind().await;
-
-    match result {
-        Ok(result) => result,
-        Err(payload) => {
-            let message = if let Some(s) = payload.downcast_ref::<&str>() {
-                (*s).to_owned()
-            } else if let Some(s) = payload.downcast_ref::<String>() {
-                s.clone()
-            } else {
-                "unknown panic".to_owned()
-            };
-            log::error!("PANIC in {method}: {message}");
-            Err(tower_lsp::jsonrpc::Error {
-                code: tower_lsp::jsonrpc::ErrorCode::InternalError,
-                message: format!("internal error in {method}").into(),
-                data: None,
-            })
-        }
-    }
-}
+use crate::workspace::Event;
 
 pub(crate) mod actions;
+pub(crate) mod capabilities;
+pub(crate) mod commands;
 pub(crate) mod cursor;
 pub(crate) mod format;
+pub(crate) mod git_watcher;
 pub(crate) mod handlers;
 pub(crate) mod helpers;
+pub(crate) mod init;
 pub(crate) mod nav;
+pub(crate) mod panic_guard;
+pub(crate) mod progress;
 pub(crate) mod rename;
 
-// ─── LSP progress reporter (outbound adapter) ────────────────────────────────
-
-mod progress {
-    use tower_lsp::lsp_types::ProgressParams;
-
-    /// `$/progress` notification — reports workspace indexing status to the editor.
-    pub(super) enum KotlinProgress {}
-    impl tower_lsp::lsp_types::notification::Notification for KotlinProgress {
-        type Params = ProgressParams;
-        const METHOD: &'static str = "$/progress";
-    }
-}
-
-/// Sends LSP `$/progress` notifications via `tower_lsp::Client`.
-pub(crate) struct LspProgressReporter(pub(crate) Client);
-
-impl ProgressReporter for LspProgressReporter {
-    async fn begin(&self, token: &NumberOrString, message: &str) {
-        let _ = tokio::time::timeout(
-            std::time::Duration::from_millis(500),
-            self.0
-                .send_request::<tower_lsp::lsp_types::request::WorkDoneProgressCreate>(
-                    WorkDoneProgressCreateParams {
-                        token: token.clone(),
-                    },
-                ),
-        )
-        .await;
-        self.0
-            .send_notification::<progress::KotlinProgress>(ProgressParams {
-                token: token.clone(),
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(
-                    WorkDoneProgressBegin {
-                        title: "kotlin-lsp".into(),
-                        cancellable: Some(false),
-                        message: Some(message.to_owned()),
-                        percentage: Some(0),
-                    },
-                )),
-            })
-            .await;
-    }
-
-    async fn report(&self, token: &NumberOrString, done: usize, total: usize) {
-        let pct = ((done * 100).checked_div(total).unwrap_or(0)) as u32;
-        self.0
-            .send_notification::<progress::KotlinProgress>(ProgressParams {
-                token: token.clone(),
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Report(
-                    WorkDoneProgressReport {
-                        cancellable: Some(false),
-                        message: Some(format!("{done}/{total} files…")),
-                        percentage: Some(pct),
-                    },
-                )),
-            })
-            .await;
-    }
-
-    async fn end(&self, token: &NumberOrString, message: &str) {
-        self.0
-            .send_notification::<progress::KotlinProgress>(ProgressParams {
-                token: token.clone(),
-                value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(WorkDoneProgressEnd {
-                    message: Some(message.to_owned()),
-                })),
-            })
-            .await;
-    }
-}
+// Re-export for external callers that use the original crate paths.
+pub(crate) use panic_guard::panic_safe;
+pub(crate) use progress::LspProgressReporter;
 
 pub(crate) struct Backend {
     pub(super) client: Client,
@@ -173,290 +55,6 @@ impl Backend {
             event_tx,
             snippet_support: Arc::new(AtomicBool::new(false)),
         }
-    }
-
-    async fn execute_command_impl(
-        &self,
-        params: ExecuteCommandParams,
-    ) -> Result<Option<serde_json::Value>> {
-        if params.command == "kotlin-lsp/reindex" {
-            let root = self.indexer.workspace_root.get();
-            let Some(root) = root else {
-                self.client
-                    .show_message(MessageType::WARNING, "kotlin-lsp: no workspace root set")
-                    .await;
-                return Ok(None);
-            };
-            let idx = Arc::clone(&self.indexer);
-            let client = self.client.clone();
-            idx.reset_index_state();
-            tokio::spawn(async move {
-                idx.index_workspace(&root, Arc::new(LspProgressReporter(client)))
-                    .await;
-            });
-            self.client
-                .show_message(MessageType::INFO, "kotlin-lsp: reindexing workspace…")
-                .await;
-        } else if params.command == "kotlin-lsp/clearCache" {
-            let arg = params
-                .arguments
-                .first()
-                .and_then(|v| v.as_str())
-                .map(|s| s.to_string());
-            let target_root = if let Some(p) = arg {
-                let pb = std::path::PathBuf::from(p);
-                if !pb.is_dir() {
-                    self.client
-                        .show_message(
-                            MessageType::WARNING,
-                            format!("kotlin-lsp/clearCache: not a directory: {}", pb.display()),
-                        )
-                        .await;
-                    return Ok(None);
-                }
-                pb
-            } else {
-                let current_root_opt = self.indexer.workspace_root.get();
-                match current_root_opt {
-                    Some(r) => r,
-                    None => {
-                        self.client
-                            .show_message(
-                                MessageType::WARNING,
-                                "kotlin-lsp/clearCache: no workspace root set and no path provided",
-                            )
-                            .await;
-                        return Ok(None);
-                    }
-                }
-            };
-            let cache_path = workspace_cache_path(&target_root);
-            if let Some(cache_dir) = cache_path.parent() {
-                match std::fs::remove_dir_all(cache_dir) {
-                    Ok(_) => {
-                        log::info!("Cleared workspace cache directory: {}", cache_dir.display());
-                        self.client
-                            .show_message(
-                                MessageType::INFO,
-                                format!("kotlin-lsp: cleared cache for {}", target_root.display()),
-                            )
-                            .await;
-                    }
-                    Err(e) => {
-                        log::warn!("Failed to remove cache dir {}: {}", cache_dir.display(), e);
-                        self.client
-                            .show_message(
-                                MessageType::WARNING,
-                                format!("kotlin-lsp: failed to clear cache: {}", e),
-                            )
-                            .await;
-                    }
-                }
-            } else {
-                self.client
-                    .show_message(
-                        MessageType::WARNING,
-                        "kotlin-lsp/clearCache: cache path parent missing",
-                    )
-                    .await;
-            }
-        }
-        Ok(None)
-    }
-
-    fn detect_snippet_support(params: &InitializeParams) -> bool {
-        params
-            .capabilities
-            .text_document
-            .as_ref()
-            .and_then(|text_document| text_document.completion.as_ref())
-            .and_then(|completion| completion.completion_item.as_ref())
-            .and_then(|completion_item| completion_item.snippet_support)
-            .unwrap_or(false)
-    }
-
-    fn resolve_workspace_root(params: &InitializeParams) -> Option<PathBuf> {
-        if std::env::var("KOTLIN_LSP_PREFER_CONFIG_ROOT").is_ok() {
-            // Copilot CLI mode: config file overrides client rootUri so
-            // kotlin_lsp_set_workspace works correctly.
-            Self::workspace_root_from_environment()
-                .or_else(Self::workspace_root_from_config)
-                .or_else(|| Self::workspace_root_from_client(params))
-        } else {
-            // Editor mode: always honour the client's rootUri.
-            Self::workspace_root_from_environment()
-                .or_else(|| Self::workspace_root_from_client(params))
-                .or_else(Self::workspace_root_from_config)
-        }
-    }
-
-    fn workspace_root_from_environment() -> Option<PathBuf> {
-        std::env::var("KOTLIN_LSP_WORKSPACE_ROOT")
-            .ok()
-            .map(PathBuf::from)
-            .filter(|workspace_root| workspace_root.is_dir())
-    }
-
-    fn workspace_root_from_client(params: &InitializeParams) -> Option<PathBuf> {
-        Self::initialize_root_uri(params)
-            .and_then(|root_uri| root_uri.to_file_path().ok())
-            .filter(|workspace_root| workspace_root.is_dir())
-            .map(|workspace_root| Self::walk_up_to_git_root(&workspace_root))
-    }
-
-    fn initialize_root_uri(params: &InitializeParams) -> Option<Url> {
-        params.root_uri.clone().or_else(|| {
-            params
-                .workspace_folders
-                .as_deref()
-                .and_then(|workspace_folders| workspace_folders.first())
-                .map(|workspace_folder| workspace_folder.uri.clone())
-        })
-    }
-
-    fn walk_up_to_git_root(workspace_root: &Path) -> PathBuf {
-        let mut current_directory = workspace_root;
-        loop {
-            if current_directory.join(".git").exists() {
-                return current_directory.to_path_buf();
-            }
-            match current_directory.parent() {
-                Some(parent_directory) => current_directory = parent_directory,
-                None => return workspace_root.to_path_buf(),
-            }
-        }
-    }
-
-    fn workspace_root_from_config() -> Option<PathBuf> {
-        let config_file = crate::util::home_dir()
-            .unwrap_or_else(|| std::path::PathBuf::from("/tmp"))
-            .join(".config/kotlin-lsp/workspace");
-        std::fs::read_to_string(config_file)
-            .ok()
-            .map(|workspace_root| PathBuf::from(workspace_root.trim()))
-            .filter(|workspace_root| workspace_root.is_dir())
-    }
-
-    async fn configure_initialized_workspace(
-        &self,
-        params: &InitializeParams,
-        workspace_root: &Path,
-        workspace_pinned: bool,
-    ) {
-        let (explicit_source_paths, ignore_patterns) =
-            self.apply_initialization_options(params.initialization_options.as_ref());
-        if self
-            .event_tx
-            .send(Event::Initialize {
-                config: Config {
-                    root: workspace_root.to_path_buf(),
-                    explicit_source_paths,
-                    ignore_patterns,
-                    pin_workspace: workspace_pinned,
-                },
-                completion_tx: None,
-            })
-            .await
-            .is_err()
-        {
-            log::error!(
-                "configure_initialized_workspace: workspace actor channel closed; \
-                 indexing will not start"
-            );
-        }
-    }
-
-    fn apply_initialization_options(
-        &self,
-        initialization_options: Option<&serde_json::Value>,
-    ) -> (Vec<String>, Vec<String>) {
-        let ignore_patterns =
-            Self::collect_indexing_option_strings(initialization_options, "ignorePatterns")
-                .unwrap_or_default();
-        if !ignore_patterns.is_empty() {
-            log::info!("ignorePatterns: {:?}", ignore_patterns);
-        }
-
-        let explicit_source_paths =
-            Self::collect_indexing_option_strings(initialization_options, "sourcePaths")
-                .unwrap_or_default();
-        if !explicit_source_paths.is_empty() {
-            log::info!("sourcePaths: {:?}", explicit_source_paths);
-        }
-
-        (explicit_source_paths, ignore_patterns)
-    }
-
-    fn collect_indexing_option_strings(
-        initialization_options: Option<&serde_json::Value>,
-        option_name: &str,
-    ) -> Option<Vec<String>> {
-        let option_values = initialization_options?
-            .get("indexingOptions")?
-            .get(option_name)?
-            .as_array()?;
-        let collected_values: Vec<String> = option_values
-            .iter()
-            .filter_map(|value| value.as_str().map(str::to_owned))
-            .collect();
-        (!collected_values.is_empty()).then_some(collected_values)
-    }
-}
-
-fn server_capabilities() -> ServerCapabilities {
-    ServerCapabilities {
-        text_document_sync: Some(TextDocumentSyncCapability::Options(
-            TextDocumentSyncOptions {
-                open_close: Some(true),
-                change: Some(TextDocumentSyncKind::FULL),
-                save: Some(TextDocumentSyncSaveOptions::SaveOptions(SaveOptions {
-                    include_text: Some(false),
-                })),
-                ..Default::default()
-            },
-        )),
-        completion_provider: Some(CompletionOptions {
-            trigger_characters: Some(vec![".".into(), ":".into(), "@".into()]),
-            resolve_provider: Some(true),
-            ..Default::default()
-        }),
-        hover_provider: Some(HoverProviderCapability::Simple(true)),
-        definition_provider: Some(OneOf::Left(true)),
-        declaration_provider: Some(DeclarationCapability::Simple(true)),
-        implementation_provider: Some(ImplementationProviderCapability::Simple(true)),
-        references_provider: Some(OneOf::Left(true)),
-        document_highlight_provider: Some(OneOf::Left(true)),
-        document_symbol_provider: Some(OneOf::Left(true)),
-        inlay_hint_provider: Some(OneOf::Left(true)),
-        workspace: Some(WorkspaceServerCapabilities {
-            workspace_folders: None,
-            file_operations: None,
-        }),
-        workspace_symbol_provider: Some(OneOf::Left(true)),
-        execute_command_provider: Some(ExecuteCommandOptions {
-            commands: vec!["kotlin-lsp/reindex".into(), "kotlin-lsp/clearCache".into()],
-            ..Default::default()
-        }),
-        rename_provider: Some(OneOf::Right(RenameOptions {
-            prepare_provider: Some(true),
-            work_done_progress_options: Default::default(),
-        })),
-        folding_range_provider: Some(FoldingRangeProviderCapability::Simple(true)),
-        code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
-        signature_help_provider: Some(SignatureHelpOptions {
-            trigger_characters: Some(vec!["(".into(), ",".into()]),
-            retrigger_characters: None,
-            work_done_progress_options: Default::default(),
-        }),
-        semantic_tokens_provider: Some(SemanticTokensServerCapabilities::SemanticTokensOptions(
-            SemanticTokensOptions {
-                legend: semantic_tokens::legend(),
-                full: Some(SemanticTokensFullOptions::Bool(true)),
-                range: Some(true),
-                work_done_progress_options: Default::default(),
-            },
-        )),
-        ..Default::default()
     }
 }
 
@@ -498,7 +96,7 @@ impl LanguageServer for Backend {
                 name: "kotlin-lsp".into(),
                 version: Some(env!("CARGO_PKG_VERSION").into()),
             }),
-            capabilities: server_capabilities(),
+            capabilities: capabilities::server_capabilities(),
         })
     }
 
@@ -520,7 +118,11 @@ impl LanguageServer for Backend {
         // when it changes — branch switches swap many files at once without sending
         // per-file workspace/didChangeWatchedFiles notifications.
         if let Some(root) = self.indexer.workspace_root.get() {
-            spawn_git_head_watcher(root, Arc::clone(&self.indexer), self.client.clone());
+            git_watcher::spawn_git_head_watcher(
+                root,
+                Arc::clone(&self.indexer),
+                self.client.clone(),
+            );
         }
     }
 
@@ -772,66 +374,4 @@ impl LanguageServer for Backend {
         })
         .await
     }
-}
-
-// ─── Git HEAD watcher ────────────────────────────────────────────────────────
-
-/// Resolves the current git commit SHA from `.git/HEAD`.
-///
-/// For a symbolic ref (`ref: refs/heads/main`), reads the pointed-to ref file.
-/// For a detached HEAD, returns the raw SHA from HEAD itself.
-/// Returns `None` if the git directory doesn't exist or files can't be read.
-fn read_git_commit(git_dir: &Path) -> Option<String> {
-    let head = std::fs::read_to_string(git_dir.join("HEAD")).ok()?;
-    let head = head.trim();
-    if let Some(ref_path) = head.strip_prefix("ref: ") {
-        // Symbolic ref — resolve to actual commit SHA.
-        std::fs::read_to_string(git_dir.join(ref_path))
-            .ok()
-            .map(|s| s.trim().to_string())
-            // If the ref file doesn't exist yet (empty branch), fall back to
-            // the symbolic ref itself so we still detect the branch name change.
-            .or_else(|| Some(head.to_string()))
-    } else {
-        // Detached HEAD.
-        Some(head.to_string())
-    }
-}
-
-/// Spawns a background task that polls `.git/HEAD` every 2 seconds.
-/// When the resolved commit SHA changes (branch switch or new commit), clears
-/// the in-memory index and triggers a full workspace reindex.
-fn spawn_git_head_watcher(root: PathBuf, indexer: Arc<Indexer>, client: Client) {
-    let git_dir = root.join(".git");
-    if !git_dir.is_dir() {
-        return;
-    }
-    let mut last_commit = read_git_commit(&git_dir).unwrap_or_default();
-    tokio::spawn(async move {
-        let mut interval = tokio::time::interval(tokio::time::Duration::from_secs(2));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            interval.tick().await;
-            let current = read_git_commit(&git_dir).unwrap_or_default();
-            if current.is_empty() || current == last_commit {
-                continue;
-            }
-            last_commit = current;
-            log::info!("git HEAD changed — triggering workspace reindex");
-            client
-                .show_message(
-                    MessageType::INFO,
-                    "kotlin-lsp: branch changed, reindexing workspace…",
-                )
-                .await;
-            let idx = Arc::clone(&indexer);
-            let root_clone = root.clone();
-            let client_clone = client.clone();
-            idx.reset_index_state();
-            tokio::spawn(async move {
-                idx.index_workspace(&root_clone, Arc::new(LspProgressReporter(client_clone)))
-                    .await;
-            });
-        }
-    });
 }

--- a/src/backend/panic_guard.rs
+++ b/src/backend/panic_guard.rs
@@ -1,0 +1,58 @@
+use futures::FutureExt;
+use tower_lsp::jsonrpc::Result;
+
+/// Wraps an async handler in `catch_unwind` so a panic in one request doesn't
+/// kill the server process. Returns an internal error to the client on panic.
+pub(crate) async fn panic_safe<F, T>(method: &str, future: F) -> Result<T>
+where
+    F: std::future::Future<Output = Result<T>> + Send,
+    T: Send + 'static,
+{
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    // Wrapper that sets PANIC_CAUGHT on each poll so the panic hook
+    // always sees the flag regardless of which thread resumes the future.
+    struct PanicGuarded<Fut>(Pin<Box<Fut>>);
+
+    impl<Fut: Future> Future for PanicGuarded<Fut> {
+        type Output = Fut::Output;
+        fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+            crate::PANIC_CAUGHT.with(|c| c.set(true));
+            let result = self.0.as_mut().poll(cx);
+            if result.is_ready() {
+                crate::PANIC_CAUGHT.with(|c| c.set(false));
+            }
+            result
+        }
+    }
+
+    impl<Fut> Drop for PanicGuarded<Fut> {
+        fn drop(&mut self) {
+            crate::PANIC_CAUGHT.with(|c| c.set(false));
+        }
+    }
+
+    let guarded = PanicGuarded(Box::pin(future));
+    let result = std::panic::AssertUnwindSafe(guarded).catch_unwind().await;
+
+    match result {
+        Ok(result) => result,
+        Err(payload) => {
+            let message = if let Some(s) = payload.downcast_ref::<&str>() {
+                (*s).to_owned()
+            } else if let Some(s) = payload.downcast_ref::<String>() {
+                s.clone()
+            } else {
+                "unknown panic".to_owned()
+            };
+            log::error!("PANIC in {method}: {message}");
+            Err(tower_lsp::jsonrpc::Error {
+                code: tower_lsp::jsonrpc::ErrorCode::InternalError,
+                message: format!("internal error in {method}").into(),
+                data: None,
+            })
+        }
+    }
+}

--- a/src/backend/progress.rs
+++ b/src/backend/progress.rs
@@ -1,0 +1,68 @@
+use crate::indexer::ProgressReporter;
+use tower_lsp::lsp_types::*;
+use tower_lsp::Client;
+
+/// `$/progress` notification — reports workspace indexing status to the editor.
+pub(super) enum KotlinProgress {}
+impl tower_lsp::lsp_types::notification::Notification for KotlinProgress {
+    type Params = ProgressParams;
+    const METHOD: &'static str = "$/progress";
+}
+
+/// Sends LSP `$/progress` notifications via `tower_lsp::Client`.
+pub(crate) struct LspProgressReporter(pub(crate) Client);
+
+impl ProgressReporter for LspProgressReporter {
+    async fn begin(&self, token: &NumberOrString, message: &str) {
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_millis(500),
+            self.0
+                .send_request::<tower_lsp::lsp_types::request::WorkDoneProgressCreate>(
+                    WorkDoneProgressCreateParams {
+                        token: token.clone(),
+                    },
+                ),
+        )
+        .await;
+        self.0
+            .send_notification::<KotlinProgress>(ProgressParams {
+                token: token.clone(),
+                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Begin(
+                    WorkDoneProgressBegin {
+                        title: "kotlin-lsp".into(),
+                        cancellable: Some(false),
+                        message: Some(message.to_owned()),
+                        percentage: Some(0),
+                    },
+                )),
+            })
+            .await;
+    }
+
+    async fn report(&self, token: &NumberOrString, done: usize, total: usize) {
+        let pct = ((done * 100).checked_div(total).unwrap_or(0)) as u32;
+        self.0
+            .send_notification::<KotlinProgress>(ProgressParams {
+                token: token.clone(),
+                value: ProgressParamsValue::WorkDone(WorkDoneProgress::Report(
+                    WorkDoneProgressReport {
+                        cancellable: Some(false),
+                        message: Some(format!("{done}/{total} files…")),
+                        percentage: Some(pct),
+                    },
+                )),
+            })
+            .await;
+    }
+
+    async fn end(&self, token: &NumberOrString, message: &str) {
+        self.0
+            .send_notification::<KotlinProgress>(ProgressParams {
+                token: token.clone(),
+                value: ProgressParamsValue::WorkDone(WorkDoneProgress::End(WorkDoneProgressEnd {
+                    message: Some(message.to_owned()),
+                })),
+            })
+            .await;
+    }
+}


### PR DESCRIPTION
## Summary

Splits `src/backend/mod.rs` (was 837 lines) into 6 focused sub-modules. Each module has a single reason to change.

## New modules

| Module | Responsibility |
|--------|---------------|
| `panic_guard.rs` | `panic_safe()` + `PanicGuarded` — panic boundary for LSP handlers |
| `progress.rs` | `LspProgressReporter` + `KotlinProgress` notification type |
| `init.rs` | Workspace-root resolution + initialization `impl Backend` methods |
| `capabilities.rs` | `server_capabilities()` free function |
| `git_watcher.rs` | `read_git_commit` + `spawn_git_head_watcher` (now handles worktrees/submodules) |
| `commands.rs` | `execute_command_impl` (reindex + clearCache) |

## After

`mod.rs` is ~375 lines (down from 837). It now contains:
- Module declarations + re-exports for preserved crate paths (`panic_safe`, `LspProgressReporter`)
- `Backend` struct + `new()`
- `LanguageServer` dispatch impl — most handlers are one-line `panic_safe` delegations; lifecycle handlers (`initialize`, `did_change`, `did_change_watched_files`) retain their implementation since they own concurrency/sequencing logic that has no natural sub-module home yet

## Also fixed
- `spawn_git_head_watcher` now handles git worktrees and submodules (where `.git` is a file with `gitdir:` pointer, not a directory)

## Verified

- ✅ 1243 tests pass
- ✅ Zero clippy warnings (`-D warnings`)