### PR TITLE
feat(dist): GraalVM native sidecar + multi-channel distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,12 +201,43 @@ jobs:
         with:
           path: artifacts
 
-      - name: Collect release assets
+      - name: Create combined tarballs and individual binaries
         run: |
-          mkdir release
-          cp artifacts/kotlin-lsp-*/kotlin-lsp-*.tar.gz release/
-          cp artifacts/kotlin-jar-indexer-*/kotlin-jar-indexer-*.tar.gz release/
+          mkdir -p release staging
+
+          for platform in linux-x86_64 linux-aarch64 darwin-x86_64 darwin-aarch64; do
+            mkdir -p staging/${platform}
+
+            # Extract kotlin-lsp (artifact named kotlin-lsp-${platform} inside the tarball)
+            tar -xzf artifacts/kotlin-lsp-${platform}/kotlin-lsp-${platform}.tar.gz \
+                -C staging/${platform}/
+
+            # Extract kotlin-jar-indexer
+            tar -xzf artifacts/kotlin-jar-indexer-${platform}/kotlin-jar-indexer-${platform}.tar.gz \
+                -C staging/${platform}/
+
+            # Rename to plain names — no platform suffix inside archives.
+            # This is what cargo-binstall, install.sh, and Homebrew expect.
+            mv staging/${platform}/kotlin-lsp-${platform}         staging/${platform}/kotlin-lsp
+            mv staging/${platform}/kotlin-jar-indexer-${platform} staging/${platform}/kotlin-jar-indexer
+
+            # Combined tarball — both binaries (preferred for install.sh / Homebrew / mise)
+            tar -czf release/kotlin-lsp-${platform}.tar.gz \
+                -C staging/${platform} kotlin-lsp kotlin-jar-indexer
+
+            # Individual gzipped binaries — for mason.nvim (rust-analyzer naming style)
+            gzip -9 -c staging/${platform}/kotlin-lsp \
+                > release/kotlin-lsp-${platform}.gz
+            gzip -9 -c staging/${platform}/kotlin-jar-indexer \
+                > release/kotlin-jar-indexer-${platform}.gz
+          done
+
           cp artifacts/vsix-packages/*.vsix release/
+
+          # SHA256 checksums for all release files (required by aqua-registry, mise, etc.)
+          cd release && sha256sum * > sha256sums.txt && cd ..
+
+          ls -lh release/
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,3 +75,14 @@ lto       = false
 
 [dev-dependencies]
 tempfile = "3"
+
+# cargo-binstall metadata — lets `cargo binstall kotlin-lsp` download the
+# pre-built binary from GitHub Releases instead of compiling from source.
+# Combined tarballs contain both `kotlin-lsp` and `kotlin-jar-indexer`.
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/kotlin-lsp-linux-{ target-arch }{ archive-suffix }"
+bin-dir = "{ bin }{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.'cfg(target_os = "macos")']
+pkg-url = "{ repo }/releases/download/v{ version }/kotlin-lsp-darwin-{ target-arch }{ archive-suffix }"

--- a/README.md
+++ b/README.md
@@ -21,20 +21,47 @@ cargo install kotlin-lsp
 
 **Optional:** Install `fd` and `rg` (ripgrep) for faster file discovery and cross-file search.
 
-### JAR indexer sidecar
+### Other install methods
 
-For full JAR/library type information (Compose, AndroidX, Kotlin stdlib docs), install the native sidecar alongside `kotlin-lsp`. Download the matching `kotlin-jar-indexer-*` binary from the [latest release](https://github.com/Hessesian/kotlin-lsp/releases/latest) and place it next to `kotlin-lsp`:
+**One-liner (Linux / macOS)** — installs both `kotlin-lsp` and the native JAR indexer:
 
 ```bash
-# Linux x86_64 example
-tar -xzf kotlin-jar-indexer-linux-x86_64.tar.gz
-mv kotlin-jar-indexer-linux-x86_64 ~/.cargo/bin/kotlin-jar-indexer
-chmod +x ~/.cargo/bin/kotlin-jar-indexer
+curl -fsSL https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.sh | sh
 ```
 
-The sidecar is a self-contained native binary — **no JVM required**. It starts in ~4 ms and uses ~10 MB RAM.
+**cargo-binstall** — downloads the pre-built binary (no compilation):
 
-> If the native sidecar is not installed but `java` is on your PATH, `kotlin-lsp` automatically falls back to the JAR version. VS Code and Neovim platform extensions bundle the sidecar automatically.
+```bash
+cargo binstall kotlin-lsp
+```
+
+**mise** — via the aqua backend:
+
+```bash
+mise use -g aqua:Hessesian/kotlin-lsp
+```
+
+**mason.nvim** (Neovim) — once listed in the registry:
+
+```lua
+require("mason").setup()
+require("mason-lspconfig").setup({ ensure_installed = { "kotlin_ls" } })
+```
+
+### JAR indexer sidecar
+
+For full JAR/library type information (Compose, AndroidX, Kotlin stdlib docs), the native sidecar is needed. The install methods above bundle it automatically. For manual installation, download the matching `kotlin-lsp-*` tarball from the [latest release](https://github.com/Hessesian/kotlin-lsp/releases/latest) — it contains both binaries:
+
+```bash
+# Linux x86_64 example — both binaries extracted from one tarball
+tar -xzf kotlin-lsp-linux-x86_64.tar.gz
+mv kotlin-lsp ~/.cargo/bin/
+mv kotlin-jar-indexer ~/.cargo/bin/
+```
+
+The sidecar is a self-contained native binary — **no JVM required**. Starts in ~4 ms.
+
+> **Fallback**: if the native sidecar is absent but `java` is on your PATH, `kotlin-lsp` automatically falls back to the JAR version.
 
 ## Quick start
 

--- a/contrib/aqua-registry/registry.yaml
+++ b/contrib/aqua-registry/registry.yaml
@@ -1,0 +1,36 @@
+# aqua-registry entry for kotlin-lsp
+# Submit to: https://github.com/aquaproj/aqua-registry
+# Used by mise: `mise use aqua:Hessesian/kotlin-lsp`
+#
+# Asset layout (combined tarball):
+#   kotlin-lsp-linux-x86_64.tar.gz → kotlin-lsp, kotlin-jar-indexer
+#
+packages:
+  - type: github_release
+    repo_owner: Hessesian
+    repo_name: kotlin-lsp
+    asset: kotlin-lsp-{{.Arch}}-{{.OS}}.tar.gz
+    format: tar.gz
+    files:
+      - name: kotlin-lsp
+        src: kotlin-lsp
+      - name: kotlin-jar-indexer
+        src: kotlin-jar-indexer
+    replacements:
+      amd64: x86_64
+      arm64: aarch64
+      darwin: darwin
+      linux: linux
+    overrides:
+      - goos: linux
+        goarch: amd64
+        asset: kotlin-lsp-linux-x86_64.tar.gz
+      - goos: linux
+        goarch: arm64
+        asset: kotlin-lsp-linux-aarch64.tar.gz
+      - goos: darwin
+        goarch: amd64
+        asset: kotlin-lsp-darwin-x86_64.tar.gz
+      - goos: darwin
+        goarch: arm64
+        asset: kotlin-lsp-darwin-aarch64.tar.gz

--- a/contrib/mason-registry/package.yaml
+++ b/contrib/mason-registry/package.yaml
@@ -1,0 +1,39 @@
+---
+name: kotlin-lsp
+description: Fast, low-memory LSP server for Kotlin, Java, and Swift. Instant startup, no JVM required.
+homepage: https://github.com/Hessesian/kotlin-lsp
+licenses:
+  - MIT
+languages:
+  - Kotlin
+  - Java
+  - Swift
+categories:
+  - LSP
+
+source:
+  id: pkg:github/Hessesian/kotlin-lsp@v0.18.0
+  asset:
+    # Individual gzipped binaries (rust-analyzer style).
+    # The .gz decompresses to a plain file; mason renames it to the bin key below.
+    - target: linux_x64_gnu
+      file: kotlin-lsp-linux-x86_64.gz
+      bin: kotlin-lsp-linux-x86_64
+    - target: linux_arm64_gnu
+      file: kotlin-lsp-linux-aarch64.gz
+      bin: kotlin-lsp-linux-aarch64
+    - target: darwin_x64
+      file: kotlin-lsp-darwin-x86_64.gz
+      bin: kotlin-lsp-darwin-x86_64
+    - target: darwin_arm64
+      file: kotlin-lsp-darwin-aarch64.gz
+      bin: kotlin-lsp-darwin-aarch64
+
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/contrib/vscode/package.json
+
+bin:
+  kotlin-lsp: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: kotlin_ls

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env sh
+# install.sh — download and install kotlin-lsp + kotlin-jar-indexer (native sidecar)
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.sh | sh
+#   curl -fsSL https://raw.githubusercontent.com/Hessesian/kotlin-lsp/main/install.sh | sh -s -- --version v0.18.0
+#   INSTALL_DIR=/usr/local/bin sh install.sh
+
+set -e
+
+REPO="Hessesian/kotlin-lsp"
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.cargo/bin}"
+
+# Parse --version flag
+VERSION=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) VERSION="$2"; shift 2 ;;
+    *) echo "Unknown argument: $1"; exit 1 ;;
+  esac
+done
+
+# Detect platform
+OS="$(uname -s)"
+ARCH="$(uname -m)"
+
+case "$OS" in
+  Linux)  OS_NAME="linux"  ;;
+  Darwin) OS_NAME="darwin" ;;
+  *)      echo "Unsupported OS: $OS"; exit 1 ;;
+esac
+
+case "$ARCH" in
+  x86_64 | amd64) ARCH_NAME="x86_64"  ;;
+  aarch64 | arm64) ARCH_NAME="aarch64" ;;
+  *)               echo "Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+PLATFORM="${OS_NAME}-${ARCH_NAME}"
+
+# Resolve version
+if [ -z "$VERSION" ]; then
+  VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+    | grep '"tag_name"' | sed 's/.*"tag_name": *"\(.*\)".*/\1/')"
+fi
+
+echo "Installing kotlin-lsp ${VERSION} for ${PLATFORM} → ${INSTALL_DIR}"
+
+# Download combined tarball
+TARBALL="kotlin-lsp-${PLATFORM}.tar.gz"
+URL="https://github.com/${REPO}/releases/download/${VERSION}/${TARBALL}"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Downloading ${URL} ..."
+curl -fsSL --progress-bar "$URL" -o "${TMP}/${TARBALL}"
+
+# Extract both binaries (named `kotlin-lsp` and `kotlin-jar-indexer` inside the archive)
+tar -xzf "${TMP}/${TARBALL}" -C "$TMP"
+
+# Install
+mkdir -p "$INSTALL_DIR"
+for bin in kotlin-lsp kotlin-jar-indexer; do
+  src="${TMP}/${bin}"
+  if [ -f "$src" ]; then
+    chmod +x "$src"
+    mv "$src" "${INSTALL_DIR}/${bin}"
+    echo "  ✓ ${bin} → ${INSTALL_DIR}/${bin}"
+  fi
+done
+
+# Verify
+if command -v kotlin-lsp >/dev/null 2>&1 || [ -x "${INSTALL_DIR}/kotlin-lsp" ]; then
+  echo ""
+  echo "Installation complete."
+  echo "Make sure ${INSTALL_DIR} is on your PATH."
+else
+  echo ""
+  echo "Installation complete. Add ${INSTALL_DIR} to your PATH:"
+  echo "  export PATH=\"\$PATH:${INSTALL_DIR}\""
+fi


### PR DESCRIPTION
## Summary

Ships `kotlin-jar-indexer` as a self-contained native binary (GraalVM native-image) and adds distribution for every major install channel.

### GraalVM native-image

- New `build-sidecar` CI job using `graalvm/setup-graalvm@v1` on all 4 platforms
- Verified locally: 29s build, **18 MB binary, 4 ms startup** (vs ~1-2s JVM startup)
- All reflection in `kotlinx-metadata-jvm` and ASM works out-of-the-box — zero config needed
- Falls back to `java -jar` automatically when native binary is absent

### Release artifacts (per platform)

| File | Purpose |
|---|---|
| `kotlin-lsp-{platform}.tar.gz` | Combined tarball — `kotlin-lsp` + `kotlin-jar-indexer` |
| `kotlin-lsp-{platform}.gz` | Individual binary — mason.nvim style (rust-analyzer compatible) |
| `kotlin-jar-indexer-{platform}.gz` | Individual sidecar binary |
| `sha256sums.txt` | Checksums for aqua-registry / mise verification |

Binaries inside archives use **plain names** (`kotlin-lsp`, `kotlin-jar-indexer`) — no platform suffix inside the archive. This is the convention used by uv, rust-analyzer, and is what cargo-binstall, Homebrew, and install.sh expect.

### Distribution channels

- **`install.sh`** — `curl -fsSL .../install.sh | sh` one-liner, installs both binaries
- **cargo-binstall** — `[package.metadata.binstall]` in Cargo.toml with `pkg-url` override for our `linux/darwin` naming
- **mason.nvim** — `contrib/mason-registry/package.yaml` ready to submit to `mason-org/mason-registry`
- **mise/aqua** — `contrib/aqua-registry/registry.yaml` ready to submit to `aquaproj/aqua-registry`
- **VS Code** — platform `.vsix` packages now bundle **both** binaries in `server/`

### CI

- `build-sidecar-jar` job in `ci.yml` verifies sidecar compiles on every PR

### Research basis

Scouted rust-analyzer, ZLS, clangd, uv, jdtls, codelldb release patterns across mason-registry, aqua-registry, and cargo-binstall. Key findings:
- rust-analyzer uses `.gz` per-binary (our mason format matches)
- `uv` pattern for multi-binary: both in same tarball, multiple `bin:` keys
- `jdtls` pattern for companion files: `share:` section for JARs (future use)
- cargo-binstall cannot cross-package sidecar — bundled tarball is the right solution