### PR TITLE
fix: address PR #149 review comments (install.sh safety + aqua template)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ require("mason-lspconfig").setup({ ensure_installed = { "kotlin_ls" } })
 
 ### JAR indexer sidecar
 
-For full JAR/library type information (Compose, AndroidX, Kotlin stdlib docs), the native sidecar is needed. The install methods above bundle it automatically. For manual installation, download the matching `kotlin-lsp-*` tarball from the [latest release](https://github.com/Hessesian/kotlin-lsp/releases/latest) — it contains both binaries:
+For full JAR/library type information (Compose, AndroidX, Kotlin stdlib docs), the native sidecar is needed. The `install.sh` and mise/aqua channels install both binaries automatically. cargo-binstall and mason.nvim install only `kotlin-lsp` — in those cases, download the matching tarball manually to get the sidecar too:
 
 ```bash
 # Linux x86_64 example — both binaries extracted from one tarball

--- a/contrib/aqua-registry/registry.yaml
+++ b/contrib/aqua-registry/registry.yaml
@@ -9,7 +9,7 @@ packages:
   - type: github_release
     repo_owner: Hessesian
     repo_name: kotlin-lsp
-    asset: kotlin-lsp-{{.Arch}}-{{.OS}}.tar.gz
+    asset: kotlin-lsp-{{.OS}}-{{.Arch}}.tar.gz
     format: tar.gz
     files:
       - name: kotlin-lsp

--- a/install.sh
+++ b/install.sh
@@ -15,7 +15,11 @@ INSTALL_DIR="${INSTALL_DIR:-$HOME/.cargo/bin}"
 VERSION=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --version) VERSION="$2"; shift 2 ;;
+    --version)
+      if [ -z "$2" ]; then
+        echo "Error: --version requires a value (e.g. --version v0.18.0)"; exit 1
+      fi
+      VERSION="$2"; shift 2 ;;
     *) echo "Unknown argument: $1"; exit 1 ;;
   esac
 done
@@ -55,18 +59,34 @@ trap 'rm -rf "$TMP"' EXIT
 echo "Downloading ${URL} ..."
 curl -fsSL --progress-bar "$URL" -o "${TMP}/${TARBALL}"
 
+# Verify SHA256 checksum
+SUMS_URL="https://github.com/${REPO}/releases/download/${VERSION}/sha256sums.txt"
+echo "Verifying checksum ..."
+curl -fsSL "$SUMS_URL" -o "${TMP}/sha256sums.txt"
+EXPECTED="$(grep " ${TARBALL}$" "${TMP}/sha256sums.txt" | awk '{print $1}')"
+if [ -z "$EXPECTED" ]; then
+  echo "Error: ${TARBALL} not found in sha256sums.txt"; exit 1
+fi
+ACTUAL="$(sha256sum "${TMP}/${TARBALL}" 2>/dev/null | awk '{print $1}' \
+         || shasum -a 256 "${TMP}/${TARBALL}" | awk '{print $1}')"
+if [ "$ACTUAL" != "$EXPECTED" ]; then
+  echo "Error: checksum mismatch for ${TARBALL}"; echo "  expected: $EXPECTED"; echo "  got:      $ACTUAL"; exit 1
+fi
+echo "  ✓ checksum OK"
+
 # Extract both binaries (named `kotlin-lsp` and `kotlin-jar-indexer` inside the archive)
 tar -xzf "${TMP}/${TARBALL}" -C "$TMP"
 
-# Install
+# Install — fail fast if an expected binary is missing from the archive
 mkdir -p "$INSTALL_DIR"
 for bin in kotlin-lsp kotlin-jar-indexer; do
   src="${TMP}/${bin}"
-  if [ -f "$src" ]; then
-    chmod +x "$src"
-    mv "$src" "${INSTALL_DIR}/${bin}"
-    echo "  ✓ ${bin} → ${INSTALL_DIR}/${bin}"
+  if [ ! -f "$src" ]; then
+    echo "Error: expected binary '${bin}' not found in archive"; exit 1
   fi
+  chmod +x "$src"
+  mv "$src" "${INSTALL_DIR}/${bin}"
+  echo "  ✓ ${bin} → ${INSTALL_DIR}/${bin}"
 done
 
 # Verify

--- a/install.sh
+++ b/install.sh
@@ -67,8 +67,13 @@ EXPECTED="$(grep " ${TARBALL}$" "${TMP}/sha256sums.txt" | awk '{print $1}')"
 if [ -z "$EXPECTED" ]; then
   echo "Error: ${TARBALL} not found in sha256sums.txt"; exit 1
 fi
-ACTUAL="$(sha256sum "${TMP}/${TARBALL}" 2>/dev/null | awk '{print $1}' \
-         || shasum -a 256 "${TMP}/${TARBALL}" | awk '{print $1}')"
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL="$(sha256sum "${TMP}/${TARBALL}" | awk '{print $1}')"
+elif command -v shasum >/dev/null 2>&1; then
+  ACTUAL="$(shasum -a 256 "${TMP}/${TARBALL}" | awk '{print $1}')"
+else
+  echo "Error: neither sha256sum nor shasum is available"; exit 1
+fi
 if [ "$ACTUAL" != "$EXPECTED" ]; then
   echo "Error: checksum mismatch for ${TARBALL}"; echo "  expected: $EXPECTED"; echo "  got:      $ACTUAL"; exit 1
 fi


### PR DESCRIPTION
Fixes all 5 review comments from #149:

- **`--version` arg check**: explicit error when `--version` is passed without a value
- **SHA256 verification**: downloads `sha256sums.txt` and verifies tarball hash before extracting
- **Fail-fast on missing binary**: if `kotlin-lsp` or `kotlin-jar-indexer` is absent from the archive, script exits with an error instead of silently succeeding
- **README accuracy**: narrowed "bundle it automatically" claim — only `install.sh` and mise/aqua install the sidecar; cargo-binstall and mason.nvim install only `kotlin-lsp`
- **aqua-registry template**: fixed OS/arch order from `{{.Arch}}-{{.OS}}` to `{{.OS}}-{{.Arch}}` to match actual asset filenames