### PR TITLE
feat: agent confluence — check, --exclude-imports, diagnose fixes, parser false positive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.22.0
+
+### Features
+
+- **`kmp-lsp check <file|dir>…`** — new subcommand for instant tree-sitter syntax validation without an LSP session or index. Accepts files and directories (walks `.kt`, `.kts`, `.java`, `.swift`). Exits 1 on any error. Optional `--json` output with structured `{files_ok, files_with_errors, errors}` payload.
+- **`kmp-lsp refs --exclude-imports`** — new flag that strips import-statement matches from `refs` output. Useful for common names (`Event`, `Result`, `State`) where import lines otherwise flood results.
+- **`kmp-lsp diagnose` now reports syntax errors** — tree-sitter syntax errors are now surfaced alongside call-arg and `when` diagnostics instead of being silently dropped.
+- **README: AI agent integration section** — top-level section with one-liner to install the Copilot skill from the repo, linking to full agent setup docs.
+
+### Bug fixes
+
+- **Parser: suppress `@file:[Ann1, Ann2]` comma false positive** — tree-sitter-kotlin 0.3 emits spurious ERROR nodes for commas inside `@file:[…]` bracket annotation syntax. These are now filtered at the current-line level to avoid inadvertently suppressing real errors elsewhere in the file.
+- **Windows: `Path::canonicalize` UNC prefix** — `canonicalize()` on Windows returns `\\?\`-prefixed extended-length paths that confused `rg` and the rg output parser. The prefix is now stripped after canonicalization and `split_rg_fields` handles it as a fallback.
+
 ## 0.21.0
 
 ### Features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "kmp-lsp"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "bincode",
  "dashmap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -822,7 +822,7 @@ dependencies = [
 
 [[package]]
 name = "kmp-lsp"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "bincode",
  "dashmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["."]
 
 [package]
 name        = "kmp-lsp"
-version = "0.21.0"
+version = "0.22.0"
 edition     = "2021"
 description = "Fast, low-memory LSP server for Kotlin, Java, and Swift. Instant startup, dot-completion, go-to-definition, hover — no JVM required."
 license     = "MIT"

--- a/README.md
+++ b/README.md
@@ -69,6 +69,27 @@ The sidecar is a self-contained native binary — **no JVM required**. Starts in
 
 > **Fallback**: if the native sidecar is absent but `java` is on your PATH, `kmp-lsp` automatically falls back to the JAR version.
 
+## AI agent integration
+
+kmp-lsp ships a ready-made skill file that teaches agents (GitHub Copilot CLI, Serena, Claude Code, etc.) how to use it for code navigation.
+
+**Download the skill for your agent:**
+
+```bash
+# Copilot CLI — drop into your skills directory
+curl -fsSL https://raw.githubusercontent.com/Hessesian/kmp-lsp/main/contrib/copilot-skill/SKILL.md \
+  -o ~/.copilot/skills/kmp-lsp.md
+
+# Or copy from the repo if you have it cloned
+cp contrib/copilot-skill/SKILL.md ~/.copilot/skills/kmp-lsp.md
+```
+
+The skill covers: LSP navigation workflow, `kmp-lsp check` for post-edit syntax verification, `kmp-lsp refs --exclude-imports` for clean reference lists, when to use Serena MCP vs the `lsp` tool, and workspace switching.
+
+[Full agent setup (Copilot CLI + Serena MCP) →](docs/copilot.md)
+
+---
+
 ## Quick start
 
 **VS Code** — download and install the `.vsix` from the [latest release](https://github.com/Hessesian/kmp-lsp/releases/latest):

--- a/contrib/copilot-skill/SKILL.md
+++ b/contrib/copilot-skill/SKILL.md
@@ -60,7 +60,7 @@ This correctly handles mono-repos (e.g. `android/settings.gradle.kts` beats mono
 - **Extension functions (dot-receiver, cross-file)** — use `lsp workspaceSymbol` with dot-qualified query (e.g. `ReceiverType.methodName`) instead of goToDefinition
 - **No type inference** — tree-sitter based, not compiler-backed; generic type params unresolved
 - **Java interop** — Java symbols indexed, but cross-language go-to-def is unreliable
-- **No diagnostics** — server never emits compile errors or warnings
+- **No compiler diagnostics** — tree-sitter only; use `kmp-lsp check <file>` (syntax errors, instant) or `kmp-lsp diagnose <file> --root .` (call-arg + syntax, needs index) for post-edit checks
 - **rg alternation syntax** — use `|` (not `\|`) in ripgrep; `\|` is GNU grep syntax
 
 ### Extension-provided tools
@@ -95,10 +95,11 @@ Restricted ripgrep for Kotlin/Java/Swift files — **fallback only** when LSP ca
 3. **`lsp documentSymbol file.kt`** — enumerate all symbols in file
 4. **`lsp hover file.kt line col`** — type info, signature, doc comment
 5. **`lsp goToDefinition file.kt line col`** — jump to source
-6. **`lsp findReferences file.kt line col`** — all usages cross-project
+6. **`lsp findReferences file.kt line col`** — all usages cross-project; for common names (`Event`, `Result`, `State`) use `kmp-lsp refs <Name> --exclude-imports` instead to strip import noise
 7. **`lsp goToImplementation file.kt line col`** — interface subtypes (transitive)
 8. **`view` with line range** — read code at known location
-9. **`kotlin_rg`** — only for free-text, extension fns, generated code (provide reason)
+9. **`kmp-lsp check <file>`** — verify syntax after edits (instant, no index needed)
+10. **`kotlin_rg`** — only for free-text, extension fns, generated code (provide reason)
 
 #### Swift (iOS)
 1. **`lsp documentSymbol file.swift`** — always works immediately; get symbols + line numbers

--- a/docs/agent-reference.md
+++ b/docs/agent-reference.md
@@ -46,10 +46,10 @@ cargo build --profile profiling && samply record ./target/profiling/kmp-lsp inde
 | `src/queries.rs` | All tree-sitter S-expression queries and node-kind constants (Kotlin + Java + Swift) |
 | `src/resolver/` | Cross-file resolution, import handling, `rg` fallback |
 | `src/language/` | Per-language keyword sets, override-declaration detection, `LanguageParser` trait |
-| `src/cli/` | Standalone CLI: `index`, `find`, `refs`, `hover`, `complete`, `diagnose`, `tokens` subcommands |
+| `src/cli/` | Standalone CLI: `find`, `refs` (`--exclude-imports`), `check`, `diagnose`, `hover`, `complete`, `index`, `sources`, `extract-sources`, `tokens` subcommands |
 | `src/types.rs` | `SymbolEntry`, `SourceSet`, `Language`, `FileData`, shared types |
 | `src/workspace_json.rs` | Auto-discovery of source roots from `workspace.json` (JetBrains Gradle plugin format) |
-| `tests/` | Integration tests invoking the compiled binary: `cli_complete.rs`, `cli_diagnose.rs`, `lsp_smoke.rs` |
+| `tests/` | Integration tests invoking the compiled binary: `cli_complete.rs`, `cli_diagnose.rs`, `cli_check.rs`, `cli_refs.rs`, `lsp_smoke.rs` |
 
 ## Key types
 
@@ -105,10 +105,9 @@ Prefer LSP over `grep`/`rg` in this order:
 ### findReferences noise mitigation
 
 `findReferences` is name-based (no type resolution). For common method names:
-- Use `rg` with a qualified pattern: `rg "ReceiverClass\.methodName\("`
+- Use `kmp-lsp refs <Name> --exclude-imports` to strip import-statement matches (e.g. `Event`, `Result`, `State`)
+- Use `rg` with a qualified pattern: `rg "ReceiverClass\.methodName\("` for further narrowing
 - Or scope to the declaring class's package directory
-
-Planned improvement: import-aware filtering — only return refs from files that import the declaring class.
 
 ## Serena MCP — agentic tooling
 

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -59,6 +59,17 @@ lsp outgoingCalls <file> <line> <col> → find all functions called by a functio
 
 **Tip:** `workspaceSymbol` results include the declaration signature (e.g. `fun processPayment(amount: BigDecimal, currency: String): Result<Unit>`), so you rarely need a follow-up `hover` call.
 
+The CLI also provides commands that complement LSP navigation:
+
+```bash
+kmp-lsp check src/Foo.kt            # instant tree-sitter syntax check — no index needed
+kmp-lsp check src/ --json           # check a whole directory, JSON output, exit 1 on errors
+kmp-lsp refs Event --exclude-imports # refs without import-statement noise
+kmp-lsp diagnose src/Foo.kt --root . # call-arg + syntax diagnostics (needs index)
+```
+
+Use `kmp-lsp check` immediately after editing a file to verify syntax before running slower LSP queries. Use `--exclude-imports` on `refs` for common names (`Event`, `Result`, `State`) that would otherwise flood output with import lines.
+
 ## Serena MCP integration
 
 [Serena](https://github.com/oraios/serena) is an MCP server that wraps an LSP backend to expose symbol-level tools (`get_symbols_overview`, `find_referencing_symbols`, `replace_symbol_body`, etc.) directly to coding agents via the Model Context Protocol.
@@ -132,12 +143,15 @@ kmp-lsp (via the `lsp` tool) and Serena MCP tools are complementary — use them
 | Cross-file semantic rename | `lsp rename` |
 | Locate symbol file + line | `lsp workspaceSymbol` |
 | Type signatures and docs | `lsp hover` |
+| Verify syntax after an edit | `kmp-lsp check <file>` (instant, no index) |
+| Refs without import noise | `kmp-lsp refs <Name> --exclude-imports` |
+| Deep diagnostics (call-arg + syntax) | `kmp-lsp diagnose <file> --root .` |
 
-**Rule of thumb:** Serena for structural orientation and body edits; kmp-lsp for type-safe navigation and renaming. They don't overlap.
+**Rule of thumb:** Serena for structural orientation and body edits; kmp-lsp LSP for type-safe navigation and renaming; kmp-lsp CLI for fast syntax checks and filtered reference queries.
 
 ### Limitations
 
-- Serena exposes kmp-lsp's structural layer only — type inference and diagnostics are not available through Serena's MCP tools
+- Serena exposes kmp-lsp's structural layer only — type inference is not available through Serena's MCP tools; for diagnostics use `kmp-lsp check` (syntax, instant) or `kmp-lsp diagnose` (call-arg + syntax, needs index)
 - `replace_symbol_body` is reliable for focused method/class swaps; fall back to direct `edit` tool for large structural rewrites
 - `lsp rename` and `lsp goToImplementation` require a completed index — call `kmp_lsp_status` before using them if the session is cold
 

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -9,6 +9,8 @@ pub(crate) enum Subcommand {
     },
     Refs {
         name: String,
+        /// Strip import-statement matches from results.
+        exclude_imports: bool,
     },
     Hover {
         file: PathBuf,
@@ -131,6 +133,7 @@ struct ParsedCliFlags {
     dot: bool,
     eol: bool,
     no_stdlib: bool,
+    exclude_imports: bool,
 }
 
 fn parse_first_argument(args: &mut lexopt::Parser) -> Result<Option<std::ffi::OsString>, String> {
@@ -178,6 +181,7 @@ fn parse_cli_flags(args: &mut lexopt::Parser) -> Result<ParsedCliFlags, String> 
         dot: false,
         eol: false,
         no_stdlib: false,
+        exclude_imports: false,
     };
 
     loop {
@@ -207,6 +211,7 @@ fn parse_cli_flags(args: &mut lexopt::Parser) -> Result<ParsedCliFlags, String> 
             Some(lexopt::Arg::Short('d') | lexopt::Arg::Long("dot")) => parsed.dot = true,
             Some(lexopt::Arg::Short('e') | lexopt::Arg::Long("eol")) => parsed.eol = true,
             Some(lexopt::Arg::Long("no-stdlib")) => parsed.no_stdlib = true,
+            Some(lexopt::Arg::Long("exclude-imports")) => parsed.exclude_imports = true,
             Some(lexopt::Arg::Short('h') | lexopt::Arg::Long("help")) => {
                 print_help();
                 std::process::exit(0);
@@ -237,6 +242,7 @@ fn build_subcommand(subcommand: &str, parsed: ParsedCliFlags) -> Result<Subcomma
         dot,
         eol,
         no_stdlib,
+        exclude_imports,
         ..
     } = parsed;
     match subcommand {
@@ -245,6 +251,7 @@ fn build_subcommand(subcommand: &str, parsed: ParsedCliFlags) -> Result<Subcomma
         }),
         "refs" => Ok(Subcommand::Refs {
             name: first_positional(positionals, "refs requires a NAME argument")?,
+            exclude_imports,
         }),
         "hover" => build_hover_subcommand(positionals),
         "complete" => build_complete_subcommand(positionals, dot, eol, no_stdlib),

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -414,6 +414,8 @@ USAGE:
 SUBCOMMANDS:
     find    <name>              Find declarations of a symbol
     refs    <name>              Find all references to a symbol
+    check   <file|dir>…        Syntax-check files (no index needed; exit 1 on errors)
+    diagnose <file>             Call-arg + syntax diagnostics (requires index)
     hover   <file> <line> <col> Show type/doc info at a position
     complete <file> <line> [col] Show completion candidates at a position
     index                       Build and cache the workspace index
@@ -427,6 +429,7 @@ OPTIONS:
     --smart             Require index; build it if missing
     --json              Output results as JSON array
     --root <dir>        Workspace root (default: nearest .git dir or cwd)
+    --exclude-imports   (refs) Strip import-statement matches from results
     --resolve           (tokens) Load index for Phase 2 cross-file resolution
     --cst-only          (tokens) Force CST-only mode (default, kept for clarity)
     --phases            (tokens) Show per-phase token breakdown with dedup markers
@@ -444,11 +447,13 @@ OPTIONS:
 EXAMPLES:
     kmp-lsp find MyViewModel
     kmp-lsp refs --fast MyViewModel --root ./android
+    kmp-lsp refs Event --exclude-imports --root ./android
+    kmp-lsp check src/Foo.kt
+    kmp-lsp check src/ --json
+    kmp-lsp diagnose src/Foo.kt --root ./android
     kmp-lsp hover src/Foo.kt 42 10 --json
     kmp-lsp complete src/Foo.kt 42 10
-    kmp-lsp complete src/Foo.kt 42 10 --json
     kmp-lsp complete src/Foo.kt 42 --dot --json
-    kmp-lsp complete src/Foo.kt 42 --eol --json
     kmp-lsp complete src/Foo.kt 42 --dot --no-stdlib --json
     kmp-lsp index --root ./android
     kmp-lsp sources --root ./android

--- a/src/cli/args.rs
+++ b/src/cli/args.rs
@@ -59,6 +59,10 @@ pub(crate) enum Subcommand {
         dry_run: bool,
         patterns: Vec<String>,
     },
+    /// Syntax-check files with tree-sitter (no index needed). Exit 1 if errors found.
+    Check {
+        files: Vec<PathBuf>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -274,6 +278,9 @@ fn build_subcommand(subcommand: &str, parsed: ParsedCliFlags) -> Result<Subcomma
             dry_run,
             patterns: positionals,
         }),
+        "check" => Ok(Subcommand::Check {
+            files: positionals.iter().map(PathBuf::from).collect(),
+        }),
         _ => unreachable!(),
     }
 }
@@ -381,6 +388,7 @@ fn is_subcommand(value: &str) -> bool {
             | "diagnose"
             | "sources"
             | "extract-sources"
+            | "check"
     )
 }
 

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -1,0 +1,115 @@
+//! `kmp-lsp check` — syntax validation without an LSP session or index.
+
+use std::path::PathBuf;
+
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+struct CheckError {
+    file: String,
+    line: u32,
+    col: u32,
+    message: String,
+}
+
+pub(crate) fn run_check(files: &[PathBuf], json: bool) {
+    use crate::parser::parse_by_extension;
+
+    let mut errors: Vec<CheckError> = Vec::new();
+    let mut files_ok: u32 = 0;
+    let mut files_err: u32 = 0;
+
+    for file in files {
+        let content = match std::fs::read_to_string(file) {
+            Ok(content) => content,
+            Err(error) => {
+                let message = format!("read error: {error}");
+                if !json {
+                    eprintln!("{}: {message}", file.display());
+                }
+                errors.push(CheckError {
+                    file: file.to_string_lossy().into_owned(),
+                    line: 0,
+                    col: 0,
+                    message,
+                });
+                files_err += 1;
+                continue;
+            }
+        };
+
+        let data = parse_by_extension(&file.to_string_lossy(), &content);
+
+        if data.syntax_errors.is_empty() {
+            files_ok += 1;
+            continue;
+        }
+
+        files_err += 1;
+        for syntax_error in &data.syntax_errors {
+            errors.push(CheckError {
+                file: file.to_string_lossy().into_owned(),
+                line: syntax_error.range.start.line + 1,
+                col: syntax_error.range.start.character + 1,
+                message: syntax_error.message.clone(),
+            });
+        }
+    }
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "files_ok": files_ok,
+                "files_with_errors": files_err,
+                "errors": errors,
+            }))
+            .expect("serialize JSON")
+        );
+    } else {
+        for error in &errors {
+            println!(
+                "{}:{}:{}: {}",
+                error.file, error.line, error.col, error.message
+            );
+        }
+        if errors.is_empty() {
+            println!("All {} files OK.", files_ok);
+        } else {
+            eprintln!("{} error(s) in {} file(s).", errors.len(), files_err);
+        }
+    }
+
+    if !errors.is_empty() {
+        std::process::exit(1);
+    }
+}
+
+/// Expand file/directory paths to individual source files.
+/// Directories are walked recursively; only `.kt`, `.kts`, `.java`, `.swift` are included.
+pub(crate) fn expand_file_list(paths: &[PathBuf]) -> Vec<PathBuf> {
+    let mut result = Vec::new();
+    for path in paths {
+        if path.is_dir() {
+            for entry in walkdir::WalkDir::new(path)
+                .into_iter()
+                .filter_map(|entry| entry.ok())
+            {
+                let path = entry.path();
+                if path.is_file() {
+                    if let Some(ext) = path.extension().and_then(|ext| ext.to_str()) {
+                        if matches!(ext, "kt" | "kts" | "java" | "swift") {
+                            result.push(path.to_path_buf());
+                        }
+                    }
+                }
+            }
+        } else {
+            if !path.exists() {
+                eprintln!("warning: {}: no such file or directory", path.display());
+            }
+            result.push(path.clone());
+        }
+    }
+    result
+}

--- a/src/cli/check.rs
+++ b/src/cli/check.rs
@@ -57,15 +57,18 @@ pub(crate) fn run_check(files: &[PathBuf], json: bool) {
     }
 
     if json {
-        println!(
-            "{}",
-            serde_json::to_string_pretty(&serde_json::json!({
-                "files_ok": files_ok,
-                "files_with_errors": files_err,
-                "errors": errors,
-            }))
-            .expect("serialize JSON")
-        );
+        let value = serde_json::json!({
+            "files_ok": files_ok,
+            "files_with_errors": files_err,
+            "errors": errors,
+        });
+        match serde_json::to_string_pretty(&value) {
+            Ok(output) => println!("{output}"),
+            Err(error) => {
+                eprintln!("error: failed to serialize JSON: {error}");
+                std::process::exit(1);
+            }
+        }
     } else {
         for error in &errors {
             println!(
@@ -87,7 +90,7 @@ pub(crate) fn run_check(files: &[PathBuf], json: bool) {
 
 /// Expand file/directory paths to individual source files.
 /// Directories are walked recursively; only `.kt`, `.kts`, `.java`, `.swift` are included.
-pub(crate) fn expand_file_list(paths: &[PathBuf]) -> Vec<PathBuf> {
+pub(crate) fn collect_files(paths: &[PathBuf]) -> Vec<PathBuf> {
     let mut result = Vec::new();
     for path in paths {
         if path.is_dir() {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -21,6 +21,7 @@
 //! All diagnostics and mode notices go to stderr only.
 
 mod args;
+pub(crate) mod check;
 mod complete;
 pub(crate) mod extract_sources;
 mod hover;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2,8 +2,10 @@
 //!
 //! Subcommands:
 //!   find  <name>                 — locate declarations for NAME
-//!   refs  <name>                 — locate all usages of NAME
+//!   refs  <name> [--exclude-imports] — locate all usages of NAME
 //!   hover <file> <line> <col>    — show symbol signature at position
+//!   check <file|dir>…            — syntax-check files (no index needed)
+//!   diagnose <file>              — call-arg + syntax diagnostics
 //!   index                        — pre-build the workspace index cache
 //!
 //! Modes (default: auto):

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -23,7 +23,7 @@
 //! All diagnostics and mode notices go to stderr only.
 
 mod args;
-pub(crate) mod check;
+mod check;
 mod complete;
 pub(crate) mod extract_sources;
 mod hover;

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -412,6 +412,14 @@ pub(crate) async fn run(args: CliArgs) {
             dry_run,
             patterns,
         }),
+        Subcommand::Check { files } => {
+            if files.is_empty() {
+                eprintln!("check requires at least one FILE or DIR argument");
+                std::process::exit(1);
+            }
+            let expanded = super::check::expand_file_list(&files);
+            super::check::run_check(&expanded, json);
+        }
     }
 }
 

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -641,6 +641,14 @@ async fn run_diagnose(root: &Path, file: &Path, _verbose: bool) {
         std::process::exit(1);
     }
 
+    // Emit syntax errors first (tree-sitter, no index required).
+    let syntax_data = crate::parser::parse_by_extension(&path_str, &source);
+    for syntax_error in &syntax_data.syntax_errors {
+        let line = syntax_error.range.start.line + 1;
+        let col = syntax_error.range.start.character + 1;
+        println!("{}:{} [error]: {}", line, col, syntax_error.message);
+    }
+
     // store_live_tree parses the file once; retrieve the result via live_doc()
     // so call_arg_diagnostics can use the same tree without a second parse.
     index.store_live_tree(&uri, &source);
@@ -652,7 +660,7 @@ async fn run_diagnose(root: &Path, file: &Path, _verbose: bool) {
     let mut diagnostics = call_arg_diagnostics(&index, &uri, &doc);
     diagnostics.extend(when_diagnostics(&index, &uri));
 
-    if diagnostics.is_empty() {
+    if syntax_data.syntax_errors.is_empty() && diagnostics.is_empty() {
         println!("No diagnostics.");
     } else {
         for diag in &diagnostics {

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -31,7 +31,20 @@ fn resolve_root(explicit: Option<&Path>) -> PathBuf {
         let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
         find_git_root(&cwd).unwrap_or(cwd)
     };
-    raw.canonicalize().unwrap_or(raw)
+    strip_unc_prefix(raw.canonicalize().unwrap_or(raw))
+}
+
+/// Strip the `\\?\` extended-length UNC prefix that `Path::canonicalize()` adds
+/// on Windows. Paths with this prefix confuse external tools like `rg`.
+fn strip_unc_prefix(path: PathBuf) -> PathBuf {
+    #[cfg(windows)]
+    {
+        let s = path.to_string_lossy();
+        if let Some(stripped) = s.strip_prefix(r"\\?\") {
+            return PathBuf::from(stripped);
+        }
+    }
+    path
 }
 
 /// Walk up from `start` looking for a `.git` directory.
@@ -59,7 +72,7 @@ fn resolve_root_for_file(explicit: Option<&Path>, file: &Path) -> PathBuf {
         };
         find_git_root(file_dir).unwrap_or_else(fallback)
     };
-    raw.canonicalize().unwrap_or(raw)
+    strip_unc_prefix(raw.canonicalize().unwrap_or(raw))
 }
 
 // ── Column resolution helpers ─────────────────────────────────────────────────

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -496,23 +496,27 @@ async fn run_refs(
     };
 
     if exclude_imports {
+        let mut file_lines_cache: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
         results.retain(|result| {
             // Smart-mode results may carry kind="import" directly.
             if result.kind == "import" {
                 return false;
             }
-            // For rg-based results with no kind, read the line from disk.
+            // For rg-based results with no kind, check the line on disk.
             if !result.kind.is_empty() {
                 return true;
             }
-            std::fs::read_to_string(&result.file)
-                .ok()
-                .and_then(|source| {
-                    source
-                        .lines()
-                        .nth(result.line.saturating_sub(1) as usize)
-                        .map(|line| !line.trim_start().starts_with("import "))
-                })
+            let lines = file_lines_cache
+                .entry(result.file.clone())
+                .or_insert_with(|| {
+                    std::fs::read_to_string(&result.file)
+                        .map(|src| src.lines().map(String::from).collect())
+                        .unwrap_or_default()
+                });
+            lines
+                .get(result.line.saturating_sub(1) as usize)
+                .map(|line| !line.trim_start().starts_with("import "))
                 .unwrap_or(true)
         });
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -420,7 +420,7 @@ pub(crate) async fn run(args: CliArgs) {
                 eprintln!("check requires at least one FILE or DIR argument");
                 std::process::exit(1);
             }
-            let expanded = super::check::expand_file_list(&files);
+            let expanded = super::check::collect_files(&files);
             super::check::run_check(&expanded, json);
         }
     }

--- a/src/cli/run.rs
+++ b/src/cli/run.rs
@@ -347,9 +347,12 @@ pub(crate) async fn run(args: CliArgs) {
             let root = resolve_root(args.root.as_deref());
             run_find(&root, args.mode, json, verbose, &name).await
         }
-        Subcommand::Refs { name } => {
+        Subcommand::Refs {
+            name,
+            exclude_imports,
+        } => {
             let root = resolve_root(args.root.as_deref());
-            run_refs(&root, args.mode, json, verbose, &name).await
+            run_refs(&root, args.mode, json, verbose, &name, exclude_imports).await
         }
         Subcommand::Hover { file, line, col } => {
             let root = resolve_root_for_file(args.root.as_deref(), &file);
@@ -463,14 +466,44 @@ async fn run_find(root: &Path, mode: Mode, json: bool, verbose: bool, name: &str
     print_results(&results, json);
 }
 
-async fn run_refs(root: &Path, mode: Mode, json: bool, verbose: bool, name: &str) {
-    let results = match effective_mode(mode, root, "refs", verbose) {
+async fn run_refs(
+    root: &Path,
+    mode: Mode,
+    json: bool,
+    verbose: bool,
+    name: &str,
+    exclude_imports: bool,
+) {
+    let mut results = match effective_mode(mode, root, "refs", verbose) {
         Mode::Fast => fast_refs(name, root),
         _ => {
             let index = build_index(root, false).await;
             smart_refs(&index, name, root)
         }
     };
+
+    if exclude_imports {
+        results.retain(|result| {
+            // Smart-mode results may carry kind="import" directly.
+            if result.kind == "import" {
+                return false;
+            }
+            // For rg-based results with no kind, read the line from disk.
+            if !result.kind.is_empty() {
+                return true;
+            }
+            std::fs::read_to_string(&result.file)
+                .ok()
+                .and_then(|source| {
+                    source
+                        .lines()
+                        .nth(result.line.saturating_sub(1) as usize)
+                        .map(|line| !line.trim_start().starts_with("import "))
+                })
+                .unwrap_or(true)
+        });
+    }
+
     exit_if_empty(&results, json, &format!("No references found for '{name}'"));
     print_results(&results, json);
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -701,9 +701,6 @@ fn is_chained_call_assignment_error(node: &Node, bytes: &[u8]) -> bool {
     )
 }
 
-/// Returns true if this ERROR node is a false positive caused by tree-sitter-kotlin
-/// not supporting nullable extension function types like `T?.() -> R`.
-/// The grammar mislabels the `.(` and `-> R)` fragments as errors.
 /// Returns true if this ERROR node is a lone `,` inside a `@file:[...]` annotation.
 /// tree-sitter-kotlin 0.3 uses `repeat1` without comma separators inside the bracket
 /// syntax, so each comma becomes a spurious ERROR node.
@@ -718,9 +715,12 @@ fn is_file_annotation_comma_error(node: &Node, bytes: &[u8]) -> bool {
     if start_byte < 5 {
         return false;
     }
+    // Restrict the search to the current line so we don't match `@file:`
+    // occurrences from earlier lines (e.g. in comments or string literals).
     let before = std::str::from_utf8(&bytes[..start_byte]).unwrap_or("");
-    if let Some(file_pos) = before.rfind("@file:") {
-        let after_file = &before[file_pos + 6..];
+    let line_start = before.rfind('\n').map(|i| i + 1).unwrap_or(0);
+    let current_line = before[line_start..].trim_start();
+    if let Some(after_file) = current_line.strip_prefix("@file:") {
         if after_file.trim_start().starts_with('[') {
             return true;
         }
@@ -728,6 +728,9 @@ fn is_file_annotation_comma_error(node: &Node, bytes: &[u8]) -> bool {
     false
 }
 
+/// Returns true if this ERROR node is a false positive caused by tree-sitter-kotlin
+/// not supporting nullable extension function types like `T?.() -> R`.
+/// The grammar mislabels the `.(` and `-> R)` fragments as errors.
 fn is_nullable_function_type_error(node: &Node, bytes: &[u8]) -> bool {
     if !node.is_error() {
         return false;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -704,6 +704,30 @@ fn is_chained_call_assignment_error(node: &Node, bytes: &[u8]) -> bool {
 /// Returns true if this ERROR node is a false positive caused by tree-sitter-kotlin
 /// not supporting nullable extension function types like `T?.() -> R`.
 /// The grammar mislabels the `.(` and `-> R)` fragments as errors.
+/// Returns true if this ERROR node is a lone `,` inside a `@file:[...]` annotation.
+/// tree-sitter-kotlin 0.3 uses `repeat1` without comma separators inside the bracket
+/// syntax, so each comma becomes a spurious ERROR node.
+fn is_file_annotation_comma_error(node: &Node, bytes: &[u8]) -> bool {
+    if !node.is_error() {
+        return false;
+    }
+    if node.utf8_text(bytes).unwrap_or("").trim() != "," {
+        return false;
+    }
+    let start_byte = node.start_byte();
+    if start_byte < 5 {
+        return false;
+    }
+    let before = std::str::from_utf8(&bytes[..start_byte]).unwrap_or("");
+    if let Some(file_pos) = before.rfind("@file:") {
+        let after_file = &before[file_pos + 6..];
+        if after_file.trim_start().starts_with('[') {
+            return true;
+        }
+    }
+    false
+}
+
 fn is_nullable_function_type_error(node: &Node, bytes: &[u8]) -> bool {
     if !node.is_error() {
         return false;
@@ -979,6 +1003,10 @@ fn collect_syntax_errors(root: Node, bytes: &[u8]) -> Vec<SyntaxError> {
             }
             // Skip errors that are chained-call property assignments: a.method().prop = value
             if is_chained_call_assignment_error(&node, bytes) {
+                continue;
+            }
+            // Skip lone `,` inside @file:[...] bracket syntax (tree-sitter-kotlin 0.3 bug).
+            if is_file_annotation_comma_error(&node, bytes) {
                 continue;
             }
             // Skip false positives from nullable extension function types: T?.() -> R

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -534,6 +534,29 @@ fn no_errors_on_valid_kotlin() {
 }
 
 #[test]
+fn no_false_positive_file_annotation_single() {
+    let data = parse_kotlin("@file:[JvmName(\"Foo\")]\npackage com.example\n");
+    assert!(
+        data.syntax_errors.is_empty(),
+        "unexpected errors: {:?}",
+        data.syntax_errors
+    );
+}
+
+#[test]
+fn no_false_positive_file_annotation_comma() {
+    // @file:[Ann1, Ann2] comma separator triggers a tree-sitter-kotlin 0.3 bug —
+    // the lone `,` must be suppressed, not reported as a syntax error.
+    let data =
+        parse_kotlin("@file:[JvmName(\"Foo\"), Suppress(\"unused\")]\npackage com.example\n");
+    assert!(
+        data.syntax_errors.is_empty(),
+        "unexpected errors: {:?}",
+        data.syntax_errors
+    );
+}
+
+#[test]
 fn missing_closing_brace_kotlin() {
     let data = parse_kotlin("class Foo {\n    fun bar() {}\n");
     assert!(

--- a/src/rg.rs
+++ b/src/rg.rs
@@ -1546,15 +1546,26 @@ pub(crate) fn parse_rg_line(line: &str) -> Option<Location> {
 /// Windows-aware: a leading `X:` drive prefix on the path is not treated as
 /// a field separator. Returns `None` if the line is malformed.
 fn split_rg_fields(line: &str) -> Option<(&str, u32, u32, &str)> {
-    // If the line starts with a Windows drive prefix (`X:` followed by `\` or
-    // `/`), advance past the colon so it isn't mistaken for the line-number
-    // separator.
+    // Determine how many bytes to skip before looking for the first field
+    // separator (`:`), so a Windows drive colon is not mistaken for the
+    // line-number separator.
+    //
+    // Handled prefixes:
+    //   `X:\...`      — regular Windows absolute path (drive letter at byte 0)
+    //   `\\?\X:\...`  — extended-length UNC path returned by `canonicalize()`
     let scan_from = if line.len() >= 3
         && line.as_bytes()[0].is_ascii_alphabetic()
         && line.as_bytes()[1] == b':'
         && (line.as_bytes()[2] == b'\\' || line.as_bytes()[2] == b'/')
     {
-        2 // skip the drive colon when looking for field separators
+        2 // skip the drive colon: `X:` → rest starts at `\...`
+    } else if line.len() >= 7
+        && line.starts_with(r"\\?\")
+        && line.as_bytes()[4].is_ascii_alphabetic()
+        && line.as_bytes()[5] == b':'
+        && (line.as_bytes()[6] == b'\\' || line.as_bytes()[6] == b'/')
+    {
+        6 // skip `\\?\X:` → rest starts at `\...`
     } else {
         0
     };

--- a/tests/cli_check.rs
+++ b/tests/cli_check.rs
@@ -56,10 +56,10 @@ fn json_output_valid_file() {
     let file = dir.path().join("Foo.kt");
     let (ok, stdout, _) = check(&["--json", file.to_str().unwrap()]);
     assert!(ok, "expected exit 0 for valid file in JSON mode");
-    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
-    assert_eq!(v["files_ok"], 1);
-    assert_eq!(v["files_with_errors"], 0);
-    assert!(v["errors"].as_array().unwrap().is_empty());
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(json["files_ok"], 1);
+    assert_eq!(json["files_with_errors"], 0);
+    assert!(json["errors"].as_array().unwrap().is_empty());
 }
 
 #[test]
@@ -69,9 +69,9 @@ fn json_output_error_file() {
     let file = dir.path().join("Bad.kt");
     let (ok, stdout, _) = check(&["--json", file.to_str().unwrap()]);
     assert!(!ok, "expected exit 1 for invalid file in JSON mode");
-    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
-    assert_eq!(v["files_with_errors"], 1);
-    assert!(!v["errors"].as_array().unwrap().is_empty());
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(json["files_with_errors"], 1);
+    assert!(!json["errors"].as_array().unwrap().is_empty());
 }
 
 #[test]

--- a/tests/cli_check.rs
+++ b/tests/cli_check.rs
@@ -1,0 +1,98 @@
+//! Integration tests for `kmp-lsp check`.
+
+use std::path::Path;
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_kmp-lsp");
+
+fn write_fixture(dir: &Path, rel_path: &str, content: &str) {
+    let full = dir.join(rel_path);
+    if let Some(parent) = full.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&full, content).unwrap();
+}
+
+fn check(args: &[&str]) -> (bool, String, String) {
+    let out = Command::new(BIN)
+        .arg("check")
+        .args(args)
+        .output()
+        .expect("failed to spawn kmp-lsp");
+    (
+        out.status.success(),
+        String::from_utf8_lossy(&out.stdout).into_owned(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+#[test]
+fn valid_file_exits_zero() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture(dir.path(), "Foo.kt", "class Foo { fun bar(): Int = 42 }\n");
+    let file = dir.path().join("Foo.kt");
+    let (ok, stdout, _) = check(&[file.to_str().unwrap()]);
+    assert!(ok, "expected exit 0 for valid file");
+    assert!(stdout.contains("OK"), "expected OK message: {stdout}");
+}
+
+#[test]
+fn syntax_error_exits_nonzero() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture(dir.path(), "Bad.kt", "class Foo {\n    fun bar() {\n");
+    let file = dir.path().join("Bad.kt");
+    let (ok, _, stderr) = check(&[file.to_str().unwrap()]);
+    assert!(!ok, "expected exit 1 for file with syntax error");
+    assert!(
+        !stderr.is_empty(),
+        "expected error count on stderr: {stderr}"
+    );
+}
+
+#[test]
+fn json_output_valid_file() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture(dir.path(), "Foo.kt", "fun greet() = println(\"hi\")\n");
+    let file = dir.path().join("Foo.kt");
+    let (ok, stdout, _) = check(&["--json", file.to_str().unwrap()]);
+    assert!(ok, "expected exit 0 for valid file in JSON mode");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(v["files_ok"], 1);
+    assert_eq!(v["files_with_errors"], 0);
+    assert!(v["errors"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn json_output_error_file() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture(dir.path(), "Bad.kt", "fun broken( {\n");
+    let file = dir.path().join("Bad.kt");
+    let (ok, stdout, _) = check(&["--json", file.to_str().unwrap()]);
+    assert!(!ok, "expected exit 1 for invalid file in JSON mode");
+    let v: serde_json::Value = serde_json::from_str(&stdout).expect("valid JSON");
+    assert_eq!(v["files_with_errors"], 1);
+    assert!(!v["errors"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn directory_arg_walks_kt_files() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture(dir.path(), "src/A.kt", "class A\n");
+    write_fixture(dir.path(), "src/B.kt", "class B\n");
+    write_fixture(dir.path(), "src/README.md", "# docs\n");
+    let (ok, stdout, _) = check(&[dir.path().join("src").to_str().unwrap()]);
+    assert!(ok, "expected exit 0 for valid directory");
+    assert!(stdout.contains("OK"), "expected OK message: {stdout}");
+}
+
+#[test]
+fn multiple_files_reports_all_errors() {
+    let dir = tempfile::tempdir().unwrap();
+    write_fixture(dir.path(), "Good.kt", "class Good\n");
+    write_fixture(dir.path(), "Bad.kt", "class Bad {\n");
+    let good = dir.path().join("Good.kt");
+    let bad = dir.path().join("Bad.kt");
+    let (ok, _, stderr) = check(&[good.to_str().unwrap(), bad.to_str().unwrap()]);
+    assert!(!ok, "expected exit 1 when any file has errors");
+    assert!(stderr.contains("error"), "expected error summary: {stderr}");
+}

--- a/tests/cli_diagnose.rs
+++ b/tests/cli_diagnose.rs
@@ -441,3 +441,26 @@ fn no_false_positive_function_type_param() {
         "complex generic function type should be handled; got: {diags:?}"
     );
 }
+
+/// diagnose must surface tree-sitter syntax errors alongside call-arg diagnostics.
+#[test]
+fn syntax_error_reported_by_diagnose() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_fixture(root, "workspace.json", r#"{"sourcePaths":[]}"#);
+    write_fixture(root, "src/Bad.kt", "class Foo {\n    fun bar() {\n");
+    let file = root.join("src/Bad.kt");
+    let out = Command::new(BIN)
+        .args(["diagnose", "--root"])
+        .arg(root)
+        .arg(&file)
+        .output()
+        .expect("failed to spawn kmp-lsp");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        stdout.lines().any(|line| line.contains("syntax error")
+            || line.contains("missing")
+            || line.contains("unexpected")),
+        "expected syntax error in diagnose output:\n{stdout}"
+    );
+}

--- a/tests/cli_refs.rs
+++ b/tests/cli_refs.rs
@@ -1,0 +1,68 @@
+//! Integration tests for `kmp-lsp refs`.
+
+use std::path::Path;
+use std::process::Command;
+
+const BIN: &str = env!("CARGO_BIN_EXE_kmp-lsp");
+
+fn write_fixture(dir: &Path, rel_path: &str, content: &str) {
+    let full = dir.join(rel_path);
+    if let Some(parent) = full.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(&full, content).unwrap();
+}
+
+#[test]
+fn exclude_imports_removes_import_lines() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = dir.path();
+    write_fixture(root, "workspace.json", r#"{"sourcePaths":[]}"#);
+    // src/A.kt imports Foo and uses it as a real reference.
+    write_fixture(
+        root,
+        "src/A.kt",
+        "import com.example.Foo\n\nfun useIt(f: Foo) {}\n",
+    );
+    write_fixture(root, "src/B.kt", "class Foo\n");
+
+    let out_default = Command::new(BIN)
+        .args(["refs", "Foo", "--fast", "--root"])
+        .arg(root)
+        .output()
+        .expect("spawn");
+    let default_output = String::from_utf8_lossy(&out_default.stdout);
+
+    let out_excluded = Command::new(BIN)
+        .args(["refs", "Foo", "--fast", "--exclude-imports", "--root"])
+        .arg(root)
+        .output()
+        .expect("spawn");
+    let excluded_output = String::from_utf8_lossy(&out_excluded.stdout);
+
+    // Default output includes the import on line 1 of A.kt.
+    let default_lines: Vec<&str> = default_output.lines().collect();
+    let excluded_lines: Vec<&str> = excluded_output.lines().collect();
+
+    // The import is on line 1; check default output has an A.kt line-1 entry.
+    assert!(
+        default_lines
+            .iter()
+            .any(|line| line.contains("A.kt") && line.contains(":1:")),
+        "expected import (A.kt:1:...) in default refs output:\n{default_output}"
+    );
+    // With --exclude-imports the A.kt:1 entry must be gone.
+    assert!(
+        !excluded_lines
+            .iter()
+            .any(|line| line.contains("A.kt") && line.contains(":1:")),
+        "expected no import line (A.kt:1:...) with --exclude-imports:\n{excluded_output}"
+    );
+    // But the real usage on line 3 must still appear.
+    assert!(
+        excluded_lines
+            .iter()
+            .any(|line| line.contains("A.kt") && line.contains(":3:")),
+        "expected parameter usage (A.kt:3:...) to survive --exclude-imports:\n{excluded_output}"
+    );
+}


### PR DESCRIPTION
## Summary

- **`kmp-lsp check <file|dir>`** — new subcommand for instant tree-sitter syntax validation without an index; exit 1 on errors; JSON output; accepts directories (walks `.kt/.kts/.java/.swift`)
- **`kmp-lsp refs --exclude-imports`** — strips import-statement matches from `refs` results; cuts noise for common names like `Event`, `Result`, `State`
- **`kmp-lsp diagnose` now reports syntax errors** — previously only reported call-arg and `when` diagnostics; now includes tree-sitter syntax errors first
- **Parser: suppress `@file:[Ann1, Ann2]` comma false positive** — tree-sitter-kotlin 0.3 emits spurious ERROR nodes for commas inside `@file:[...]` bracket annotation syntax
- **Docs/skill updated** — `docs/agent-reference.md`, `docs/copilot.md`, `contrib/copilot-skill/SKILL.md`, help text, and Serena memory all updated to reflect new commands

## Test plan

- [ ] `cargo test` — all tests pass (1304+ unit + integration)
- [ ] `kmp-lsp check src/parser.rs` — exits 0, prints "All N files OK."
- [ ] `kmp-lsp check /tmp/bad.kt` (with unclosed brace) — exits 1, prints error with line:col
- [ ] `kmp-lsp check src/ --json` — valid JSON with `files_ok`/`files_with_errors`/`errors`
- [ ] `kmp-lsp refs Event --exclude-imports --root .` — no import lines in output
- [ ] `kmp-lsp diagnose src/parser.rs --root .` — includes syntax error lines if any

🤖 Generated with [Claude Code](https://claude.com/claude-code)