### PR TITLE
fix(perf+indexer): scan.lock sentinel, spawn_blocking apply, O(n) bulk insert

### DIFF
--- a/java-sidecar/build.gradle.kts
+++ b/java-sidecar/build.gradle.kts
@@ -24,6 +24,16 @@ dependencies {
     testImplementation("org.junit.jupiter:junit-jupiter:5.11.3")
 }
 
+// Real-world fixture JAR for the deprecation regression test: coroutines 1.11.0
+// ships @Deprecated "guidance" overloads of `launch` (e.g. `launch(context: Job)`).
+// Resolved into its own configuration (non-transitive) so its newer kotlin-stdlib
+// never lands on the compile classpath — the test only needs the jar file, whose
+// path is handed to it via the `coroutines.jar` system property below.
+val coroutinesFixture by configurations.creating { isTransitive = false }
+dependencies {
+    coroutinesFixture("org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.11.0")
+}
+
 application {
     mainClass.set("io.github.hessesian.jarindexer.MainKt")
 }
@@ -34,6 +44,12 @@ kotlin {
 
 tasks.test {
     useJUnitPlatform()
+    // Hand the fixture jar path to the deprecation regression test.
+    doFirst {
+        coroutinesFixture.files
+            .firstOrNull { it.name.startsWith("kotlinx-coroutines-core-jvm") }
+            ?.let { systemProperty("coroutines.jar", it.absolutePath) }
+    }
 }
 
 tasks.shadowJar {

--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
@@ -6,6 +6,8 @@ import kotlinx.metadata.jvm.*
 import org.objectweb.asm.AnnotationVisitor
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.ClassVisitor
+import org.objectweb.asm.FieldVisitor
+import org.objectweb.asm.MethodVisitor
 import org.objectweb.asm.Opcodes
 
 // ── ASM: extract @kotlin.Metadata annotation bytes ───────────────────────────
@@ -61,10 +63,35 @@ private class MetadataAnnotationVisitor : AnnotationVisitor(Opcodes.ASM9) {
     )
 }
 
+private val DEPRECATED_ANNOTATIONS = setOf("Lkotlin/Deprecated;", "Ljava/lang/Deprecated;")
+
+/// MethodVisitor/FieldVisitor that records its key into `sink` when it sees an
+/// `@Deprecated` annotation. `kotlin.Deprecated` has BINARY retention, so it
+/// arrives as an invisible annotation — we accept both visible and invisible.
+private class DeprecationMethodVisitor(private val key: String, private val sink: MutableSet<String>) :
+    MethodVisitor(Opcodes.ASM9) {
+    override fun visitAnnotation(descriptor: String, visible: Boolean): AnnotationVisitor? {
+        if (descriptor in DEPRECATED_ANNOTATIONS) sink.add(key)
+        return null
+    }
+}
+
+private class DeprecationFieldVisitor(private val key: String, private val sink: MutableSet<String>) :
+    FieldVisitor(Opcodes.ASM9) {
+    override fun visitAnnotation(descriptor: String, visible: Boolean): AnnotationVisitor? {
+        if (descriptor in DEPRECATED_ANNOTATIONS) sink.add(key)
+        return null
+    }
+}
+
 private class ClassMetadataVisitor : ClassVisitor(Opcodes.ASM9) {
     var simpleClassName: String = ""
     var metadataVisitor: MetadataAnnotationVisitor? = null
     var isPublic: Boolean = false
+    /** JVM method signatures (`name` + `descriptor`) carrying `@Deprecated`. */
+    val deprecatedMethods = mutableSetOf<String>()
+    /** Field names carrying `@Deprecated` (backing fields of deprecated properties). */
+    val deprecatedFields = mutableSetOf<String>()
 
     override fun visit(version: Int, access: Int, name: String, signature: String?, superName: String?, interfaces: Array<out String>?) {
         simpleClassName = name.substringAfterLast('/')
@@ -77,6 +104,14 @@ private class ClassMetadataVisitor : ClassVisitor(Opcodes.ASM9) {
         }
         return null
     }
+
+    override fun visitMethod(
+        access: Int, name: String, descriptor: String, signature: String?, exceptions: Array<out String>?,
+    ): MethodVisitor = DeprecationMethodVisitor(name + descriptor, deprecatedMethods)
+
+    override fun visitField(
+        access: Int, name: String, descriptor: String, signature: String?, value: Any?,
+    ): FieldVisitor = DeprecationFieldVisitor(name + descriptor, deprecatedFields)
 }
 
 // ── Type rendering ─────────────────────────────────────────────────────────────
@@ -250,7 +285,7 @@ private fun extensionReceiverRenderedForProp(prop: KmProperty, classTypeParams: 
     return prop.receiverParameterType?.render(typeParamsMap) ?: ""
 }
 
-private fun entriesFromClass(klass: KmClass): List<SymbolEntry> {
+private fun entriesFromClass(klass: KmClass, dep: DeprecationInfo): List<SymbolEntry> {
     val entries = mutableListOf<SymbolEntry>()
     val simpleName = klass.name.substringAfterLast('/')
     val containerName = simpleName
@@ -279,6 +314,7 @@ private fun entriesFromClass(klass: KmClass): List<SymbolEntry> {
             typeParams = functionTypeParamNames(fn),
             extensionReceiverType = extensionReceiverRendered(fn, klass.typeParameters),
             trailingLambda = fn.hasTrailingLambda(),
+            deprecated = fn.isDeprecated(dep),
         )
     }
     for (prop in klass.properties) {
@@ -287,12 +323,13 @@ private fun entriesFromClass(klass: KmClass): List<SymbolEntry> {
         val kind = if (prop.isVar) "var" else "val"
         entries += SymbolEntry(prop.name, kind, containerName, renderProperty(prop, recv, klass.typeParameters),
             extensionReceiverType = extensionReceiverRenderedForProp(prop, klass.typeParameters),
+            deprecated = prop.isDeprecated(dep),
         )
     }
     return entries
 }
 
-private fun entriesFromPackage(pkg: KmPackage, containerName: String): List<SymbolEntry> {
+private fun entriesFromPackage(pkg: KmPackage, containerName: String, dep: DeprecationInfo): List<SymbolEntry> {
     val entries = mutableListOf<SymbolEntry>()
     for (fn in pkg.functions) {
         if (!fn.visibility.isPublicLike()) continue
@@ -302,6 +339,7 @@ private fun entriesFromPackage(pkg: KmPackage, containerName: String): List<Symb
             typeParams = functionTypeParamNames(fn),
             extensionReceiverType = extensionReceiverRendered(fn, emptyList()),
             trailingLambda = fn.hasTrailingLambda(),
+            deprecated = fn.isDeprecated(dep),
         )
     }
     for (prop in pkg.properties) {
@@ -310,6 +348,7 @@ private fun entriesFromPackage(pkg: KmPackage, containerName: String): List<Symb
         val kind = if (prop.isVar) "var" else "val"
         entries += SymbolEntry(prop.name, kind, containerName, renderProperty(prop, recv),
             extensionReceiverType = extensionReceiverRenderedForProp(prop, emptyList()),
+            deprecated = prop.isDeprecated(dep),
         )
     }
     return entries
@@ -317,6 +356,23 @@ private fun entriesFromPackage(pkg: KmPackage, containerName: String): List<Symb
 
 private fun Visibility?.isPublicLike() =
     this == Visibility.PUBLIC || this == Visibility.PROTECTED || this == null
+
+/// Deprecation signatures harvested from the class bytecode by ASM, used to flag
+/// the matching Kotlin-metadata declarations.
+private class DeprecationInfo(val methods: Set<String>, val fields: Set<String>) {
+    companion object { val EMPTY = DeprecationInfo(emptySet(), emptySet()) }
+}
+
+/// Match a metadata function to its bytecode `@Deprecated` flag via JVM signature
+/// (`name` + `descriptor`), which is exactly the key ASM recorded.
+private fun KmFunction.isDeprecated(dep: DeprecationInfo): Boolean =
+    signature?.toString()?.let { it in dep.methods } ?: false
+
+private fun KmProperty.isDeprecated(dep: DeprecationInfo): Boolean {
+    getterSignature?.toString()?.let { if (it in dep.methods) return true }
+    fieldSignature?.toString()?.let { if (it in dep.fields) return true }
+    return false
+}
 
 // ── Java fallback (no Kotlin metadata) ────────────────────────────────────────
 
@@ -365,10 +421,11 @@ fun indexClassBytes(bytes: ByteArray): List<SymbolEntry> {
             val isFacade = metadata is KotlinClassMetadata.FileFacade || metadata is KotlinClassMetadata.MultiFileClassPart
             // Skip anonymous/inner synthetic helpers for regular Class only
             if (!isFacade && name.contains('$') && !name.endsWith("\$Companion")) return emptyList()
+            val dep = DeprecationInfo(visitor.deprecatedMethods, visitor.deprecatedFields)
             when (metadata) {
-                is KotlinClassMetadata.Class              -> entriesFromClass(metadata.kmClass)
-                is KotlinClassMetadata.FileFacade         -> entriesFromPackage(metadata.kmPackage, name)
-                is KotlinClassMetadata.MultiFileClassPart -> entriesFromPackage(metadata.kmPackage, name)
+                is KotlinClassMetadata.Class              -> entriesFromClass(metadata.kmClass, dep)
+                is KotlinClassMetadata.FileFacade         -> entriesFromPackage(metadata.kmPackage, name, dep)
+                is KotlinClassMetadata.MultiFileClassPart -> entriesFromPackage(metadata.kmPackage, name, dep)
                 else -> emptyList()
             }
         } else {

--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/model/SymbolEntry.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/model/SymbolEntry.kt
@@ -27,4 +27,6 @@ data class SymbolEntry(
     /** True when the last value parameter is a function type (lambda). */
     @SerialName("trailing_lambda")
     val trailingLambda: Boolean = false,
+    /** True when the declaration carries an `@Deprecated` annotation (kotlin or java). */
+    val deprecated: Boolean = false,
 )

--- a/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
+++ b/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
@@ -1,0 +1,228 @@
+package io.github.hessesian.jarindexer
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.jar.JarOutputStream
+import java.util.zip.ZipEntry
+
+class IndexerTest {
+
+    /** Helper: create a minimal JAR containing the given .class entries (name → bytes). */
+    private fun createTestJar(dir: File, name: String, entries: Map<String, ByteArray>): File {
+        val jarFile = File(dir, name)
+        JarOutputStream(jarFile.outputStream()).use { jos ->
+            for ((entryName, bytes) in entries) {
+                jos.putNextEntry(ZipEntry(entryName))
+                jos.write(bytes)
+                jos.closeEntry()
+            }
+        }
+        return jarFile
+    }
+
+    /** Helper: create a minimal valid .class file bytes for a public class. */
+    fun minimalClassBytes(className: String): ByteArray {
+        // Minimal class file: magic (0xCAFEBABE), version 52 (Java 8), 1 public class with no methods
+        // We use ASM to generate proper bytecode
+        val cw = org.objectweb.asm.ClassWriter(0)
+        cw.visit(
+            org.objectweb.asm.Opcodes.V1_8,
+            org.objectweb.asm.Opcodes.ACC_PUBLIC,
+            className,
+            null,
+            "java/lang/Object",
+            null
+        )
+        // Add default constructor
+        val mv = cw.visitMethod(
+            org.objectweb.asm.Opcodes.ACC_PUBLIC,
+            "<init>",
+            "()V",
+            null,
+            null
+        )
+        mv.visitCode()
+        mv.visitVarInsn(org.objectweb.asm.Opcodes.ALOAD, 0)
+        mv.visitMethodInsn(
+            org.objectweb.asm.Opcodes.INVOKESPECIAL,
+            "java/lang/Object",
+            "<init>",
+            "()V",
+            false
+        )
+        mv.visitInsn(org.objectweb.asm.Opcodes.RETURN)
+        mv.visitMaxs(1, 1)
+        mv.visitEnd()
+        cw.visitEnd()
+        return cw.toByteArray()
+    }
+
+    @Test
+    @DisplayName("indexJarFile returns empty list for nonexistent JAR")
+    fun testNonexistentJar(@TempDir tmpDir: File) {
+        val result = indexJarFile("/nonexistent/path/foo.jar")
+        assertTrue(result.isEmpty(), "should return empty for missing file")
+    }
+
+    @Test
+    @DisplayName("indexJarFile indexes a Java class from JAR")
+    fun testJavaClass(@TempDir tmpDir: File) {
+        val classBytes = minimalClassBytes("com/example/TestClass")
+        val jarFile = createTestJar(tmpDir, "test.jar", mapOf("com/example/TestClass.class" to classBytes))
+
+        val result = indexJarFile(jarFile.absolutePath)
+
+        assertTrue(result.isNotEmpty(), "should index at least one symbol")
+        assertTrue(result.any { it.name == "TestClass" && it.kind == "class" },
+            "should find TestClass class entry; got: ${result.map { it.name }}")
+    }
+
+    @Test
+    @DisplayName("indexJarFile returns empty list for corrupted JAR")
+    fun testCorruptedJar(@TempDir tmpDir: File) {
+        val jarFile = File(tmpDir, "corrupt.jar")
+        jarFile.writeBytes(notAZipArchive())
+
+        val result = indexJarFile(jarFile.absolutePath)
+        assertTrue(result.isEmpty(), "should return empty for corrupted JAR")
+    }
+
+    @Test
+    @DisplayName("indexJarFile returns empty list for JAR with no .class entries")
+    fun testEmptyJar(@TempDir tmpDir: File) {
+        val jarFile = createTestJar(tmpDir, "empty.jar", emptyMap())
+        val result = indexJarFile(jarFile.absolutePath)
+        assertTrue(result.isEmpty(), "should return empty for JAR with no .class files")
+    }
+
+    @Test
+    @DisplayName("indexJarFile handles .aar with classes.jar inside")
+    fun testAar(@TempDir tmpDir: File) {
+        val classBytes = minimalClassBytes("com/example/AarClass")
+        val classesJarBytes = java.io.ByteArrayOutputStream().also { baos ->
+            JarOutputStream(baos).use { jos ->
+                jos.putNextEntry(ZipEntry("com/example/AarClass.class"))
+                jos.write(classBytes)
+                jos.closeEntry()
+            }
+        }.toByteArray()
+
+        val aarFile = createTestJar(tmpDir, "test.aar", mapOf("classes.jar" to classesJarBytes))
+        val result = indexJarFile(aarFile.absolutePath)
+
+        assertTrue(result.isNotEmpty(), "should index symbols from AAR")
+        assertTrue(result.any { it.name == "AarClass" },
+            "should find AarClass; got: ${result.map { it.name }}")
+    }
+
+    @Test
+    @DisplayName("indexClassBytes handles class with \$ in name (inner class)")
+    fun testInnerClass(@TempDir tmpDir: File) {
+        val innerBytes = minimalClassBytes("com/example/Outer\$Inner")
+        val result = indexClassBytes(innerBytes)
+        // Inner classes with $ should be skipped unless they end with $Companion
+        assertTrue(result.isEmpty(), "should skip inner class with \$ in name")
+    }
+
+    @Test
+    @DisplayName("indexClassBytes accepts Companion classes")
+    fun testCompanionClass(@TempDir tmpDir: File) {
+        val companionBytes = minimalClassBytes("com/example/Foo\$Companion")
+        val result = indexClassBytes(companionBytes)
+        // No Kotlin metadata → Java fallback path; ACC_PUBLIC class but name has $
+        // JavaClassVisitor skips names containing '$'
+        assertTrue(result.isEmpty(), "JavaClassVisitor skips \$ names")
+    }
+
+    @Test
+    @DisplayName("indexClassBytes handles non-public class")
+    fun testNonPublicClass(@TempDir tmpDir: File) {
+        val cw = org.objectweb.asm.ClassWriter(0)
+        cw.visit(
+            org.objectweb.asm.Opcodes.V1_8,
+            0, // no ACC_PUBLIC
+            "com/example/PackagePrivate",
+            null,
+            "java/lang/Object",
+            null
+        )
+        cw.visitEnd()
+
+        val result = indexClassBytes(cw.toByteArray())
+        assertTrue(result.isEmpty(), "should skip non-public class")
+    }
+
+    @Test
+    @DisplayName("SourcesKdocReader.findSourcesJar returns null for nonexistent path")
+    fun testFindSourcesJarNonexistent() {
+        val result = SourcesKdocReader.readKdocMap("/nonexistent/path/foo.jar")
+        assertTrue(result.isEmpty(), "should return empty for nonexistent path")
+    }
+
+    @Test
+    @DisplayName("SourcesKdocReader.extractKdocFromSource finds KDoc comments")
+    fun testKdocExtraction() {
+        val source = """
+            /** A test function. */
+            fun testFunc() = 42
+
+            /** Another function
+             * with multiple lines.
+             */
+            fun otherFunc(x: Int): String = "${'$'}x"
+        """.trimIndent()
+
+        val result = SourcesKdocReader.extractKdocFromSource(source)
+
+        assertTrue(result.containsKey("testFunc"), "should find testFunc; got keys: ${result.keys}")
+        assertEquals("A test function.", result["testFunc"])
+        assertTrue(result.containsKey("otherFunc"), "should find otherFunc")
+    }
+
+    private fun notAZipArchive(): ByteArray = "this is not a zip file".toByteArray()
+
+    @Test
+    @DisplayName("indexJarFile flags @Deprecated guidance overloads of launch")
+    fun testDeprecatedGuidanceOverloadsAreFlagged() {
+        // kotlinx-coroutines 1.11.0 ships @Deprecated "guidance" overloads in
+        // Guidance.kt that exist purely to surface a compile error when you pass a
+        // Job / NonCancellable where a CoroutineContext is expected:
+        //   @Deprecated(...) fun CoroutineScope.launch(context: Job, ...): Job
+        //   @Deprecated(...) fun CoroutineScope.launch(context: NonCancellable, ...): Job
+        // The real overload `launch(context: CoroutineContext, ...)` is NOT deprecated.
+        // Without deprecation capture these three all leak into completion as
+        // separate `launch` suggestions.
+        val jarPath = System.getProperty("coroutines.jar")
+        assertNotNull(jarPath, "coroutines.jar system property must be set by the build")
+
+        val launches = indexJarFile(jarPath!!)
+            .filter { it.name == "launch" && it.extensionReceiverType == "CoroutineScope" }
+        assertTrue(
+            launches.size >= 3,
+            "expected the real + two guidance launch overloads; got: ${launches.map { it.detail }}",
+        )
+
+        val real = launches.filter { it.detail.contains("context: CoroutineContext") }
+        val guidance = launches.filter {
+            it.detail.contains("context: Job") || it.detail.contains("context: NonCancellable")
+        }
+
+        assertTrue(real.isNotEmpty(), "real launch(context: CoroutineContext) overload missing")
+        assertTrue(
+            real.none { it.deprecated },
+            "real launch(context: CoroutineContext) must NOT be flagged deprecated",
+        )
+        assertEquals(
+            2, guidance.size,
+            "expected exactly the Job + NonCancellable guidance overloads; got: ${guidance.map { it.detail }}",
+        )
+        assertTrue(
+            guidance.all { it.deprecated },
+            "guidance launch(Job)/launch(NonCancellable) overloads must be flagged deprecated; " +
+                "got: ${guidance.map { "${it.detail} -> deprecated=${it.deprecated}" }}",
+        )
+    }
+}

--- a/src/backend/actions.rs
+++ b/src/backend/actions.rs
@@ -9,18 +9,39 @@ impl Backend {
         params: CompletionParams,
     ) -> Result<Option<CompletionResponse>> {
         let pp = params.text_document_position;
-        let uri = &pp.text_document.uri;
+        let uri = pp.text_document.uri.clone();
+        let uri_key = uri.to_string();
+
+        // Server-side debounce: increment the sequence for this URI, sleep briefly,
+        // then bail if a newer request arrived during the sleep. This prevents a burst
+        // of per-keystroke requests (from editors without their own debounce) from each
+        // spawning a full compute — only the last one in a burst does real work.
+        let seq = {
+            let mut entry = self.completion_seq.entry(uri_key.clone()).or_insert(0);
+            *entry += 1;
+            *entry
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        if self.completion_seq.get(&uri_key).map(|v| *v) != Some(seq) {
+            return Ok(None);
+        }
+
         let position = pp.position;
         let snippets = self
             .snippet_support
             .load(std::sync::atomic::Ordering::Relaxed);
+        let indexer = std::sync::Arc::clone(&self.indexer);
 
-        Ok(crate::features::completion::compute_completions(
-            uri,
-            position,
-            snippets,
-            self.indexer.as_ref(),
-        ))
+        Ok(tokio::task::spawn_blocking(move || {
+            crate::features::completion::compute_completions(
+                &uri,
+                position,
+                snippets,
+                indexer.as_ref(),
+            )
+        })
+        .await
+        .unwrap_or(None))
     }
 
     pub(super) async fn code_action_impl(

--- a/src/backend/capabilities.rs
+++ b/src/backend/capabilities.rs
@@ -44,7 +44,7 @@ pub(super) fn server_capabilities() -> ServerCapabilities {
         code_action_provider: Some(CodeActionProviderCapability::Simple(true)),
         signature_help_provider: Some(SignatureHelpOptions {
             trigger_characters: Some(vec!["(".into(), ",".into()]),
-            retrigger_characters: None,
+            retrigger_characters: Some(vec!["(".into(), ",".into()]),
             work_done_progress_options: Default::default(),
         }),
         document_on_type_formatting_provider: Some(DocumentOnTypeFormattingOptions {

--- a/src/backend/commands.rs
+++ b/src/backend/commands.rs
@@ -70,16 +70,26 @@ impl Backend {
                         log::info!("Cleared workspace cache directory: {}", cache_dir.display());
                         // Reindex immediately so the next scan is a cold scan
                         // that discovers all files instead of relying on stale cache.
+                        // Canonicalize both sides so a relative / symlinked / differently
+                        // normalized path still matches the active root.
+                        let canon =
+                            |p: &std::path::Path| p.canonicalize().unwrap_or(p.to_path_buf());
                         let is_current_root = self
                             .indexer
                             .workspace_root
                             .get()
-                            .is_some_and(|r| r == target_root);
+                            .is_some_and(|r| canon(&r) == canon(&target_root));
                         if is_current_root {
                             let idx = Arc::clone(&self.indexer);
                             let client = self.client.clone();
-                            idx.reset_index_state();
                             tokio::spawn(async move {
+                                // Run the (DashMap-clearing) reset on the blocking pool so
+                                // it can't starve the async executor, then scan from clean state.
+                                let reset_idx = Arc::clone(&idx);
+                                let _ = tokio::task::spawn_blocking(move || {
+                                    reset_idx.reset_index_state()
+                                })
+                                .await;
                                 idx.index_workspace(
                                     &target_root,
                                     Arc::new(LspProgressReporter(client)),

--- a/src/backend/commands.rs
+++ b/src/backend/commands.rs
@@ -68,12 +68,38 @@ impl Backend {
                 match std::fs::remove_dir_all(cache_dir) {
                     Ok(_) => {
                         log::info!("Cleared workspace cache directory: {}", cache_dir.display());
-                        self.client
-                            .show_message(
-                                MessageType::INFO,
-                                format!("kmp-lsp: cleared cache for {}", target_root.display()),
-                            )
-                            .await;
+                        // Reindex immediately so the next scan is a cold scan
+                        // that discovers all files instead of relying on stale cache.
+                        let is_current_root = self
+                            .indexer
+                            .workspace_root
+                            .get()
+                            .is_some_and(|r| r == target_root);
+                        if is_current_root {
+                            let idx = Arc::clone(&self.indexer);
+                            let client = self.client.clone();
+                            idx.reset_index_state();
+                            tokio::spawn(async move {
+                                idx.index_workspace(
+                                    &target_root,
+                                    Arc::new(LspProgressReporter(client)),
+                                )
+                                .await;
+                            });
+                            self.client
+                                .show_message(
+                                    MessageType::INFO,
+                                    "kmp-lsp: cache cleared, reindexing workspace…",
+                                )
+                                .await;
+                        } else {
+                            self.client
+                                .show_message(
+                                    MessageType::INFO,
+                                    format!("kmp-lsp: cleared cache for {}", target_root.display()),
+                                )
+                                .await;
+                        }
                     }
                     Err(e) => {
                         log::warn!("Failed to remove cache dir {}: {}", cache_dir.display(), e);

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -36,6 +36,14 @@ pub(crate) struct Backend {
     /// True if the client advertised `snippetSupport: true` during initialize.
     /// Used to decide whether to send `InsertTextFormat::SNIPPET` in completions.
     pub(super) snippet_support: Arc<AtomicBool>,
+    /// Per-URI sequence counter for server-side completion debounce.
+    pub(super) completion_seq: Arc<dashmap::DashMap<String, u64>>,
+    /// Per-URI sequence counter for server-side semantic-tokens debounce.
+    /// Rapid didChange events cause nvim to send a semantic-tokens request per
+    /// keystroke. Each response is a large data array that blocks nvim's Lua
+    /// thread. Coalescing bursts to a single response prevents the popup from
+    /// being delayed by a queue of redundant token payloads.
+    pub(super) semtok_seq: Arc<dashmap::DashMap<String, u64>>,
 }
 
 impl Backend {
@@ -54,6 +62,8 @@ impl Backend {
             indexer,
             event_tx,
             snippet_support: Arc::new(AtomicBool::new(false)),
+            completion_seq: Arc::new(dashmap::DashMap::new()),
+            semtok_seq: Arc::new(dashmap::DashMap::new()),
         }
     }
 }
@@ -368,19 +378,33 @@ impl LanguageServer for Backend {
         &self,
         params: SemanticTokensParams,
     ) -> Result<Option<SemanticTokensResult>> {
+        let uri_key = params.text_document.uri.to_string();
+        let seq = {
+            let mut e = self.semtok_seq.entry(uri_key.clone()).or_insert(0);
+            *e += 1;
+            *e
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        if self.semtok_seq.get(&uri_key).map(|v| *v) != Some(seq) {
+            return Ok(None);
+        }
         panic_safe("semantic_tokens_full", async {
-            let uri = params.text_document.uri.to_string();
-            let language = crate::Language::from_path(&uri);
-            // Use live_doc_or_parse so that requests arriving in the window
-            // between did_change clearing the tree and the actor rebuilding it
-            // still get correct tokens (parsed from the fresh live_lines).
+            let language = crate::Language::from_path(&uri_key);
             let Some(doc) = self.indexer.live_doc_or_parse(&params.text_document.uri) else {
                 return Ok(None);
             };
             let parsed_uri = params.text_document.uri;
-            Ok(Some(SemanticTokensResult::Tokens(
-                semantic_tokens::full_tokens(&self.indexer, &parsed_uri, &doc, language),
-            )))
+            let indexer = std::sync::Arc::clone(&self.indexer);
+            Ok(tokio::task::spawn_blocking(move || {
+                Some(SemanticTokensResult::Tokens(semantic_tokens::full_tokens(
+                    &indexer,
+                    &parsed_uri,
+                    &doc,
+                    language,
+                )))
+            })
+            .await
+            .unwrap_or(None))
         })
         .await
     }
@@ -389,22 +413,31 @@ impl LanguageServer for Backend {
         &self,
         params: SemanticTokensRangeParams,
     ) -> Result<Option<SemanticTokensRangeResult>> {
+        let uri_key = params.text_document.uri.to_string();
+        let seq = {
+            let mut e = self.semtok_seq.entry(uri_key.clone()).or_insert(0);
+            *e += 1;
+            *e
+        };
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        if self.semtok_seq.get(&uri_key).map(|v| *v) != Some(seq) {
+            return Ok(None);
+        }
         panic_safe("semantic_tokens_range", async {
-            let uri = params.text_document.uri.to_string();
-            let language = crate::Language::from_path(&uri);
+            let language = crate::Language::from_path(&uri_key);
             let Some(doc) = self.indexer.live_doc_or_parse(&params.text_document.uri) else {
                 return Ok(None);
             };
             let parsed_uri = params.text_document.uri;
-            Ok(Some(SemanticTokensRangeResult::Tokens(
-                semantic_tokens::range_tokens(
-                    &self.indexer,
-                    &parsed_uri,
-                    &doc,
-                    language,
-                    &params.range,
-                ),
-            )))
+            let range = params.range;
+            let indexer = std::sync::Arc::clone(&self.indexer);
+            Ok(tokio::task::spawn_blocking(move || {
+                Some(SemanticTokensRangeResult::Tokens(
+                    semantic_tokens::range_tokens(&indexer, &parsed_uri, &doc, language, &range),
+                ))
+            })
+            .await
+            .unwrap_or(None))
         })
         .await
     }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -333,16 +333,28 @@ impl LanguageServer for Backend {
         let uri = &params.text_document_position.text_document.uri;
         let position = params.text_document_position.position;
         let Some(lines) = self.indexer.lines_for(uri) else {
+            log::debug!("on_type_formatting: no lines for {uri}");
             return Ok(None);
         };
-        Ok(
-            crate::features::on_type_formatting::compute_on_type_formatting(
-                &lines,
-                position,
-                &params.ch,
-                &params.options,
-            ),
-        )
+        let ch = &params.ch;
+        log::debug!(
+            "on_type_formatting: ch={ch:?} pos=({},{}) prev={:?} cur={:?}",
+            position.line,
+            position.character,
+            lines.get(position.line.saturating_sub(1) as usize),
+            lines.get(position.line as usize),
+        );
+        let result = crate::features::on_type_formatting::compute_on_type_formatting(
+            &lines,
+            position,
+            ch,
+            &params.options,
+        );
+        log::debug!(
+            "on_type_formatting: result has {} edits",
+            result.as_ref().map_or(0, |v| v.len())
+        );
+        Ok(result)
     }
 
     async fn code_action(

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -141,7 +141,7 @@ impl LanguageServer for Backend {
         // immediately. The process stays alive until the `exit` notification
         // arrives, giving the write enough time to complete for typical caches.
         let idx = Arc::clone(&self.indexer);
-        tokio::task::spawn_blocking(move || idx.save_cache_to_disk());
+        tokio::task::spawn_blocking(move || idx.save_cache_to_disk(false));
         Ok(())
     }
 

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -371,7 +371,10 @@ impl LanguageServer for Backend {
         panic_safe("semantic_tokens_full", async {
             let uri = params.text_document.uri.to_string();
             let language = crate::Language::from_path(&uri);
-            let Some(doc) = self.indexer.live_doc(&params.text_document.uri) else {
+            // Use live_doc_or_parse so that requests arriving in the window
+            // between did_change clearing the tree and the actor rebuilding it
+            // still get correct tokens (parsed from the fresh live_lines).
+            let Some(doc) = self.indexer.live_doc_or_parse(&params.text_document.uri) else {
                 return Ok(None);
             };
             let parsed_uri = params.text_document.uri;
@@ -389,7 +392,7 @@ impl LanguageServer for Backend {
         panic_safe("semantic_tokens_range", async {
             let uri = params.text_document.uri.to_string();
             let language = crate::Language::from_path(&uri);
-            let Some(doc) = self.indexer.live_doc(&params.text_document.uri) else {
+            let Some(doc) = self.indexer.live_doc_or_parse(&params.text_document.uri) else {
                 return Ok(None);
             };
             let parsed_uri = params.text_document.uri;

--- a/src/features/call_arg_diagnostics.rs
+++ b/src/features/call_arg_diagnostics.rs
@@ -26,9 +26,38 @@ use crate::queries::{
 pub(crate) fn call_arg_diagnostics(indexer: &Indexer, uri: &Url, doc: &LiveDoc) -> Vec<Diagnostic> {
     let bytes = &doc.bytes;
     let root = doc.tree.root_node();
+    let mut stats = DiagStats::default();
+    // Cache resolve_call_signature results within one diagnostic run.
+    // Many call_expression nodes call the same function; caching avoids O(N×K)
+    // symbol-index scans where N = distinct names and K = definition locations.
+    let mut sig_cache: std::collections::HashMap<(String, Option<String>), SignatureResult> =
+        std::collections::HashMap::new();
     let mut diagnostics = Vec::new();
-    collect_call_nodes(root, bytes, indexer, uri, &mut diagnostics);
+    collect_call_nodes(
+        root,
+        bytes,
+        indexer,
+        uri,
+        &mut diagnostics,
+        &mut stats,
+        &mut sig_cache,
+    );
+    log::debug!(
+        "call_arg_diagnostics: {} call_expr nodes, {} skipped(lambda), {} skipped(scope), {} resolved ({} cache hits), {}ms",
+        stats.total, stats.skipped_trailing_lambda, stats.skipped_scope, stats.resolved,
+        stats.cache_hits, stats.resolve_ms
+    );
     diagnostics
+}
+
+#[derive(Default)]
+struct DiagStats {
+    total: usize,
+    skipped_trailing_lambda: usize,
+    skipped_scope: usize,
+    resolved: usize,
+    cache_hits: usize,
+    resolve_ms: u128,
 }
 
 fn collect_call_nodes(
@@ -37,9 +66,11 @@ fn collect_call_nodes(
     indexer: &Indexer,
     uri: &Url,
     diagnostics: &mut Vec<Diagnostic>,
+    stats: &mut DiagStats,
+    sig_cache: &mut std::collections::HashMap<(String, Option<String>), SignatureResult>,
 ) {
     if node.kind() == KIND_CALL_EXPR {
-        if let Some(diag) = check_call_args(&node, bytes, indexer, uri) {
+        if let Some(diag) = check_call_args(&node, bytes, indexer, uri, stats, sig_cache) {
             diagnostics.push(diag);
         }
     }
@@ -47,7 +78,15 @@ fn collect_call_nodes(
     let mut cursor = node.walk();
     if cursor.goto_first_child() {
         loop {
-            collect_call_nodes(cursor.node(), bytes, indexer, uri, diagnostics);
+            collect_call_nodes(
+                cursor.node(),
+                bytes,
+                indexer,
+                uri,
+                diagnostics,
+                stats,
+                sig_cache,
+            );
             if !cursor.goto_next_sibling() {
                 break;
             }
@@ -60,9 +99,14 @@ fn check_call_args(
     bytes: &[u8],
     indexer: &Indexer,
     uri: &Url,
+    stats: &mut DiagStats,
+    sig_cache: &mut std::collections::HashMap<(String, Option<String>), SignatureResult>,
 ) -> Option<Diagnostic> {
+    stats.total += 1;
+
     // Skip calls with trailing lambdas — too complex without SAM resolution
     if has_trailing_lambda(call_node) {
+        stats.skipped_trailing_lambda += 1;
         return None;
     }
 
@@ -72,6 +116,7 @@ fn check_call_args(
     // These have an implicit `this` receiver that we cannot resolve, so global lookup
     // would match the wrong overload.
     if qualifier.is_none() && is_inside_scope_function_lambda(call_node, bytes) {
+        stats.skipped_scope += 1;
         return None;
     }
 
@@ -79,19 +124,33 @@ fn check_call_args(
     // inferred without full type resolution, so cross-file lookup may pick a JAR
     // copy() with a different arity, producing false positives.
     if qualifier.is_none() && fn_name == "copy" && is_inside_any_lambda(call_node) {
+        stats.skipped_scope += 1;
         return None;
     }
 
     let value_arguments = call_node.find_value_arguments();
     let provided_count = count_provided_args(value_arguments.as_ref(), bytes);
 
-    // Resolve signature through the unified pipeline.
-    let call = CallSite {
-        name: &fn_name,
-        qualifier: qualifier.as_deref(),
-        caller_uri: uri,
+    // Resolve signature — use per-run cache to avoid redundant index scans for
+    // the same function name called multiple times in one file.
+    let cache_key = (fn_name.clone(), qualifier.clone());
+    let sig_result = if let Some(cached) = sig_cache.get(&cache_key) {
+        stats.cache_hits += 1;
+        cached.clone()
+    } else {
+        let call = CallSite {
+            name: &fn_name,
+            qualifier: qualifier.as_deref(),
+            caller_uri: uri,
+        };
+        stats.resolved += 1;
+        let t0 = std::time::Instant::now();
+        let result = resolve_call_signature(&call, indexer);
+        stats.resolve_ms += t0.elapsed().as_millis();
+        sig_cache.insert(cache_key, result.clone());
+        result
     };
-    let (params_text, (required, total)) = match resolve_call_signature(&call, indexer) {
+    let (params_text, (required, total)) = match sig_result {
         SignatureResult::Unique {
             params_text,
             param_counts,

--- a/src/features/call_arg_diagnostics_tests.rs
+++ b/src/features/call_arg_diagnostics_tests.rs
@@ -1019,6 +1019,7 @@ fn data_class_copy_not_confused_by_jar_copy() {
         container: Some("AbstractList".to_owned()),
         doc: String::new(),
         trailing_lambda: false,
+        deprecated: false,
     }];
     let jar_file_data = std::sync::Arc::new(crate::types::FileData {
         symbols: jar_symbols,
@@ -1120,6 +1121,7 @@ fn copy_inside_custom_receiver_lambda_no_false_positive() {
         container: Some("AbstractList".to_owned()),
         doc: String::new(),
         trailing_lambda: false,
+        deprecated: false,
     }];
     let jar_file_data = std::sync::Arc::new(crate::types::FileData {
         symbols: jar_symbols,

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -133,8 +133,8 @@ pub(crate) fn run_completions(
     let before = before_cursor(&line, position.character);
     let (prefix, before_prefix) = split_prefix(before);
     let cache_key = completion_cache_key(uri, before_prefix, position.line);
-    if let Some(cached) = cache_hit(index, &cache_key) {
-        return (cached, false);
+    if let Some((cached, hit_cap)) = cache_hit(index, &cache_key) {
+        return (cached, hit_cap);
     }
 
     if index.workspace_root.generation() != gen {
@@ -190,7 +190,7 @@ pub(crate) fn run_completions(
         add_named_arg_completions(index, &mut items, uri, prefix, ctx.call_info.as_ref());
     }
 
-    store_in_cache(index, cache_key, &items, epoch);
+    store_in_cache(index, cache_key, &items, hit_cap, epoch);
     (items, hit_cap)
 }
 
@@ -206,11 +206,11 @@ fn completion_cache_key(uri: &Url, before_prefix: &str, line: u32) -> String {
     format!("{}|{}|{}", uri.as_str(), before_prefix, line)
 }
 
-/// Return cached items if the last completion key matches, `None` otherwise.
-fn cache_hit(index: &Indexer, key: &str) -> Option<Vec<CompletionItem>> {
+/// Return cached `(items, hit_cap)` if the last completion key matches, `None` otherwise.
+fn cache_hit(index: &Indexer, key: &str) -> Option<(Vec<CompletionItem>, bool)> {
     let guard = index.last_completion.lock().ok()?;
-    let (ref k, _, ref cached) = (*guard).as_ref()?;
-    (k.as_str() == key).then(|| cached.clone())
+    let (ref k, _, ref cached, hit_cap) = *(*guard).as_ref()?;
+    (k.as_str() == key).then(|| (cached.clone(), hit_cap))
 }
 
 /// Persist the latest completion result for subsequent identical requests.
@@ -218,14 +218,20 @@ fn cache_hit(index: &Indexer, key: &str) -> Option<Vec<CompletionItem>> {
 /// Only stores if `epoch` still matches the current `completion_epoch` — guards
 /// against an in-flight request storing stale results after JAR indexing
 /// incremented the epoch and cleared the cache.
-fn store_in_cache(index: &Indexer, key: String, items: &[CompletionItem], epoch: u64) {
+fn store_in_cache(
+    index: &Indexer,
+    key: String,
+    items: &[CompletionItem],
+    hit_cap: bool,
+    epoch: u64,
+) {
     if let Ok(mut guard) = index.last_completion.lock() {
         if index
             .completion_epoch
             .load(std::sync::atomic::Ordering::Acquire)
             == epoch
         {
-            *guard = Some((key, String::new(), items.to_vec()));
+            *guard = Some((key, String::new(), items.to_vec(), hit_cap));
         }
     }
 }

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -44,16 +44,19 @@ pub(crate) fn compute_completions(
     index: &impl CompletionIndex,
 ) -> Option<CompletionResponse> {
     let (mut items, hit_cap) = index.completions(uri, position, snippets);
-    let still_indexing = index.is_indexing_in_progress();
-    if items.is_empty() && !still_indexing {
+    // Always return None for an empty list — returning {items:[], isIncomplete:true}
+    // causes clients like nvim-cmp to clear the popup and fall back to buffer source.
+    if items.is_empty() {
         return None;
     }
+    let still_indexing = index.is_indexing_in_progress();
     // Pre-select the best match so the editor highlights it without an extra keystroke.
     if let Some(first) = items.first_mut() {
         first.preselect = Some(true);
     }
     // When hit_cap is true the list was truncated — tell the client to re-request
-    // on every keystroke. Also mark incomplete while indexing is in progress.
+    // on every keystroke. Also mark incomplete while indexing is in progress so
+    // JAR symbols (launch, collect, etc.) surface automatically when ready.
     Some(CompletionResponse::List(CompletionList {
         is_incomplete: hit_cap || still_indexing,
         items,

--- a/src/features/completion.rs
+++ b/src/features/completion.rs
@@ -121,9 +121,6 @@ pub(crate) fn run_completions(
     snippets: bool,
 ) -> (Vec<CompletionItem>, bool) {
     let gen = index.workspace_root.generation();
-    // Capture epoch before any computation. If JAR indexing completes while we
-    // are computing, the epoch will advance and store_in_cache will refuse to
-    // persist the (now-potentially-stale) result.
     let epoch = index
         .completion_epoch
         .load(std::sync::atomic::Ordering::Acquire);
@@ -135,12 +132,11 @@ pub(crate) fn run_completions(
     };
     let before = before_cursor(&line, position.character);
     let (prefix, before_prefix) = split_prefix(before);
-    let cache_key = completion_cache_key(uri, before_prefix, position.line, prefix);
+    let cache_key = completion_cache_key(uri, before_prefix, position.line);
     if let Some(cached) = cache_hit(index, &cache_key) {
         return (cached, false);
     }
 
-    // Generation changed while we were preparing — stale result, bail.
     if index.workspace_root.generation() != gen {
         return (vec![], false);
     }
@@ -188,12 +184,13 @@ pub(crate) fn run_completions(
         ctx.annotation_only,
         Some(position.line),
     );
+
     if ctx.receiver.is_none() {
         add_lambda_param_completions(&mut items, &ctx.scope, prefix);
         add_named_arg_completions(index, &mut items, uri, prefix, ctx.call_info.as_ref());
     }
 
-    store_in_cache(index, cache_key, prefix, &items, epoch);
+    store_in_cache(index, cache_key, &items, epoch);
     (items, hit_cap)
 }
 
@@ -201,16 +198,12 @@ pub(crate) fn run_completions(
 
 /// Build the cache key for a completion request.
 ///
-/// Dot-completion: key omits `prefix` so repeated keystrokes after `.` are fast
-/// (the client fuzzy-filters the full member list).
-/// Bare-word completion: key includes `prefix` so each keystroke gets a fresh,
-/// precisely-capped result rather than a stale earlier query.
-fn completion_cache_key(uri: &Url, before_prefix: &str, line: u32, prefix: &str) -> String {
-    if before_prefix.ends_with('.') {
-        format!("{}|{}|{}", uri.as_str(), before_prefix, line)
-    } else {
-        format!("{}|{}|{}|{}", uri.as_str(), before_prefix, line, prefix)
-    }
+/// The key always omits the prefix so that subsequent keystrokes (e.g. `l` →
+/// `la` → `lau`) hit the cache and the client fuzzy-filters the result list.
+/// One server round-trip per context (uri + line + preceding text), then instant
+/// for every additional character typed.
+fn completion_cache_key(uri: &Url, before_prefix: &str, line: u32) -> String {
+    format!("{}|{}|{}", uri.as_str(), before_prefix, line)
 }
 
 /// Return cached items if the last completion key matches, `None` otherwise.
@@ -225,20 +218,14 @@ fn cache_hit(index: &Indexer, key: &str) -> Option<Vec<CompletionItem>> {
 /// Only stores if `epoch` still matches the current `completion_epoch` — guards
 /// against an in-flight request storing stale results after JAR indexing
 /// incremented the epoch and cleared the cache.
-fn store_in_cache(
-    index: &Indexer,
-    key: String,
-    prefix: &str,
-    items: &[CompletionItem],
-    epoch: u64,
-) {
+fn store_in_cache(index: &Indexer, key: String, items: &[CompletionItem], epoch: u64) {
     if let Ok(mut guard) = index.last_completion.lock() {
         if index
             .completion_epoch
             .load(std::sync::atomic::Ordering::Acquire)
             == epoch
         {
-            *guard = Some((key, prefix.to_owned(), items.to_vec()));
+            *guard = Some((key, String::new(), items.to_vec()));
         }
     }
 }

--- a/src/features/on_type_formatting.rs
+++ b/src/features/on_type_formatting.rs
@@ -71,7 +71,38 @@ fn brace_newline(
         )]);
     }
 
-    // No closing brace on this line — fix indentation if it's wrong.
+    // Cursor is on a blank line. `}` may have landed on the next line without
+    // indentation (Helix auto-indent path: blank inner line + unindented `}`).
+    if cur_trimmed.is_empty() {
+        if let Some(next_line) = lines.get(cursor_line + 1) {
+            let next_trimmed = next_line.trim_start();
+            if next_trimmed.starts_with('}') {
+                let next_indent_len = next_line.len() - next_trimmed.len();
+                let mut edits = Vec::new();
+                if cur_indent_len != inner_indent.len() {
+                    edits.push(text_edit(
+                        cursor_line as u32,
+                        0,
+                        cursor_line as u32,
+                        cur_indent_len as u32,
+                        inner_indent,
+                    ));
+                }
+                if next_indent_len != indent.len() {
+                    edits.push(text_edit(
+                        (cursor_line + 1) as u32,
+                        0,
+                        (cursor_line + 1) as u32,
+                        next_indent_len as u32,
+                        indent.to_string(),
+                    ));
+                }
+                return if edits.is_empty() { None } else { Some(edits) };
+            }
+        }
+    }
+
+    // No closing brace visible — fix cursor line indentation if wrong.
     if cur_indent_len != inner_indent.len() {
         return Some(vec![text_edit(
             cursor_line as u32,
@@ -293,6 +324,26 @@ mod tests {
         let edits = fmt(src, 1).expect("should continue block comment body");
         let result = apply(src, edits);
         assert_eq!(result, "    * some text\n    * ");
+    }
+
+    #[test]
+    fn brace_newline_helix_blank_line_with_close_below() {
+        // Helix auto-indent path: cursor lands on a blank inner-indented line,
+        // `}` moves to the next line with no indentation.
+        let src = "    viewModelScope.launch {\n        \n}";
+        let edits = fmt(src, 1).expect("should fix } indentation");
+        let result = apply(src, edits);
+        // cursor line already has correct inner indent → only } is moved
+        assert_eq!(result, "    viewModelScope.launch {\n        \n    }");
+    }
+
+    #[test]
+    fn brace_newline_helix_blank_line_wrong_indent_and_close_below() {
+        // Both cursor line (wrong indent) and `}` below need fixing.
+        let src = "    viewModelScope.launch {\n\n}";
+        let edits = fmt(src, 1).expect("should fix both lines");
+        let result = apply(src, edits);
+        assert_eq!(result, "    viewModelScope.launch {\n        \n    }");
     }
 
     #[test]

--- a/src/features/traits_impl.rs
+++ b/src/features/traits_impl.rs
@@ -139,7 +139,18 @@ impl CompletionIndex for Indexer {
     }
 
     fn is_indexing_in_progress(&self) -> bool {
-        self.indexing_in_progress.load(Ordering::Acquire)
+        if self.indexing_in_progress.load(Ordering::Acquire) {
+            return true;
+        }
+        // Also treat JAR indexing as "still loading" so clients keep refreshing
+        // completions until JAR symbols (e.g. `launch {}`) are available.
+        matches!(
+            self.jar_phase.lock().ok().as_deref().cloned(),
+            Some(
+                crate::indexer::jar_phase::JarPhase::Pending
+                    | crate::indexer::jar_phase::JarPhase::InProgress
+            )
+        )
     }
 }
 

--- a/src/features/traits_impl.rs
+++ b/src/features/traits_impl.rs
@@ -139,7 +139,19 @@ impl CompletionIndex for Indexer {
     }
 
     fn is_indexing_in_progress(&self) -> bool {
-        self.indexing_in_progress.load(Ordering::Acquire)
+        if self.indexing_in_progress.load(Ordering::Acquire) {
+            return true;
+        }
+        // JAR indexing (launch, collect, Flow, etc.) runs after the workspace
+        // scan. Mark as incomplete while it's pending or running so clients
+        // keep re-requesting and pick up JAR symbols as soon as they land.
+        matches!(
+            self.jar_phase.lock().ok().as_deref().cloned(),
+            Some(
+                crate::indexer::jar_phase::JarPhase::Pending
+                    | crate::indexer::jar_phase::JarPhase::InProgress
+            )
+        )
     }
 }
 

--- a/src/features/traits_impl.rs
+++ b/src/features/traits_impl.rs
@@ -139,18 +139,7 @@ impl CompletionIndex for Indexer {
     }
 
     fn is_indexing_in_progress(&self) -> bool {
-        if self.indexing_in_progress.load(Ordering::Acquire) {
-            return true;
-        }
-        // Also treat JAR indexing as "still loading" so clients keep refreshing
-        // completions until JAR symbols (e.g. `launch {}`) are available.
-        matches!(
-            self.jar_phase.lock().ok().as_deref().cloned(),
-            Some(
-                crate::indexer::jar_phase::JarPhase::Pending
-                    | crate::indexer::jar_phase::JarPhase::InProgress
-            )
-        )
+        self.indexing_in_progress.load(Ordering::Acquire)
     }
 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -593,13 +593,21 @@ impl Indexer {
         });
         self.content_hashes.retain(|uri, _| is_library(uri));
         self.completion_cache.clear();
-        // `extension_by_receiver` uses an explicit iter + remove loop instead of
+        // `extension_by_receiver` uses an explicit iter + collect loop instead of
         // `DashMap::retain`.  In DashMap 5.x, `retain` with a closure that both
         // mutates the inner Vec (`entries.retain`) and reads back its length
         // (`!entries.is_empty()`) hangs on this specific map (other maps with
-        // the same closure shape — definitions, subtypes — don't).  The
-        // explicit form is functionally equivalent and avoids the deadlock.
+        // the same closure shape — definitions, subtypes — don't).
+        //
+        // CRITICAL: all mutations must be deferred until AFTER the iterator is
+        // fully dropped.  An `iter()` holds a read guard on the current shard;
+        // calling `insert`/`remove` for a key on that same shard while the guard
+        // is alive requests a write lock the thread can never get (parking_lot
+        // RwLocks are non-reentrant) → self-deadlock.  This fires only when a
+        // receiver has mixed library+workspace entries, so it is data-dependent
+        // and was previously intermittent.  Collect first, then mutate.
         let mut empty_keys: Vec<String> = Vec::new();
+        let mut updated: Vec<(String, Vec<crate::types::ExtensionEntry>)> = Vec::new();
         for entry in self.extension_by_receiver.iter() {
             let mut entries = entry.value().clone();
             let before = entries.len();
@@ -607,9 +615,11 @@ impl Indexer {
             if entries.is_empty() {
                 empty_keys.push(entry.key().clone());
             } else if entries.len() != before {
-                self.extension_by_receiver
-                    .insert(entry.key().clone(), entries);
+                updated.push((entry.key().clone(), entries));
             }
+        }
+        for (key, entries) in updated {
+            self.extension_by_receiver.insert(key, entries);
         }
         for key in empty_keys {
             self.extension_by_receiver.remove(&key);

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -140,6 +140,8 @@ pub(crate) struct StaleKeys {
     pub package: Option<String>,
 }
 
+pub(crate) type CompletionCacheEntry = (String, String, Vec<CompletionItem>, bool);
+
 pub(crate) struct Indexer {
     /// URI string → parsed file data.
     pub(crate) files: DashMap<String, Arc<FileData>>,
@@ -181,7 +183,7 @@ pub(crate) struct Indexer {
     /// `context_key` = line text up to (but not including) the current word.
     /// When the key matches, the cached items are returned without recomputation —
     /// covers the common "typing more characters in the same word/after same dot" case.
-    pub(crate) last_completion: std::sync::Mutex<Option<(String, String, Vec<CompletionItem>)>>,
+    pub(crate) last_completion: std::sync::Mutex<Option<CompletionCacheEntry>>,
     /// Cache for the ancestor type-name sets computed by `collect_this_extensions`.
     /// Key: `"ClassName@file_uri"`. Value: the resolved ancestor set.
     /// Avoids re-running `walk_hierarchy` + `resolve_symbol_no_rg` on every line change.
@@ -628,6 +630,7 @@ impl Indexer {
         if let Ok(mut last) = self.last_completion.lock() {
             *last = None;
         }
+        self.this_ext_ancestor_cache.clear();
         self.completion_epoch.fetch_add(1, Ordering::Release);
         self.sig_cache.clear();
         // Clear enrichment dedup so symbols are re-attempted after reindex.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -182,6 +182,12 @@ pub(crate) struct Indexer {
     /// When the key matches, the cached items are returned without recomputation —
     /// covers the common "typing more characters in the same word/after same dot" case.
     pub(crate) last_completion: std::sync::Mutex<Option<(String, String, Vec<CompletionItem>)>>,
+    /// Cache for the ancestor type-name sets computed by `collect_this_extensions`.
+    /// Key: `"ClassName@file_uri"`. Value: the resolved ancestor set.
+    /// Avoids re-running `walk_hierarchy` + `resolve_symbol_no_rg` on every line change.
+    /// Cleared together with the rest of the completion caches on reindex / JAR finish.
+    pub(crate) this_ext_ancestor_cache:
+        DashMap<String, std::sync::Arc<std::collections::HashSet<String>>>,
     /// Monotonically incremented whenever index state changes in a way that could
     /// invalidate an in-flight completion result (JAR indexing completes, workspace
     /// reindex). Completion requests capture this epoch before computing and refuse
@@ -494,6 +500,7 @@ impl Indexer {
             bare_name_cache: std::sync::RwLock::new(Vec::new()),
             bare_names_dirty: AtomicBool::new(true),
             last_completion: std::sync::Mutex::new(None),
+            this_ext_ancestor_cache: DashMap::new(),
             completion_epoch: AtomicU64::new(0),
             indexing_in_progress: std::sync::atomic::AtomicBool::new(false),
             pending_reindex: std::sync::atomic::AtomicBool::new(false),
@@ -812,6 +819,7 @@ impl Indexer {
         if let Ok(mut last) = self.last_completion.lock() {
             *last = None;
         }
+        self.this_ext_ancestor_cache.clear();
         self.completion_epoch.fetch_add(1, Ordering::Release);
     }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -805,6 +805,16 @@ impl Indexer {
         self.files.remove(uri.as_str());
     }
 
+    /// Bust the completion cache so the next request recomputes with the latest
+    /// index state. Called when JAR indexing finishes to surface new symbols
+    /// (e.g. `launch {}`) without requiring the user to retype.
+    pub(crate) fn invalidate_completion_cache(&self) {
+        if let Ok(mut last) = self.last_completion.lock() {
+            *last = None;
+        }
+        self.completion_epoch.fetch_add(1, Ordering::Release);
+    }
+
     // ─── completion helpers (methods on Indexer) ─────────────────────────────
 
     /// Ensures the file at `uri` is indexed, loading from disk if needed.

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -203,6 +203,7 @@ pub(crate) fn contributions_from_data(
                 visibility: sym.visibility,
                 package: file_data.package.clone(),
                 trailing_lambda: sym.trailing_lambda,
+                deprecated: sym.deprecated,
             });
     }
 
@@ -406,6 +407,7 @@ impl LibraryBatch {
                     visibility: sym.visibility,
                     package: file_data.package.clone(),
                     trailing_lambda: sym.trailing_lambda,
+                    deprecated: sym.deprecated,
                 });
         }
 
@@ -552,9 +554,11 @@ impl Indexer {
             result.stats.files_parsed,
             result.stats.cache_hits
         );
+        let t0 = std::time::Instant::now();
 
         // Full replace — clear stale state from any previous root or run.
         self.reset_index_state();
+        log::debug!("apply: reset_index_state done in {:?}", t0.elapsed());
 
         // Fast path: after reset the maps are empty so dedup checks are
         // unnecessary.  Use apply_contributions_fresh which skips the O(n)
@@ -564,13 +568,21 @@ impl Indexer {
             let contrib = file_contributions(file_result);
             self.apply_contributions_fresh(contrib);
         }
+        log::debug!("apply: contributions done in {:?}", t0.elapsed());
 
+        // Force a rebuild against the now-complete index. apply_contributions_fresh
+        // deliberately does not touch this flag, but a completion request arriving
+        // mid-apply may have consumed the dirty flag set by reset_index_state and
+        // rebuilt the bare-name cache against a partial index. Re-marking dirty here
+        // guarantees the final rebuild runs against the full symbol set.
+        self.bare_names_dirty.store(true, Ordering::Release);
         self.rebuild_bare_name_cache();
 
         log::info!(
-            "Index ready: {} symbols from {} files",
+            "Index ready: {} symbols from {} files ({:?} total)",
             self.definitions.len(),
-            self.files.len()
+            self.files.len(),
+            t0.elapsed()
         );
     }
 
@@ -607,7 +619,10 @@ impl Indexer {
             let mut slot = self.extension_by_receiver.entry(receiver).or_default();
             slot.extend(new_entries);
         }
-        self.bare_names_dirty.store(true, Ordering::Release);
+        // Intentionally no bare_names_dirty.store(true) here — this function is
+        // only called from apply_workspace_result which calls rebuild_bare_name_cache
+        // once at the end.  Setting dirty on every file would cause concurrent
+        // completion requests to trigger O(files²) rebuilds during the bulk apply.
     }
 
     /// Index all configured `sourcePaths` additively — without clearing the workspace index.

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -556,9 +556,13 @@ impl Indexer {
         // Full replace — clear stale state from any previous root or run.
         self.reset_index_state();
 
+        // Fast path: after reset the maps are empty so dedup checks are
+        // unnecessary.  Use apply_contributions_fresh which skips the O(n)
+        // iter().any() scans inside each DashMap entry, turning the overall
+        // apply from O(files²) to O(files).
         for file_result in &result.files {
             let contrib = file_contributions(file_result);
-            self.apply_contributions(contrib);
+            self.apply_contributions_fresh(contrib);
         }
 
         self.rebuild_bare_name_cache();
@@ -568,6 +572,42 @@ impl Indexer {
             self.definitions.len(),
             self.files.len()
         );
+    }
+
+    /// Like `apply_contributions` but skips duplicate checks — safe only when
+    /// the index maps have just been cleared (i.e. after `reset_index_state`).
+    fn apply_contributions_fresh(&self, contrib: FileContributions) {
+        let (uri_str, file_data) = contrib.file_data;
+        let (hash_key, hash_val) = contrib.content_hash;
+        let file_data = self.with_classified_source_set(&uri_str, file_data);
+
+        self.content_hashes.insert(hash_key, hash_val);
+        self.files.insert(uri_str.clone(), file_data);
+
+        for (name, locs) in contrib.definitions {
+            let mut entry = self.definitions.entry(name).or_default();
+            entry.extend(locs);
+        }
+
+        for (key, loc) in contrib.qualified {
+            self.qualified.insert(key, loc);
+        }
+
+        for (pkg, uris) in contrib.packages {
+            let mut entry = self.packages.entry(pkg).or_default();
+            entry.extend(uris);
+        }
+
+        for (super_name, locs) in contrib.subtypes {
+            let mut entry = self.subtypes.entry(super_name).or_default();
+            entry.extend(locs);
+        }
+
+        for (receiver, new_entries) in contrib.extensions {
+            let mut slot = self.extension_by_receiver.entry(receiver).or_default();
+            slot.extend(new_entries);
+        }
+        self.bare_names_dirty.store(true, Ordering::Release);
     }
 
     /// Index all configured `sourcePaths` additively — without clearing the workspace index.

--- a/src/indexer/apply_tests.rs
+++ b/src/indexer/apply_tests.rs
@@ -632,3 +632,77 @@ fn rebuild_bare_name_cache_is_idempotent_issue_apply() {
 
     assert_eq!(first, second, "rebuild_bare_name_cache must be idempotent");
 }
+
+/// Regression: `reset_index_state` must not self-deadlock when an extension
+/// receiver carries BOTH a library and a workspace entry.
+///
+/// The old code inserted into `extension_by_receiver` *while iterating it*
+/// (`iter()` holds a read guard on the current shard; `insert(entry.key())`
+/// then requests a write lock on that same shard). parking_lot RwLocks are
+/// non-reentrant, so the thread deadlocks on itself. It only fires when the
+/// retained set differs from the original (`entries.len() != before`), i.e. a
+/// receiver with mixed library+workspace entries — data-dependent, which is why
+/// it surfaced only on large real workspaces and looked intermittent.
+///
+/// Runs `reset_index_state` under a watchdog so a regression fails via timeout
+/// instead of hanging the whole test binary.
+#[test]
+fn reset_index_state_mixed_extension_receiver_no_deadlock() {
+    use crate::types::{ExtensionEntry, FileData, Visibility};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    let lib_uri = "jar:file:///dep-sources.jar!/com/example/Lib.kt".to_string();
+    let ws_uri = uri("/Workspace.kt").to_string();
+
+    let idx = Arc::new(Indexer::new());
+    // The library file is registered so the is_library check retains its entry;
+    // both files live in `files` so they survive the earlier `files.retain` pass.
+    idx.library_uris.insert(lib_uri.clone());
+    idx.files
+        .insert(lib_uri.clone(), Arc::new(FileData::default()));
+    idx.files
+        .insert(ws_uri.clone(), Arc::new(FileData::default()));
+
+    let mk = |file_uri: &str, name: &str| ExtensionEntry {
+        file_uri: file_uri.to_string(),
+        name: name.to_string(),
+        kind: SymbolKind::FUNCTION,
+        detail: String::new(),
+        visibility: Visibility::Public,
+        package: None,
+        trailing_lambda: false,
+        deprecated: false,
+    };
+    // Mixed receiver: reset keeps the library entry and drops the workspace one,
+    // forcing the `entries.len() != before` insert branch — the deadlock trigger.
+    idx.extension_by_receiver.insert(
+        "Foo".to_string(),
+        vec![mk(&lib_uri, "libExt"), mk(&ws_uri, "wsExt")],
+    );
+
+    let (tx, rx) = mpsc::channel();
+    let idx2 = Arc::clone(&idx);
+    let handle = std::thread::spawn(move || {
+        idx2.reset_index_state();
+        let _ = tx.send(());
+    });
+    match rx.recv_timeout(Duration::from_secs(10)) {
+        Ok(()) => handle.join().unwrap(),
+        Err(_) => panic!(
+            "reset_index_state deadlocked on a mixed extension receiver \
+             (insert while iterating extension_by_receiver)"
+        ),
+    }
+
+    let entries = idx
+        .extension_by_receiver
+        .get("Foo")
+        .expect("Foo receiver should be retained");
+    assert_eq!(
+        entries.len(),
+        1,
+        "only the library extension entry should remain after reset"
+    );
+    assert_eq!(entries[0].file_uri, lib_uri);
+}

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -103,6 +103,10 @@ pub(crate) fn workspace_cache_path(root: &Path) -> PathBuf {
         .join("index.bin")
 }
 
+pub(crate) fn workspace_scan_lock_path(root: &Path) -> PathBuf {
+    workspace_cache_path(root).with_file_name("scan.lock")
+}
+
 // ─── Status file ─────────────────────────────────────────────────────────────
 
 /// Write a human-readable status blob to `~/.cache/kmp-lsp/status.json`.

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -21,7 +21,8 @@ use crate::types::{FileData, FileIndexResult, Visibility};
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 /// Bump when the serialized format changes; invalidates any older cache files.
-pub(crate) const CACHE_VERSION: u32 = 27;
+/// v28: added `SymbolEntry.deprecated` (forces reparse so it populates).
+pub(crate) const CACHE_VERSION: u32 = 28;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -101,10 +102,6 @@ pub(crate) fn workspace_cache_path(root: &Path) -> PathBuf {
         .join("kmp-lsp")
         .join(format!("{root_hash:016x}"))
         .join("index.bin")
-}
-
-pub(crate) fn workspace_scan_lock_path(root: &Path) -> PathBuf {
-    workspace_cache_path(root).with_file_name("scan.lock")
 }
 
 // ─── Status file ─────────────────────────────────────────────────────────────
@@ -210,6 +207,7 @@ pub(super) fn save_cache(
     content_hashes: &DashMap<String, u64>,
     library_uris: &DashSet<String>,
     complete_scan: bool,
+    allow_shrink: bool,
 ) {
     let cache_path = workspace_cache_path(root);
     if let Some(parent) = cache_path.parent() {
@@ -262,8 +260,10 @@ pub(super) fn save_cache(
     };
     match bincode::serialize(&cache) {
         Ok(bytes) => {
-            // Don't overwrite a complete cache with an incomplete one.
-            if !complete_scan {
+            // Unless the caller is authoritative (allow_shrink), never replace a
+            // larger cache with a smaller one — guards against a partial/reset
+            // index state overwriting a good full cache.
+            if !allow_shrink {
                 if let Ok(meta) = std::fs::metadata(&cache_path) {
                     if meta.len() > bytes.len() as u64 {
                         log::info!(

--- a/src/indexer/cache.rs
+++ b/src/indexer/cache.rs
@@ -267,8 +267,8 @@ pub(super) fn save_cache(
                 if let Ok(meta) = std::fs::metadata(&cache_path) {
                     if meta.len() > bytes.len() as u64 {
                         log::info!(
-                            "Cache save skipped: existing cache ({} KB) is larger than \
-                             incomplete new cache ({} KB)",
+                            "Cache save skipped: existing cache ({} KB) is larger than the new \
+                             one ({} KB) and this save is not allowed to shrink it",
                             meta.len() / 1024,
                             bytes.len() / 1024
                         );

--- a/src/indexer/cache_tests.rs
+++ b/src/indexer/cache_tests.rs
@@ -40,6 +40,7 @@ fn cache_entry_to_file_result_supertypes_extracted() {
         param_counts: (0, 0),
         doc: String::new(),
         trailing_lambda: false,
+        deprecated: false,
     });
     data.supers.push((0, "IAnimal".into(), vec![]));
 
@@ -82,6 +83,7 @@ fn cache_entry_to_file_result_preserves_hash() {
         param_counts: (0, 0),
         doc: String::new(),
         trailing_lambda: false,
+        deprecated: false,
     });
 
     let entry = FileCacheEntry {
@@ -156,6 +158,7 @@ fn save_and_load_cache_roundtrip() {
             &idx.content_hashes,
             &idx.library_uris,
             true,
+            true,
         );
 
         let loaded = try_load_cache(&root).expect("cache should exist after save");
@@ -175,6 +178,105 @@ fn save_and_load_cache_roundtrip() {
         assert!(
             has_class,
             "RoundtripClass symbol missing from cache roundtrip"
+        );
+    });
+}
+
+/// Regression: an ambient save (`allow_shrink = false`) must NOT overwrite a
+/// populated cache with a near-empty index. This is the cache-clobber bug where
+/// a save firing during a reindex's `reset_index_state` window wrote a 3-file
+/// cache over the full one, forcing a cold rescan on every subsequent start.
+#[test]
+fn ambient_save_does_not_clobber_populated_cache() {
+    use crate::indexer::Indexer;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("workspace");
+    std::fs::create_dir(&root).expect("create workspace dir");
+
+    let src = "package com.example\nclass KeepMeClass";
+    let kt_file = tmp.path().join("KeepMeClass.kt");
+    std::fs::write(&kt_file, src).expect("write kt file");
+    let u = Url::from_file_path(&kt_file).expect("valid file URL");
+
+    let populated = Indexer::new();
+    populated.index_content(&u, src);
+    let empty = Indexer::new();
+
+    with_xdg_cache(tmp.path(), || {
+        // Authoritative save of the full index.
+        save_cache(
+            &root,
+            &populated.files,
+            &populated.content_hashes,
+            &populated.library_uris,
+            true,
+            true,
+        );
+
+        // Ambient save (allow_shrink = false) of an empty index must be refused
+        // because the existing cache is larger.
+        save_cache(
+            &root,
+            &empty.files,
+            &empty.content_hashes,
+            &empty.library_uris,
+            true,
+            false,
+        );
+
+        let loaded = try_load_cache(&root).expect("cache should still exist");
+        let file_path = kt_file.to_string_lossy().to_string();
+        assert!(
+            loaded.entries.contains_key(&file_path),
+            "ambient empty save clobbered the populated cache"
+        );
+    });
+}
+
+/// An authoritative save (`allow_shrink = true`) IS allowed to shrink the cache —
+/// e.g. when a branch switch genuinely deletes files. The guard only protects
+/// against non-authoritative (ambient) saves.
+#[test]
+fn authoritative_save_may_shrink_cache() {
+    use crate::indexer::Indexer;
+
+    let tmp = tempfile::tempdir().expect("tempdir");
+    let root = tmp.path().join("workspace");
+    std::fs::create_dir(&root).expect("create workspace dir");
+
+    let src = "package com.example\nclass BigClass";
+    let kt_file = tmp.path().join("BigClass.kt");
+    std::fs::write(&kt_file, src).expect("write kt file");
+    let u = Url::from_file_path(&kt_file).expect("valid file URL");
+
+    let populated = Indexer::new();
+    populated.index_content(&u, src);
+    let empty = Indexer::new();
+
+    with_xdg_cache(tmp.path(), || {
+        save_cache(
+            &root,
+            &populated.files,
+            &populated.content_hashes,
+            &populated.library_uris,
+            true,
+            true,
+        );
+        // Authoritative shrink to empty is permitted.
+        save_cache(
+            &root,
+            &empty.files,
+            &empty.content_hashes,
+            &empty.library_uris,
+            true,
+            true,
+        );
+
+        let loaded = try_load_cache(&root).expect("cache should exist");
+        assert!(
+            loaded.entries.is_empty(),
+            "authoritative save should have shrunk the cache to empty"
         );
     });
 }

--- a/src/indexer/infer/cst_lambda.rs
+++ b/src/indexer/infer/cst_lambda.rs
@@ -393,7 +393,7 @@ pub(super) fn cst_it_or_this_type(
     uri: &Url,
 ) -> Option<String> {
     let mut cur = start_node;
-    log::debug!(
+    log::trace!(
         "cst_it_or_this_type: start_node kind={}, text={:?}",
         start_node.kind(),
         start_node
@@ -402,14 +402,14 @@ pub(super) fn cst_it_or_this_type(
             .map(|s| s.chars().take(40).collect::<String>())
     );
     loop {
-        log::debug!(
+        log::trace!(
             "cst_it_or_this_type: cur kind={} at {:?}",
             cur.kind(),
             cur.start_position()
         );
         if cur.kind() == KIND_LAMBDA_LIT && !cur.has_lambda_named_params(&doc.bytes) {
             let Some((before_brace, ln)) = lambda_before_brace_context(cur, doc) else {
-                log::debug!(
+                log::trace!(
                     "cst_it_or_this_type: no before_brace context for lambda at {:?}",
                     cur.start_position()
                 );
@@ -650,7 +650,7 @@ fn find_enclosing_call_and_param<'a>(
     loop {
         let parent = cur.parent()?;
         let kind = parent.kind();
-        log::debug!(
+        log::trace!(
             "find_enclosing_call_and_param: parent kind={kind} at {:?}",
             parent.start_position()
         );
@@ -669,18 +669,18 @@ fn find_enclosing_call_and_param<'a>(
         }
         if kind == KIND_CALL_SUFFIX {
             let call_expr = lambda.enclosing_call_expression()?;
-            log::debug!(
+            log::trace!(
                 "find_enclosing_call_and_param: call_suffix, call_expr fn={:?}",
                 call_expr.call_fn_name(bytes)
             );
             let sig = receiver_aware_params(call_expr, bytes, deps, uri).or_else(|| {
                 let fn_name = call_expr.call_fn_name(bytes)?;
-                log::debug!(
+                log::trace!(
                     "find_enclosing_call_and_param: looking up params for fn_name={fn_name}"
                 );
                 deps.find_fun_params_text(&fn_name, uri)
             })?;
-            log::debug!("find_enclosing_call_and_param: sig={sig}");
+            log::trace!("find_enclosing_call_and_param: sig={sig}");
             let last_type = last_fun_param_type_str(&sig)?;
             return Some((call_expr, last_type.to_owned()));
         }

--- a/src/indexer/infer/it_this_tests.rs
+++ b/src/indexer/infer/it_this_tests.rs
@@ -1914,6 +1914,7 @@ fn insert_fake_jar_symbol(
         extension_receiver_type: ext_receiver_type.to_owned(),
         doc: String::new(),
         trailing_lambda: false,
+        deprecated: false,
     };
     idx.jar_files.insert(
         fake_uri_str.clone(),

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -40,7 +40,7 @@ pub(crate) struct CallSite<'a> {
 }
 
 /// Result of resolving a call site's signature.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum SignatureResult {
     /// Exactly one arity envelope — safe to emit a diagnostic.
     Unique {

--- a/src/indexer/infer/sig_tests.rs
+++ b/src/indexer/infer/sig_tests.rs
@@ -429,6 +429,7 @@ fn resolve_qualified_jar_extension_overloads_with_source_member() {
         type_params: vec![],
         doc: String::new(),
         trailing_lambda: false,
+        deprecated: false,
     };
     let jar_file_data = std::sync::Arc::new(FileData {
         symbols: vec![jar_symbol],
@@ -456,6 +457,7 @@ fn resolve_qualified_jar_extension_overloads_with_source_member() {
             visibility: Visibility::Public,
             package: Some("com.example".into()),
             trailing_lambda: false,
+            deprecated: false,
         });
 
     let call = CallSite {
@@ -672,6 +674,7 @@ mod import_reachable {
             container: Some(container.to_owned()),
             doc: String::new(),
             trailing_lambda: false,
+            deprecated: false,
         }
     }
 

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -669,6 +669,7 @@ fn build_jar_file_data(
             extension_receiver_type: sym.extension_receiver_type.clone(),
             doc: sym.doc.clone(),
             trailing_lambda: sym.trailing_lambda,
+            deprecated: sym.deprecated,
         });
         indexer
             .jar_definitions
@@ -766,6 +767,7 @@ fn build_jar_file_data(
                 visibility: Visibility::Public,
                 package: package.clone(),
                 trailing_lambda: sym.trailing_lambda,
+                deprecated: sym.deprecated,
             });
     }
 

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -22,7 +22,8 @@ use crate::sidecar::SidecarSymbol;
 /// Bump when `JarCacheEntry` schema changes.
 /// v3 → v4: SidecarSymbol gained `trailing_lambda: bool` (bincode 1.x is positional, no serde(default)).
 /// v4 → v5: SidecarSymbol gained `doc: String` inserted before `type_params` — positional mismatch.
-const JAR_CACHE_VERSION: u32 = 5;
+/// v5 → v6: SidecarSymbol gained `deprecated: bool` after `trailing_lambda` — positional mismatch.
+const JAR_CACHE_VERSION: u32 = 6;
 
 #[derive(Serialize, Deserialize)]
 struct JarCache {

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -29,6 +29,7 @@ fn make_sidecar_symbol(name: &str, kind: &str, detail: &str, container: &str) ->
         type_params: Vec::new(),
         extension_receiver_type: String::new(),
         trailing_lambda: false,
+        deprecated: false,
     }
 }
 
@@ -42,6 +43,7 @@ fn make_sidecar_extension(name: &str, receiver_type: &str, detail: &str) -> Side
         type_params: Vec::new(),
         extension_receiver_type: receiver_type.to_owned(),
         trailing_lambda: false,
+        deprecated: false,
     }
 }
 

--- a/src/indexer/resolution_tests.rs
+++ b/src/indexer/resolution_tests.rs
@@ -72,6 +72,7 @@ fn make_sym(name: &str, kind: SymbolKind, start_line: u32, end_line: u32) -> Sym
         param_counts: (0, 0),
         doc: String::new(),
         trailing_lambda: false,
+        deprecated: false,
     }
 }
 
@@ -272,6 +273,7 @@ fn make_sym_col(
         param_counts: (0, 0),
         doc: String::new(),
         trailing_lambda: false,
+        deprecated: false,
     }
 }
 

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -945,19 +945,23 @@ impl Indexer {
         let result = std::sync::Arc::new(result);
         let idx = Arc::clone(&self);
         let r = Arc::clone(&result);
-        tokio::task::spawn_blocking(move || idx.apply_workspace_result(&r))
+        let apply_ok = tokio::task::spawn_blocking(move || idx.apply_workspace_result(&r))
             .await
-            .unwrap_or_else(|e| log::error!("apply_workspace_result panicked: {e}"));
+            .map_err(|e| log::error!("apply_workspace_result panicked: {e}"))
+            .is_ok();
         Arc::clone(&self).index_source_paths(root).await;
-        // Always save when a complete scan ran — this trims deleted-file entries from
-        // the on-disk cache even when files_parsed == 0 (all cache hits).  Skip only
-        // for partial / truncated scans where nothing new was parsed.
-        if files_parsed > 0 || complete_scan {
-            self.save_cache_to_disk();
-        } else {
-            log::info!("Partial scan, nothing new parsed — skipping workspace cache save");
+        if apply_ok {
+            // Always save when a complete scan ran — this trims deleted-file entries from
+            // the on-disk cache even when files_parsed == 0 (all cache hits).  Skip only
+            // for partial / truncated scans where nothing new was parsed.
+            if files_parsed > 0 || complete_scan {
+                self.save_cache_to_disk();
+            } else {
+                log::info!("Partial scan, nothing new parsed — skipping workspace cache save");
+            }
+            let _ = std::fs::remove_file(&lock_path);
         }
-        let _ = std::fs::remove_file(&lock_path);
+        // On panic: skip cache save and leave scan.lock so next startup forces a cold scan.
         // Drop guard FIRST to clear indexing_in_progress, then notify the client.
         // This ensures any request the client sends after the end notification
         // (e.g. textDocument/completion) sees is_indexing_in_progress() == false.

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -919,11 +919,12 @@ impl Indexer {
         let complete_scan = result.complete_scan;
         let result = std::sync::Arc::new(result);
         let idx = Arc::clone(&self);
-        let r = Arc::clone(&result);
-        let apply_ok = tokio::task::spawn_blocking(move || idx.apply_workspace_result(&r))
-            .await
-            .map_err(|e| log::error!("apply_workspace_result panicked: {e}"))
-            .is_ok();
+        let result_for_apply = Arc::clone(&result);
+        let apply_ok =
+            tokio::task::spawn_blocking(move || idx.apply_workspace_result(&result_for_apply))
+                .await
+                .map_err(|e| log::error!("apply_workspace_result panicked: {e}"))
+                .is_ok();
         if apply_ok {
             // Always save when a complete scan ran — this trims deleted-file entries from
             // the on-disk cache even when files_parsed == 0 (all cache hits).  Skip only

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -686,7 +686,9 @@ impl Indexer {
             .index_workspace_impl(root, max, Arc::clone(&reporter))
             .await;
         if let Some(guard) = guard_opt {
-            if !result.aborted {
+            if result.aborted {
+                Self::cancel_progress(&*reporter).await;
+            } else {
                 Arc::clone(&self)
                     .finalize_workspace_scan(result, guard, Arc::clone(&reporter))
                     .await;
@@ -705,7 +707,9 @@ impl Indexer {
             .index_workspace_impl(root, max, Arc::clone(&reporter))
             .await;
         if let Some(guard) = guard_opt {
-            if !result.aborted {
+            if result.aborted {
+                Self::cancel_progress(&*reporter).await;
+            } else {
                 Arc::clone(&self)
                     .finalize_workspace_scan(result, guard, Arc::clone(&reporter))
                     .await;
@@ -807,7 +811,9 @@ impl Indexer {
             .index_workspace_impl(root, max, Arc::clone(&reporter))
             .await;
         if let Some(guard) = guard_opt {
-            if !result.aborted {
+            if result.aborted {
+                Self::cancel_progress(&*reporter).await;
+            } else {
                 Arc::clone(&self)
                     .finalize_workspace_scan(result, guard, Arc::clone(&reporter))
                     .await;
@@ -863,6 +869,10 @@ impl Indexer {
                 .index_workspace_impl(&root, max, Arc::clone(&reporter))
                 .await;
             if result.aborted {
+                // guard_opt.is_some() means Begin was sent — close the bar.
+                if guard_opt.is_some() {
+                    Self::cancel_progress(&*reporter).await;
+                }
                 // Lost the scan guard to a concurrent caller — restore the queued
                 // request so that caller's run_pending_reindex will drain it.
                 {
@@ -888,6 +898,13 @@ impl Indexer {
     /// Clears `indexing_in_progress` BEFORE sending the progress-end notification
     /// so that clients cannot observe `isIncomplete` in a completion response
     /// that arrives after the `$/progress` end message.
+    /// Called when `index_workspace_impl` returns a guard but the scan was aborted
+    /// (generation changed). `Begin` was already sent — send `End` to close the bar.
+    async fn cancel_progress<R: ProgressReporter>(reporter: &R) {
+        let token = NumberOrString::String("kmp-lsp/indexing".into());
+        reporter.end(&token, "Indexing interrupted").await;
+    }
+
     async fn finalize_workspace_scan<R: ProgressReporter + 'static>(
         self: Arc<Self>,
         result: WorkspaceIndexResult,

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -18,10 +18,7 @@ use tower_lsp::lsp_types::*;
 const MAX_READ_FAILURES_LOGGED: usize = 5;
 
 use crate::indexer::{
-    cache::{
-        cache_entry_to_file_result, save_cache, try_load_cache, workspace_scan_lock_path,
-        write_status_file,
-    },
+    cache::{cache_entry_to_file_result, save_cache, try_load_cache, write_status_file},
     discover::{find_source_files, warm_discover_files},
     Indexer, MAX_FILES_UNLIMITED,
 };
@@ -228,7 +225,6 @@ struct ScanSetup {
     start_gen: u64,
     cache: Option<super::cache::IndexCache>,
     discovered: DiscoveredPaths,
-    scan_lock_path: PathBuf,
 }
 
 #[derive(Clone, Default)]
@@ -284,26 +280,7 @@ fn prepare_scan(indexer: &Arc<Indexer>, root: &Path, max: usize) -> ScanSetup {
 
     let start_gen = indexer.workspace_root.generation();
 
-    // If a lock from the previous scan still exists, that scan was interrupted
-    // before it could save a valid cache — force a cold scan so we don't reuse
-    // a potentially incomplete cache manifest.
-    let scan_lock_path = workspace_scan_lock_path(root);
-    let stale_lock = scan_lock_path.exists();
-    if stale_lock {
-        log::info!(
-            "prepare_scan: stale scan.lock found — previous scan interrupted; forcing cold scan"
-        );
-    }
-    if let Some(parent) = scan_lock_path.parent() {
-        let _ = std::fs::create_dir_all(parent);
-    }
-    let _ = std::fs::write(&scan_lock_path, b"");
-
-    let cache = if stale_lock {
-        None
-    } else {
-        try_load_cache(root)
-    };
+    let cache = try_load_cache(root);
     let matcher: Option<Arc<IgnoreMatcher>> = indexer.ignore_matcher.read().unwrap().clone();
     let discovered = discover_workspace_paths(root, max, &cache, matcher.as_deref());
 
@@ -312,7 +289,6 @@ fn prepare_scan(indexer: &Arc<Indexer>, root: &Path, max: usize) -> ScanSetup {
         start_gen,
         cache,
         discovered,
-        scan_lock_path,
     }
 }
 
@@ -939,7 +915,6 @@ impl Indexer {
         self.last_scan_complete
             .store(result.complete_scan, std::sync::atomic::Ordering::Release);
         let root = result.workspace_root.clone();
-        let lock_path = workspace_scan_lock_path(&root);
         let files_parsed = result.stats.files_parsed;
         let complete_scan = result.complete_scan;
         let result = std::sync::Arc::new(result);
@@ -949,25 +924,26 @@ impl Indexer {
             .await
             .map_err(|e| log::error!("apply_workspace_result panicked: {e}"))
             .is_ok();
-        Arc::clone(&self).index_source_paths(root).await;
         if apply_ok {
             // Always save when a complete scan ran — this trims deleted-file entries from
             // the on-disk cache even when files_parsed == 0 (all cache hits).  Skip only
             // for partial / truncated scans where nothing new was parsed.
             if files_parsed > 0 || complete_scan {
-                self.save_cache_to_disk();
+                self.save_cache_to_disk(true);
             } else {
                 log::info!("Partial scan, nothing new parsed — skipping workspace cache save");
             }
-            let _ = std::fs::remove_file(&lock_path);
         }
-        // On panic: skip cache save and leave scan.lock so next startup forces a cold scan.
+        // On panic: skip cache save; the last good atomic cache on disk remains valid.
         // Drop guard FIRST to clear indexing_in_progress, then notify the client.
         // This ensures any request the client sends after the end notification
         // (e.g. textDocument/completion) sees is_indexing_in_progress() == false.
+        // index_source_paths runs AFTER progress end so a slow library-source scan
+        // (slow path, no cache) does not keep the progress bar open for minutes.
         drop(guard);
         let token = NumberOrString::String("kmp-lsp/indexing".into());
         send_progress_end(&*reporter, &token, &result).await;
+        Arc::clone(&self).index_source_paths(root).await;
     }
 
     /// Core workspace indexing: file discovery → cache partition → concurrent parse.
@@ -1000,7 +976,6 @@ impl Indexer {
             start_gen,
             cache,
             discovered,
-            scan_lock_path,
         } = prepare_scan(&self, root, max);
         let session = ScanSession {
             start_gen,
@@ -1049,7 +1024,6 @@ impl Indexer {
             aborted_early = true;
         }
         if aborted_early {
-            let _ = std::fs::remove_file(&scan_lock_path);
             return (aborted_scan_result(root), Some(guard));
         }
 
@@ -1074,7 +1048,7 @@ impl Indexer {
 
     /// Serialize the current index to `~/.cache/kmp-lsp/<root-hash>/index.bin`.
     /// Safe to call from a background thread. Logs warnings on error; never panics.
-    pub(crate) fn save_cache_to_disk(&self) {
+    pub(crate) fn save_cache_to_disk(&self, allow_shrink: bool) {
         let Some(root) = self.workspace_root.get() else {
             return;
         };
@@ -1087,6 +1061,7 @@ impl Indexer {
             &self.content_hashes,
             &self.library_uris,
             complete_scan,
+            allow_shrink,
         );
     }
 }

--- a/src/indexer/scan.rs
+++ b/src/indexer/scan.rs
@@ -18,7 +18,10 @@ use tower_lsp::lsp_types::*;
 const MAX_READ_FAILURES_LOGGED: usize = 5;
 
 use crate::indexer::{
-    cache::{cache_entry_to_file_result, save_cache, try_load_cache, write_status_file},
+    cache::{
+        cache_entry_to_file_result, save_cache, try_load_cache, workspace_scan_lock_path,
+        write_status_file,
+    },
     discover::{find_source_files, warm_discover_files},
     Indexer, MAX_FILES_UNLIMITED,
 };
@@ -225,6 +228,7 @@ struct ScanSetup {
     start_gen: u64,
     cache: Option<super::cache::IndexCache>,
     discovered: DiscoveredPaths,
+    scan_lock_path: PathBuf,
 }
 
 #[derive(Clone, Default)]
@@ -279,7 +283,27 @@ fn prepare_scan(indexer: &Arc<Indexer>, root: &Path, max: usize) -> ScanSetup {
     };
 
     let start_gen = indexer.workspace_root.generation();
-    let cache = try_load_cache(root);
+
+    // If a lock from the previous scan still exists, that scan was interrupted
+    // before it could save a valid cache — force a cold scan so we don't reuse
+    // a potentially incomplete cache manifest.
+    let scan_lock_path = workspace_scan_lock_path(root);
+    let stale_lock = scan_lock_path.exists();
+    if stale_lock {
+        log::info!(
+            "prepare_scan: stale scan.lock found — previous scan interrupted; forcing cold scan"
+        );
+    }
+    if let Some(parent) = scan_lock_path.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&scan_lock_path, b"");
+
+    let cache = if stale_lock {
+        None
+    } else {
+        try_load_cache(root)
+    };
     let matcher: Option<Arc<IgnoreMatcher>> = indexer.ignore_matcher.read().unwrap().clone();
     let discovered = discover_workspace_paths(root, max, &cache, matcher.as_deref());
 
@@ -288,6 +312,7 @@ fn prepare_scan(indexer: &Arc<Indexer>, root: &Path, max: usize) -> ScanSetup {
         start_gen,
         cache,
         discovered,
+        scan_lock_path,
     }
 }
 
@@ -914,17 +939,25 @@ impl Indexer {
         self.last_scan_complete
             .store(result.complete_scan, std::sync::atomic::Ordering::Release);
         let root = result.workspace_root.clone();
+        let lock_path = workspace_scan_lock_path(&root);
         let files_parsed = result.stats.files_parsed;
-        self.apply_workspace_result(&result);
+        let complete_scan = result.complete_scan;
+        let result = std::sync::Arc::new(result);
+        let idx = Arc::clone(&self);
+        let r = Arc::clone(&result);
+        tokio::task::spawn_blocking(move || idx.apply_workspace_result(&r))
+            .await
+            .unwrap_or_else(|e| log::error!("apply_workspace_result panicked: {e}"));
         Arc::clone(&self).index_source_paths(root).await;
         // Always save when a complete scan ran — this trims deleted-file entries from
         // the on-disk cache even when files_parsed == 0 (all cache hits).  Skip only
         // for partial / truncated scans where nothing new was parsed.
-        if files_parsed > 0 || result.complete_scan {
+        if files_parsed > 0 || complete_scan {
             self.save_cache_to_disk();
         } else {
             log::info!("Partial scan, nothing new parsed — skipping workspace cache save");
         }
+        let _ = std::fs::remove_file(&lock_path);
         // Drop guard FIRST to clear indexing_in_progress, then notify the client.
         // This ensures any request the client sends after the end notification
         // (e.g. textDocument/completion) sees is_indexing_in_progress() == false.
@@ -963,6 +996,7 @@ impl Indexer {
             start_gen,
             cache,
             discovered,
+            scan_lock_path,
         } = prepare_scan(&self, root, max);
         let session = ScanSession {
             start_gen,
@@ -1011,6 +1045,7 @@ impl Indexer {
             aborted_early = true;
         }
         if aborted_early {
+            let _ = std::fs::remove_file(&scan_lock_path);
             return (aborted_scan_result(root), Some(guard));
         }
 

--- a/src/indexer/sources_jar_cache.rs
+++ b/src/indexer/sources_jar_cache.rs
@@ -34,7 +34,7 @@ use crate::types::FileData;
 /// `cache::CACHE_VERSION`, which the project rule (mem:core) already bumps on
 /// every such change — bincode 1.x is positional and can silently mis-decode
 /// reordered same-shaped fields, so filename coupling is load-bearing.
-const SOURCES_JAR_CACHE_VERSION: u32 = 1;
+const SOURCES_JAR_CACHE_VERSION: u32 = 2;
 
 #[derive(Deserialize)]
 struct SourcesJarCacheDisk {

--- a/src/indexer_tests.rs
+++ b/src/indexer_tests.rs
@@ -1672,6 +1672,7 @@ fn stale_keys_includes_both_qualified_aliases() {
         param_counts: (0, 0),
         doc: String::new(),
         trailing_lambda: false,
+        deprecated: false,
     };
     data.symbols.push(sym);
     let stale = super::stale_keys_for(&uri, &data);
@@ -1712,6 +1713,7 @@ fn stale_keys_stem_equals_sym_no_alias() {
         param_counts: (0, 0),
         doc: String::new(),
         trailing_lambda: false,
+        deprecated: false,
     };
     data.symbols.push(sym);
     let stale = super::stale_keys_for(&uri, &data);
@@ -2997,6 +2999,7 @@ fn jar_symbol_resolved_via_import() {
         type_params: vec![],
         doc: "A ViewModel class".into(),
         trailing_lambda: false,
+        deprecated: false,
     };
 
     let package: Option<String> = Some("androidx.lifecycle".into());

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -381,6 +381,7 @@ fn push_def_symbols(
             };
             let trailing_lambda = matches!(kind, SymbolKind::FUNCTION)
                 && last_value_param_is_function_type(root, bytes, &range);
+            let deprecated = deprecated_at_line(lines, sel.start.line as usize);
             symbols.push(SymbolEntry {
                 name,
                 kind,
@@ -396,6 +397,7 @@ fn push_def_symbols(
                 param_counts,
                 doc: String::new(),
                 trailing_lambda,
+                deprecated,
             });
         }
     }
@@ -439,6 +441,7 @@ fn synthesize_data_class_copy(root: Node, bytes: &[u8], symbols: &mut Vec<Symbol
             container: Some(cls.name),
             doc: String::new(),
             trailing_lambda: false,
+            deprecated: cls.deprecated,
         });
     }
 }
@@ -826,6 +829,7 @@ fn push_interface_symbol(
     let sel = ts_to_lsp(sel_node_range);
     let detail = extract_detail_from_node(*node, bytes, &data.lines);
     let type_params = node.extract_type_params_or_error_child(bytes);
+    let deprecated = deprecated_at_line(&data.lines, range.start.line as usize);
     data.symbols.push(SymbolEntry {
         name: name.to_owned(),
         kind: SymbolKind::INTERFACE,
@@ -841,6 +845,7 @@ fn push_interface_symbol(
         param_counts: (0, 0),
         doc: String::new(),
         trailing_lambda: false,
+        deprecated,
     });
 }
 
@@ -935,6 +940,7 @@ fn extract_secondary_constructors(root: Node, bytes: &[u8], data: &mut FileData)
                 );
                 let detail = extract_detail(&data.lines, range.start.line, range.end.line);
                 let visibility = visibility_at_line(&data.lines, range.start.line as usize);
+                let deprecated = deprecated_at_line(&data.lines, range.start.line as usize);
                 data.symbols.push(SymbolEntry {
                     name,
                     kind: SymbolKind::CONSTRUCTOR,
@@ -950,6 +956,7 @@ fn extract_secondary_constructors(root: Node, bytes: &[u8], data: &mut FileData)
                     param_counts,
                     doc: String::new(),
                     trailing_lambda: false,
+                    deprecated,
                 });
             }
         }
@@ -1754,6 +1761,53 @@ pub(crate) fn visibility_at_line(lines: &[String], line_no: usize) -> Visibility
     )
 }
 
+/// Detect an `@Deprecated` annotation on the declaration at `line_no`.
+///
+/// Handles both same-line (`@Deprecated fun foo()`) and the common stacked form
+/// where the annotation sits on its own line(s) above the declaration:
+///
+/// ```kotlin
+/// @Deprecated("Use bar instead")
+/// @JvmStatic
+/// fun foo()
+/// ```
+///
+/// Scans upward over contiguous annotation/comment/blank lines; stops at the
+/// first real code line. Matches `@Deprecated`, `@Deprecated(...)`, and
+/// package-qualified forms like `@kotlin.Deprecated` / `@java.lang.Deprecated`.
+pub(crate) fn deprecated_at_line(lines: &[String], line_no: usize) -> bool {
+    if lines.get(line_no).is_some_and(|l| line_has_deprecated(l)) {
+        return true;
+    }
+    let mut i = line_no;
+    while i > 0 {
+        i -= 1;
+        let trimmed = lines[i].trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with("//")
+            || trimmed.starts_with('*')
+            || trimmed.starts_with("/*")
+        {
+            continue; // skip blank / comment lines between annotation and decl
+        }
+        if trimmed.starts_with('@') {
+            if line_has_deprecated(trimmed) {
+                return true;
+            }
+            continue; // stacked annotation — keep scanning up
+        }
+        break; // first real code line above → stop
+    }
+    false
+}
+
+fn line_has_deprecated(line: &str) -> bool {
+    let Some(at) = line.find('@') else {
+        return false;
+    };
+    contains_word(&line[at + 1..], "Deprecated")
+}
+
 /// Swift visibility detection.
 ///
 /// Swift modifiers: `private`, `fileprivate`, `internal`, `public`, `open`.
@@ -2255,6 +2309,7 @@ impl crate::types::FileData {
                 } else {
                     (String::new(), (0, 0))
                 };
+            let deprecated = deprecated_at_line(&self.lines, range.start.line as usize);
             self.symbols.push(SymbolEntry {
                 name,
                 kind,
@@ -2270,6 +2325,7 @@ impl crate::types::FileData {
                 param_counts,
                 doc: String::new(),
                 trailing_lambda: false,
+                deprecated,
             });
         }
     }
@@ -2292,6 +2348,7 @@ impl crate::types::FileData {
         };
         let nr = ts_to_lsp(node.range());
         let vis = visibility_at_line(&self.lines, node.range().start_point.row);
+        let dep = deprecated_at_line(&self.lines, node.range().start_point.row);
         let detail = extract_detail_from_node(*node, bytes, &self.lines);
         for child in node.children_of_kind(KIND_VAR_DECLARATOR) {
             if let Some((name, sel)) = first_identifier(&child, bytes) {
@@ -2310,6 +2367,7 @@ impl crate::types::FileData {
                     param_counts: (0, 0),
                     doc: String::new(),
                     trailing_lambda: false,
+                    deprecated: dep,
                 });
             }
         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1791,10 +1791,17 @@ pub(crate) fn deprecated_at_line(lines: &[String], line_no: usize) -> bool {
             continue; // skip blank / comment lines between annotation and decl
         }
         if trimmed.starts_with('@') {
+            // A line that is itself a declaration (annotation + declaration on one
+            // line, e.g. `@Deprecated fun old() {}`) belongs to a *previous*
+            // symbol — its annotation is not ours. Stop the upward scan so we
+            // don't attribute it to the current declaration.
+            if line_is_declaration(trimmed) {
+                break;
+            }
             if line_has_deprecated(trimmed) {
                 return true;
             }
-            continue; // stacked annotation — keep scanning up
+            continue; // annotation-only line — keep scanning up
         }
         break; // first real code line above → stop
     }
@@ -1806,6 +1813,28 @@ fn line_has_deprecated(line: &str) -> bool {
         return false;
     };
     contains_word(&line[at + 1..], "Deprecated")
+}
+
+/// Whether a trimmed line is itself a full declaration rather than a bare
+/// annotation. Used to stop the upward `@Deprecated` scan at a previous
+/// single-line annotated declaration. A bare annotation (`@Foo`, `@Foo("x")`)
+/// has no declaration keyword and does not end in a body/terminator.
+fn line_is_declaration(trimmed: &str) -> bool {
+    const DECL_KEYWORDS: &[&str] = &[
+        "fun",
+        "val",
+        "var",
+        "class",
+        "object",
+        "interface",
+        "enum",
+        "typealias",
+        "constructor",
+    ];
+    DECL_KEYWORDS.iter().any(|kw| contains_word(trimmed, kw))
+        || trimmed.ends_with('{')
+        || trimmed.ends_with('}')
+        || trimmed.ends_with(';')
 }
 
 /// Swift visibility detection.

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -392,6 +392,31 @@ fn visibility_internal_class() {
 }
 
 #[test]
+fn deprecated_annotation_on_line_above_is_captured() {
+    let data = parse_kotlin("@Deprecated(\"Use bar instead\")\nfun foo() {}");
+    let foo = sym(&data, "foo").expect("foo not indexed");
+    assert!(foo.deprecated, "foo should be flagged deprecated");
+}
+
+#[test]
+fn deprecated_annotation_same_line_is_captured() {
+    let data = parse_kotlin("@Deprecated fun foo() {}");
+    assert!(sym(&data, "foo").expect("foo not indexed").deprecated);
+}
+
+#[test]
+fn deprecated_annotation_stacked_with_other_annotations() {
+    let data = parse_kotlin("@JvmStatic\n@Deprecated(\"x\")\nfun foo() {}");
+    assert!(sym(&data, "foo").expect("foo not indexed").deprecated);
+}
+
+#[test]
+fn non_deprecated_symbol_is_not_flagged() {
+    let data = parse_kotlin("@JvmStatic\nfun foo() {}");
+    assert!(!sym(&data, "foo").expect("foo not indexed").deprecated);
+}
+
+#[test]
 fn dot_completion_hides_private() {
     let vm_uri = uri("/VM.kt");
     let repo_uri = uri("/Repo.kt");

--- a/src/parser_tests.rs
+++ b/src/parser_tests.rs
@@ -417,6 +417,17 @@ fn non_deprecated_symbol_is_not_flagged() {
 }
 
 #[test]
+fn deprecated_on_previous_single_line_decl_does_not_leak() {
+    // The @Deprecated belongs to `old`, not `fresh` on the next line.
+    let data = parse_kotlin("@Deprecated fun old() {}\nfun fresh() {}");
+    assert!(sym(&data, "old").expect("old not indexed").deprecated);
+    assert!(
+        !sym(&data, "fresh").expect("fresh not indexed").deprecated,
+        "deprecation must not leak to the following declaration"
+    );
+}
+
+#[test]
 fn dot_completion_hides_private() {
     let vm_uri = uri("/VM.kt");
     let repo_uri = uri("/Repo.kt");

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -1687,7 +1687,7 @@ pub(crate) fn complete_bare(
     annotation_only: bool,
     cursor_line: Option<u32>,
 ) -> (Vec<CompletionItem>, bool) {
-    let t = std::time::Instant::now();
+    let start_time = std::time::Instant::now();
     let mut completion_walk = BareCompletionWalk::new(
         indexer,
         prefix,
@@ -1697,17 +1697,20 @@ pub(crate) fn complete_bare(
         cursor_line,
     );
     completion_walk.collect_local_file();
-    log::debug!("bare: local_file {}ms", t.elapsed().as_millis());
+    log::debug!("bare: local_file {}ms", start_time.elapsed().as_millis());
     completion_walk.collect_same_package();
-    log::debug!("bare: same_package {}ms", t.elapsed().as_millis());
+    log::debug!("bare: same_package {}ms", start_time.elapsed().as_millis());
     completion_walk.collect_star_imported_functions();
-    log::debug!("bare: star_imported {}ms", t.elapsed().as_millis());
+    log::debug!("bare: star_imported {}ms", start_time.elapsed().as_millis());
     completion_walk.collect_cross_package();
-    log::debug!("bare: cross_package {}ms", t.elapsed().as_millis());
+    log::debug!("bare: cross_package {}ms", start_time.elapsed().as_millis());
     completion_walk.collect_stdlib();
-    log::debug!("bare: stdlib {}ms", t.elapsed().as_millis());
+    log::debug!("bare: stdlib {}ms", start_time.elapsed().as_millis());
     completion_walk.collect_this_extensions();
-    log::debug!("bare: this_extensions {}ms", t.elapsed().as_millis());
+    log::debug!(
+        "bare: this_extensions {}ms",
+        start_time.elapsed().as_millis()
+    );
     completion_walk.finish()
 }
 

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -1304,6 +1304,13 @@ impl<'a> BareCompletionWalk<'a> {
             })
             .unwrap_or_default();
 
+        let caller_source_set = self
+            .indexer
+            .files
+            .get(self.from_uri.as_str())
+            .map(|f| f.source_set)
+            .unwrap_or_default();
+
         for import in &imports {
             if !import.is_star {
                 continue;
@@ -1318,6 +1325,11 @@ impl<'a> BareCompletionWalk<'a> {
                 let Some(file) = self.indexer.files.get(pkg_uri.as_str()) else {
                     continue;
                 };
+                if file.source_set == crate::types::SourceSet::Test
+                    && caller_source_set != crate::types::SourceSet::Test
+                {
+                    continue;
+                }
                 for symbol in &file.symbols {
                     // Classes / interfaces / objects / enums are handled by
                     // collect_cross_package; skip them here to avoid tier inflation.

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -118,7 +118,7 @@ fn camel_acronym_match(name: &str, prefix: &str) -> bool {
 
 /// Maximum completion items returned per response.
 /// When capped, `is_incomplete` should be set so the client re-queries.
-pub(crate) const COMPLETION_CAP: usize = 150;
+pub(crate) const COMPLETION_CAP: usize = 500;
 
 /// Prefix length at which local-symbol relevance score is reduced (longer prefix → more confident match).
 const MIN_PREFIX_SCORE_REDUCTION: usize = 4;
@@ -1280,6 +1280,74 @@ impl<'a> BareCompletionWalk<'a> {
             .filter(|package_name| !package_name.is_empty())
     }
 
+    /// Wave 2: functions and properties from star-imported packages (`import pkg.*`).
+    ///
+    /// Fills the gap between project-source symbols (wave 1) and the cross-package
+    /// class-name index (wave 3). Covers lowercase symbols like `launch`, `flowOf`,
+    /// `withContext`, etc., which are excluded from `collect_cross_package` (uppercase
+    /// only) but are directly usable because they are already star-imported.
+    fn collect_star_imported_functions(&mut self) {
+        if self.completer.annotation_only || !self.completer.lowercase_mode {
+            return;
+        }
+        // Resolve imports from live_lines when available so newly added imports work.
+        let imports = self
+            .indexer
+            .live_lines
+            .get(self.from_uri.as_str())
+            .map(|ll| ll.parse_imports())
+            .or_else(|| {
+                self.indexer
+                    .files
+                    .get(self.from_uri.as_str())
+                    .map(|f| f.imports.clone())
+            })
+            .unwrap_or_default();
+
+        for import in &imports {
+            if !import.is_star {
+                continue;
+            }
+            let Some(pkg_uris) = self.indexer.packages.get(&import.full_path) else {
+                continue;
+            };
+            for pkg_uri in pkg_uris.iter() {
+                if pkg_uri.as_str() == self.from_uri.as_str() {
+                    continue; // already covered by collect_local_file
+                }
+                let Some(file) = self.indexer.files.get(pkg_uri.as_str()) else {
+                    continue;
+                };
+                for symbol in &file.symbols {
+                    // Classes / interfaces / objects / enums are handled by
+                    // collect_cross_package; skip them here to avoid tier inflation.
+                    if matches!(
+                        symbol.kind,
+                        SymbolKind::CLASS
+                            | SymbolKind::INTERFACE
+                            | SymbolKind::STRUCT
+                            | SymbolKind::ENUM
+                            | SymbolKind::OBJECT
+                    ) {
+                        continue;
+                    }
+                    self.completer.add(
+                        &symbol.name,
+                        symbol_kind_to_completion(symbol.kind),
+                        1, // same tier as same-package
+                        self.prefix,
+                        &symbol.detail,
+                        Some(serde_json::json!({
+                            DATA_URI: pkg_uri.as_str(),
+                            DATA_LINE: symbol.selection_start(),
+                            DATA_COL: symbol.selection_range.start.character
+                        })),
+                    );
+                }
+            }
+        }
+    }
+
     fn collect_cross_package(&mut self) {
         // Only run for uppercase-starting prefixes — the bare_name_cache holds
         // class names (PascalCase/SCREAMING_SNAKE), so digits, underscores, or
@@ -1458,22 +1526,35 @@ impl<'a> BareCompletionWalk<'a> {
         };
 
         // Collect all ancestor type names (including the class itself).
-        let mut ancestor_names: std::collections::HashSet<String> =
-            std::collections::HashSet::from([enclosing_class.clone()]);
-
-        let caller = CallerContext {
-            uri: Some(self.from_uri.as_str()),
-            cursor_line: self.cursor_line,
-        };
-        let supers: Vec<String> = walk_hierarchy(
-            self.indexer,
-            &enclosing_class,
-            &class_uri,
-            caller,
-            8,
-            |_idx, super_name, _super_uri, _caller| vec![super_name.to_owned()],
-        );
-        ancestor_names.extend(supers);
+        // The hierarchy is stable within a session — cache it to avoid re-running
+        // walk_hierarchy + resolve_symbol_no_rg (depth-8 traversal) on every line change.
+        let cache_key = format!("{}@{}", enclosing_class, class_uri);
+        let ancestor_names: std::sync::Arc<std::collections::HashSet<String>> = self
+            .indexer
+            .this_ext_ancestor_cache
+            .get(&cache_key)
+            .map(|r| std::sync::Arc::clone(&*r))
+            .unwrap_or_else(|| {
+                let mut set = std::collections::HashSet::from([enclosing_class.clone()]);
+                let caller = CallerContext {
+                    uri: Some(self.from_uri.as_str()),
+                    cursor_line: self.cursor_line,
+                };
+                let supers: Vec<String> = walk_hierarchy(
+                    self.indexer,
+                    &enclosing_class,
+                    &class_uri,
+                    caller,
+                    8,
+                    |_idx, super_name, _super_uri, _caller| vec![super_name.to_owned()],
+                );
+                set.extend(supers);
+                let arc = std::sync::Arc::new(set);
+                self.indexer
+                    .this_ext_ancestor_cache
+                    .insert(cache_key, std::sync::Arc::clone(&arc));
+                arc
+            });
 
         // Build the extension completion context (import tracking, package).
         let ext_context = ExtensionCompletionContext::build(self.indexer, self.from_uri);
@@ -1481,7 +1562,7 @@ impl<'a> BareCompletionWalk<'a> {
 
         // Use the reverse index: O(ancestors × entries_per_receiver) instead of O(all_files).
         let prefix = self.prefix;
-        for ancestor in &ancestor_names {
+        for ancestor in ancestor_names.iter() {
             let Some(entries) = self.indexer.extension_by_receiver.get(ancestor) else {
                 continue;
             };
@@ -1540,6 +1621,7 @@ pub(crate) fn complete_bare(
     annotation_only: bool,
     cursor_line: Option<u32>,
 ) -> (Vec<CompletionItem>, bool) {
+    let t = std::time::Instant::now();
     let mut completion_walk = BareCompletionWalk::new(
         indexer,
         prefix,
@@ -1549,10 +1631,17 @@ pub(crate) fn complete_bare(
         cursor_line,
     );
     completion_walk.collect_local_file();
+    log::debug!("bare: local_file {}ms", t.elapsed().as_millis());
     completion_walk.collect_same_package();
+    log::debug!("bare: same_package {}ms", t.elapsed().as_millis());
+    completion_walk.collect_star_imported_functions();
+    log::debug!("bare: star_imported {}ms", t.elapsed().as_millis());
     completion_walk.collect_cross_package();
+    log::debug!("bare: cross_package {}ms", t.elapsed().as_millis());
     completion_walk.collect_stdlib();
+    log::debug!("bare: stdlib {}ms", t.elapsed().as_millis());
     completion_walk.collect_this_extensions();
+    log::debug!("bare: this_extensions {}ms", t.elapsed().as_millis());
     completion_walk.finish()
 }
 

--- a/src/resolver/complete.rs
+++ b/src/resolver/complete.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 use tower_lsp::lsp_types::{
-    CompletionItem, CompletionItemKind, InsertTextFormat, Position, SymbolKind, Url,
+    CompletionItem, CompletionItemKind, CompletionItemTag, InsertTextFormat, Position, SymbolKind,
+    Url,
 };
 
 use crate::indexer::Indexer;
@@ -318,7 +319,8 @@ fn extension_fn_completions(
         if let Some(entries) = indexer.extension_by_receiver.get(ancestor) {
             for entry in entries.iter() {
                 if crate::Language::from_path(&entry.file_uri) == crate::Language::Kotlin {
-                    builder.add_entry(entry);
+                    let is_library = is_library_extension(indexer, &entry.file_uri);
+                    builder.add_entry(entry, is_library);
                 }
             }
         }
@@ -386,22 +388,37 @@ impl<'a> ExtensionCompletionBuilder<'a> {
         }
     }
 
-    fn add_entry(&mut self, entry: &crate::types::ExtensionEntry) {
+    fn add_entry(&mut self, entry: &crate::types::ExtensionEntry, is_library: bool) {
         let is_same_file = entry.file_uri == self.context.from_uri;
+        // Inaccessible from this file: private/protected from another file always;
+        // `internal` when the symbol comes from a library (an external module's
+        // internal members cannot be referenced from workspace code).
         if !is_same_file
-            && matches!(
+            && (matches!(
                 entry.visibility,
                 Visibility::Private | Visibility::Protected
-            )
+            ) || (is_library && entry.visibility == Visibility::Internal))
         {
             return;
         }
-        // Dedup by name+signature so the same extension from multiple JARs
-        // (e.g. kotlinx-coroutines-core and kotlinx-coroutines-android) collapses to one entry.
-        // Note: two different-package extensions with identical names and signatures would also
-        // be collapsed — a known limitation until package is threaded through SidecarSymbol.
-        let key = format!("{}:{}", entry.name, entry.detail);
-        if !self.seen.insert(key.clone()) {
+        // Deprecated policy: hide deprecated *library* symbols entirely (you can't
+        // fix them, and editors like Android Studio keep them out of the list).
+        // Deprecated *workspace* symbols are kept but tagged + deprioritized below,
+        // since you may still reference your own code during a migration.
+        if entry.deprecated && is_library {
+            return;
+        }
+        // Dedup by name alone so a receiver shows a single completion entry per
+        // extension, matching how IDEs present one `launch` (signature help
+        // disambiguates overloads later). Keying on the signature instead would
+        // surface every overload — and the same function arrives multiple ways:
+        // coroutines 1.11.0's compiled JAR emits `launch` overloads, and the
+        // sources JAR re-emits the same `launch` with a *different* package field
+        // (the compiled path infers one imprecise per-jar package, the sources
+        // path has the exact per-file one), so package-scoped keys wouldn't merge
+        // them. The trailing-lambda form keeps its own `:lam` key so both
+        // `launch(…)` and `launch { }` still appear.
+        if !self.seen.insert(entry.name.clone()) {
             return;
         }
         self.items
@@ -409,7 +426,7 @@ impl<'a> ExtensionCompletionBuilder<'a> {
 
         // Offer a trailing-lambda variant when the last parameter is a function type.
         if entry.trailing_lambda {
-            let lambda_key = format!("{}:lam", key);
+            let lambda_key = format!("{}:lam", entry.name);
             if self.seen.insert(lambda_key) {
                 self.items
                     .push(self.build_lambda_item_from_entry(entry, is_same_file));
@@ -435,7 +452,7 @@ impl<'a> ExtensionCompletionBuilder<'a> {
         } else {
             needs_import.then(|| package_of_fqn(&fqn).to_owned())
         };
-        CompletionItem {
+        let mut item = CompletionItem {
             label: entry.name.clone(),
             kind: Some(ck),
             insert_text: (self.snippets && is_callable).then(|| format!("{}($1)", entry.name)),
@@ -445,7 +462,9 @@ impl<'a> ExtensionCompletionBuilder<'a> {
             command: (self.snippets && is_callable).then(trigger_parameter_hints),
             additional_text_edits: self.import_edit(&fqn, needs_import),
             ..Default::default()
-        }
+        };
+        mark_deprecated(&mut item, entry.deprecated);
+        item
     }
 
     fn build_lambda_item_from_entry(
@@ -461,7 +480,7 @@ impl<'a> ExtensionCompletionBuilder<'a> {
         } else {
             needs_import.then(|| package_of_fqn(&fqn).to_owned())
         };
-        CompletionItem {
+        let mut item = CompletionItem {
             label: format!("{} {{ }}", entry.name),
             kind: Some(CompletionItemKind::FUNCTION),
             insert_text: self.snippets.then(|| format!("{} {{ $1 }}", entry.name)),
@@ -472,7 +491,9 @@ impl<'a> ExtensionCompletionBuilder<'a> {
             command: None,
             additional_text_edits: self.import_edit(&fqn, needs_import),
             ..Default::default()
-        }
+        };
+        mark_deprecated(&mut item, entry.deprecated);
+        item
     }
 
     fn needs_import(&self, fqn: &str, is_same_file: bool) -> bool {
@@ -498,6 +519,32 @@ impl<'a> ExtensionCompletionBuilder<'a> {
     fn finish(self) -> Vec<CompletionItem> {
         self.items
     }
+}
+
+/// Whether an extension entry comes from a library (JAR/sources-JAR or a path
+/// registered in `library_uris`) rather than workspace source.
+///
+/// Library symbols get the strict deprecated/internal filtering (hidden);
+/// workspace symbols keep deprecated entries (tagged + deprioritized).
+fn is_library_extension(indexer: &Indexer, file_uri: &str) -> bool {
+    file_uri.starts_with("jar:") || indexer.library_uris.contains(file_uri)
+}
+
+/// Tag a completion item as deprecated and push it to the bottom of the list.
+///
+/// Sets the LSP `Deprecated` tag (clients render it struck-through) and rewrites
+/// `sort_text` with a high-digit prefix so deprecated entries rank below all live
+/// ones. No-op when `deprecated` is false. Used only for workspace symbols —
+/// deprecated library symbols are filtered out entirely before reaching here.
+fn mark_deprecated(item: &mut CompletionItem, deprecated: bool) {
+    if !deprecated {
+        return;
+    }
+    item.tags = Some(vec![CompletionItemTag::DEPRECATED]);
+    item.sort_text = Some(match item.sort_text.take() {
+        Some(existing) => format!("99:{existing}"),
+        None => format!("99:{}", item.label),
+    });
 }
 
 fn extension_symbol_fqn(package_name: &str, symbol_name: &str) -> String {
@@ -1583,11 +1630,18 @@ impl<'a> BareCompletionWalk<'a> {
                     continue;
                 }
                 let is_same_file = entry.file_uri == ext_context.from_uri;
-                if matches!(
-                    entry.visibility,
-                    Visibility::Private | Visibility::Protected
-                ) && !is_same_file
+                let is_library = is_library_extension(self.indexer, &entry.file_uri);
+                if !is_same_file
+                    && (matches!(
+                        entry.visibility,
+                        Visibility::Private | Visibility::Protected
+                    ) || (is_library && entry.visibility == Visibility::Internal))
                 {
+                    continue;
+                }
+                // Hide deprecated library symbols; workspace-deprecated ones are
+                // kept and tagged/deprioritized by `build_item_from_entry`.
+                if entry.deprecated && is_library {
                     continue;
                 }
                 if match_score(&entry.name, prefix).is_none() {

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -453,7 +453,6 @@ fn find_extension_property_type(indexer: &Indexer, prop_name: &str, uri: &Url) -
     // for a proper fix; the primary (line-scanning) path handles the common case.
     use super::walk_hierarchy;
     use crate::types::{CallerContext, Visibility};
-
     // Use ensure_file_data so the function works even when the file has not been
     // indexed yet (e.g. first open before the workspace scan completes).
     let file = ensure_file_data(indexer, uri)?;

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::indexer::Indexer;
 use crate::parser::{parse_java, parse_kotlin};
 use crate::stdlib::dot_completions_for;
-use tower_lsp::lsp_types::{InsertTextFormat, Url};
+use tower_lsp::lsp_types::{CompletionItem, CompletionItemTag, InsertTextFormat, Url};
 
 fn uri(path: &str) -> Url {
     Url::parse(&format!("file:///test{path}")).unwrap()
@@ -2803,6 +2803,7 @@ fn jar_extension_appears_in_dot_completion() {
             visibility: crate::types::Visibility::Public,
             package: Some("androidx.lifecycle".to_owned()),
             trailing_lambda: false,
+            deprecated: false,
         });
 
     // 2. fun CoroutineScope.launch(block: suspend CoroutineScope.() -> Unit): Job
@@ -2818,6 +2819,7 @@ fn jar_extension_appears_in_dot_completion() {
             visibility: crate::types::Visibility::Public,
             package: Some("kotlinx.coroutines".to_owned()),
             trailing_lambda: true,
+            deprecated: false,
         });
 
     let vm_uri = Url::parse("file:///app/MyViewModel.kt").unwrap();
@@ -2842,6 +2844,240 @@ fn jar_extension_appears_in_dot_completion() {
     assert!(
         labels.contains(&"launch { }"),
         "expected trailing-lambda `launch {{ }}` item from JAR path, got: {labels:?}"
+    );
+}
+
+/// Deprecated and internal library overloads must be filtered out of
+/// dot-completion, leaving only the current public `launch` (plus its
+/// trailing-lambda form). Mirrors Android Studio, which hides the deprecated
+/// binary-compat shims and internal impl helpers coroutines ships.
+#[test]
+fn library_deprecated_internal_extensions_hidden() {
+    let idx = Indexer::new();
+    idx.index_content(
+        &Url::parse("file:///sdk/ViewModel.kt").unwrap(),
+        "package androidx.lifecycle\nopen class ViewModel",
+    );
+    idx.extension_by_receiver
+        .entry("ViewModel".to_owned())
+        .or_default()
+        .push(crate::types::ExtensionEntry {
+            file_uri: "jar:file:///lifecycle-ktx.jar/ViewModel.class".to_owned(),
+            name: "viewModelScope".to_owned(),
+            kind: tower_lsp::lsp_types::SymbolKind::PROPERTY,
+            detail: "val ViewModel.viewModelScope: CoroutineScope".to_owned(),
+            visibility: crate::types::Visibility::Public,
+            package: Some("androidx.lifecycle".to_owned()),
+            trailing_lambda: false,
+            deprecated: false,
+        });
+
+    let mk = |detail: &str, vis, deprecated| crate::types::ExtensionEntry {
+        file_uri: "jar:file:///coroutines-core.jar/Builders.class".to_owned(),
+        name: "launch".to_owned(),
+        kind: tower_lsp::lsp_types::SymbolKind::FUNCTION,
+        detail: detail.to_owned(),
+        visibility: vis,
+        package: Some("kotlinx.coroutines".to_owned()),
+        trailing_lambda: true,
+        deprecated,
+    };
+    {
+        let mut slot = idx
+            .extension_by_receiver
+            .entry("CoroutineScope".to_owned())
+            .or_default();
+        // Current public overload — should appear.
+        slot.push(mk(
+            "fun CoroutineScope.launch(block: suspend () -> Unit): Job",
+            crate::types::Visibility::Public,
+            false,
+        ));
+        // Deprecated binary-compat shim — should be hidden (library + deprecated).
+        slot.push(mk(
+            "fun CoroutineScope.launch(parent: Job, block: suspend () -> Unit): Job",
+            crate::types::Visibility::Public,
+            true,
+        ));
+        // Internal impl helper — should be hidden (library + internal).
+        slot.push(mk(
+            "fun CoroutineScope.launch(impl: Int): Job",
+            crate::types::Visibility::Internal,
+            false,
+        ));
+    }
+
+    let vm_uri = Url::parse("file:///app/MyViewModel.kt").unwrap();
+    idx.index_content(
+        &vm_uri,
+        concat!(
+            "package app\n",
+            "import androidx.lifecycle.ViewModel\n",
+            "class MyViewModel : ViewModel() {\n",
+            "    fun load() { viewModelScope.launch {} }\n",
+            "}\n",
+        ),
+    );
+
+    let items = complete_dot(&idx, "viewModelScope", &vm_uri, true, None);
+    let launch_items: Vec<&CompletionItem> = items
+        .iter()
+        .filter(|i| i.label == "launch" || i.label == "launch { }")
+        .collect();
+    let labels: Vec<&str> = launch_items.iter().map(|i| i.label.as_str()).collect();
+    // Exactly the current overload's two ergonomic forms — deprecated + internal gone.
+    assert_eq!(
+        launch_items.len(),
+        2,
+        "expected only launch() + launch {{ }} for the current overload, got: {labels:?}"
+    );
+    assert!(
+        launch_items.iter().all(|i| i.tags.is_none()),
+        "no item should be tagged deprecated"
+    );
+}
+
+/// Overloads of one library extension collapse to a single completion entry
+/// (plus its trailing-lambda form). Reproduces the coroutines 1.11.0 sidecar
+/// artifact where `CoroutineScope.launch` is emitted three times with bogus
+/// first-param types (`CoroutineContext`, `Job`, `NonCancellable`); the user
+/// should see only `launch` + `launch { }`, not three of each.
+#[test]
+fn extension_overloads_collapse_to_single_entry() {
+    let idx = Indexer::new();
+    idx.index_content(
+        &Url::parse("file:///sdk/ViewModel.kt").unwrap(),
+        "package androidx.lifecycle\nopen class ViewModel",
+    );
+    idx.extension_by_receiver
+        .entry("ViewModel".to_owned())
+        .or_default()
+        .push(crate::types::ExtensionEntry {
+            file_uri: "jar:file:///lifecycle-ktx.jar/ViewModel.class".to_owned(),
+            name: "viewModelScope".to_owned(),
+            kind: tower_lsp::lsp_types::SymbolKind::PROPERTY,
+            detail: "val ViewModel.viewModelScope: CoroutineScope".to_owned(),
+            visibility: crate::types::Visibility::Public,
+            package: Some("androidx.lifecycle".to_owned()),
+            trailing_lambda: false,
+            deprecated: false,
+        });
+    let mk = |first_param: &str, pkg: &str, defaults: bool| crate::types::ExtensionEntry {
+        file_uri: "jar:file:///coroutines-core.jar/Builders.class".to_owned(),
+        name: "launch".to_owned(),
+        kind: tower_lsp::lsp_types::SymbolKind::FUNCTION,
+        detail: if defaults {
+            format!("fun CoroutineScope.launch(context: {first_param} = EmptyCoroutineContext, block: suspend () -> Unit): Job")
+        } else {
+            format!(
+                "fun CoroutineScope.launch(context: {first_param}, block: suspend () -> Unit): Job"
+            )
+        },
+        visibility: crate::types::Visibility::Public,
+        package: Some(pkg.to_owned()),
+        trailing_lambda: true,
+        deprecated: false,
+    };
+    {
+        let mut slot = idx
+            .extension_by_receiver
+            .entry("CoroutineScope".to_owned())
+            .or_default();
+        // Compiled-JAR overloads (no defaults) under one inferred package…
+        slot.push(mk("CoroutineContext", "kotlinx.coroutines", false));
+        slot.push(mk("Job", "kotlinx.coroutines", false));
+        slot.push(mk("NonCancellable", "kotlinx.coroutines", false));
+        // …plus the sources-JAR copy of the SAME function with default values and
+        // a different (exact) package. Must still collapse into the single entry.
+        slot.push(mk("CoroutineContext", "kotlinx.coroutines.core", true));
+    }
+
+    let vm_uri = Url::parse("file:///app/MyViewModel.kt").unwrap();
+    idx.index_content(
+        &vm_uri,
+        concat!(
+            "package app\n",
+            "import androidx.lifecycle.ViewModel\n",
+            "class MyViewModel : ViewModel() {\n",
+            "    fun load() { viewModelScope.launch {} }\n",
+            "}\n",
+        ),
+    );
+
+    let items = complete_dot(&idx, "viewModelScope", &vm_uri, true, None);
+    let n_plain = items.iter().filter(|i| i.label == "launch").count();
+    let n_lambda = items.iter().filter(|i| i.label == "launch { }").count();
+    assert_eq!(n_plain, 1, "expected exactly one `launch`, got {n_plain}");
+    assert_eq!(
+        n_lambda, 1,
+        "expected exactly one `launch {{ }}`, got {n_lambda}"
+    );
+}
+
+/// Deprecated WORKSPACE extensions are kept (you may still call your own code
+/// mid-migration) but tagged Deprecated and sorted to the bottom. Uses the same
+/// `viewModelScope → CoroutineScope` resolution the test above relies on, then
+/// adds a workspace-sourced deprecated extension on `CoroutineScope`.
+#[test]
+fn deprecated_workspace_extension_kept_tagged() {
+    let idx = Indexer::new();
+    idx.index_content(
+        &Url::parse("file:///sdk/ViewModel.kt").unwrap(),
+        "package androidx.lifecycle\nopen class ViewModel",
+    );
+    // JAR property resolves viewModelScope → CoroutineScope.
+    idx.extension_by_receiver
+        .entry("ViewModel".to_owned())
+        .or_default()
+        .push(crate::types::ExtensionEntry {
+            file_uri: "jar:file:///lifecycle-ktx.jar/ViewModel.class".to_owned(),
+            name: "viewModelScope".to_owned(),
+            kind: tower_lsp::lsp_types::SymbolKind::PROPERTY,
+            detail: "val ViewModel.viewModelScope: CoroutineScope".to_owned(),
+            visibility: crate::types::Visibility::Public,
+            package: Some("androidx.lifecycle".to_owned()),
+            trailing_lambda: false,
+            deprecated: false,
+        });
+    // A WORKSPACE-sourced deprecated extension on CoroutineScope (file:// URI).
+    idx.index_content(
+        &Url::parse("file:///app/ext.kt").unwrap(),
+        concat!(
+            "package kotlinx.coroutines\n",
+            "@Deprecated(\"use newWork\")\n",
+            "fun CoroutineScope.legacyWork() {}\n",
+        ),
+    );
+
+    let vm_uri = Url::parse("file:///app/MyViewModel.kt").unwrap();
+    idx.index_content(
+        &vm_uri,
+        concat!(
+            "package app\n",
+            "import androidx.lifecycle.ViewModel\n",
+            "class MyViewModel : ViewModel() {\n",
+            "    fun load() { viewModelScope.legacyWork() }\n",
+            "}\n",
+        ),
+    );
+
+    let items = complete_dot(&idx, "viewModelScope", &vm_uri, false, None);
+    let legacy = items
+        .iter()
+        .find(|i| i.label == "legacyWork")
+        .expect("deprecated workspace extension should still be offered");
+    assert_eq!(
+        legacy.tags.as_deref(),
+        Some(&[CompletionItemTag::DEPRECATED][..]),
+        "workspace deprecated item should carry the Deprecated tag"
+    );
+    assert!(
+        legacy
+            .sort_text
+            .as_deref()
+            .is_some_and(|s| s.starts_with("99:")),
+        "deprecated item should sort to the bottom, got: {:?}",
+        legacy.sort_text
     );
 }
 

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -1868,8 +1868,8 @@ fn tier2_single_char_excludes_camel_acronym_noise() {
 fn result_cap_sets_hit_cap() {
     let idx = Indexer::new();
     let cur_uri = uri("/app/Screen.kt");
-    // Generate 200 unique class names → exceeds COMPLETION_CAP (150).
-    let src = (0..200)
+    // Generate 600 unique class names → exceeds COMPLETION_CAP (500).
+    let src = (0..600)
         .map(|i| format!("class Cls{i:03}"))
         .collect::<Vec<_>>()
         .join("\n");

--- a/src/sidecar.rs
+++ b/src/sidecar.rs
@@ -55,6 +55,9 @@ pub(crate) struct SidecarSymbol {
     /// True when the last value parameter is a function type (lambda).
     #[serde(default)]
     pub trailing_lambda: bool,
+    /// True when the declaration carries an `@Deprecated` annotation.
+    #[serde(default)]
+    pub deprecated: bool,
 }
 
 pub(crate) struct SidecarHandle {

--- a/src/types.rs
+++ b/src/types.rs
@@ -190,6 +190,10 @@ pub(crate) struct SymbolEntry {
     /// may use trailing-lambda syntax: `foo { }` instead of `foo({ })`.
     #[serde(default)]
     pub trailing_lambda: bool,
+    /// True when the declaration carries an `@Deprecated` annotation.
+    /// Used by completion to hide (library) or deprioritize + tag (workspace) the symbol.
+    #[serde(default)]
+    pub deprecated: bool,
 }
 
 impl SymbolEntry {
@@ -216,6 +220,8 @@ pub(crate) struct ExtensionEntry {
     pub package: Option<String>,
     /// True when the last value parameter is a function type — trailing-lambda call is valid.
     pub trailing_lambda: bool,
+    /// True when the declaring symbol carries an `@Deprecated` annotation.
+    pub deprecated: bool,
 }
 
 /// One import statement parsed from a Kotlin file.

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -392,9 +392,6 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             // Invalidate the completion cache so the next request returns JAR
             // symbols (launch, collect, etc.) without requiring a retype.
             indexer.invalidate_completion_cache();
-            // Save the updated index (now including JAR symbols) to disk so
-            // CLI tools (kmp-lsp complete) can load the complete index.
-            indexer.save_cache_to_disk();
             in_progress.store(false, Ordering::Release);
         });
     }

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -361,6 +361,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 in_progress.store(false, Ordering::Release);
                 return;
             }
+
             log::info!(
                 "jar: found {} compiled JARs/AARs in Gradle cache",
                 paths.len()
@@ -388,6 +389,9 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             if let Ok(mut phase) = indexer.jar_phase.lock() {
                 *phase = final_phase;
             }
+            // Invalidate the completion cache so the next request returns JAR
+            // symbols (launch, collect, etc.) without requiring a retype.
+            indexer.invalidate_completion_cache();
             // Save the updated index (now including JAR symbols) to disk so
             // CLI tools (kmp-lsp complete) can load the complete index.
             indexer.save_cache_to_disk();


### PR DESCRIPTION
## Summary

- **scan.lock sentinel**: write `scan.lock` at scan start, delete it after a successful cache save. A stale lock forces a cold scan on next startup, preventing warm-discover from reusing an incomplete cache manifest when the previous scan was killed mid-apply. Replaces arbitrary heuristics.
- **spawn_blocking for `apply_workspace_result`**: the bulk DashMap insert for 12k+ files is synchronous CPU work that was running directly on the tokio async executor, starving all LSP request handlers and causing request timeouts during indexing. Offloaded to the blocking thread pool.
- **`apply_contributions_fresh`**: `apply_workspace_result` always follows `reset_index_state()` which clears all maps, making the `iter().any()` duplicate checks in `apply_contributions` unnecessary — O(n²) total for 12k files. New function skips those checks for an O(n) bulk apply.
- **`clearCache` auto-reindex**: clearing the current workspace's cache now immediately triggers a reindex instead of requiring an LSP restart.

## Test plan

- [ ] Start LSP on a large project (~12k files), verify hover/completion remain responsive during indexing
- [ ] Kill nvim mid-index, restart — verify `scan.lock` exists and next startup does a full cold scan
- [ ] After a cold scan completes, verify `scan.lock` is removed and subsequent startups use warm discover
- [ ] Run `kmp-lsp/clearCache` — verify it immediately reindexes without restart
- [ ] Run `kmp-lsp/clearCache` on a non-current root — verify it just clears without reindexing

🤖 Generated with [Claude Code](https://claude.com/claude-code)