### PR TITLE
fix(diagnostics): resolve library call-arg false positives via JAR overloads

### DIFF
--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/KotlinClassIndexer.kt
@@ -86,6 +86,8 @@ private class DeprecationFieldVisitor(private val key: String, private val sink:
 
 private class ClassMetadataVisitor : ClassVisitor(Opcodes.ASM9) {
     var simpleClassName: String = ""
+    /** Package of the class, derived from the JVM internal name (`a/b/Foo` → `a.b`). */
+    var packageName: String = ""
     var metadataVisitor: MetadataAnnotationVisitor? = null
     var isPublic: Boolean = false
     /** JVM method signatures (`name` + `descriptor`) carrying `@Deprecated`. */
@@ -95,6 +97,7 @@ private class ClassMetadataVisitor : ClassVisitor(Opcodes.ASM9) {
 
     override fun visit(version: Int, access: Int, name: String, signature: String?, superName: String?, interfaces: Array<out String>?) {
         simpleClassName = name.substringAfterLast('/')
+        packageName = if (name.contains('/')) name.substringBeforeLast('/').replace('/', '.') else ""
         isPublic = (access and Opcodes.ACC_PUBLIC) != 0
     }
 
@@ -285,7 +288,7 @@ private fun extensionReceiverRenderedForProp(prop: KmProperty, classTypeParams: 
     return prop.receiverParameterType?.render(typeParamsMap) ?: ""
 }
 
-private fun entriesFromClass(klass: KmClass, dep: DeprecationInfo): List<SymbolEntry> {
+private fun entriesFromClass(klass: KmClass, dep: DeprecationInfo, pkg: String): List<SymbolEntry> {
     val entries = mutableListOf<SymbolEntry>()
     val simpleName = klass.name.substringAfterLast('/')
     val containerName = simpleName
@@ -304,7 +307,7 @@ private fun entriesFromClass(klass: KmClass, dep: DeprecationInfo): List<SymbolE
         val tps = klass.typeParameters.joinToString(", ") { it.name }
         "$classKind $simpleName<$tps>"
     }
-    entries += SymbolEntry(simpleName, classKind, "", classDetail)
+    entries += SymbolEntry(simpleName, classKind, "", classDetail, pkg = pkg, topLevel = true)
 
     for (fn in klass.functions) {
         if (!fn.visibility.isPublicLike()) continue
@@ -315,6 +318,7 @@ private fun entriesFromClass(klass: KmClass, dep: DeprecationInfo): List<SymbolE
             extensionReceiverType = extensionReceiverRendered(fn, klass.typeParameters),
             trailingLambda = fn.hasTrailingLambda(),
             deprecated = fn.isDeprecated(dep),
+            pkg = pkg, topLevel = false,
         )
     }
     for (prop in klass.properties) {
@@ -324,12 +328,13 @@ private fun entriesFromClass(klass: KmClass, dep: DeprecationInfo): List<SymbolE
         entries += SymbolEntry(prop.name, kind, containerName, renderProperty(prop, recv, klass.typeParameters),
             extensionReceiverType = extensionReceiverRenderedForProp(prop, klass.typeParameters),
             deprecated = prop.isDeprecated(dep),
+            pkg = pkg, topLevel = false,
         )
     }
     return entries
 }
 
-private fun entriesFromPackage(pkg: KmPackage, containerName: String, dep: DeprecationInfo): List<SymbolEntry> {
+private fun entriesFromPackage(pkg: KmPackage, containerName: String, dep: DeprecationInfo, pkgName: String): List<SymbolEntry> {
     val entries = mutableListOf<SymbolEntry>()
     for (fn in pkg.functions) {
         if (!fn.visibility.isPublicLike()) continue
@@ -340,6 +345,7 @@ private fun entriesFromPackage(pkg: KmPackage, containerName: String, dep: Depre
             extensionReceiverType = extensionReceiverRendered(fn, emptyList()),
             trailingLambda = fn.hasTrailingLambda(),
             deprecated = fn.isDeprecated(dep),
+            pkg = pkgName, topLevel = true,
         )
     }
     for (prop in pkg.properties) {
@@ -349,6 +355,7 @@ private fun entriesFromPackage(pkg: KmPackage, containerName: String, dep: Depre
         entries += SymbolEntry(prop.name, kind, containerName, renderProperty(prop, recv),
             extensionReceiverType = extensionReceiverRenderedForProp(prop, emptyList()),
             deprecated = prop.isDeprecated(dep),
+            pkg = pkgName, topLevel = true,
         )
     }
     return entries
@@ -376,7 +383,7 @@ private fun KmProperty.isDeprecated(dep: DeprecationInfo): Boolean {
 
 // ── Java fallback (no Kotlin metadata) ────────────────────────────────────────
 
-private class JavaClassVisitor(private val entries: MutableList<SymbolEntry>) : ClassVisitor(Opcodes.ASM9) {
+private class JavaClassVisitor(private val entries: MutableList<SymbolEntry>, private val pkg: String) : ClassVisitor(Opcodes.ASM9) {
     private var className = ""
     private var isPublicClass = false
 
@@ -384,7 +391,7 @@ private class JavaClassVisitor(private val entries: MutableList<SymbolEntry>) : 
         className = name.substringAfterLast('/')
         isPublicClass = (access and Opcodes.ACC_PUBLIC) != 0
         if (isPublicClass && !className.contains('$')) {
-            entries += SymbolEntry(className, "class", "", "class $className")
+            entries += SymbolEntry(className, "class", "", "class $className", pkg = pkg, topLevel = true)
         }
     }
 
@@ -395,7 +402,7 @@ private class JavaClassVisitor(private val entries: MutableList<SymbolEntry>) : 
         val isBridge = (access and Opcodes.ACC_BRIDGE) != 0
         if (!isPublic || isSynthetic || isBridge || name == "<init>" || name == "<clinit>") return null
         if (name.contains('$')) return null
-        entries += SymbolEntry(name, "fun", className, "fun $name(...)")
+        entries += SymbolEntry(name, "fun", className, "fun $name(...)", pkg = pkg, topLevel = false)
         return null
     }
 }
@@ -422,17 +429,18 @@ fun indexClassBytes(bytes: ByteArray): List<SymbolEntry> {
             // Skip anonymous/inner synthetic helpers for regular Class only
             if (!isFacade && name.contains('$') && !name.endsWith("\$Companion")) return emptyList()
             val dep = DeprecationInfo(visitor.deprecatedMethods, visitor.deprecatedFields)
+            val pkg = visitor.packageName
             when (metadata) {
-                is KotlinClassMetadata.Class              -> entriesFromClass(metadata.kmClass, dep)
-                is KotlinClassMetadata.FileFacade         -> entriesFromPackage(metadata.kmPackage, name, dep)
-                is KotlinClassMetadata.MultiFileClassPart -> entriesFromPackage(metadata.kmPackage, name, dep)
+                is KotlinClassMetadata.Class              -> entriesFromClass(metadata.kmClass, dep, pkg)
+                is KotlinClassMetadata.FileFacade         -> entriesFromPackage(metadata.kmPackage, name, dep, pkg)
+                is KotlinClassMetadata.MultiFileClassPart -> entriesFromPackage(metadata.kmPackage, name, dep, pkg)
                 else -> emptyList()
             }
         } else {
             // Pure Java: use JVM access flags
             if (!visitor.isPublic) return emptyList()
             val entries = mutableListOf<SymbolEntry>()
-            ClassReader(bytes).accept(JavaClassVisitor(entries), ClassReader.SKIP_CODE or ClassReader.SKIP_DEBUG)
+            ClassReader(bytes).accept(JavaClassVisitor(entries, visitor.packageName), ClassReader.SKIP_CODE or ClassReader.SKIP_DEBUG)
             entries
         }
     } catch (_: Exception) {

--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/SourcesKdocReader.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/SourcesKdocReader.kt
@@ -31,13 +31,32 @@ object SourcesKdocReader {
         val versionDir = File(mainJarPath).parentFile?.parentFile ?: return null
         if (!versionDir.isDirectory) return null
 
-        val artifactName = File(mainJarPath).nameWithoutExtension
-            .removeSuffix("-jvm")  // kotlinx-coroutines-core-jvm-1.7.3 → kotlinx-coroutines-core
-            .substringBeforeLast("-")  // strip version suffix
-
-        return versionDir.walkTopDown()
+        val candidates = versionDir.walkTopDown()
             .filter { it.isFile && it.name.endsWith("-sources.jar", ignoreCase = true) }
-            .firstOrNull()
+            .toList()
+        val chosen = selectSourcesJar(candidates.map { it.name }, File(mainJarPath).nameWithoutExtension)
+            ?: return null
+        return candidates.firstOrNull { it.name == chosen }
+    }
+
+    /**
+     * Pick the best `-sources.jar` for a main artifact among `candidateNames`.
+     *
+     * Many AARs ship both the real API sources (`ui-android-1.11.2-sources.jar`) and a
+     * **samples** jar (`ui-1.11.2-samples-sources.jar`) that contains usage examples, not
+     * the documented declarations. The old code took the first match and frequently grabbed
+     * the samples jar → empty KDoc for `stringResource`, `remember`, etc. Exclude samples and
+     * prefer the jar whose name matches the main artifact stem.
+     */
+    fun selectSourcesJar(candidateNames: List<String>, mainStem: String): String? {
+        val real = candidateNames.filterNot {
+            it.endsWith("-samples-sources.jar", ignoreCase = true)
+        }
+        if (real.isEmpty()) return null
+        val norm = mainStem.removeSuffix("-jvm").removeSuffix("-android")
+        return real.firstOrNull { it.startsWith(mainStem) }
+            ?: real.firstOrNull { it.startsWith(norm) }
+            ?: real.first()
     }
 
     /**
@@ -64,13 +83,16 @@ object SourcesKdocReader {
     }
 
     private val KDOC_DECL_PATTERN = Regex(
-        """/\*\*(.*?)\*/\s*(?:@\w[^\n]*\n\s*)*(?:(?:public|internal|protected|private|actual|expect|inline|suspend|override|operator|infix|tailrec|external|open|abstract|sealed|data|enum|annotation|inner|companion|value|const|lateinit|var|val)\s+)*(?:fun|class|interface|object|typealias|val|var)\s+(?:\w[\w.<>, ?]*\.)?\s*(\w+)""",
+        """/\*\*(.*?)\*/\s*(?:@[\w.:]+\s*(?:\([^)]*\))?\s*)*(?:(?:public|internal|protected|private|actual|expect|inline|suspend|override|operator|infix|tailrec|external|open|abstract|sealed|data|enum|annotation|inner|companion|value|const|lateinit|var|val)\s+)*(?:fun|class|interface|object|typealias|val|var)\s+(?:<[^>]*>\s*)?(?:\w[\w.<>, ?]*\.)?\s*(\w+)""",
         setOf(RegexOption.DOT_MATCHES_ALL, RegexOption.MULTILINE)
     )
 
     fun extractKdocFromSource(source: String): Map<String, String> {
         val result = mutableMapOf<String, String>()
-        for (match in KDOC_DECL_PATTERN.findAll(source)) {
+        // Strip line/block comments (but keep KDoc) so that comments containing `)`
+        // inside a multi-line annotation — e.g. `@Target( // @Composable fun Foo() ... )`
+        // before `annotation class Composable` — don't truncate the paren match.
+        for (match in KDOC_DECL_PATTERN.findAll(stripNonKdocComments(source))) {
             val rawDoc = match.groupValues[1]
             val name = match.groupValues[2]
             if (name.isNotEmpty()) {
@@ -78,6 +100,45 @@ object SourcesKdocReader {
             }
         }
         return result
+    }
+
+    /** Remove `//` line and `/* */` block comments while preserving `/** */` KDoc. */
+    fun stripNonKdocComments(source: String): String {
+        val sb = StringBuilder(source.length)
+        var i = 0
+        val n = source.length
+        while (i < n) {
+            val c = source[i]
+            val next = if (i + 1 < n) source[i + 1] else ' '
+            when {
+                c == '/' && next == '*' -> {
+                    val isKdoc = i + 2 < n && source[i + 2] == '*' &&
+                        !(i + 3 < n && source[i + 3] == '/')
+                    val end = source.indexOf("*/", i + 2)
+                    if (end < 0) {
+                        if (isKdoc) sb.append(source, i, n)
+                        i = n
+                    } else {
+                        if (isKdoc) sb.append(source, i, end + 2) else sb.append(' ')
+                        i = end + 2
+                    }
+                }
+                c == '/' && next == '/' -> {
+                    val end = source.indexOf('\n', i)
+                    if (end < 0) {
+                        i = n
+                    } else {
+                        sb.append('\n')
+                        i = end + 1
+                    }
+                }
+                else -> {
+                    sb.append(c)
+                    i++
+                }
+            }
+        }
+        return sb.toString()
     }
 
     /** Strip leading `*` and whitespace from each KDoc line. */

--- a/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/model/SymbolEntry.kt
+++ b/java-sidecar/src/main/kotlin/io/github/hessesian/jarindexer/model/SymbolEntry.kt
@@ -29,4 +29,9 @@ data class SymbolEntry(
     val trailingLambda: Boolean = false,
     /** True when the declaration carries an `@Deprecated` annotation (kotlin or java). */
     val deprecated: Boolean = false,
+    /** Fully-qualified package of the declaring class, e.g. "androidx.compose.runtime". Empty for the default package. */
+    val pkg: String = "",
+    /** True for top-level declarations (a top-level fun/val, or a class/interface/object itself). */
+    @SerialName("top_level")
+    val topLevel: Boolean = false,
 )

--- a/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
+++ b/java-sidecar/src/test/kotlin/io/github/hessesian/jarindexer/IndexerTest.kt
@@ -81,6 +81,105 @@ class IndexerTest {
     }
 
     @Test
+    @DisplayName("indexClassBytes captures package and top-level flag")
+    fun testPackageAndTopLevel() {
+        val result = indexClassBytes(minimalClassBytes("androidx/compose/runtime/Composables"))
+        val cls = result.firstOrNull { it.name == "Composables" && it.kind == "class" }
+        assertTrue(cls != null, "should index the class; got: ${result.map { it.name }}")
+        assertEquals("androidx.compose.runtime", cls!!.pkg, "class package")
+        assertTrue(cls.topLevel, "a class is a top-level declaration")
+    }
+
+    @Test
+    @DisplayName("selectSourcesJar prefers real API sources over samples")
+    fun testSelectSourcesJar() {
+        // Compose ships both a samples jar and the real API sources for `ui`.
+        val candidates = listOf(
+            "ui-1.11.2-samples-sources.jar",
+            "ui-android-1.11.2-sources.jar",
+        )
+        assertEquals(
+            "ui-android-1.11.2-sources.jar",
+            SourcesKdocReader.selectSourcesJar(candidates, "ui"),
+            "must skip the samples jar and pick the real API sources",
+        )
+        // Only a samples jar → nothing usable.
+        assertEquals(
+            null,
+            SourcesKdocReader.selectSourcesJar(listOf("ui-1.11.2-samples-sources.jar"), "ui"),
+        )
+        // Single real sources jar → that one.
+        assertEquals(
+            "kotlinx-coroutines-core-1.7.3-sources.jar",
+            SourcesKdocReader.selectSourcesJar(listOf("kotlinx-coroutines-core-1.7.3-sources.jar"), "kotlinx-coroutines-core-jvm"),
+        )
+    }
+
+    @Test
+    @DisplayName("KDoc is extracted for generic + annotated functions")
+    fun testKdocGenericAnnotatedFunction() {
+        val source = """
+            package androidx.compose.runtime
+            /**
+             * Remember the value produced by calculation.
+             */
+            @Composable
+            public inline fun <T> remember(crossinline calculation: () -> T): T = TODO()
+
+            /** Load a string resource. */
+            @Composable
+            @ReadOnlyComposable
+            fun stringResource(id: Int): String = TODO()
+        """.trimIndent()
+        val map = SourcesKdocReader.extractKdocFromSource(source)
+        assertTrue(
+            map["remember"]?.startsWith("Remember the value") == true,
+            "generic `fun <T> remember` KDoc must be captured; got: ${map["remember"]}",
+        )
+        assertTrue(
+            map["stringResource"]?.startsWith("Load a string") == true,
+            "annotated `fun stringResource` KDoc must be captured; got: ${map["stringResource"]}",
+        )
+    }
+
+    @Test
+    @DisplayName("KDoc survives multi-line annotations (e.g. @Composable)")
+    fun testKdocMultilineAnnotation() {
+        val source = """
+            package androidx.compose.runtime
+            /**
+             * Functions and the values they produce can be marked as Composable.
+             */
+            @MustBeDocumented
+            @Retention(AnnotationRetention.BINARY)
+            @Target(
+                // function declarations
+                // @Composable fun Foo() { ... }
+                AnnotationTarget.FUNCTION,
+                // type usages: foo: @Composable () -> Unit
+                AnnotationTarget.TYPE,
+                AnnotationTarget.PROPERTY_GETTER,
+            )
+            public annotation class Composable
+        """.trimIndent()
+        val map = SourcesKdocReader.extractKdocFromSource(source)
+        assertTrue(
+            map["Composable"]?.startsWith("Functions and the values") == true,
+            "KDoc before a multi-line @Target annotation (with comments containing parens) must be captured; got: ${map["Composable"]}",
+        )
+    }
+
+    @Test
+    @DisplayName("stripNonKdocComments preserves KDoc URLs, drops other comments")
+    fun testStripNonKdocComments() {
+        val src = "/** see https://example.com */\nfun f() {} // trailing\n/* block */ val x = 1"
+        val out = SourcesKdocReader.stripNonKdocComments(src)
+        assertTrue(out.contains("https://example.com"), "KDoc URL must survive: $out")
+        assertTrue(!out.contains("trailing"), "line comment dropped: $out")
+        assertTrue(!out.contains("block"), "block comment dropped: $out")
+    }
+
+    @Test
     @DisplayName("indexJarFile returns empty list for corrupted JAR")
     fun testCorruptedJar(@TempDir tmpDir: File) {
         val jarFile = File(tmpDir, "corrupt.jar")

--- a/src/features/call_arg_diagnostics.rs
+++ b/src/features/call_arg_diagnostics.rs
@@ -24,6 +24,19 @@ use crate::queries::{
 /// The caller provides a `LiveDoc` parsed from the *same text* that was just
 /// indexed, guaranteeing the CST and the indexed signature data are consistent.
 pub(crate) fn call_arg_diagnostics(indexer: &Indexer, uri: &Url, doc: &LiveDoc) -> Vec<Diagnostic> {
+    // Suppress while JAR indexing is in flight: the index is partial, so a library
+    // call (e.g. compose `WindowInsets(0,0,0,0)`) can transiently resolve to the
+    // wrong workspace overload and flash a false positive. The actor republishes
+    // diagnostics once JAR indexing reaches a terminal phase (see scan_handler /
+    // actor `jar_done`), so the correct results land as soon as symbols exist.
+    if indexer
+        .jar_phase
+        .lock()
+        .map(|p| p.is_loading())
+        .unwrap_or(false)
+    {
+        return Vec::new();
+    }
     let bytes = &doc.bytes;
     let root = doc.tree.root_node();
     let mut stats = DiagStats::default();

--- a/src/features/call_arg_diagnostics_tests.rs
+++ b/src/features/call_arg_diagnostics_tests.rs
@@ -1160,6 +1160,8 @@ fn jar_symbol(name: &str, detail: &str, container: &str) -> crate::sidecar::Side
         extension_receiver_type: String::new(),
         trailing_lambda: false,
         deprecated: false,
+        pkg: String::new(),
+        top_level: container.is_empty(),
     }
 }
 

--- a/src/features/call_arg_diagnostics_tests.rs
+++ b/src/features/call_arg_diagnostics_tests.rs
@@ -1311,3 +1311,25 @@ fn diagnostics_suppressed_while_jars_loading() {
         "diagnostics must resume once JAR indexing is done"
     );
 }
+
+/// Regression: a qualified call to a *member* method defined in another file
+/// (reached via the receiver type, not an import) must be diagnosed. Previously
+/// the method's file was rejected by import-reachability because the caller only
+/// imports the class, never its methods.
+#[test]
+fn qualified_member_method_cross_file_is_diagnosed() {
+    let (uri, idx, src) = setup(&[
+        ("/repo.kt", "package data\ninterface Repo {\n    fun save(id: String)\n}\n"),
+        (
+            "/main.kt",
+            "package app\nimport data.Repo\nclass T(val repo: Repo) {\n    fun go() {\n        repo.save()\n    }\n}\n",
+        ),
+    ]);
+    let diags = run_diagnostics(&idx, &uri, &src);
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.message.contains("save") && d.message.contains("expected 1")),
+        "cross-file member method call must be diagnosed: {diags:?}"
+    );
+}

--- a/src/features/call_arg_diagnostics_tests.rs
+++ b/src/features/call_arg_diagnostics_tests.rs
@@ -1148,3 +1148,164 @@ fn copy_inside_custom_receiver_lambda_no_false_positive() {
         "copy() inside a custom receiver lambda must not produce false positives; got: {diagnostics:?}"
     );
 }
+
+fn jar_symbol(name: &str, detail: &str, container: &str) -> crate::sidecar::SidecarSymbol {
+    crate::sidecar::SidecarSymbol {
+        name: name.to_owned(),
+        kind: "fun".to_owned(),
+        container: container.to_owned(),
+        detail: detail.to_owned(),
+        doc: String::new(),
+        type_params: Vec::new(),
+        extension_receiver_type: String::new(),
+        trailing_lambda: false,
+        deprecated: false,
+    }
+}
+
+/// Regression (mirrors the real `androidx.compose.foundation.layout.WindowInsets`
+/// factory overloads): a multi-arity JAR function resolves to `Overloaded`, so the
+/// call-arg diagnostic skips it. Reproduces the nowinandroid `WindowInsets(0,0,0,0)`
+/// false positive, which was caused by stale `(0,0)` JAR param counts + the testDemo
+/// extension leaking in. Now the JAR overloads carry real arities and win.
+#[test]
+fn jar_multi_overload_call_is_not_diagnosed() {
+    let idx = Indexer::new();
+    let symbols = vec![
+        jar_symbol(
+            "WindowInsets",
+            "fun WindowInsets(): WindowInsets",
+            "WindowInsetsKt",
+        ),
+        jar_symbol(
+            "WindowInsets",
+            "fun WindowInsets(left: Int, top: Int, right: Int, bottom: Int): WindowInsets",
+            "WindowInsetsKt",
+        ),
+        jar_symbol(
+            "WindowInsets",
+            "fun WindowInsets(left: Dp, top: Dp, right: Dp, bottom: Dp): WindowInsets",
+            "WindowInsetsKt",
+        ),
+    ];
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        "/home/test/.gradle/foundation-layout.jar".as_ref(),
+        &symbols,
+    );
+    let src = concat!(
+        "class Screen {\n",
+        "  fun build() {\n",
+        "    val w = WindowInsets(0, 0, 0, 0)\n",
+        "  }\n",
+        "}\n",
+    );
+    let u = uri("/Screen.kt");
+    idx.index_content(&u, src);
+    let doc = parse_live(src, tree_sitter_kotlin::language()).unwrap();
+    let diags = call_arg_diagnostics(&idx, &u, &doc);
+    assert!(
+        diags.iter().all(|d| !d.message.contains("WindowInsets")),
+        "overloaded JAR factory must not be diagnosed: {diags:?}"
+    );
+}
+
+/// A single-overload JAR function whose real declaration has default parameters
+/// (e.g. `fun pad(a: Int, b: Int = 0)`) must not produce a "too few args" false
+/// positive when called with fewer args. The sidecar `detail` omits defaults, so
+/// `required` is clamped to 0 for library symbols — only over-supply is flagged.
+#[test]
+fn jar_single_overload_with_defaults_allows_fewer_args() {
+    let idx = Indexer::new();
+    let symbols = vec![jar_symbol(
+        "pad",
+        "fun pad(a: Int, b: Int): Modifier",
+        "PadKt",
+    )];
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        "/home/test/.gradle/lib.jar".as_ref(),
+        &symbols,
+    );
+    let src = concat!(
+        "class Screen {\n",
+        "  fun build() {\n",
+        "    val m = pad(1)\n",
+        "  }\n",
+        "}\n",
+    );
+    let u = uri("/Screen.kt");
+    idx.index_content(&u, src);
+    let doc = parse_live(src, tree_sitter_kotlin::language()).unwrap();
+    let diags = call_arg_diagnostics(&idx, &u, &doc);
+    assert!(
+        diags.iter().all(|d| !d.message.contains("pad")),
+        "library call relying on a default must not be flagged 'too few': {diags:?}"
+    );
+}
+
+/// Over-supplying arguments to a library function is still flagged — `total`
+/// (the parameter-list length) is reliable from the sidecar, only `required` isn't.
+#[test]
+fn jar_call_with_too_many_args_is_still_diagnosed() {
+    let idx = Indexer::new();
+    let symbols = vec![jar_symbol(
+        "pad",
+        "fun pad(a: Int, b: Int): Modifier",
+        "PadKt",
+    )];
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        "/home/test/.gradle/lib.jar".as_ref(),
+        &symbols,
+    );
+    let src = concat!(
+        "class Screen {\n",
+        "  fun build() {\n",
+        "    val m = pad(1, 2, 3)\n",
+        "  }\n",
+        "}\n",
+    );
+    let u = uri("/Screen.kt");
+    idx.index_content(&u, src);
+    let doc = parse_live(src, tree_sitter_kotlin::language()).unwrap();
+    let diags = call_arg_diagnostics(&idx, &u, &doc);
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.message.contains("pad") && d.message.contains("at most 2")),
+        "over-supplying a library call must be flagged: {diags:?}"
+    );
+}
+
+/// While JAR indexing is in flight the index is partial, so call-arg diagnostics
+/// are suppressed to avoid flashing a false positive against the wrong overload.
+/// They resume (and are republished by the actor) once indexing reaches a terminal
+/// phase.
+#[test]
+fn diagnostics_suppressed_while_jars_loading() {
+    use crate::indexer::jar_phase::JarPhase;
+    let (uri, idx, src) = setup(&[(
+        "/a.kt",
+        concat!(
+            "fun greet(name: String, age: Int) {}\n",
+            "fun main() {\n",
+            "    greet(\"Alice\")\n",
+            "}\n",
+        ),
+    )]);
+
+    *idx.jar_phase.lock().unwrap() = JarPhase::InProgress;
+    let diags = run_diagnostics(&idx, &uri, &src);
+    assert!(
+        diags.is_empty(),
+        "diagnostics must be suppressed while JARs load: {diags:?}"
+    );
+
+    *idx.jar_phase.lock().unwrap() = JarPhase::Ready { count: 1 };
+    let diags = run_diagnostics(&idx, &uri, &src);
+    assert!(
+        !diags.is_empty(),
+        "diagnostics must resume once JAR indexing is done"
+    );
+}

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -282,6 +282,12 @@ pub(crate) struct Indexer {
     /// Enables O(symbols_in_jar) removal instead of O(total_jar_symbols).
     /// NOT cleared by `reset_index_state()`.
     pub(crate) jar_uri_to_defs: DashMap<String, Vec<String>>,
+    /// JAR URI → per-symbol package, index-aligned with the jar's `FileData.symbols`
+    /// (and the synthetic line number, which equals the symbol's index). Lets import
+    /// resolution filter a JAR symbol by its *real* package instead of the unreliable
+    /// one-package-per-jar inference. Empty string where the sidecar gave no package.
+    /// NOT cleared by `reset_index_state()`.
+    pub(crate) jar_symbol_packages: DashMap<String, Vec<String>>,
 }
 
 impl InferDeps for Indexer {
@@ -299,6 +305,10 @@ impl InferDeps for Indexer {
     }
     fn find_fun_return_type(&self, fn_name: &str) -> Option<String> {
         crate::resolver::infer::find_fun_return_type_by_name(self, fn_name)
+    }
+
+    fn find_fun_return_type_reachable(&self, fn_name: &str, uri: &Url) -> Option<String> {
+        crate::resolver::infer::find_fun_return_type_reachable(self, fn_name, uri)
     }
     fn find_class_type_params(&self, class_name: &str) -> Vec<String> {
         let Some(locations) = self.definitions.get(class_name) else {
@@ -526,6 +536,7 @@ impl Indexer {
             jar_files: DashMap::new(),
             jar_definitions: DashMap::new(),
             jar_uri_to_defs: DashMap::new(),
+            jar_symbol_packages: DashMap::new(),
             extension_by_receiver: DashMap::new(),
         }
     }

--- a/src/indexer/apply.rs
+++ b/src/indexer/apply.rs
@@ -39,14 +39,30 @@ fn classify_source_set(uri: &str, source_paths: &[String]) -> SourceSet {
             return SourceSet::Library;
         }
     }
-    if uri.contains("/src/test/")
-        || uri.contains("/src/androidTest/")
-        || uri.contains("/src/commonTest/")
-        || uri.contains("/src/iosTest/")
-    {
+    if is_test_source_set(uri) {
         return SourceSet::Test;
     }
     SourceSet::Main
+}
+
+/// Whether `uri` lives in a test source set. Handles plain Gradle/AGP sets
+/// (`test`, `androidTest`), Android **flavored** variants (`testDemo`,
+/// `testProd`, `androidTestDemo`), and Kotlin-Multiplatform target sets
+/// (`commonTest`, `jvmTest`, `iosTest`, …). The source-set directory is the
+/// path segment immediately after `/src/`.
+fn is_test_source_set(uri: &str) -> bool {
+    let Some(rest) = uri.split("/src/").nth(1) else {
+        return false;
+    };
+    let segment = rest.split('/').next().unwrap_or("");
+    // `testFixtures` is a *production* source set consumed by other modules' main
+    // and test code — not test-only — so it must stay `Main`.
+    if segment == "testFixtures" {
+        return false;
+    }
+    segment.starts_with("test")        // test, testDemo, testProd
+        || segment.starts_with("androidTest") // androidTest, androidTestDemo
+        || segment.ends_with("Test") // commonTest, jvmTest, iosTest, desktopTest
 }
 
 // ─── Source-path scan helpers ─────────────────────────────────────────────────

--- a/src/indexer/apply_tests.rs
+++ b/src/indexer/apply_tests.rs
@@ -706,3 +706,46 @@ fn reset_index_state_mixed_extension_receiver_no_deadlock() {
     );
     assert_eq!(entries[0].file_uri, lib_uri);
 }
+
+/// Regression: Android flavored test source sets (`testDemo`, `testProd`,
+/// `androidTestDemo`) and KMP target test sets (`commonTest`, `jvmTest`,
+/// `iosTest`) must classify as `Test`, so test-only symbols don't leak into
+/// main-code resolution (e.g. a `testDemo` `WindowInsets` extension shadowing
+/// the real library factory and producing arg-count false positives).
+#[test]
+fn classify_source_set_handles_flavored_kmp_test_sets() {
+    use crate::types::SourceSet;
+    let classify = |path: &str| super::classify_source_set(path, &[]);
+    assert_eq!(
+        classify("file:///p/app/src/main/kotlin/A.kt"),
+        SourceSet::Main
+    );
+    assert_eq!(
+        classify("file:///p/app/src/test/kotlin/A.kt"),
+        SourceSet::Test
+    );
+    assert_eq!(
+        classify("file:///p/app/src/testDemo/kotlin/A.kt"),
+        SourceSet::Test
+    );
+    assert_eq!(
+        classify("file:///p/app/src/testProd/kotlin/A.kt"),
+        SourceSet::Test
+    );
+    assert_eq!(
+        classify("file:///p/app/src/androidTest/kotlin/A.kt"),
+        SourceSet::Test
+    );
+    assert_eq!(
+        classify("file:///p/app/src/androidTestDemo/kotlin/A.kt"),
+        SourceSet::Test
+    );
+    assert_eq!(
+        classify("file:///p/shared/src/commonTest/kotlin/A.kt"),
+        SourceSet::Test
+    );
+    assert_eq!(
+        classify("file:///p/shared/src/iosTest/kotlin/A.kt"),
+        SourceSet::Test
+    );
+}

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -461,22 +461,22 @@ pub(super) fn resolve_call_expr_type(
 /// `call_suffix → annotated_lambda → lambda_literal` nesting that tree-sitter
 /// produces for `f { … }` and `f(args) { … }`.
 fn find_trailing_lambda_literal(call: tree_sitter::Node<'_>) -> Option<tree_sitter::Node<'_>> {
-    let mut cursor = call.walk();
-    for child in call.children(&mut cursor) {
+    let mut call_cursor = call.walk();
+    for child in call.children(&mut call_cursor) {
         if child.kind() == KIND_LAMBDA_LIT {
             return Some(child);
         }
         if child.kind() == KIND_CALL_SUFFIX {
-            let mut c2 = child.walk();
-            for gc in child.children(&mut c2) {
-                if gc.kind() == KIND_LAMBDA_LIT {
-                    return Some(gc);
+            let mut suffix_cursor = child.walk();
+            for suffix_child in child.children(&mut suffix_cursor) {
+                if suffix_child.kind() == KIND_LAMBDA_LIT {
+                    return Some(suffix_child);
                 }
                 // call_suffix → annotated_lambda → lambda_literal
-                let mut c3 = gc.walk();
-                for ggc in gc.children(&mut c3) {
-                    if ggc.kind() == KIND_LAMBDA_LIT {
-                        return Some(ggc);
+                let mut annotated_cursor = suffix_child.walk();
+                for annotated_child in suffix_child.children(&mut annotated_cursor) {
+                    if annotated_child.kind() == KIND_LAMBDA_LIT {
+                        return Some(annotated_child);
                     }
                 }
             }

--- a/src/indexer/infer/chain.rs
+++ b/src/indexer/infer/chain.rs
@@ -4,13 +4,13 @@ use tower_lsp::lsp_types::Url;
 
 use crate::indexer::NodeExt;
 use crate::queries::{
-    KIND_CALL_EXPR, KIND_CLASS_DECL, KIND_NAV_EXPR, KIND_NAV_SUFFIX, KIND_OBJECT_DECL,
-    KIND_SIMPLE_IDENT, KIND_TYPE_IDENT,
+    KIND_CALL_EXPR, KIND_CALL_SUFFIX, KIND_CLASS_DECL, KIND_LAMBDA_LIT, KIND_NAV_EXPR,
+    KIND_NAV_SUFFIX, KIND_OBJECT_DECL, KIND_SIMPLE_IDENT, KIND_STATEMENTS, KIND_TYPE_IDENT,
 };
 use crate::StrExt;
 
 use super::deps::InferDeps;
-use super::lambda::SCOPE_FUNCTIONS;
+use super::lambda::{LAMBDA_RESULT_FNS, SCOPE_FUNCTIONS};
 use super::receiver::uppercase_dotted_type_prefix;
 use super::type_subst::{
     apply_simple_subst, build_fn_subst, build_type_arg_subst, capitalize_first_char,
@@ -386,9 +386,6 @@ pub(super) fn resolve_root_node_type(
     }
 }
 
-/// Resolve the return type of a call_expression node used as a root in a nav chain.
-///
-/// Handles both simple calls (`foo()`) and method calls (`receiver.method()`).
 pub(super) fn resolve_call_expr_type(
     node: tree_sitter::Node<'_>,
     bytes: &[u8],
@@ -399,6 +396,13 @@ pub(super) fn resolve_call_expr_type(
     if SCOPE_FUNCTIONS.contains(&fn_name.as_str()) {
         let callee = node.child(0)?;
         return resolve_root_node_type(callee, bytes, deps, uri);
+    }
+    // Lambda-result functions (e.g. Compose `remember { Foo() }`) return their
+    // trailing lambda's value. Infer that directly and never fall through to the
+    // global same-name lookup, which would otherwise pick an unrelated overload
+    // (the Kotlin compiler ships an internal `remember` returning `RealVariable`).
+    if LAMBDA_RESULT_FNS.contains(&fn_name.as_str()) {
+        return infer_lambda_result_type(node, bytes, deps, uri);
     }
     let callee = node.child(0)?;
     let receiver_type = if callee.kind() == KIND_NAV_EXPR {
@@ -425,7 +429,11 @@ pub(super) fn resolve_call_expr_type(
             }
         }
     }
-    let mut result = deps.find_fun_return_type(&fn_name);
+    // Prefer the import-aware lookup (binds to the actually-imported symbol);
+    // fall back to the looser global-name scan only when resolution finds nothing.
+    let mut result = deps
+        .find_fun_return_type_reachable(&fn_name, uri)
+        .or_else(|| deps.find_fun_return_type(&fn_name));
     // Apply call-site type argument substitution for generic functions.
     if let Some(call_type_args) = node.call_site_type_arg_strings(bytes) {
         if let Some(callable_info) = deps.find_fun_callable_info(&fn_name, uri) {
@@ -437,7 +445,63 @@ pub(super) fn resolve_call_expr_type(
             }
         }
     }
+    // Constructor fallback: `Foo(...)` with no resolvable function return type is
+    // a constructor call whose type is `Foo`. Only when the callee is a bare
+    // (unqualified or dotted) identifier whose leaf starts uppercase.
+    if result.is_none()
+        && fn_name.starts_with_uppercase()
+        && matches!(callee.kind(), k if k == KIND_SIMPLE_IDENT || k == KIND_NAV_EXPR || k == KIND_TYPE_IDENT)
+    {
+        return Some(fn_name);
+    }
     result
+}
+
+/// Locate the trailing `lambda_literal` of a call expression, handling the
+/// `call_suffix → annotated_lambda → lambda_literal` nesting that tree-sitter
+/// produces for `f { … }` and `f(args) { … }`.
+fn find_trailing_lambda_literal(call: tree_sitter::Node<'_>) -> Option<tree_sitter::Node<'_>> {
+    let mut cursor = call.walk();
+    for child in call.children(&mut cursor) {
+        if child.kind() == KIND_LAMBDA_LIT {
+            return Some(child);
+        }
+        if child.kind() == KIND_CALL_SUFFIX {
+            let mut c2 = child.walk();
+            for gc in child.children(&mut c2) {
+                if gc.kind() == KIND_LAMBDA_LIT {
+                    return Some(gc);
+                }
+                // call_suffix → annotated_lambda → lambda_literal
+                let mut c3 = gc.walk();
+                for ggc in gc.children(&mut c3) {
+                    if ggc.kind() == KIND_LAMBDA_LIT {
+                        return Some(ggc);
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+/// Infer the type of a lambda-result call (`remember { … }`) as the type of the
+/// trailing lambda's last expression. Returns `None` for an empty lambda or when
+/// the last expression's type can't be determined.
+fn infer_lambda_result_type(
+    call: tree_sitter::Node<'_>,
+    bytes: &[u8],
+    deps: &impl InferDeps,
+    uri: &Url,
+) -> Option<String> {
+    let lambda = find_trailing_lambda_literal(call)?;
+    let statements = lambda.first_child_of_kind(KIND_STATEMENTS)?;
+    let count = statements.named_child_count();
+    if count == 0 {
+        return None;
+    }
+    let last = statements.named_child(count - 1)?;
+    resolve_root_node_type(last, bytes, deps, uri)
 }
 
 /// Resolve a chain of segments to a type (without returning method name).

--- a/src/indexer/infer/deps.rs
+++ b/src/indexer/infer/deps.rs
@@ -59,6 +59,17 @@ pub(crate) trait InferDeps {
         None
     }
 
+    /// Import-aware variant of [`find_fun_return_type`]: resolves `fn_name` from
+    /// `uri`'s imports/package (no rg) and reads the *resolved* symbol's return
+    /// type. Avoids the unfiltered global scan picking an unrelated same-named
+    /// overload — e.g. a test-only extension `AndroidComposeTestRule.stringResource`
+    /// instead of the imported `androidx.compose.ui.res.stringResource: String`.
+    ///
+    /// Returns `None` by default; overridden by `Indexer`.
+    fn find_fun_return_type_reachable(&self, _fn_name: &str, _uri: &Url) -> Option<String> {
+        None
+    }
+
     /// Look up the raw declared type of `field_name` inside class `class_name`,
     /// searching across indexed files.  Preserves generic parameters so that
     /// `extract_collection_element_type` can extract the element type.

--- a/src/indexer/infer/expr_type_tests.rs
+++ b/src/indexer/infer/expr_type_tests.rs
@@ -191,3 +191,34 @@ fn elvis_no_hint() {
 fn when_expr_no_hint() {
     assert_eq!(infer(r#"when { x > 0 -> "pos"; else -> "neg" }"#), None);
 }
+
+// ─── constructor + lambda-result (remember) ───────────────────────────────────
+
+#[test]
+fn constructor_call_infers_type_name() {
+    // `Foo(...)` with no resolvable function return type is a constructor → `Foo`.
+    assert_eq!(infer("Foo(1, 2)"), Some("Foo".into()));
+}
+
+#[test]
+fn lowercase_call_is_not_a_constructor() {
+    // `foo()` (lowercase) is a function call, not a constructor — no bogus type.
+    assert_eq!(infer("foo()"), None);
+}
+
+#[test]
+fn remember_infers_lambda_constructor_result() {
+    // Compose `remember { Foo() }` returns its lambda's value → `Foo`, instead of
+    // resolving against an unrelated same-named overload.
+    assert_eq!(infer("remember { Foo() }"), Some("Foo".into()));
+}
+
+#[test]
+fn remember_saveable_infers_lambda_result() {
+    assert_eq!(infer("rememberSaveable { Bar() }"), Some("Bar".into()));
+}
+
+#[test]
+fn remember_empty_lambda_is_none() {
+    assert_eq!(infer("remember { }"), None);
+}

--- a/src/indexer/infer/lambda.rs
+++ b/src/indexer/infer/lambda.rs
@@ -19,6 +19,12 @@ pub(crate) const RECEIVER_THIS_FNS: &[&str] = &["run", "apply"];
 pub(crate) const SCOPE_FUNCTIONS: &[&str] =
     &["let", "also", "run", "apply", "takeIf", "takeUnless"];
 
+/// Functions whose return value is the result of their trailing lambda, so the
+/// inferred type is the lambda's last expression. Compose `remember { Foo() }`
+/// returns `Foo`; without this the call resolves against an unrelated same-named
+/// overload (e.g. the Kotlin compiler's `VariableStorage.remember`).
+pub(crate) const LAMBDA_RESULT_FNS: &[&str] = &["remember", "rememberSaveable"];
+
 /// Return the Nth (0-based) input type from a functional type expression.
 ///
 /// `lambda_type_nth_input("(String, Boolean) -> Unit", 0)` → `Some("String")`

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -697,12 +697,13 @@ fn collect_params_from_file(
     scope: ResolutionScope,
     receiver_base: Option<&str>,
 ) -> Vec<(String, (u8, u8))> {
-    // Look up data from source files first, then JAR cache.
-    let Some(data) = idx
-        .files
-        .get(file_uri)
-        .or_else(|| idx.jar_files.get(file_uri))
-    else {
+    // Look up data from source files first, then the compiled-JAR cache. Track which:
+    // only compiled-JAR (sidecar) symbols lack default-value markers.
+    let (data, is_compiled_jar) = if let Some(d) = idx.files.get(file_uri) {
+        (d, false)
+    } else if let Some(d) = idx.jar_files.get(file_uri) {
+        (d, true)
+    } else {
         return vec![];
     };
     if scope == ResolutionScope::CrossFile && !is_import_reachable(idx, caller_uri, file_uri, name)
@@ -722,14 +723,14 @@ fn collect_params_from_file(
     };
     let is_java = file_uri.ends_with(".java");
 
-    // Library/JAR symbols come from the compiled-jar sidecar, whose signature
-    // `detail` carries parameter *types* but no default-value markers (e.g.
-    // `fun WindowInsets(left: Int, …)` even when the real declaration is
-    // `left: Int = 0`). So we can trust the total arity (the param-list length)
-    // but not `required`. Clamp `required` to 0 for these to avoid "expected N,
-    // found <N" false positives on calls that rely on library defaults; the
-    // compiler already validates required arguments for library calls.
-    let is_library = file_uri.starts_with("jar:") || data.source_set == SourceSet::Library;
+    // Compiled-JAR (sidecar) symbols carry parameter *types* in their signature
+    // `detail` but no default-value markers (e.g. `fun WindowInsets(left: Int, …)`
+    // even when the real declaration is `left: Int = 0`). So we trust the total
+    // arity but not `required` — clamp `required` to 0 to avoid "expected N, found
+    // <N" false positives on calls relying on library defaults. This applies ONLY
+    // to compiled-JAR symbols: sources-JAR (`jar:…!/….kt`) and `sourcePaths`
+    // `SourceSet::Library` files are parsed with tree-sitter and DO carry real
+    // defaults, so their `required` is accurate and must be honoured.
 
     let name_matches = |symbol: &&SymbolEntry| {
         symbol.name == name
@@ -773,7 +774,7 @@ fn collect_params_from_file(
                         }
                     })?
             };
-            let counts = if is_library {
+            let counts = if is_compiled_jar {
                 (0, s.param_counts.1)
             } else {
                 s.param_counts

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -706,7 +706,13 @@ fn collect_params_from_file(
     } else {
         return vec![];
     };
-    if scope == ResolutionScope::CrossFile && !is_import_reachable(idx, caller_uri, file_uri, name)
+    // File-level import reachability gates only UNQUALIFIED cross-file resolution.
+    // Qualified (receiver-based) resolution reaches *members* via the receiver type,
+    // not via an import (you import the class, never its methods), so don't reject the
+    // file here; extension functions still get a per-symbol import check below.
+    if scope == ResolutionScope::CrossFile
+        && receiver_base.is_none()
+        && !is_import_reachable(idx, caller_uri, file_uri, name)
     {
         return vec![];
     }
@@ -748,10 +754,18 @@ fn collect_params_from_file(
     let receiver_matches = |symbol: &&SymbolEntry| match receiver_base {
         None => true,
         Some(base) => {
-            let is_member = symbol.container.as_deref() == Some(base);
-            let is_extension =
-                symbol.container.is_none() && symbol.extension_receiver.as_str() == base;
-            is_member || is_extension
+            if symbol.container.as_deref() == Some(base) {
+                // Member of the receiver type — reachable via the receiver instance,
+                // no import needed.
+                true
+            } else if symbol.container.is_none() && symbol.extension_receiver.as_str() == base {
+                // Extension function — must be import-reachable (or same package),
+                // just like a top-level function.
+                scope != ResolutionScope::CrossFile
+                    || is_import_reachable(idx, caller_uri, file_uri, name)
+            } else {
+                false
+            }
         }
     };
 

--- a/src/indexer/infer/sig.rs
+++ b/src/indexer/infer/sig.rs
@@ -722,6 +722,15 @@ fn collect_params_from_file(
     };
     let is_java = file_uri.ends_with(".java");
 
+    // Library/JAR symbols come from the compiled-jar sidecar, whose signature
+    // `detail` carries parameter *types* but no default-value markers (e.g.
+    // `fun WindowInsets(left: Int, …)` even when the real declaration is
+    // `left: Int = 0`). So we can trust the total arity (the param-list length)
+    // but not `required`. Clamp `required` to 0 for these to avoid "expected N,
+    // found <N" false positives on calls that rely on library defaults; the
+    // compiler already validates required arguments for library calls.
+    let is_library = file_uri.starts_with("jar:") || data.source_set == SourceSet::Library;
+
     let name_matches = |symbol: &&SymbolEntry| {
         symbol.name == name
             && !(scope == ResolutionScope::CrossFile
@@ -764,7 +773,12 @@ fn collect_params_from_file(
                         }
                     })?
             };
-            Some((params_text, s.param_counts))
+            let counts = if is_library {
+                (0, s.param_counts.1)
+            } else {
+                s.param_counts
+            };
+            Some((params_text, counts))
         })
         .collect()
 }

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -512,6 +512,7 @@ pub(crate) fn index_jars(
     indexer.jar_files.clear();
     indexer.jar_definitions.clear();
     indexer.jar_uri_to_defs.clear();
+    indexer.jar_symbol_packages.clear();
 
     let mut jar_cache = super::jar_cache::load_jar_cache();
     let mut total = 0usize;
@@ -734,6 +735,14 @@ fn build_jar_file_data(
         .jar_uri_to_defs
         .insert(fake_uri_str.to_owned(), jar_names);
 
+    // Per-symbol package side table, index-aligned with `symbols` (and the
+    // synthetic line number == symbol index). Used by import resolution to
+    // filter a JAR symbol by its real package.
+    indexer.jar_symbol_packages.insert(
+        fake_uri_str.to_owned(),
+        sidecar_symbols.iter().map(|s| s.pkg.clone()).collect(),
+    );
+
     let lines: Vec<String> = sidecar_symbols.iter().map(|s| s.detail.clone()).collect();
 
     let count = symbols.len();
@@ -777,24 +786,36 @@ fn build_jar_file_data(
         })
     });
 
-    // Add to qualified index so FQN resolution works for JAR symbols.
-    // For nested classes (container is set), use container.name as the FQN.
-    if let Some(ref pkg) = package {
-        for sym in &symbols {
-            let fqn = match &sym.container {
-                Some(container) if !container.is_empty() => {
-                    format!("{}.{}.{}", pkg, container, sym.name)
-                }
-                _ => format!("{}.{}", pkg, sym.name),
-            };
-            indexer.qualified.insert(
-                fqn,
-                tower_lsp::lsp_types::Location {
-                    uri: fake_uri.clone(),
-                    range: sym.range,
-                },
-            );
-        }
+    // Add to qualified index so FQN resolution works for JAR symbols, using the
+    // sidecar's *real* per-symbol package. Top-level declarations (a top-level
+    // fun/val, or a class/interface/object itself) use `pkg.name`; class members
+    // use `pkg.Container.name`. This is what makes an `import a.b.c.remember`
+    // resolve to the public top-level `remember` rather than an unrelated
+    // `SomeClass.remember` in another jar — the previous code keyed top-level
+    // functions under their JVM facade (`pkg.ComposablesKt.remember`), so the
+    // exact-FQN lookup missed and resolution fell back to an unfiltered scan.
+    for (i, sym) in sidecar_symbols.iter().enumerate() {
+        // Prefer the sidecar's real per-symbol package; fall back to the per-jar
+        // inferred package for older sidecars that don't emit `pkg` (no regression).
+        let effective_pkg = if !sym.pkg.is_empty() {
+            sym.pkg.as_str()
+        } else if let Some(ref p) = package {
+            p.as_str()
+        } else {
+            continue;
+        };
+        let fqn = if sym.top_level || sym.container.is_empty() {
+            format!("{}.{}", effective_pkg, sym.name)
+        } else {
+            format!("{}.{}.{}", effective_pkg, sym.container, sym.name)
+        };
+        indexer.qualified.insert(
+            fqn,
+            tower_lsp::lsp_types::Location {
+                uri: fake_uri.clone(),
+                range: symbols[i].range,
+            },
+        );
     }
 
     // Populate extension_by_receiver.

--- a/src/indexer/jar.rs
+++ b/src/indexer/jar.rs
@@ -623,6 +623,48 @@ pub(crate) fn populate_from_symbols(
     build_jar_file_data(indexer, &fake_uri, &fake_uri_str, sidecar_symbols)
 }
 
+/// Parse the value-parameter text and `(required, total)` counts from a sidecar
+/// signature `detail` (e.g. `fun WindowInsets(left: Int, top: Int = 0): WindowInsets`).
+///
+/// Required = params without a `=` default. Returns `("", (0, 0))` when there is
+/// no value-parameter list. Matches the first balanced `(…)` after the name so a
+/// function-type parameter like `block: () -> Unit` doesn't terminate early.
+pub(crate) fn params_from_detail(detail: &str) -> (String, (u8, u8)) {
+    let Some(open) = detail.find('(') else {
+        return (String::new(), (0, 0));
+    };
+    let mut depth = 0i32;
+    let mut close = None;
+    for (offset, ch) in detail[open..].char_indices() {
+        match ch {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    close = Some(open + offset);
+                    break;
+                }
+            }
+            _ => {}
+        }
+    }
+    let Some(close) = close else {
+        return (String::new(), (0, 0));
+    };
+    let inner = detail[open + 1..close].trim();
+    if inner.is_empty() {
+        return (String::new(), (0, 0));
+    }
+    let parts = crate::indexer::split_params_at_depth_zero(inner);
+    let total = parts.len().min(u8::MAX as usize) as u8;
+    let required = parts
+        .iter()
+        .filter(|p| !p.contains('='))
+        .count()
+        .min(u8::MAX as usize) as u8;
+    (inner.to_owned(), (required, total))
+}
+
 /// Build `FileData` + definition entries for one JAR and insert them into the index.
 fn build_jar_file_data(
     indexer: &crate::indexer::Indexer,
@@ -650,6 +692,11 @@ fn build_jar_file_data(
             .next()
             .unwrap_or("")
             .to_owned();
+        // The sidecar doesn't emit parameter counts, but its `detail` is the full
+        // signature — parse counts from it so JAR functions get real arities.
+        // Without this every JAR function looks 0-arg, producing call-arg false
+        // positives (e.g. `WindowInsets(0,0,0,0)`) and breaking overload detection.
+        let (params_text, param_counts) = params_from_detail(&sym.detail);
         symbols.push(SymbolEntry {
             name: sym.name.clone(),
             kind: kind_str_to_lsp(&sym.kind),
@@ -662,8 +709,8 @@ fn build_jar_file_data(
             } else {
                 Some(sym.container.clone())
             },
-            params: String::new(),
-            param_counts: (0, 0),
+            params: params_text,
+            param_counts,
             type_params: sym.type_params.clone(),
             extension_receiver,
             extension_receiver_type: sym.extension_receiver_type.clone(),

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -25,7 +25,16 @@ use crate::sidecar::SidecarSymbol;
 /// v5 → v6: SidecarSymbol gained `deprecated: bool` after `trailing_lambda` — positional mismatch.
 /// v6 → v7: JAR `SymbolEntry`s now carry real `(required, total)` param counts parsed
 ///          from the sidecar signature `detail` (`params_from_detail`); v6 stored `(0, 0)`.
-const JAR_CACHE_VERSION: u32 = 7;
+/// v7 → v8: `SidecarSymbol` gained `pkg` + `top_level` (real per-symbol package);
+///          positional bincode layout changed.
+/// v8 → v9: sidecar now picks the real `-sources.jar` over `-samples-sources.jar`,
+///          so JAR symbols (e.g. compose `stringResource`) carry real KDoc — force re-scan.
+/// v9 → v10: sidecar KDoc regex now handles generic functions (`fun <T> remember`) — re-scan.
+/// v10 → v11: sidecar KDoc regex now skips multi-line annotations (`@Target(...)` before
+///            `annotation class Composable`) — re-scan.
+/// v11 → v12: sidecar strips non-KDoc comments before matching, so comments containing `)`
+///            inside a multi-line annotation no longer hide the declaration (`@Composable`).
+const JAR_CACHE_VERSION: u32 = 12;
 
 #[derive(Serialize, Deserialize)]
 struct JarCache {

--- a/src/indexer/jar_cache.rs
+++ b/src/indexer/jar_cache.rs
@@ -23,7 +23,9 @@ use crate::sidecar::SidecarSymbol;
 /// v3 → v4: SidecarSymbol gained `trailing_lambda: bool` (bincode 1.x is positional, no serde(default)).
 /// v4 → v5: SidecarSymbol gained `doc: String` inserted before `type_params` — positional mismatch.
 /// v5 → v6: SidecarSymbol gained `deprecated: bool` after `trailing_lambda` — positional mismatch.
-const JAR_CACHE_VERSION: u32 = 6;
+/// v6 → v7: JAR `SymbolEntry`s now carry real `(required, total)` param counts parsed
+///          from the sidecar signature `detail` (`params_from_detail`); v6 stored `(0, 0)`.
+const JAR_CACHE_VERSION: u32 = 7;
 
 #[derive(Serialize, Deserialize)]
 struct JarCache {

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -30,6 +30,8 @@ fn make_sidecar_symbol(name: &str, kind: &str, detail: &str, container: &str) ->
         extension_receiver_type: String::new(),
         trailing_lambda: false,
         deprecated: false,
+        pkg: String::new(),
+        top_level: container.is_empty(),
     }
 }
 
@@ -44,6 +46,8 @@ fn make_sidecar_extension(name: &str, receiver_type: &str, detail: &str) -> Side
         extension_receiver_type: receiver_type.to_owned(),
         trailing_lambda: false,
         deprecated: false,
+        pkg: String::new(),
+        top_level: true,
     }
 }
 
@@ -1469,6 +1473,8 @@ fn jar_symbol_gets_real_param_counts() {
             extension_receiver_type: String::new(),
             trailing_lambda: false,
             deprecated: false,
+            pkg: String::new(),
+            top_level: true,
         }],
     );
     let found = indexer
@@ -1478,4 +1484,54 @@ fn jar_symbol_gets_real_param_counts() {
         .find(|s| s.name == "WindowInsets")
         .expect("WindowInsets indexed");
     assert_eq!(found.param_counts, (4, 4), "expected real arity, not (0,0)");
+}
+
+fn sym_with_pkg(name: &str, container: &str, pkg: &str, top_level: bool) -> SidecarSymbol {
+    SidecarSymbol {
+        name: name.to_owned(),
+        kind: "fun".to_owned(),
+        container: container.to_owned(),
+        detail: format!("fun {name}()"),
+        doc: String::new(),
+        type_params: vec![],
+        extension_receiver_type: String::new(),
+        trailing_lambda: false,
+        deprecated: false,
+        pkg: pkg.to_owned(),
+        top_level,
+    }
+}
+
+/// A top-level JAR function registers in `qualified` as `pkg.name` (not
+/// `pkg.Facade.name`), while a class member registers as `pkg.Container.name`.
+/// This is what lets `import androidx.compose.runtime.remember` resolve to the
+/// public top-level overload via the exact-FQN path.
+#[test]
+fn jar_top_level_plus_member_register_distinct_fqns() {
+    let indexer = idx();
+    populate_from_symbols(
+        &indexer,
+        std::path::Path::new("/fake/runtime.jar"),
+        &[
+            sym_with_pkg(
+                "remember",
+                "ComposablesKt",
+                "androidx.compose.runtime",
+                true,
+            ),
+            sym_with_pkg("remember", "Composer", "androidx.compose.runtime", false),
+        ],
+    );
+
+    let top = indexer
+        .qualified
+        .get("androidx.compose.runtime.remember")
+        .expect("top-level FQN registered");
+    assert_eq!(top.range.start.line, 0, "top-level remember is symbol 0");
+
+    let member = indexer
+        .qualified
+        .get("androidx.compose.runtime.Composer.remember")
+        .expect("member FQN registered");
+    assert_eq!(member.range.start.line, 1, "member remember is symbol 1");
 }

--- a/src/indexer/jar_tests.rs
+++ b/src/indexer/jar_tests.rs
@@ -1411,3 +1411,71 @@ fn index_sources_jars_prunes_deleted_jar_entries() {
     );
     assert_eq!(reloaded.len(), 1, "only the live JAR remains");
 }
+
+// ── params_from_detail: arity parsing from sidecar signature strings ──────────
+
+#[test]
+fn params_from_detail_counts_required_plus_total() {
+    use crate::indexer::jar::params_from_detail;
+    // No params.
+    assert_eq!(params_from_detail("interface WindowInsets").1, (0, 0));
+    assert_eq!(
+        params_from_detail("fun WindowInsets(): WindowInsets").1,
+        (0, 0)
+    );
+    // All required.
+    assert_eq!(
+        params_from_detail(
+            "fun WindowInsets(left: Int, top: Int, right: Int, bottom: Int): WindowInsets"
+        )
+        .1,
+        (4, 4)
+    );
+    // Defaults → optional (required < total).
+    assert_eq!(
+        params_from_detail("fun WindowInsets(left: Int = 0, top: Int = 0, right: Int = 0, bottom: Int = 0): WindowInsets").1,
+        (0, 4)
+    );
+    // Function-type param must not terminate the list early.
+    assert_eq!(
+        params_from_detail("fun launch(context: CoroutineContext, block: suspend () -> Unit): Job")
+            .1,
+        (2, 2)
+    );
+    // Generic commas don't inflate the count.
+    assert_eq!(
+        params_from_detail("fun put(entry: Map<String, Int>): Unit").1,
+        (1, 1)
+    );
+}
+
+/// Regression: a JAR function (e.g. compose `WindowInsets`) must carry real
+/// arities parsed from its sidecar detail, not the old hardcoded (0,0) that
+/// produced call-arg false positives like `WindowInsets(0,0,0,0)`.
+#[test]
+fn jar_symbol_gets_real_param_counts() {
+    let indexer = idx();
+    crate::indexer::jar::populate_from_symbols(
+        &indexer,
+        std::path::Path::new("/fake/foundation-layout.jar"),
+        &[SidecarSymbol {
+            name: "WindowInsets".to_owned(),
+            kind: "fun".to_owned(),
+            container: String::new(),
+            detail: "fun WindowInsets(left: Int, top: Int, right: Int, bottom: Int): WindowInsets"
+                .to_owned(),
+            doc: String::new(),
+            type_params: vec![],
+            extension_receiver_type: String::new(),
+            trailing_lambda: false,
+            deprecated: false,
+        }],
+    );
+    let found = indexer
+        .jar_files
+        .iter()
+        .flat_map(|f| f.value().symbols.clone())
+        .find(|s| s.name == "WindowInsets")
+        .expect("WindowInsets indexed");
+    assert_eq!(found.param_counts, (4, 4), "expected real arity, not (0,0)");
+}

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -158,7 +158,12 @@ pub(crate) fn infer_receiver_type(
     uri: &Url,
 ) -> Option<ReceiverType> {
     let raw = match kind {
-        ReceiverKind::Variable(name) => infer_variable_type_raw(indexer, name, uri)?,
+        ReceiverKind::Variable(name) => match infer_variable_type_raw(indexer, name, uri) {
+            Some(raw) => raw,
+            // CST fallback for initializers the line heuristics miss (e.g.
+            // `val x = remember { Foo() }` → `Foo`).
+            None => infer_variable_type_from_cst(indexer, name, uri)?,
+        },
         ReceiverKind::Contextual { name, position } => {
             // Lambda / implicit-receiver path.
             if let Some(type_str) = indexer.infer_lambda_param_type_at(name, uri, position) {
@@ -343,6 +348,59 @@ fn infer_variable_type_core(
     };
     infer_method_return_type(indexer, var_name, &lines, uri, depth - 1)
         .or_else(|| find_extension_property_type(indexer, var_name, uri))
+}
+
+/// CST fallback for variable type inference: find `val <var_name> = <init>` in
+/// the live tree and infer the initializer's type via `infer_expr_type`. Catches
+/// cases the line-based heuristics miss — notably lambda-result calls like
+/// Compose `remember { Foo() }` (→ `Foo`) and constructor calls.
+fn infer_variable_type_from_cst(indexer: &Indexer, var_name: &str, uri: &Url) -> Option<String> {
+    let doc = indexer.live_doc_or_parse(uri)?;
+    let bytes = doc.bytes.as_slice();
+    let init = find_prop_initializer(doc.tree.root_node(), bytes, var_name)?;
+    crate::indexer::infer_expr_type(init, bytes, indexer, uri)
+}
+
+/// Depth-first search for the initializer expression of `val/var <var_name> = …`.
+fn find_prop_initializer<'a>(
+    node: tree_sitter::Node<'a>,
+    bytes: &[u8],
+    var_name: &str,
+) -> Option<tree_sitter::Node<'a>> {
+    use crate::queries::{KIND_EQ, KIND_PROP_DECL};
+    if node.kind() == KIND_PROP_DECL && prop_decl_name(node, bytes).as_deref() == Some(var_name) {
+        let mut cursor = node.walk();
+        let mut past_eq = false;
+        for child in node.children(&mut cursor) {
+            if child.kind() == KIND_EQ {
+                past_eq = true;
+                continue;
+            }
+            if past_eq {
+                return Some(child);
+            }
+        }
+        return None;
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if let Some(found) = find_prop_initializer(child, bytes, var_name) {
+            return Some(found);
+        }
+    }
+    None
+}
+
+/// Extract the declared variable name from a `property_declaration` node.
+fn prop_decl_name(prop: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<String> {
+    use crate::queries::{KIND_SIMPLE_IDENT, KIND_VAR_DECL};
+    let mut c = prop.walk();
+    let vd = prop.children(&mut c).find(|n| n.kind() == KIND_VAR_DECL)?;
+    let mut vc = vd.walk();
+    let ident = vd
+        .children(&mut vc)
+        .find(|n| n.kind() == KIND_SIMPLE_IDENT)?;
+    ident.utf8_text(bytes).ok().map(str::to_owned)
 }
 
 /// Scan a specific (possibly un-indexed) file for the declared type of `field_name`.
@@ -589,9 +647,13 @@ fn infer_method_return_type(
         }
     }
 
-    // Secondary pass: plain function calls whose return type is in the definitions index.
+    // Secondary pass: plain function calls. Prefer the import-aware lookup (binds
+    // to the imported symbol, e.g. compose `stringResource: String`) over the loose
+    // global-name scan (which may grab a test-only same-named extension).
     for fn_name in &plain_fn_candidates {
-        if let Some(ret) = find_fun_return_type_by_name(indexer, fn_name) {
+        if let Some(ret) = find_fun_return_type_reachable(indexer, fn_name, uri)
+            .or_else(|| find_fun_return_type_by_name(indexer, fn_name))
+        {
             return Some(ret);
         }
     }
@@ -632,6 +694,50 @@ pub(crate) fn find_fun_return_type_by_name(indexer: &Indexer, fn_name: &str) -> 
         }
     }
     None
+}
+
+/// Import-aware return-type lookup. Resolves `fn_name` via the no-rg resolver
+/// (imports → same-package → star → qualified/jars, package-filtered) and reads
+/// the *resolved* symbol's return type — i.e. the symbol the call actually binds
+/// to, not an arbitrary same-named overload from a test file or unrelated jar.
+/// Falls back to `None` so callers can defer to the looser `find_fun_return_type_by_name`.
+pub(crate) fn find_fun_return_type_reachable(
+    indexer: &Indexer,
+    fn_name: &str,
+    uri: &Url,
+) -> Option<String> {
+    let locations = crate::resolver::resolve_symbol_no_rg(indexer, fn_name, uri);
+    let mut fallback: Option<String> = None;
+    for loc in &locations {
+        let Some(file_data) = indexer
+            .files
+            .get(loc.uri.as_str())
+            .or_else(|| indexer.jar_files.get(loc.uri.as_str()))
+        else {
+            continue;
+        };
+        for symbol in &file_data.symbols {
+            if symbol.name != fn_name {
+                continue;
+            }
+            if !matches!(
+                symbol.kind,
+                SymbolKind::FUNCTION | SymbolKind::METHOD | SymbolKind::OPERATOR
+            ) {
+                continue;
+            }
+            let ret = extract_return_type_from_detail(&symbol.detail);
+            if symbol.selection_range.start == loc.range.start {
+                // The symbol the resolver actually bound to.
+                if ret.is_some() {
+                    return ret;
+                }
+            } else if fallback.is_none() {
+                fallback = ret;
+            }
+        }
+    }
+    fallback
 }
 
 pub(crate) fn find_method_return_type(

--- a/src/resolver/infer.rs
+++ b/src/resolver/infer.rs
@@ -394,11 +394,13 @@ fn find_prop_initializer<'a>(
 /// Extract the declared variable name from a `property_declaration` node.
 fn prop_decl_name(prop: tree_sitter::Node<'_>, bytes: &[u8]) -> Option<String> {
     use crate::queries::{KIND_SIMPLE_IDENT, KIND_VAR_DECL};
-    let mut c = prop.walk();
-    let vd = prop.children(&mut c).find(|n| n.kind() == KIND_VAR_DECL)?;
-    let mut vc = vd.walk();
-    let ident = vd
-        .children(&mut vc)
+    let mut prop_cursor = prop.walk();
+    let var_decl = prop
+        .children(&mut prop_cursor)
+        .find(|n| n.kind() == KIND_VAR_DECL)?;
+    let mut var_decl_cursor = var_decl.walk();
+    let ident = var_decl
+        .children(&mut var_decl_cursor)
         .find(|n| n.kind() == KIND_SIMPLE_IDENT)?;
     ident.utf8_text(bytes).ok().map(str::to_owned)
 }

--- a/src/resolver/infer_tests.rs
+++ b/src/resolver/infer_tests.rs
@@ -279,3 +279,78 @@ fn property_type_no_keyword_returns_none() {
         None,
     );
 }
+
+/// Completion/hover path: a `val` initialized by `remember { Constructor() }`
+/// must resolve to the constructed type via the CST fallback (the line-based
+/// heuristics can't see through the lambda), so `navigator.` offers the right
+/// members.
+#[test]
+fn remember_initializer_resolves_via_cst_fallback() {
+    use super::super::{infer_receiver_type, ReceiverKind};
+    use crate::indexer::Indexer;
+    use tower_lsp::lsp_types::Url;
+
+    let uri = Url::parse("file:///app/Nav.kt").unwrap();
+    let idx = Indexer::new();
+    let src = "package app\nclass Navigator\nfun screen() {\n    val navigator = remember { Navigator() }\n}\n";
+    idx.index_content(&uri, src);
+    idx.store_live_tree(&uri, src);
+
+    let rt = infer_receiver_type(&idx, ReceiverKind::Variable("navigator"), &uri);
+    assert_eq!(
+        rt.map(|r| r.raw),
+        Some("Navigator".into()),
+        "val from `remember {{ Navigator() }}` must infer Navigator"
+    );
+}
+
+/// Import-aware return-type lookup must bind to the *imported* function, not an
+/// arbitrary same-named overload. Mirrors nowinandroid `stringResource`: the
+/// imported compose `stringResource: String` must win over a workspace test
+/// extension `AndroidComposeTestRule.stringResource: ReadOnlyProperty<…>`.
+#[test]
+fn return_type_reachable_prefers_imported_symbol() {
+    use super::find_fun_return_type_reachable;
+    use crate::indexer::Indexer;
+    use crate::sidecar::SidecarSymbol;
+    use tower_lsp::lsp_types::Url;
+
+    let idx = Indexer::new();
+    // Compiled-jar compose `stringResource(): String`.
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/compose-ui.jar"),
+        &[SidecarSymbol {
+            name: "stringResource".into(),
+            kind: "fun".into(),
+            container: "StringResourcesKt".into(),
+            detail: "fun stringResource(id: Int): String".into(),
+            doc: String::new(),
+            type_params: vec![],
+            extension_receiver_type: String::new(),
+            trailing_lambda: false,
+            deprecated: false,
+            pkg: "androidx.compose.ui.res".into(),
+            top_level: true,
+        }],
+    );
+    // Workspace decoy with the same name but a different return type.
+    let decoy = Url::parse("file:///app/TestExt.kt").unwrap();
+    idx.index_content(
+        &decoy,
+        "package app.test\nfun stringResource(id: Int): ReadOnlyProperty = TODO()\n",
+    );
+
+    // Caller imports the compose one.
+    let caller = Url::parse("file:///app/Screen.kt").unwrap();
+    idx.index_content(
+        &caller,
+        "package app\nimport androidx.compose.ui.res.stringResource\nfun s() { val x = stringResource(1) }\n",
+    );
+
+    assert_eq!(
+        find_fun_return_type_reachable(&idx, "stringResource", &caller),
+        Some("String".into()),
+        "must bind to the imported compose stringResource (String), not the decoy"
+    );
+}

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -704,20 +704,19 @@ fn resolve_via_imports(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Location
             let filtered: Vec<_> = all_locations
                 .iter()
                 .filter(|loc| {
-                    // Compiled-JAR symbols: filter by the sidecar's real per-symbol
-                    // package (from the `jar_symbol_packages` side table). This keeps
-                    // an `import a.b.c.remember` from also matching an unrelated
+                    // Compiled-JAR (sidecar) symbols: filter by the sidecar's real
+                    // per-symbol package (the `jar_symbol_packages` side table is
+                    // populated only for compiled JARs). This keeps an
+                    // `import a.b.c.remember` from also matching an unrelated
                     // `remember` in the Kotlin compiler / gradle plugin / KSP jars.
-                    // Fall back to accepting when the package is unknown (older jar
-                    // cache predating per-symbol packages) so we never regress.
-                    if loc.uri.as_str().starts_with("jar:") {
-                        return match jar_symbol_package(indexer, loc) {
-                            Some(p) => {
-                                p == expected_pkg || p.starts_with(&format!("{expected_pkg}."))
-                            }
-                            None => true,
-                        };
+                    if let Some(pkg) = jar_symbol_package(indexer, loc) {
+                        return pkg == expected_pkg || pkg.starts_with(&format!("{expected_pkg}."));
                     }
+                    // Everything else — workspace, `sourcePaths` libraries, AND
+                    // sources-JARs (which are `jar:…!/….kt` URIs but live in `files`
+                    // with a real package) — filters by the file's package. Fail open
+                    // when the package is unknown (e.g. compiled JAR on an older cache
+                    // with no per-symbol package) so we never regress.
                     indexer
                         .files
                         .get(loc.uri.as_str())

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -651,6 +651,18 @@ fn resolve_local(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Location> {
         .unwrap_or_default()
 }
 
+/// Package of the JAR symbol at `loc`, from the `jar_symbol_packages` side table.
+/// JAR symbols use a synthetic range whose line number equals the symbol's index
+/// within the jar's `FileData.symbols`, so the line indexes the package vector.
+/// Returns `None` when unknown (no entry, or pre-per-symbol-package jar cache).
+fn jar_symbol_package(indexer: &Indexer, loc: &Location) -> Option<String> {
+    let packages = indexer.jar_symbol_packages.get(loc.uri.as_str())?;
+    packages
+        .get(loc.range.start.line as usize)
+        .filter(|p| !p.is_empty())
+        .cloned()
+}
+
 /// Step 2 — explicit single-symbol imports.
 ///
 /// Handles three cases:
@@ -692,13 +704,19 @@ fn resolve_via_imports(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Location
             let filtered: Vec<_> = all_locations
                 .iter()
                 .filter(|loc| {
-                    // Compiled-JAR symbols carry an unreliable per-jar inferred
-                    // package (one value for an entire multi-package jar like
-                    // androidx.compose.runtime), so the package prefix doesn't
-                    // identify the symbol's real package — don't reject them on a
-                    // mismatch. The exact-FQN import already scoped the lookup.
+                    // Compiled-JAR symbols: filter by the sidecar's real per-symbol
+                    // package (from the `jar_symbol_packages` side table). This keeps
+                    // an `import a.b.c.remember` from also matching an unrelated
+                    // `remember` in the Kotlin compiler / gradle plugin / KSP jars.
+                    // Fall back to accepting when the package is unknown (older jar
+                    // cache predating per-symbol packages) so we never regress.
                     if loc.uri.as_str().starts_with("jar:") {
-                        return true;
+                        return match jar_symbol_package(indexer, loc) {
+                            Some(p) => {
+                                p == expected_pkg || p.starts_with(&format!("{expected_pkg}."))
+                            }
+                            None => true,
+                        };
                     }
                     indexer
                         .files

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -3355,3 +3355,62 @@ fn jar_symbol_resolves_despite_wrong_per_jar_package() {
         locs.iter().map(|l| l.uri.as_str()).collect::<Vec<_>>()
     );
 }
+
+/// `import androidx.compose.runtime.remember` must resolve to the compose
+/// top-level `remember`, not a same-named symbol in an unrelated jar (the Kotlin
+/// compiler / gradle plugin / KSP all ship a `remember`). Driven by the sidecar's
+/// real per-symbol package (`jar_symbol_packages`) + the corrected top-level FQN.
+#[test]
+fn import_resolves_jar_symbol_to_correct_package() {
+    use crate::sidecar::SidecarSymbol;
+
+    let mk = |name: &str, container: &str, pkg: &str, top_level: bool| SidecarSymbol {
+        name: name.into(),
+        kind: "fun".into(),
+        container: container.into(),
+        detail: format!("fun {name}()"),
+        doc: String::new(),
+        type_params: vec![],
+        extension_receiver_type: String::new(),
+        trailing_lambda: false,
+        deprecated: false,
+        pkg: pkg.into(),
+        top_level,
+    };
+
+    let idx = Indexer::new();
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/runtime.jar"),
+        &[mk(
+            "remember",
+            "ComposablesKt",
+            "androidx.compose.runtime",
+            true,
+        )],
+    );
+    crate::indexer::jar::populate_from_symbols(
+        &idx,
+        std::path::Path::new("/fake/kotlin-compiler.jar"),
+        &[mk(
+            "remember",
+            "VariableStorage",
+            "org.jetbrains.kotlin.fir",
+            false,
+        )],
+    );
+
+    let caller = Url::parse("file:///app/Foo.kt").unwrap();
+    idx.index_content(
+        &caller,
+        "package app\nimport androidx.compose.runtime.remember\n",
+    );
+    let locs = resolve_symbol(&idx, "remember", None, &caller);
+
+    assert!(!locs.is_empty(), "remember should resolve");
+    assert!(
+        locs.iter().all(|l| l.uri.as_str().contains("runtime.jar")),
+        "must resolve only to the compose-runtime jar, got: {:?}",
+        locs.iter().map(|l| l.uri.as_str()).collect::<Vec<_>>()
+    );
+}

--- a/src/sidecar.rs
+++ b/src/sidecar.rs
@@ -58,6 +58,13 @@ pub(crate) struct SidecarSymbol {
     /// True when the declaration carries an `@Deprecated` annotation.
     #[serde(default)]
     pub deprecated: bool,
+    /// Fully-qualified package of the declaring class, e.g. "androidx.compose.runtime".
+    /// Empty for the default package or older sidecars.
+    #[serde(default)]
+    pub pkg: String,
+    /// True for top-level declarations (a top-level fun/val, or a class/interface/object itself).
+    #[serde(default)]
+    pub top_level: bool,
 }
 
 pub(crate) struct SidecarHandle {

--- a/src/workspace/actor.rs
+++ b/src/workspace/actor.rs
@@ -39,6 +39,11 @@ use super::{Config, Event};
 pub(crate) struct Actor<R: ProgressReporter + 'static> {
     rx: mpsc::Receiver<Event>,
     scan_done_rx: mpsc::UnboundedReceiver<()>,
+    /// Fires when background JAR indexing reaches a terminal phase. The index was
+    /// partial when open files were first diagnosed, so we recompute their
+    /// diagnostics once JAR symbols are available (e.g. a compose `WindowInsets`
+    /// call that looked wrong against workspace-only overloads now resolves).
+    jar_done_rx: mpsc::UnboundedReceiver<()>,
     scan_handler: ScanHandler<R>,
     file_change_handler: FileChangeHandler,
     document_handler: DocumentHandler,
@@ -58,14 +63,17 @@ impl<R: ProgressReporter + 'static> Actor<R> {
     ) -> Self {
         let state = Arc::new(RwLock::new(State::Uninitialized));
         let (scan_done_tx, scan_done_rx) = mpsc::unbounded_channel();
+        let (jar_done_tx, jar_done_rx) = mpsc::unbounded_channel();
         Self {
             rx,
             scan_done_rx,
+            jar_done_rx,
             scan_handler: ScanHandler::new(
                 Arc::clone(&indexer),
                 reporter,
                 Arc::clone(&state),
                 scan_done_tx,
+                jar_done_tx,
             ),
             file_change_handler: FileChangeHandler::new(Arc::clone(&indexer), client.clone()),
             document_handler: DocumentHandler::new(indexer, client),
@@ -98,6 +106,11 @@ impl<R: ProgressReporter + 'static> Actor<R> {
                 }
                 Some(()) = self.scan_done_rx.recv() => {
                     self.scan_handler.on_scan_completed();
+                }
+                Some(()) = self.jar_done_rx.recv() => {
+                    // JAR indexing finished — recompute diagnostics for open files
+                    // that were diagnosed against a JAR-less (partial) index.
+                    self.document_handler.republish_open_file_diagnostics();
                 }
             }
             let is_ready = self.is_ready().await;

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -17,6 +17,9 @@ pub(crate) struct ScanHandler<R: ProgressReporter + 'static> {
     state: Arc<RwLock<State>>,
     scan_queue: Mutex<ScanQueue>,
     scan_done_tx: mpsc::UnboundedSender<()>,
+    /// Signals the actor when background JAR indexing reaches a terminal phase so
+    /// it can recompute diagnostics for files diagnosed against a partial index.
+    jar_done_tx: mpsc::UnboundedSender<()>,
     /// Guard that prevents concurrent Gradle-cache crawls.
     jar_indexing_in_progress: Arc<AtomicBool>,
 }
@@ -27,6 +30,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
         reporter: Arc<R>,
         state: Arc<RwLock<State>>,
         scan_done_tx: mpsc::UnboundedSender<()>,
+        jar_done_tx: mpsc::UnboundedSender<()>,
     ) -> Self {
         Self {
             indexer,
@@ -34,6 +38,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             state,
             scan_queue: Mutex::new(ScanQueue::new()),
             scan_done_tx,
+            jar_done_tx,
             jar_indexing_in_progress: Arc::new(AtomicBool::new(false)),
         }
     }
@@ -311,6 +316,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
 
         let indexer = Arc::clone(&self.indexer);
         let in_progress = Arc::clone(&self.jar_indexing_in_progress);
+        let jar_done_tx = self.jar_done_tx.clone();
 
         // Capture current workspace generation so stale tasks don't overwrite state.
         let expected_gen = indexer
@@ -359,6 +365,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                     *phase = JarPhase::Ready { count: 0 };
                 }
                 in_progress.store(false, Ordering::Release);
+                let _ = jar_done_tx.send(());
                 return;
             }
 
@@ -393,6 +400,8 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             // symbols (launch, collect, etc.) without requiring a retype.
             indexer.invalidate_completion_cache();
             in_progress.store(false, Ordering::Release);
+            // Wake the actor to recompute diagnostics now that JAR symbols exist.
+            let _ = jar_done_tx.send(());
         });
     }
 }

--- a/src/workspace/scan_handler.rs
+++ b/src/workspace/scan_handler.rs
@@ -333,7 +333,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 .generation_atomic()
                 .load(Ordering::Acquire);
             if current_gen != expected_gen {
-                in_progress.store(false, Ordering::Release);
+                abandon_stale_jar_scan(&indexer, &in_progress, &jar_done_tx);
                 return;
             }
 
@@ -349,7 +349,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 .generation_atomic()
                 .load(Ordering::Acquire);
             if current_gen != expected_gen {
-                in_progress.store(false, Ordering::Release);
+                abandon_stale_jar_scan(&indexer, &in_progress, &jar_done_tx);
                 return;
             }
 
@@ -380,7 +380,7 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
                 .generation_atomic()
                 .load(Ordering::Acquire);
             if current_gen != expected_gen {
-                in_progress.store(false, Ordering::Release);
+                abandon_stale_jar_scan(&indexer, &in_progress, &jar_done_tx);
                 return;
             }
 
@@ -404,6 +404,28 @@ impl<R: ProgressReporter + 'static> ScanHandler<R> {
             let _ = jar_done_tx.send(());
         });
     }
+}
+
+/// Clean up after a background JAR scan abandons because the workspace generation
+/// changed mid-scan. A newer scan may have been coalesced away while this one held
+/// the in-flight guard, so we must not leave `jar_phase` stuck in a loading state —
+/// that would keep `call_arg_diagnostics` suppressed indefinitely. Move the phase
+/// out of `Pending`/`InProgress` and wake the actor to republish diagnostics.
+fn abandon_stale_jar_scan(
+    indexer: &Indexer,
+    in_progress: &AtomicBool,
+    jar_done_tx: &mpsc::UnboundedSender<()>,
+) {
+    use crate::indexer::jar_phase::JarPhase;
+    in_progress.store(false, Ordering::Release);
+    if let Ok(mut phase) = indexer.jar_phase.lock() {
+        if matches!(*phase, JarPhase::InProgress | JarPhase::Pending) {
+            *phase = JarPhase::Ready {
+                count: indexer.jar_definitions.len(),
+            };
+        }
+    }
+    let _ = jar_done_tx.send(());
 }
 
 #[cfg(test)]

--- a/src/workspace/scan_handler_tests.rs
+++ b/src/workspace/scan_handler_tests.rs
@@ -10,11 +10,13 @@ use super::ScanHandler;
 
 fn make_handler(indexer: Arc<Indexer>) -> ScanHandler<NoopReporter> {
     let (scan_done_tx, _scan_done_rx) = mpsc::unbounded_channel();
+    let (jar_done_tx, _jar_done_rx) = mpsc::unbounded_channel();
     ScanHandler::new(
         indexer,
         Arc::new(NoopReporter),
         Arc::new(RwLock::new(State::Uninitialized)),
         scan_done_tx,
+        jar_done_tx,
     )
 }
 

--- a/src/workspace/scan_handler_tests.rs
+++ b/src/workspace/scan_handler_tests.rs
@@ -96,3 +96,33 @@ fn jar_phase_is_loading_helpers() {
     assert!(!JarPhase::Ready { count: 0 }.is_loading());
     assert!(!JarPhase::Failed("oops".to_owned()).is_loading());
 }
+
+/// Regression: a stale JAR scan that abandons on a generation change must not
+/// leave `jar_phase` stuck in a loading state (which would keep call-arg
+/// diagnostics suppressed forever via the `is_loading()` gate). It moves the
+/// phase out of loading and fires `jar_done` so the actor republishes.
+#[test]
+fn abandon_stale_jar_scan_clears_loading_signals() {
+    use crate::indexer::jar_phase::JarPhase;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    let indexer = Arc::new(Indexer::new());
+    *indexer.jar_phase.lock().unwrap() = JarPhase::InProgress;
+    let in_progress = AtomicBool::new(true);
+    let (jar_done_tx, mut jar_done_rx) = mpsc::unbounded_channel();
+
+    super::abandon_stale_jar_scan(&indexer, &in_progress, &jar_done_tx);
+
+    assert!(
+        !indexer.jar_phase.lock().unwrap().is_loading(),
+        "phase must leave the loading state so diagnostics resume"
+    );
+    assert!(
+        !in_progress.load(Ordering::Acquire),
+        "in-flight guard cleared"
+    );
+    assert!(
+        jar_done_rx.try_recv().is_ok(),
+        "jar_done must fire to republish"
+    );
+}


### PR DESCRIPTION
## Problem

The call-arg diagnostic flagged valid **library** calls — e.g. Jetpack Compose `WindowInsets(0, 0, 0, 0)` was reported as "expected at most 1 argument, found 4". Two root causes, plus a refresh gap:

1. JAR symbols carried hardcoded `(0, 0)` parameter counts, so the diagnostic resolved against a wrong workspace overload (the `testDemo` extension) instead of the real factory.
2. The fix for (1) never took effect because the JAR-symbol cache version wasn't bumped — the stale `(0, 0)` counts kept loading.
3. Diagnostics computed for an open file *before* background JAR indexing finished were never recomputed, so a transient false positive stuck around even after the index became complete.

Verified against the real `nowinandroid` project + 754 Gradle JARs: `resolve_call_signature("WindowInsets")` now returns `Overloaded`, so the diagnostic correctly skips it.

## Changes

- **`jar.rs`** — `params_from_detail` parses real `(required, total)` arities from the sidecar signature `detail` instead of `(0, 0)`.
- **`jar_cache.rs`** — bump the JAR-symbol cache version so the new data takes effect. **This branch now lands at `JAR_CACHE_VERSION = 12`** (stacked bumps: v7 param counts, v8 per-symbol package, v9–v12 sidecar KDoc fixes). First index after upgrade re-scans JARs once.
- **`sig.rs`** — for library/JAR symbols, trust `total` but clamp `required` to 0. The sidecar emits no default-value markers, so `fun f(a, b = 0)` must not be flagged "too few args". Over-supply (`> total`) is still flagged.
- **`apply.rs`** — classify Android flavored (`testDemo`/`testProd`/`androidTestDemo`) and KMP (`commonTest`/`jvmTest`/`iosTest`) test source sets so test-only overloads stop leaking into main resolution. `testFixtures` stays `Main` (it's production code consumed by other modules).
- **`call_arg_diagnostics.rs`** — suppress diagnostics while JAR indexing is in flight (the index is partial), avoiding transient false positives; removed the earlier blunt "skip any name in `jar_definitions`" guard, which silently disabled checking for every workspace function sharing a name with a stdlib symbol (`run`, `map`, `apply`, …).
- **`scan_handler.rs` / `actor.rs`** — signal `jar_done` when JAR indexing reaches a terminal phase so the actor republishes open-file diagnostics with the now-complete index.

## Tests

- `jar_multi_overload_call_is_not_diagnosed` — reproduces the `WindowInsets` overload set → `Overloaded` → no diagnostic.
- `jar_single_overload_with_defaults_allows_fewer_args` — library default-arg call not flagged "too few".
- `jar_call_with_too_many_args_is_still_diagnosed` — over-supply still flagged.
- `diagnostics_suppressed_while_jars_loading` — no diagnostics while `jar_phase.is_loading()`, resume after.
- `params_from_detail_*`, `classify_source_set_handles_flavored_kmp_test_sets`.

Full suite: 1346 passing, clippy clean.

## Note

Stacked on top of #168 (`fix/jar-resolution-and-hover`); retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)