### PR TITLE
docs: document jarPaths + recent resolution/hover improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- **`jarPaths` — index compiled jars without a build system** — for projects with no Gradle cache (Make/Bazel/manual builds), point the indexer directly at compiled `.jar`/`.aar` dependencies. Set `jarPaths` in `workspace.json` (`"jarPaths": ["<WORKSPACE>/libs", "/opt/deps/foo.jar"]` — files or directories, `<WORKSPACE>` and relative paths supported) or via LSP `initializationOptions.indexingOptions.jarPaths`. Indexed in addition to the Gradle cache; hover docs are read from a sibling `*-sources.jar` when one is present.
+- **Accurate library resolution via real per-symbol packages** — JAR symbols now carry their true package (emitted by the sidecar), so go-to-definition, hover, completion, and call-arg diagnostics bind to the *imported* overload instead of an arbitrary same-named symbol from an unrelated jar (e.g. compose `remember`, `stringResource`). Library hover JavaDoc/KDoc now renders for annotated and generic declarations (`@Composable`, `remember`, `stringResource`, …).
+
+### Bug fixes
+
+- **Qualified member-method arg diagnostics** — `receiver.method()` calls into a member defined in another file/package are now arg-count-checked (previously skipped because the method's file was wrongly gated by import reachability).
+- **JAR indexing no longer stuck "loading"** — a cancelled or coalesced background JAR scan can no longer leave open-file diagnostics suppressed indefinitely.
+- **Generic angle brackets in hover docs** — `List<String>` / `Map<K, V>` in KDoc/JavaDoc are no longer stripped as if they were HTML tags.
+
 ## 0.24.0
 
 ### Features

--- a/docs/features.md
+++ b/docs/features.md
@@ -108,6 +108,14 @@ Android SDK, `workspace.json`, and the Gradle cache are all picked up automatica
 
 The extractor deduplicates by artifact — when multiple versions are cached, only the latest is extracted.
 
+**No build system?** For projects without a Gradle cache (Make/Bazel/manual builds), set `jarPaths` in `workspace.json` to point the indexer directly at your compiled dependency jars — files or directories, `<WORKSPACE>` and relative paths supported, indexed in addition to the Gradle cache:
+
+```json
+{ "jarPaths": ["<WORKSPACE>/build/libs", "/opt/deps/some-library.jar"] }
+```
+
+The same list can be passed via LSP `initializationOptions.indexingOptions.jarPaths`. Hover docs come from a sibling `*-sources.jar` when present; otherwise you still get signatures, completions, and go-to-definition to the compiled symbol.
+
 ## What gets indexed
 
 **Kotlin:** `class`, `interface`, `object`, `fun`, `val`, `var`, `typealias`, constructor parameters, enum entries  


### PR DESCRIPTION
Documents the `jarPaths` feature (#170) and the recent resolution/hover-doc improvements:

- **CHANGELOG**: new `## Unreleased` section — `jarPaths`, per-symbol-package library resolution, qualified member-method diagnostics, stuck-loading fix, generics-in-hover-docs fix.
- **features.md**: "No build system?" note under the indexing section showing the `jarPaths` config (both `workspace.json` and init-options surfaces).

(README was already updated in #170.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)