### PR TITLE
feat(godef): open library source on go-to-definition (lazy jar extraction)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- **Go-to-definition into library source actually opens the file** — jumping into a dependency that ships a `*-sources.jar` now opens the real source. The relevant entry is extracted on demand to a read-only file under `~/.cache/kmp-lsp/jar-sources/` and returned as a `file://` location the editor can open; previously these resolved to non-openable `jar:` URIs (so hover/completion worked, but the jump didn't). Compiled-only jars with no sources still show the signature.
 - **`jarPaths` — index compiled jars without a build system** — for projects with no Gradle cache (Make/Bazel/manual builds), point the indexer directly at compiled `.jar`/`.aar` dependencies. Set `jarPaths` in `workspace.json` (`"jarPaths": ["<WORKSPACE>/libs", "/opt/deps/foo.jar"]` — files or directories, `<WORKSPACE>` and relative paths supported) or via LSP `initializationOptions.indexingOptions.jarPaths`. Indexed in addition to the Gradle cache; hover docs are read from a sibling `*-sources.jar` when one is present.
 - **Accurate library resolution via real per-symbol packages** — JAR symbols now carry their true package (emitted by the sidecar), so go-to-definition, hover, completion, and call-arg diagnostics bind to the *imported* overload instead of an arbitrary same-named symbol from an unrelated jar (e.g. compose `remember`, `stringResource`). Library hover JavaDoc/KDoc now renders for annotated and generic declarations (`@Composable`, `remember`, `stringResource`, …).
 

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ command = "kmp-lsp"
 1. Open a Kotlin/Java file — hover, go-to-definition, and completions work immediately via `rg` fallback while the index builds in the background.
 2. Library sources are discovered automatically — no configuration needed in most cases:
    - **Android SDK** (`Activity`, `Context`, `View`, …) — detected from `local.properties` → `$ANDROID_HOME` → `$ANDROID_SDK_ROOT`
-   - **Gradle library sources** (Compose, coroutines, AndroidX, …) — `*-sources.jar` files are auto-mounted from `~/.gradle/caches` at startup. Hover docs and completions work immediately; go-to-definition into library code also works as long as a `*-sources.jar` is present in the Gradle cache (run a Gradle sync or `./gradlew dependencies` if it isn't). The manual `extract-sources` step is no longer needed.
+   - **Gradle library sources** (Compose, coroutines, AndroidX, …) — `*-sources.jar` files are auto-mounted from `~/.gradle/caches` at startup. Hover docs and completions work immediately; go-to-definition into library code also works as long as a `*-sources.jar` is present in the Gradle cache (run a Gradle sync or `./gradlew dependencies` if it isn't) — the source is extracted on demand to a read-only file under `~/.cache/kmp-lsp/jar-sources/` so your editor can open it. The manual `extract-sources` step is no longer needed.
    - **IntelliJ/Android Studio projects** — `workspace.json` source roots are picked up automatically, including any `sourcePaths` you've configured there.
 
 ---

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -17,7 +17,11 @@ impl Backend {
             return Ok(None);
         };
 
-        Ok(def::find_definition(&ctx, &*self.indexer, uri, position).await)
+        // Rewrite `jar:…!/Foo.kt` targets into extracted `file://` ones the editor
+        // can actually open (in-memory library sources aren't navigable otherwise).
+        Ok(def::find_definition(&ctx, &*self.indexer, uri, position)
+            .await
+            .map(|response| crate::jar_extract::rewrite_jar_definitions(&self.indexer, response)))
     }
 
     pub(super) async fn goto_implementation_impl(
@@ -32,6 +36,12 @@ impl Backend {
             return Ok(None);
         };
 
-        Ok(imp::find_implementation(&ctx.word, &*self.indexer, uri, position.line).await)
+        Ok(
+            imp::find_implementation(&ctx.word, &*self.indexer, uri, position.line)
+                .await
+                .map(|response| {
+                    crate::jar_extract::rewrite_jar_definitions(&self.indexer, response)
+                }),
+        )
     }
 }

--- a/src/backend/nav.rs
+++ b/src/backend/nav.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use super::cursor::CursorContext;
 use super::Backend;
 use crate::features::definition as def;
@@ -17,11 +19,8 @@ impl Backend {
             return Ok(None);
         };
 
-        // Rewrite `jar:…!/Foo.kt` targets into extracted `file://` ones the editor
-        // can actually open (in-memory library sources aren't navigable otherwise).
-        Ok(def::find_definition(&ctx, &*self.indexer, uri, position)
-            .await
-            .map(|response| crate::jar_extract::rewrite_jar_definitions(&self.indexer, response)))
+        let response = def::find_definition(&ctx, &*self.indexer, uri, position).await;
+        Ok(self.rewrite_jar_targets_off_thread(response).await)
     }
 
     pub(super) async fn goto_implementation_impl(
@@ -36,12 +35,24 @@ impl Backend {
             return Ok(None);
         };
 
-        Ok(
-            imp::find_implementation(&ctx.word, &*self.indexer, uri, position.line)
-                .await
-                .map(|response| {
-                    crate::jar_extract::rewrite_jar_definitions(&self.indexer, response)
-                }),
-        )
+        let response =
+            imp::find_implementation(&ctx.word, &*self.indexer, uri, position.line).await;
+        Ok(self.rewrite_jar_targets_off_thread(response).await)
+    }
+
+    /// Rewrite `jar:…!/Foo.kt` definition targets into extracted `file://` ones the
+    /// editor can actually open. The extraction does zip + disk I/O, so it runs on a
+    /// blocking thread to avoid stalling the Tokio executor on the request path.
+    async fn rewrite_jar_targets_off_thread(
+        &self,
+        response: Option<GotoDefinitionResponse>,
+    ) -> Option<GotoDefinitionResponse> {
+        let response = response?;
+        let indexer = Arc::clone(&self.indexer);
+        tokio::task::spawn_blocking(move || {
+            crate::jar_extract::rewrite_jar_definitions(&indexer, response)
+        })
+        .await
+        .ok()
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -57,6 +57,7 @@ pub(crate) use self::infer::{
 
 mod cache;
 pub(crate) use self::cache::workspace_cache_path;
+pub(crate) use self::cache::xdg_cache_base;
 
 pub(crate) mod enrich;
 pub(crate) use self::enrich::EnrichmentHandle;

--- a/src/jar_extract.rs
+++ b/src/jar_extract.rs
@@ -23,9 +23,38 @@ use crate::indexer::Indexer;
 pub(crate) fn parse_jar_entry_uri(uri: &str) -> Option<(PathBuf, String)> {
     let rest = uri.strip_prefix("jar:")?;
     let (jar_part, entry) = rest.split_once("!/")?;
+    if entry.is_empty() || is_unsafe_entry(entry) {
+        return None;
+    }
     // Reuse `Url::to_file_path` so percent-encoding in the path is decoded.
     let jar_path = Url::parse(jar_part).ok()?.to_file_path().ok()?;
     Some((jar_path, entry.to_owned()))
+}
+
+/// Directory under which jar entries are extracted (`~/.cache/kmp-lsp/jar-sources`).
+fn jar_sources_cache_dir() -> PathBuf {
+    crate::indexer::xdg_cache_base()
+        .join("kmp-lsp")
+        .join("jar-sources")
+}
+
+/// Whether `uri` points at a file we extracted from a jar. Such files must not be
+/// re-indexed as workspace documents when the editor opens them — their symbols are
+/// already in the index under the original `jar:` URI, so indexing the extracted
+/// `file://` copy too would duplicate every library definition.
+pub(crate) fn is_extracted_jar_source(uri: &Url) -> bool {
+    uri.to_file_path()
+        .map(|path| path.starts_with(jar_sources_cache_dir()))
+        .unwrap_or(false)
+}
+
+/// Reject entry paths that could escape the extraction cache dir when joined:
+/// absolute paths, Windows drive letters, and any `..` traversal segment.
+fn is_unsafe_entry(entry: &str) -> bool {
+    entry.starts_with('/')
+        || entry.starts_with('\\')
+        || (entry.len() >= 2 && entry.as_bytes()[1] == b':') // C:\…
+        || entry.split(['/', '\\']).any(|segment| segment == "..")
 }
 
 /// Extract `entry` from `jar_path` into the on-disk cache and return a `file://`
@@ -33,6 +62,11 @@ pub(crate) fn parse_jar_entry_uri(uri: &str) -> Option<(PathBuf, String)> {
 /// for the jar's current `(mtime, size)` is reused. Returns `None` on any
 /// I/O / zip error or if the entry is absent.
 pub(crate) fn extract_jar_entry_to_disk(jar_path: &Path, entry: &str) -> Option<Url> {
+    // Defensive: never let an entry path escape the cache dir, even if a caller
+    // passes something other than a zip-validated name.
+    if entry.is_empty() || is_unsafe_entry(entry) {
+        return None;
+    }
     let metadata = std::fs::metadata(jar_path).ok()?;
     let mtime_secs = metadata
         .modified()
@@ -51,9 +85,7 @@ pub(crate) fn extract_jar_entry_to_disk(jar_path: &Path, entry: &str) -> Option<
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or("jar");
-    let dest = crate::indexer::xdg_cache_base()
-        .join("kmp-lsp")
-        .join("jar-sources")
+    let dest = jar_sources_cache_dir()
         .join(format!("{stem}-{fingerprint:016x}"))
         .join(entry);
 

--- a/src/jar_extract.rs
+++ b/src/jar_extract.rs
@@ -1,0 +1,143 @@
+//! Lazy extraction of JAR/sources-JAR entries to disk for go-to-definition.
+//!
+//! Auto-mounted library sources are indexed in-memory and exposed under
+//! `jar:file://…!/Foo.kt` URIs. Hover/completion work from the index, but go-def
+//! hands the *editor* a URI to open, and editors only open `file://`. So when a
+//! go-def target is a `jar:` entry, we extract just that one zip entry to a
+//! read-only cache file and return a `file://` Location (same range) the editor
+//! can actually navigate into. Compiled-only JAR URIs (no `!/entry`) have no
+//! source to extract and are left unchanged.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use tower_lsp::lsp_types::{GotoDefinitionResponse, Location, LocationLink, Url};
+
+use crate::indexer::Indexer;
+
+/// Parse a `jar:file://<jar>!/<entry>` URI into `(jar_path, entry)`.
+/// Returns `None` for non-`jar:` URIs and for compiled-only JAR URIs that carry
+/// no `!/entry` (nothing to extract).
+pub(crate) fn parse_jar_entry_uri(uri: &str) -> Option<(PathBuf, String)> {
+    let rest = uri.strip_prefix("jar:")?;
+    let (jar_part, entry) = rest.split_once("!/")?;
+    // Reuse `Url::to_file_path` so percent-encoding in the path is decoded.
+    let jar_path = Url::parse(jar_part).ok()?.to_file_path().ok()?;
+    Some((jar_path, entry.to_owned()))
+}
+
+/// Extract `entry` from `jar_path` into the on-disk cache and return a `file://`
+/// `Url` for the extracted (read-only) file. Idempotent: a file already present
+/// for the jar's current `(mtime, size)` is reused. Returns `None` on any
+/// I/O / zip error or if the entry is absent.
+pub(crate) fn extract_jar_entry_to_disk(jar_path: &Path, entry: &str) -> Option<Url> {
+    let metadata = std::fs::metadata(jar_path).ok()?;
+    let mtime_secs = metadata
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let mut hasher = DefaultHasher::new();
+    jar_path.hash(&mut hasher);
+    mtime_secs.hash(&mut hasher);
+    metadata.len().hash(&mut hasher);
+    let fingerprint = hasher.finish();
+
+    let stem = jar_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("jar");
+    let dest = crate::indexer::xdg_cache_base()
+        .join("kmp-lsp")
+        .join("jar-sources")
+        .join(format!("{stem}-{fingerprint:016x}"))
+        .join(entry);
+
+    if dest.is_file() {
+        return Url::from_file_path(&dest).ok();
+    }
+
+    let file = std::fs::File::open(jar_path).ok()?;
+    let mut archive = zip::ZipArchive::new(file).ok()?;
+    let mut zip_entry = archive.by_name(entry).ok()?;
+    let mut bytes = Vec::new();
+    zip_entry.read_to_end(&mut bytes).ok()?;
+
+    if let Some(parent) = dest.parent() {
+        std::fs::create_dir_all(parent).ok()?;
+    }
+    std::fs::write(&dest, &bytes).ok()?;
+    set_read_only(&dest);
+    Url::from_file_path(&dest).ok()
+}
+
+/// Rewrite any `jar:…!/entry` definition target to a `file://` one backed by an
+/// extracted on-disk file. Non-`jar:` / unextractable targets pass through.
+pub(crate) fn rewrite_jar_definitions(
+    indexer: &Indexer,
+    response: GotoDefinitionResponse,
+) -> GotoDefinitionResponse {
+    match response {
+        GotoDefinitionResponse::Scalar(location) => {
+            GotoDefinitionResponse::Scalar(rewrite_location(indexer, location))
+        }
+        GotoDefinitionResponse::Array(locations) => GotoDefinitionResponse::Array(
+            locations
+                .into_iter()
+                .map(|location| rewrite_location(indexer, location))
+                .collect(),
+        ),
+        GotoDefinitionResponse::Link(links) => GotoDefinitionResponse::Link(
+            links
+                .into_iter()
+                .map(|link| rewrite_link(indexer, link))
+                .collect(),
+        ),
+    }
+}
+
+fn rewrite_location(indexer: &Indexer, location: Location) -> Location {
+    match rewrite_jar_uri(indexer, &location.uri) {
+        Some(file_uri) => Location {
+            uri: file_uri,
+            range: location.range,
+        },
+        None => location,
+    }
+}
+
+fn rewrite_link(indexer: &Indexer, mut link: LocationLink) -> LocationLink {
+    if let Some(file_uri) = rewrite_jar_uri(indexer, &link.target_uri) {
+        link.target_uri = file_uri;
+    }
+    link
+}
+
+/// Extract the `jar:` URI's entry and return the `file://` URL, registering it
+/// as a library URI so references/indexing treat it as read-only library source.
+fn rewrite_jar_uri(indexer: &Indexer, uri: &Url) -> Option<Url> {
+    if uri.scheme() != "jar" {
+        return None;
+    }
+    let (jar_path, entry) = parse_jar_entry_uri(uri.as_str())?;
+    let file_uri = extract_jar_entry_to_disk(&jar_path, &entry)?;
+    indexer.library_uris.insert(file_uri.as_str().to_owned());
+    Some(file_uri)
+}
+
+#[cfg(unix)]
+fn set_read_only(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o444));
+}
+
+#[cfg(not(unix))]
+fn set_read_only(_path: &Path) {}
+
+#[cfg(test)]
+#[path = "jar_extract_tests.rs"]
+mod tests;

--- a/src/jar_extract_tests.rs
+++ b/src/jar_extract_tests.rs
@@ -24,6 +24,10 @@ fn parse_jar_entry_uri_splits_entry() {
     assert!(parse_jar_entry_uri("jar:file:///x/foo.aar").is_none());
     // Not a jar: URI.
     assert!(parse_jar_entry_uri("file:///x.kt").is_none());
+    // Empty entry and path-traversal / absolute entries are rejected (extraction safety).
+    assert!(parse_jar_entry_uri("jar:file:///x/foo.jar!/").is_none());
+    assert!(parse_jar_entry_uri("jar:file:///x/foo.jar!/../etc/passwd").is_none());
+    assert!(parse_jar_entry_uri("jar:file:///x/foo.jar!//abs.kt").is_none());
 }
 
 #[test]
@@ -68,7 +72,10 @@ fn rewrite_converts_jar_definition_to_file() {
     let indexer = Indexer::new();
     let range = tower_lsp::lsp_types::Range::default();
 
-    let jar_uri = Url::parse(&format!("jar:file://{}!/a/B.kt", jar.display())).unwrap();
+    // Build the jar: URI via Url::from_file_path so it's well-formed cross-platform
+    // (Windows drive letters / backslashes).
+    let jar_file_url = Url::from_file_path(&jar).unwrap();
+    let jar_uri = Url::parse(&format!("jar:{jar_file_url}!/a/B.kt")).unwrap();
     let rewritten = rewrite_jar_definitions(
         &indexer,
         GotoDefinitionResponse::Scalar(Location {

--- a/src/jar_extract_tests.rs
+++ b/src/jar_extract_tests.rs
@@ -17,8 +17,13 @@ fn make_jar(dir: &Path, name: &str, entries: &[(&str, &str)]) -> PathBuf {
 
 #[test]
 fn parse_jar_entry_uri_splits_entry() {
-    let (jar, entry) = parse_jar_entry_uri("jar:file:///x/foo-sources.jar!/a/B.kt").unwrap();
-    assert_eq!(jar, PathBuf::from("/x/foo-sources.jar"));
+    // Build the jar URI from a real path via Url::from_file_path so it round-trips
+    // through Url::to_file_path cross-platform (Windows needs a drive letter).
+    let tmp = tempfile::tempdir().unwrap();
+    let jar_path = tmp.path().join("foo-sources.jar");
+    let jar_url = Url::from_file_path(&jar_path).unwrap();
+    let (jar, entry) = parse_jar_entry_uri(&format!("jar:{jar_url}!/a/B.kt")).unwrap();
+    assert_eq!(jar, jar_path);
     assert_eq!(entry, "a/B.kt");
     // Compiled-only JAR URI (no `!/entry`) → nothing to extract.
     assert!(parse_jar_entry_uri("jar:file:///x/foo.aar").is_none());

--- a/src/jar_extract_tests.rs
+++ b/src/jar_extract_tests.rs
@@ -1,0 +1,101 @@
+use super::*;
+use std::io::Write;
+use zip::write::SimpleFileOptions;
+
+fn make_jar(dir: &Path, name: &str, entries: &[(&str, &str)]) -> PathBuf {
+    let path = dir.join(name);
+    let file = std::fs::File::create(&path).unwrap();
+    let mut zip = zip::ZipWriter::new(file);
+    for (entry, content) in entries {
+        zip.start_file(*entry, SimpleFileOptions::default())
+            .unwrap();
+        zip.write_all(content.as_bytes()).unwrap();
+    }
+    zip.finish().unwrap();
+    path
+}
+
+#[test]
+fn parse_jar_entry_uri_splits_entry() {
+    let (jar, entry) = parse_jar_entry_uri("jar:file:///x/foo-sources.jar!/a/B.kt").unwrap();
+    assert_eq!(jar, PathBuf::from("/x/foo-sources.jar"));
+    assert_eq!(entry, "a/B.kt");
+    // Compiled-only JAR URI (no `!/entry`) → nothing to extract.
+    assert!(parse_jar_entry_uri("jar:file:///x/foo.aar").is_none());
+    // Not a jar: URI.
+    assert!(parse_jar_entry_uri("file:///x.kt").is_none());
+}
+
+#[test]
+fn extract_round_trips_entry_to_file() {
+    let _lock = crate::indexer::test_helpers::XDG_CACHE_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::tempdir().unwrap();
+    let _xdg = crate::indexer::test_helpers::EnvVarGuard::set("XDG_CACHE_HOME", tmp.path());
+
+    let jar = make_jar(
+        tmp.path(),
+        "lib-sources.jar",
+        &[("com/example/Foo.kt", "package com.example\nclass Foo")],
+    );
+
+    let url = extract_jar_entry_to_disk(&jar, "com/example/Foo.kt").unwrap();
+    assert_eq!(url.scheme(), "file");
+    let content = std::fs::read_to_string(url.to_file_path().unwrap()).unwrap();
+    assert!(
+        content.contains("class Foo"),
+        "extracted content: {content:?}"
+    );
+
+    // Idempotent — second call returns the same path.
+    let url_again = extract_jar_entry_to_disk(&jar, "com/example/Foo.kt").unwrap();
+    assert_eq!(url, url_again);
+
+    // Absent entry → None.
+    assert!(extract_jar_entry_to_disk(&jar, "no/such.kt").is_none());
+}
+
+#[test]
+fn rewrite_converts_jar_definition_to_file() {
+    let _lock = crate::indexer::test_helpers::XDG_CACHE_LOCK
+        .lock()
+        .unwrap_or_else(|e| e.into_inner());
+    let tmp = tempfile::tempdir().unwrap();
+    let _xdg = crate::indexer::test_helpers::EnvVarGuard::set("XDG_CACHE_HOME", tmp.path());
+
+    let jar = make_jar(tmp.path(), "ui-sources.jar", &[("a/B.kt", "class B")]);
+    let indexer = Indexer::new();
+    let range = tower_lsp::lsp_types::Range::default();
+
+    let jar_uri = Url::parse(&format!("jar:file://{}!/a/B.kt", jar.display())).unwrap();
+    let rewritten = rewrite_jar_definitions(
+        &indexer,
+        GotoDefinitionResponse::Scalar(Location {
+            uri: jar_uri,
+            range,
+        }),
+    );
+    let GotoDefinitionResponse::Scalar(loc) = rewritten else {
+        panic!("expected scalar");
+    };
+    assert_eq!(loc.uri.scheme(), "file", "jar target must become file://");
+    assert!(
+        indexer.library_uris.contains(loc.uri.as_str()),
+        "extracted source must be registered as a library URI"
+    );
+
+    // A compiled-only jar URI (no source entry) is left unchanged.
+    let aar = Url::parse("jar:file:///x/foo.aar").unwrap();
+    let passthrough = rewrite_jar_definitions(
+        &indexer,
+        GotoDefinitionResponse::Scalar(Location {
+            uri: aar.clone(),
+            range,
+        }),
+    );
+    let GotoDefinitionResponse::Scalar(loc2) = passthrough else {
+        panic!("expected scalar");
+    };
+    assert_eq!(loc2.uri, aar, "compiled-only jar URI must pass through");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod cli;
 mod features;
 mod indexer;
 mod inlay_hints;
+mod jar_extract;
 mod language;
 mod lines_ext;
 mod parser;

--- a/src/workspace/document_handler.rs
+++ b/src/workspace/document_handler.rs
@@ -56,6 +56,15 @@ impl DocumentHandler {
         let opened_file_path = uri.to_file_path().ok();
         let workspace_pinned = self.indexer.workspace_pinned.load(Ordering::Relaxed);
 
+        // A library source we extracted from a jar for go-to-definition: its symbols
+        // are already indexed under the original `jar:` URI, so store live state for
+        // in-file hover/completion but do NOT re-index it (would duplicate every
+        // library definition).
+        if crate::jar_extract::is_extracted_jar_source(&uri) {
+            self.store_live_document_state(&uri, &content).await;
+            return;
+        }
+
         if let Some(workspace_root) =
             self.detect_workspace_root_switch(workspace_pinned, opened_file_path.as_deref())
         {


### PR DESCRIPTION
## Problem

Auto-mounted sources-JAR symbols resolve to `jar:file://…!/Foo.kt` URIs. Hover/completion work (the server computes content from the in-memory index), but go-to-definition hands the **editor** a URI to open — and editors only open `file://`. So jumping into library code silently did nothing, even though resolution was correct.

## What this adds

New **`jar_extract`** module: when a go-def / go-implementation target is a `jar:…!/entry`, extract that **one** zip entry to a read-only file under `~/.cache/kmp-lsp/jar-sources/<jar>-<hash>/<entry>` (keyed by the jar's mtime+size, idempotent) and return a `file://` Location with the **same range**. The extracted URI is registered in `library_uris`. Compiled-only jar URIs (no `!/entry`, i.e. no source) pass through unchanged.

In-memory indexing is untouched — disk is hit only for the entry you actually jump to (no eager extraction, preserves fast startup). This makes the README's existing "go-def into library works when a `*-sources.jar` is present" claim actually true.

Wired into `goto_definition`, `goto_declaration` (shares the impl), and `goto_implementation`.

## Out of scope

- **Compiled-only jars with no `*-sources.jar`** — only bytecode; would need a decompiler. They keep showing the signature.

## Tests

`jar_extract_tests.rs`: URI parsing (incl. compiled-only/non-jar → `None`), extract round-trip + idempotency + missing-entry, and the response rewrite (jar → `file://` + library-URI registration; compiled-only URI passes through). Full suite 1371 passing, clippy clean.

## Note

This also unblocks the **definition-site** half of the find-references-on-JAR-symbols work (Task 3 of that plan) — once the cursor can sit on an extracted JAR source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)