### PR TITLE
fix(resolver): disambiguate imported nested-class members by container chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 
+- **Go-to-definition on imported nested-class members no longer returns duplicates** — when two sealed classes in the same package/interface expose identically-named members (the MVI `Contract` pattern: `Contract.State.Idle` vs `Contract.Event.Idle`), an explicit nested import now resolves to the member of the imported enclosing type only. Resolution matches the full enclosing-type chain from the import, so it disambiguates arbitrarily deep nesting (`Contract.State.Sub.Idle`). Regression from the per-symbol-JAR-package resolver rewrite, which dropped the container filter.
 - **Qualified member-method arg diagnostics** — `receiver.method()` calls into a member defined in another file/package are now arg-count-checked (previously skipped because the method's file was wrongly gated by import reachability).
 - **JAR indexing no longer stuck "loading"** — a cancelled or coalesced background JAR scan can no longer leave open-file diagnostics suppressed indefinitely.
 - **Generic angle brackets in hover docs** — `List<String>` / `Map<K, V>` in KDoc/JavaDoc are no longer stripped as if they were HTML tags.

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -511,7 +511,7 @@ fn primary_ctor_class_params(root: Node, bytes: &[u8], cls: &SymbolEntry) -> Vec
 // ─── Container assignment (post-extraction pass) ─────────────────────────────
 
 /// Classify container-like symbol kinds (class, interface, object, enum).
-fn is_container_kind(kind: SymbolKind) -> bool {
+pub(crate) fn is_container_kind(kind: SymbolKind) -> bool {
     matches!(
         kind,
         SymbolKind::CLASS

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -663,6 +663,62 @@ fn jar_symbol_package(indexer: &Indexer, loc: &Location) -> Option<String> {
         .cloned()
 }
 
+/// The enclosing-type chain named by a nested import, outermost-first.
+///
+/// `com.app.Contract.State.Idle` (symbol `Idle`) → `["Contract", "State"]`.
+/// All segments before the imported `symbol`, restricted to type names (uppercase
+/// first letter), so leading package segments and the symbol itself are dropped.
+/// Returns an empty vec for top-level imports (no enclosing type).
+fn import_container_chain(full_path: &str, symbol: &str) -> Vec<String> {
+    let mut segments: Vec<&str> = full_path.split('.').collect();
+    // Drop the trailing symbol segment (the import's leaf), then keep type segments.
+    if segments.last() == Some(&symbol) {
+        segments.pop();
+    }
+    segments
+        .into_iter()
+        .filter(|s| s.starts_with_uppercase())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// The chain of enclosing container types (class/interface/object/enum/struct) for
+/// the symbol declared at `loc`, outermost-first, looked up across workspace and
+/// JAR files. Computed by range nesting so it handles arbitrarily deep nesting.
+/// Empty when the file/symbol isn't found or the symbol is top-level.
+fn enclosing_container_chain(indexer: &Indexer, loc: &Location) -> Vec<String> {
+    let Some(file_data) = indexer.file_data_for(loc.uri.as_str()) else {
+        return vec![];
+    };
+    let target = loc.range;
+    let mut enclosing: Vec<&crate::types::SymbolEntry> = file_data
+        .symbols
+        .iter()
+        .filter(|s| {
+            crate::parser::is_container_kind(s.kind)
+                // Exclude the symbol itself (a container can be the imported symbol).
+                && s.selection_range != target
+                && range_encloses(s.range, target)
+        })
+        .collect();
+    // Outermost first: earliest start, latest end.
+    enclosing.sort_by(|a, b| {
+        pos_tuple(a.range.start)
+            .cmp(&pos_tuple(b.range.start))
+            .then_with(|| pos_tuple(b.range.end).cmp(&pos_tuple(a.range.end)))
+    });
+    enclosing.into_iter().map(|s| s.name.clone()).collect()
+}
+
+fn pos_tuple(p: tower_lsp::lsp_types::Position) -> (u32, u32) {
+    (p.line, p.character)
+}
+
+/// Whether `outer` fully contains `inner` (start ≤ start and end ≥ end).
+fn range_encloses(outer: tower_lsp::lsp_types::Range, inner: tower_lsp::lsp_types::Range) -> bool {
+    pos_tuple(outer.start) <= pos_tuple(inner.start) && pos_tuple(inner.end) <= pos_tuple(outer.end)
+}
+
 /// Step 2 — explicit single-symbol imports.
 ///
 /// Handles three cases:
@@ -693,6 +749,12 @@ fn resolve_via_imports(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Location
         //     This avoids returning an unrelated `Event` from another package.
         let short = imp.full_path.last_segment();
         let expected_pkg = package_prefix(&imp.full_path);
+        // The enclosing-type chain named by a nested import, outermost-first:
+        // `com.app.Contract.State.Idle` → ["Contract", "State"]. Classes can nest
+        // arbitrarily deep, so we compare the *whole* chain rather than just the
+        // immediate parent — `Contract.State.Sub.Idle` and `Contract.Event.Sub.Idle`
+        // share the immediate container `Sub` but differ higher up.
+        let expected_chain = import_container_chain(&imp.full_path, short);
         let mut all_locations: Vec<tower_lsp::lsp_types::Location> = Vec::new();
         if let Some(locs) = indexer.definitions.get(short) {
             all_locations.extend(locs.iter().cloned());
@@ -701,7 +763,7 @@ fn resolve_via_imports(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Location
             all_locations.extend(locs.iter().cloned());
         }
         if !all_locations.is_empty() {
-            let filtered: Vec<_> = all_locations
+            let mut filtered: Vec<_> = all_locations
                 .iter()
                 .filter(|loc| {
                     // Compiled-JAR (sidecar) symbols: filter by the sidecar's real
@@ -726,6 +788,26 @@ fn resolve_via_imports(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Location
                 })
                 .cloned()
                 .collect();
+
+            // Nested-class disambiguation: when the import names an enclosing-type
+            // chain (e.g. `Contract.State.Idle`), prefer candidates whose enclosing
+            // container chain matches it. Two sealed classes in the same
+            // package/interface can expose identically-named members (`State.Idle` vs
+            // `Event.Idle`); the package filter alone keeps both, so go-to-definition
+            // would jump to both. Only narrows when at least one candidate matches, so
+            // a set that can't be container-resolved (e.g. JAR symbols whose synthetic
+            // ranges don't line up with the symbol entry) is never emptied.
+            if !expected_chain.is_empty() {
+                let chain_matches: Vec<_> = filtered
+                    .iter()
+                    .filter(|loc| enclosing_container_chain(indexer, loc) == expected_chain)
+                    .cloned()
+                    .collect();
+                if !chain_matches.is_empty() {
+                    filtered = chain_matches;
+                }
+            }
+
             if !filtered.is_empty() {
                 return filtered;
             }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -3414,3 +3414,74 @@ fn import_resolves_jar_symbol_to_correct_package() {
         locs.iter().map(|l| l.uri.as_str()).collect::<Vec<_>>()
     );
 }
+
+/// Two sealed classes with identically-named members inside one interface
+/// (the MVI `Contract` pattern: `State.Idle` and `Event.Idle`). An explicit
+/// nested-class import (`Contract.State.Idle`) must resolve go-to-definition to
+/// the member of the *imported* enclosing type only — not both. The container
+/// segment in the import (`State`) disambiguates same-package members sharing a
+/// short name. Regression guard: the per-symbol-JAR-package rewrite dropped this
+/// container filter, so go-def returned both `Idle` objects.
+#[test]
+fn import_disambiguates_same_package_nested_member_by_container() {
+    let idx = Indexer::new();
+    let contract = uri("/Contract.kt");
+    let use_uri = uri("/ui/Use.kt");
+    idx.index_content(
+        &contract,
+        "package com.app\ninterface Contract {\n  sealed class State {\n    object Idle : State()\n  }\n  sealed class Event {\n    object Idle : Event()\n  }\n}",
+    );
+    idx.index_content(
+        &use_uri,
+        "package com.app.ui\nimport com.app.Contract.State.Idle\nval x = Idle",
+    );
+    let locs = resolve_symbol(&idx, "Idle", None, &use_uri);
+    assert_eq!(
+        locs.len(),
+        1,
+        "expected only State.Idle; got {:?}",
+        locs.iter().map(|l| l.range.start.line).collect::<Vec<_>>()
+    );
+    // `State.Idle` is the object on line 3 (0-indexed); `Event.Idle` is line 6.
+    assert_eq!(locs[0].range.start.line, 3);
+}
+
+/// Deeply-nested variant: the disambiguating container differs *above* the
+/// immediate parent. `Contract.State.Sub.Idle` and `Contract.Event.Sub.Idle`
+/// share the immediate container `Sub`, so only a full enclosing-chain match
+/// resolves the import to the right one.
+#[test]
+fn import_disambiguates_deeply_nested_member_by_full_chain() {
+    let idx = Indexer::new();
+    let contract = uri("/Contract.kt");
+    let use_uri = uri("/ui/Use.kt");
+    idx.index_content(
+        &contract,
+        "package com.app\n\
+         interface Contract {\n\
+         \x20 sealed class State {\n\
+         \x20   sealed class Sub {\n\
+         \x20     object Idle : Sub()\n\
+         \x20   }\n\
+         \x20 }\n\
+         \x20 sealed class Event {\n\
+         \x20   sealed class Sub {\n\
+         \x20     object Idle : Sub()\n\
+         \x20   }\n\
+         \x20 }\n\
+         }",
+    );
+    idx.index_content(
+        &use_uri,
+        "package com.app.ui\nimport com.app.Contract.State.Sub.Idle\nval x = Idle",
+    );
+    let locs = resolve_symbol(&idx, "Idle", None, &use_uri);
+    assert_eq!(
+        locs.len(),
+        1,
+        "expected only State.Sub.Idle; got {:?}",
+        locs.iter().map(|l| l.range.start.line).collect::<Vec<_>>()
+    );
+    // State.Sub.Idle is the object on line 4 (0-indexed); Event.Sub.Idle is line 9.
+    assert_eq!(locs[0].range.start.line, 4);
+}


### PR DESCRIPTION
## The bug (regression)

Go-to-definition on an explicitly-imported member of a nested class jumped to **every** same-named member in the package. With the MVI `Contract` pattern — two sealed classes inside one interface exposing identically-named members:

```kotlin
interface Contract {
    sealed class State { object Idle : State() }
    sealed class Event { object Idle : Event() }   // identical member name
}
```

`import com.app.Contract.State.Idle` + go-def on `Idle` returned **both** `State.Idle` and `Event.Idle`.

## Root cause

The per-symbol-JAR-package rewrite of `resolve_via_imports` (commit `1bd198b`, unreleased — landed after `0.24.0`, which is what made this a regression) dropped the `expected_container` filter that previously disambiguated same-package nested members. Only a package-prefix check remained, and that prefix (`com.app`) is identical for both candidates.

## Fix

Restore container disambiguation, but compare the **full enclosing-type chain** named by the import against each candidate's enclosing container chain (computed by range nesting), instead of just the immediate parent. This handles arbitrarily deep nesting — `Contract.State.Sub.Idle` vs `Contract.Event.Sub.Idle` share the immediate container `Sub` but differ higher up.

Only narrows when **at least one** candidate's chain matches, so a set that can't be container-resolved (e.g. JAR symbols whose synthetic ranges don't line up with the symbol entry) is never emptied — no regression for cross-package / JAR resolution, which the package filter already handles.

- `parser`: expose `is_container_kind` as `pub(crate)`.
- `resolver`: add `import_container_chain` + `enclosing_container_chain` helpers.

## Testing

- `import_disambiguates_same_package_nested_member_by_container` — the reported case (returns only `State.Idle`).
- `import_disambiguates_deeply_nested_member_by_full_chain` — `Contract.State.Sub.Idle` (immediate container `Sub` is shared; full chain disambiguates).
- Full suite: 1378 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)