### PR TITLE
fix(resolver): correct package prefix for lowercase top-level imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 ### Bug fixes
 
+- **Import resolution for lowercase top-level functions** — resolving an explicit import of a lowercase top-level function/property (e.g. `import androidx.compose.ui.res.stringResource`) computed the wrong declaring package: the all-lowercase path made the package heuristic swallow the function name itself. Imports are now keyed off the package with the imported symbol's own segment stripped, so go-to-definition / hover / find-references bind such imports to the correct library symbol via the import path instead of falling through to the (less precise) project-wide search.
 - **Go-to-definition on imported nested-class members no longer returns duplicates** — when two sealed classes in the same package/interface expose identically-named members (the MVI `Contract` pattern: `Contract.State.Idle` vs `Contract.Event.Idle`), an explicit nested import now resolves to the member of the imported enclosing type only. Resolution matches the full enclosing-type chain from the import, so it disambiguates arbitrarily deep nesting (`Contract.State.Sub.Idle`). Regression from the per-symbol-JAR-package resolver rewrite, which dropped the container filter.
 - **Qualified member-method arg diagnostics** — `receiver.method()` calls into a member defined in another file/package are now arg-count-checked (previously skipped because the method's file was wrongly gated by import reachability).
 - **JAR indexing no longer stuck "loading"** — a cancelled or coalesced background JAR scan can no longer leave open-file diagnostics suppressed indefinitely.

--- a/src/resolver/fd.rs
+++ b/src/resolver/fd.rs
@@ -22,6 +22,25 @@ pub(super) fn package_prefix(import_path: &str) -> String {
         .join(".")
 }
 
+/// The declaring package of an *imported* symbol, derived from its full import path.
+///
+/// Unlike [`package_prefix`], this first drops the trailing segment — the imported
+/// entity itself — before taking the lowercase package prefix. That matters for
+/// imports of lowercase top-level functions/properties (`a.b.c.stringResource`),
+/// where `package_prefix` would otherwise swallow the function name into the
+/// "package" (every segment is lowercase) and produce `a.b.c.stringResource`.
+///
+/// `androidx.compose.ui.res.stringResource` → `"androidx.compose.ui.res"`
+/// `com.example.OuterClass.InnerClass`      → `"com.example"`
+/// `com.example.Foo`                        → `"com.example"`
+pub(super) fn import_package_prefix(import_path: &str) -> String {
+    let without_symbol = import_path
+        .rsplit_once('.')
+        .map(|(pkg, _symbol)| pkg)
+        .unwrap_or(import_path);
+    package_prefix(without_symbol)
+}
+
 /// Uppercase segment stems in priority order — outer class first.
 ///
 /// `com.example.OuterClass.InnerClass` → `["OuterClass", "InnerClass"]`

--- a/src/resolver/mod.rs
+++ b/src/resolver/mod.rs
@@ -37,7 +37,7 @@ pub(crate) use complete::{
 #[cfg(test)]
 use fd::import_file_stems;
 #[cfg(test)]
-use fd::package_prefix;
+use fd::{import_package_prefix, package_prefix};
 #[cfg(test)]
 pub(crate) use infer::infer_variable_type;
 #[cfg(test)]

--- a/src/resolver/resolve.rs
+++ b/src/resolver/resolve.rs
@@ -31,7 +31,7 @@ use crate::rg::{build_rg_pattern, parse_rg_line, rg_find_definition};
 use crate::types::{CallerContext, FileData};
 use crate::StrExt;
 
-use super::fd::{fd_find_and_parse, package_prefix};
+use super::fd::{fd_find_and_parse, import_package_prefix};
 use super::find::{find_local_declaration, find_name_in_uri, find_name_in_uri_after_line};
 use super::hierarchy::walk_hierarchy;
 use super::infer::{infer_field_type, infer_variable_type};
@@ -372,7 +372,7 @@ fn resolve_via_imports_index_only(indexer: &Indexer, name: &str, uri: &Url) -> V
 
         // ii) short-name index filtered to the expected package
         let short = imp.full_path.last_segment();
-        let expected_pkg = package_prefix(&imp.full_path);
+        let expected_pkg = import_package_prefix(&imp.full_path);
         // For nested class imports (e.g. OverviewProductContract.Event), extract
         // the container name to disambiguate when multiple classes with the same
         // short name exist in the same package.
@@ -748,7 +748,7 @@ fn resolve_via_imports(indexer: &Indexer, name: &str, uri: &Url) -> Vec<Location
         //     `…accountpicker` (all-lowercase prefix segments).
         //     This avoids returning an unrelated `Event` from another package.
         let short = imp.full_path.last_segment();
-        let expected_pkg = package_prefix(&imp.full_path);
+        let expected_pkg = import_package_prefix(&imp.full_path);
         // The enclosing-type chain named by a nested import, outermost-first:
         // `com.app.Contract.State.Idle` → ["Contract", "State"]. Classes can nest
         // arbitrarily deep, so we compare the *whole* chain rather than just the
@@ -1082,7 +1082,7 @@ fn package_dir_in_source_roots(
     root: Option<&std::path::Path>,
     source_roots: &[String],
 ) -> bool {
-    let pkg = package_prefix(import_path);
+    let pkg = import_package_prefix(import_path);
     if pkg.is_empty() {
         return true;
     }

--- a/src/resolver/tests.rs
+++ b/src/resolver/tests.rs
@@ -33,6 +33,23 @@ fn package_prefix_standard() {
 }
 
 #[test]
+fn import_package_prefix_strips_lowercase_leaf() {
+    // A lowercase top-level function import (`a.b.c.stringResource`) is all-lowercase,
+    // so the bare `package_prefix` would swallow the function name into the "package".
+    // `import_package_prefix` drops the imported symbol's own (last) segment first.
+    assert_eq!(
+        import_package_prefix("androidx.compose.ui.res.stringResource"),
+        "androidx.compose.ui.res"
+    );
+    // Class / nested-class imports (uppercase leaf) are unaffected.
+    assert_eq!(
+        import_package_prefix("com.example.OuterClass.InnerClass"),
+        "com.example"
+    );
+    assert_eq!(import_package_prefix("com.example.Foo"), "com.example");
+}
+
+#[test]
 fn import_candidates_top_level() {
     let c = import_file_candidates("com.example.Foo");
     assert_eq!(c[0], "Foo.kt");


### PR DESCRIPTION
## Bug

Resolving an explicit import of a **lowercase top-level function/property** computed the wrong declaring package:

```kotlin
import androidx.compose.ui.res.stringResource
```

`package_prefix` derives the package by taking leading lowercase dot-segments — but a lowercase function name (`stringResource`) is *also* lowercase, so the whole path was treated as the package (`androidx.compose.ui.res.stringResource`). The import then matched nothing in the package-filtered candidate set, and resolution fell through to the project-wide rg/global fallback (slower, and can bind to a same-named workspace symbol instead of the imported library one).

## Fix

Add `import_package_prefix`, which strips the imported symbol's own trailing segment before taking the package prefix, and use it at all three import-resolution call sites (`resolve_via_imports`, `resolve_via_imports_index_only`, `package_dir_in_source_roots`).

- `androidx.compose.ui.res.stringResource` → `androidx.compose.ui.res` ✓
- `com.example.OuterClass.InnerClass` → `com.example` (unchanged) ✓
- `com.example.Foo` → `com.example` (unchanged) ✓

Class / nested-class imports are unaffected (their leaf is uppercase, so it was never absorbed into the package).

Surfaced while running a missing-import precision POC against nowInAndroid.

## Testing

- `import_package_prefix_strips_lowercase_leaf` unit test.
- Full suite: 1380 passed; clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)